### PR TITLE
docs(api): fix ACTION_REQUIRED description in transaction status codes

### DIFF
--- a/reference/Yuno API Reference/manage-payments/status-and-response-codes/transaction.md
+++ b/reference/Yuno API Reference/manage-payments/status-and-response-codes/transaction.md
@@ -400,7 +400,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
         <tbody>
           <tr>
             <td><code>ACTION_REQUIRED</code></td>
-            <td>Chargeback or Inquiry received. Decision or documentation must be provided</td>
+            <td>Payment created but requires additional user action. This occurs in 3D Secure authentication flows, payment method redirections, Headless SDK flows requiring continuePayment, or async payment methods with additional steps. Check the <code>redirect_url</code> or <code>sdk_action_required</code> field for next steps.</td>
             <td>N/A</td>
             <td>-</td>
           </tr>

--- a/reference/Yuno API Reference/manage-payments/status-and-response-codes/transactions-copy.md
+++ b/reference/Yuno API Reference/manage-payments/status-and-response-codes/transactions-copy.md
@@ -388,7 +388,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
         <tbody>
           <tr>
             <td>ACTION_REQUIRED</td>
-            <td>Chargeback or Inquiry received. Decision or documentation must be provided</td>
+            <td>Payment created but requires additional user action. This occurs in 3D Secure authentication flows, payment method redirections, Headless SDK flows requiring continuePayment, or async payment methods with additional steps. Check the <code>redirect_url</code> or <code>sdk_action_required</code> field for next steps.</td>
             <td>N/A</td>
             <td>-</td>
           </tr>


### PR DESCRIPTION
## Description
Corrects the `ACTION_REQUIRED` response code description in the transaction status documentation. The previous description was incorrect and only mentioned chargebacks/inquiries.

## Changes
- Updated `ACTION_REQUIRED` description to accurately reflect when it occurs:
  - 3D Secure authentication flows
  - Payment method redirections
  - Headless SDK flows requiring `continuePayment`
  - Async payment methods with additional steps
- Added guidance to check `redirect_url` or `sdk_action_required` fields for next steps
- Updated both transaction documentation files for consistency

## Files Updated
- `reference/Yuno API Reference/manage-payments/status-and-response-codes/transaction.md`
- `reference/Yuno API Reference/manage-payments/status-and-response-codes/transactions-copy.md`