### PR TITLE
docs: Add iOS SDK 2.7.1 release notes

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/ios-release-notes.md
+++ b/docs/SDKs/ios-sdk-integrations/ios-release-notes.md
@@ -9,6 +9,8 @@ The iOS SDK release notes provide a comprehensive overview of the updates, impro
 
 | Version | Changes                                                                                                                                                                                                           |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.7.1   | **NEW**: Added support for Click to Pay (CTP) with Passkey.                                                                                                                                                       |
+|         | **NEW**: Notify pending status in enrollment when sending to deeplink.                                                                                                                                          |
 | 2.7.0   | **NEW**: Added ClearSale with web integration.                                                                                                                                                                    |
 |         | **FIX**: Various bug fixes and improvements.                                                                                                                                                                      |
 | 2.6.0   | **NEW**: Added a navigation toolbar to forms when the keyboard is shown.                                                                                                                                          |


### PR DESCRIPTION
## Description
Adds release notes for iOS SDK version 2.7.1 to the changelog.

## Changes Made
- Added version 2.7.1 entry to `ios-release-notes.md`
- Documented two new features:
  - Added support for Click to Pay (CTP) with Passkey
  - Notify pending status in enrollment when sending to deeplink