### PR TITLE
Standardize error responses across recipient and onboarding endpoints

### DIFF
--- a/reference/openapi.json
+++ b/reference/openapi.json
@@ -2973,6 +2973,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -2983,6 +2993,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "code": "AUTHORIZATION_REQUIRED",
+                      "messages": [
+                        "The merchant has no authorization to use this API."
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3137,16 +3157,6 @@
                       ]
                     }
                   }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3539,6 +3549,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Invalid Request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Invalid request format"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3549,6 +3569,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3559,16 +3589,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "code": "AUTHORIZATION_REQUIRED",
+                      "messages": [
+                        "The merchant has no authorization to use this API."
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3589,6 +3619,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3599,23 +3639,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 },
                 "examples": {
-                  "Not Found": {
+                  "Forbidden": {
                     "value": {
-                      "code": "RECIPIENT_NOT_FOUND",
+                      "code": "AUTHORIZATION_REQUIRED",
                       "messages": [
-                        "Recipient not found"
+                        "The merchant has no authorization to use this API."
                       ]
                     }
                   }
@@ -3704,6 +3734,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3714,23 +3754,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 },
                 "examples": {
-                  "Not Found": {
+                  "Forbidden": {
                     "value": {
-                      "code": "RECIPIENT_NOT_FOUND",
+                      "code": "AUTHORIZATION_REQUIRED",
                       "messages": [
-                        "Recipient not found"
+                        "The merchant has no authorization to use this API."
                       ]
                     }
                   }
@@ -3819,6 +3849,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3829,23 +3869,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 },
                 "examples": {
-                  "Not Found": {
+                  "Forbidden": {
                     "value": {
-                      "code": "RECIPIENT_NOT_FOUND",
+                      "code": "AUTHORIZATION_REQUIRED",
                       "messages": [
-                        "Recipient not found"
+                        "The merchant has no authorization to use this API."
                       ]
                     }
                   }
@@ -3934,6 +3964,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -3944,23 +3984,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Recipient not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 },
                 "examples": {
-                  "Not Found": {
+                  "Forbidden": {
                     "value": {
-                      "code": "RECIPIENT_NOT_FOUND",
+                      "code": "AUTHORIZATION_REQUIRED",
                       "messages": [
-                        "Recipient not found"
+                        "The merchant has no authorization to use this API."
                       ]
                     }
                   }
@@ -4674,9 +4704,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Recipient not found"
           }
         }
       }
@@ -5783,9 +5810,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Recipient not found"
           }
         }
       }
@@ -6184,16 +6208,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Onboarding not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         }
       },
@@ -6340,6 +6354,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -6350,23 +6374,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Onboarding not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 },
                 "examples": {
-                  "Not Found": {
+                  "Forbidden": {
                     "value": {
-                      "code": "ONBOARDING_NOT_FOUND",
+                      "code": "AUTHORIZATION_REQUIRED",
                       "messages": [
-                        "Onboarding not found"
+                        "The merchant has no authorization to use this API."
                       ]
                     }
                   }


### PR DESCRIPTION
## Summary
Standardized all 40X error responses across recipient and onboarding endpoints in both `recipients-api.json` and `openapi.json` files. Removed all 404 responses and ensured consistent error response format with proper examples.

## Changes Made
- **Removed all 404 responses** from recipient and onboarding endpoints
- **Added missing error response examples** to 400, 401, and 403 responses
- **Standardized error response format** across all endpoints

## Files Modified
- `reference/recipients-api.json`
- `reference/openapi.json`

## Endpoints Updated

### Recipients API (`recipients-api.json`)
- `create-recipient`
- `list-recipients` 
- `get-recipient`
- `update-recipient`
- `delete-recipient`
- `cancel-recipient`
- `block-recipient`
- `unblock-recipient`

### OpenAPI (`openapi.json`)
- `post_{id}onboardings` (Create Onboarding)
- `continue-onboarding`
- `update-onboarding`
- `post_recipients{:id}onboardings{:id}transfer` (Transfer Onboarding)
- All recipient management endpoints

## Verification
- All 400, 401, and 403 responses now have proper examples
- All 404 responses have been removed
- Error response format is consistent across all endpoints
- Both files have been thoroughly reviewed and updated