### PR TITLE
Fix: Make alternative_amount field optional in checkout session API

### DIFF
--- a/reference/checkout-api.json
+++ b/reference/checkout-api.json
@@ -132,6 +132,7 @@
                   "alternative_amount": {
                     "type": "object",
                     "description": "Alternative currency representation of the transaction amount.",
+                    "nullable": true,
                     "required": [
                       "currency",
                       "value"
@@ -267,6 +268,20 @@
                       "currency": "USD",
                       "value": 520
                     }
+                  }
+                },
+                "Checkout Session (without alternative_amount)": {
+                  "value": {
+                    "account_id": "493e9374-510a-4201-9e09-de669d75f256",
+                    "merchant_order_id": "1717681150",
+                    "payment_description": "Test Cards",
+                    "country": "CO",
+                    "customer_id": "55006822-7c79-490b-bea1-81798b9afc74",
+                    "amount": {
+                      "currency": "COP",
+                      "value": 8000
+                    },
+                    "alternative_amount": null
                   }
                 }
               }


### PR DESCRIPTION
## Description
Fixes issue reported by David Ríos where the `alternative_amount` field in the checkout session API documentation was being treated as required, preventing users from removing it from requests.

## Changes Made
- Added `nullable: true` to the `alternative_amount` object in the OpenAPI schema
- Updated examples to demonstrate that `alternative_amount` can be omitted or set to null
- Added new example showing explicit `null` value for `alternative_amount`
