### PR TITLE
docs(google-pay): add highlighted SDK-required note to Direct integration

### DIFF
--- a/docs/Wallets/google-pay/google-pay-direct-integration.md
+++ b/docs/Wallets/google-pay/google-pay-direct-integration.md
@@ -10,6 +10,11 @@ metadata:
 next:
   description: ''
 ---
+
+> ❗️ **SDK Required**
+>
+> Google Pay Direct integration requires using one of Yuno's SDKs (Web, Android, or iOS) for implementation. This feature cannot be implemented without an SDK integration.
+
 This page provides instructions for connecting and offering Google Pay™ as a payment option to your customers using the Direct integration.
 
 ## Requirements


### PR DESCRIPTION
- PR description:
  - Description
    - Adds a prominent note clarifying that Google Pay Direct requires using one of Yuno’s SDKs (Web, Android, or iOS).
  - Changes
    - Inserted a highlighted warning callout below the frontmatter explaining SDK requirement.
  - File updated
    - docs/Wallets/google-pay/google-pay-direct-integration.md
  - References
    - Internal context: Slack thread from TAM team reporting confusion about SDK requirement.