### PR TITLE
Add missing error response examples to update-recipient endpoint

### DIFF
--- a/reference/recipients-api.json
+++ b/reference/recipients-api.json
@@ -1616,6 +1616,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Invalid Request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Invalid request format"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1626,6 +1636,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1636,16 +1656,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "code": "AUTHORIZATION_REQUIRED",
+                      "messages": [
+                        "The merchant has no authorization to use this API."
+                      ]
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary
Added missing error response examples to the update-recipient endpoint in the recipients-api.json file.

## Changes Made
- Added example responses for 400, 401, and 403 error codes
- Removed 404 response from the update-recipient endpoint
- Updated error responses to follow standard Yuno API error format