### PR TITLE
docs(web-sdk): add card.onChange to startCheckout (Full & Lite)

### DIFF
--- a/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
+++ b/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
@@ -76,6 +76,13 @@ yuno.startCheckout({
   showPaymentStatus: true,
   card: {
     isCreditCardProcessingOnly: true,
+    onChange: ({ error, data }) => {
+      if (error) {
+        console.log('Card form error:', error);
+      } else {
+        console.log('Card form data:', data);
+      }
+    },
   },
   onLoading: (args) => {
     console.log(args);
@@ -332,6 +339,7 @@ yuno.startCheckout({
     styles: "",
     cardSaveEnable: false,
     texts: {},
+    isCreditCardProcessingOnly: true,
     onChange: ({ error, data }) => {
       if (error) {
         console.log('Card form error:', error);

--- a/docs/SDKs/web-sdk-integrations/lite-checkout-sdk/lite-web-sdk-payment.md
+++ b/docs/SDKs/web-sdk-integrations/lite-checkout-sdk/lite-web-sdk-payment.md
@@ -56,6 +56,16 @@ yuno.startCheckout({
   showLoading: true,
   issuersFormEnable: true,
   showPaymentStatus: true,
+  card: {
+    isCreditCardProcessingOnly: true,
+    onChange: ({ error, data }) => {
+      if (error) {
+        console.log('Card form error:', error);
+      } else {
+        console.log('Card form data:', data);
+      }
+    },
+  },
   onLoading: (args) => {
     console.log(args);
   },
@@ -371,6 +381,7 @@ yuno.startCheckout({
     styles: "",
     cardSaveEnable: false,
     texts: {},
+    isCreditCardProcessingOnly: true,
     onChange: ({ error, data }) => {
       if (error) {
         console.log('Card form error:', error);


### PR DESCRIPTION
## Description
Documents the new `card.onChange` callback inside `startCheckout` for Web Full SDK and Web Lite SDK (payment flow). Mirrors Secure Fields `options.onChange` behavior and details when it fires.

## Changes
- Added `onChange` parameter to card configuration table and example in `full-checkout-sdk/full-sdk-implementation.md`
- Added `onChange` parameter to card configuration table and example in `lite-checkout-sdk/lite-web-sdk-payment.md`
- Clarified events that trigger `onChange` (loading, completion, network selection, form reset) and payload `{ error, data }` alignment with Secure Fields