### PR TITLE
[DM-1] Implement mountExternalButtons method in SDK

### DIFF
--- a/docs/SDKs/build-your-integration/the-ultimate-checkout-lite.md
+++ b/docs/SDKs/build-your-integration/the-ultimate-checkout-lite.md
@@ -18,11 +18,16 @@ The **Lite SDK** provides full control over your payment experience. Unlike the 
 
 Additionally, the Lite SDK supports enrolling payment methods for future use. For more details, see [Lite SDK (Enrollment)](doc:enrollment-lite).
 
+> 📘 Google Pay and Apple Pay in Lite SDK
+>
+> Google Pay and Apple Pay are not available as built-in payment options in the Lite SDK. To use these payment methods, you must use the `mountExternalButtons` method. See the platform-specific guides for implementation details.
+
 With the Lite SDK, you can:
 
 * Execute the payment process
 * Enroll a credit card while making a payment
 * Use a vaulted token from an enrolled payment method to complete a transaction
+* Use Google Pay and Apple Pay via the `mountExternalButtons` method
 
 Use the following guides to implement each process:
 

--- a/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
+++ b/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
@@ -111,6 +111,10 @@ yuno.startCheckout({
 >
 > For all APMs, including Google Pay, Apple Pay, and PayPal, `onPaymentMethodSelected` is triggered as soon as the customer chooses the payment method (before the payment flow begins). Define `onPaymentMethodSelected` in `startCheckout` before `mountCheckout`.
 
+> 📘 Google Pay and Apple Pay Display
+>
+> From SDK version 1.5, Google Pay and Apple Pay appear as direct buttons instead of radio buttons in the payment methods list. They are displayed separately from other payment methods.
+
 ## Step 4: Mount the SDK
 
 Display the payment methods:
@@ -196,6 +200,7 @@ When the method returns an object, you can handle your application's payment flo
 
 Yuno Web SDK provides additional services and configurations you can use to improve customers' experience:
 
+* [Mount external buttons](#mount-external-buttons)
 * [Form loader](#form-loader)
 * [Render mode ](#render-mode)
 * [Card form configurations ](#card-form-configurations)
@@ -204,6 +209,44 @@ Yuno Web SDK provides additional services and configurations you can use to impr
   * [Text payment form buttons](#text-payment-form-buttons)
   * [Persist credit card form to retry payments](#persist-credit-card-form-to-retry-payments)
   * [Hide Pay button](#hide-pay-button)
+
+### Mount external buttons
+
+You can use the `mountExternalButtons` method to render Google Pay and Apple Pay buttons in custom locations within your UI. This gives you control over where these buttons are displayed.
+
+```javascript
+await yuno.mountExternalButtons([
+  {
+    paymentMethodType: 'APPLE_PAY',
+    elementSelector: '#apple-pay',
+  },
+  {
+    paymentMethodType: 'GOOGLE_PAY',
+    elementSelector: '#google-pay',
+  },
+]);
+```
+
+#### Parameters
+
+| Parameter           | Description                                                                                                 |
+| :------------------ | :---------------------------------------------------------------------------------------------------------- |
+| `paymentMethodType` | The payment method type. Must be either `'APPLE_PAY'` or `'GOOGLE_PAY'`.                                    |
+| `elementSelector`   | The CSS selector for the HTML element where the button should be rendered (e.g., `'#apple-pay'`, `'.button'`). |
+
+#### Unmounting buttons
+
+You can unmount a single external button by payment method type:
+
+```javascript
+yuno.unmountExternalButton('APPLE_PAY');
+```
+
+Or unmount all external buttons at once:
+
+```javascript
+yuno.unmountAllExternalButtons();
+```
 
 ### Form loader
 

--- a/docs/SDKs/web-sdk-integrations/lite-checkout-sdk/lite-web-sdk-payment.md
+++ b/docs/SDKs/web-sdk-integrations/lite-checkout-sdk/lite-web-sdk-payment.md
@@ -95,7 +95,7 @@ Use the `yuno.mountCheckoutLite()` function by selecting an HTML element and usi
 ```javascript
 yuno.mountCheckoutLite({
   /**
-   * can be one of 'PAYPAL' | 'PIX' | 'APPLE_PAY' | 'GOOGLE_PAY' | CARD
+   * can be one of 'PAYPAL' | 'PIX' | CARD
    */
   paymentMethodType: PAYMENT_METHOD_TYPE,
   /**
@@ -109,7 +109,47 @@ yuno.mountCheckoutLite({
 
 After mounting the SDK, the selected payment method flow will start automatically.
 
-## Step 5: Initiate the payment process
+> 📘 Google Pay and Apple Pay in Lite SDK
+>
+> Google Pay and Apple Pay are not available as built-in payment options in the Lite SDK. To use these payment methods, you must use the `mountExternalButtons` method. See [Mount external buttons](#mount-external-buttons) for more information.
+
+## Step 5: Mount external buttons (Optional)
+
+If you want to use Google Pay or Apple Pay in the Lite SDK, you can mount these payment buttons externally using the `mountExternalButtons` method. This method allows you to choose where each button is displayed in your UI.
+
+```javascript
+// Mount external buttons
+await yuno.mountExternalButtons([
+  {
+    paymentMethodType: 'APPLE_PAY',
+    elementSelector: '#apple-pay',
+  },
+  {
+    paymentMethodType: 'GOOGLE_PAY',
+    elementSelector: '#google-pay',
+  },
+]);
+```
+
+The `mountExternalButtons` method accepts an array of objects, each containing:
+- `paymentMethodType`: Either `'APPLE_PAY'` or `'GOOGLE_PAY'`
+- `elementSelector`: The CSS selector for the HTML element where the button should be rendered
+
+### Unmounting external buttons
+
+You can unmount a single external button:
+
+```javascript
+yuno.unmountExternalButton('APPLE_PAY');
+```
+
+Or unmount all external buttons at once:
+
+```javascript
+yuno.unmountAllExternalButtons();
+```
+
+## Step 6: Initiate the payment process
 
 After the user has selected a payment method, remember to call `yuno.startPayment()` to initiate the payment flow. Below, you will find an example where `yuno.startPayment()` is called when the user clicks on `button-pay`:
 
@@ -121,7 +161,7 @@ PayButton.addEventListener("click", () => {
 });
 ```
 
-## Step 6: Get the OTT (one-time token)
+## Step 7: Get the OTT (one-time token)
 
 Once the customer fills out the requested data in Yuno's payment forms, the SDK provides the one-time token. The configuration function `yunoCreatePayment(oneTimeToken)` is then triggered with the one-time token.
 
@@ -139,7 +179,7 @@ yunoCreatePayment(oneTimeToken, tokenWithInformation);
 >
 > The merchant is responsible for managing the loader. Yuno provides a default loader option, but merchants may implement their own loader if preferred. In that case, they are responsible for making the necessary configurations.
 
-## Step 7: Create the Payment
+## Step 8: Create the Payment
 
 Once you have completed the steps described before, you will be able to create a payment. The back-to-back payment creation must be carried out using the [Create Payment endpoint](https://docs.y.uno/reference/create-payment). The merchant should call their backend to create the payment within Yuno, using the one-time token and the checkout session.
 
@@ -151,6 +191,7 @@ Once you have completed the steps described before, you will be able to create a
 
 Yuno Web SDK provides additional services and configurations you can use to improve customers' experience:
 
+* [Mount external buttons](#mount-external-buttons)
 * [Form loader](doc:lite-checkout-sdk#loader)
 * [Bank Issuer List](doc:lite-checkout-sdk#form-of-the-issuer)
 * [Render mode ](doc:lite-checkout-sdk#mode-of-form-rendering)
@@ -160,6 +201,44 @@ Yuno Web SDK provides additional services and configurations you can use to impr
   * [Text payment form buttons](doc:lite-checkout-sdk#text-payment-form-buttons)
   * [Persist credit card form to retry payments](doc:lite-checkout-sdk#persist-credit-card-form-to-retry-payments)
   * [Hide Pay button](doc:lite-checkout-sdk#hide-pay-button)
+
+### Mount external buttons
+
+Use the `mountExternalButtons` method to render Google Pay and Apple Pay buttons in your custom UI. This method is required if you want to use these payment methods in the Lite SDK, as they are not available as built-in payment options.
+
+```javascript
+await yuno.mountExternalButtons([
+  {
+    paymentMethodType: 'APPLE_PAY',
+    elementSelector: '#apple-pay',
+  },
+  {
+    paymentMethodType: 'GOOGLE_PAY',
+    elementSelector: '#google-pay',
+  },
+]);
+```
+
+#### Parameters
+
+| Parameter           | Description                                                                                                 |
+| :------------------ | :---------------------------------------------------------------------------------------------------------- |
+| `paymentMethodType` | The payment method type. Must be either `'APPLE_PAY'` or `'GOOGLE_PAY'`.                                    |
+| `elementSelector`   | The CSS selector for the HTML element where the button should be rendered (e.g., `'#apple-pay'`, `'.button'`). |
+
+#### Unmounting buttons
+
+You can unmount a single external button by payment method type:
+
+```javascript
+yuno.unmountExternalButton('APPLE_PAY');
+```
+
+Or unmount all external buttons at once:
+
+```javascript
+yuno.unmountAllExternalButtons();
+```
 
 ### Loader
 

--- a/docs/SDKs/web-sdk-integrations/seamless-sdk-payment-web.md
+++ b/docs/SDKs/web-sdk-integrations/seamless-sdk-payment-web.md
@@ -66,6 +66,10 @@ To initialize the payment flow, create a new `checkout_session` using the [Creat
 >
 > For all APMs, including Google Pay, Apple Pay, and PayPal, `onPaymentMethodSelected` is triggered as soon as the customer chooses the payment method (before the payment flow begins). Define `onPaymentMethodSelected` in `startSeamlessCheckout` before `mountSeamlessCheckout`.
 
+> 📘 Google Pay and Apple Pay Display
+>
+> From SDK version 1.5, Google Pay and Apple Pay appear as direct buttons instead of radio buttons in the payment methods list. They are displayed separately from other payment methods.
+
 ## Step 4: Start the checkout process
 
 Use the configuration below to provide a seamless and user-friendly payment experience for your customers:
@@ -187,6 +191,44 @@ payButton.addEventListener('click', () => {
 > 📘 Demo App
 >
 > In addition to the code examples provided, you can access the [Demo App](doc:demo-app) for a complete implementation of Yuno SDKs. The demo app includes working examples of all Yuno SDKs and can be cloned from the [GitHub repository](https://github.com/yuno-payments/yuno-sdk-web).
+
+## Mount external buttons
+
+You can use the `mountExternalButtons` method to render Google Pay and Apple Pay buttons in custom locations within your UI. This gives you control over where these buttons are displayed.
+
+```javascript
+await yuno.mountExternalButtons([
+  {
+    paymentMethodType: 'APPLE_PAY',
+    elementSelector: '#apple-pay',
+  },
+  {
+    paymentMethodType: 'GOOGLE_PAY',
+    elementSelector: '#google-pay',
+  },
+]);
+```
+
+### Parameters
+
+| Parameter           | Description                                                                                                 |
+| :------------------ | :---------------------------------------------------------------------------------------------------------- |
+| `paymentMethodType` | The payment method type. Must be either `'APPLE_PAY'` or `'GOOGLE_PAY'`.                                    |
+| `elementSelector`   | The CSS selector for the HTML element where the button should be rendered (e.g., `'#apple-pay'`, `'.button'`). |
+
+### Unmounting buttons
+
+You can unmount a single external button by payment method type:
+
+```javascript
+yuno.unmountExternalButton('APPLE_PAY');
+```
+
+Or unmount all external buttons at once:
+
+```javascript
+yuno.unmountAllExternalButtons();
+```
 
 ## Stay Updated
 


### PR DESCRIPTION
## Summary
Documents the new `mountExternalButtons` method introduced in SDK version 1.5, along with display updates for Google Pay and Apple Pay, and restrictions on their availability in the Lite SDK.

## Changes

### Documentation Updates
- Documented `mountExternalButtons` method for custom placement of Google Pay and Apple Pay buttons
- Documented `unmountExternalButton` and `unmountAllExternalButtons` methods
- Updated Lite SDK to remove Google Pay and Apple Pay from built-in payment options
- Updated Full SDK and Seamless SDK to show Google Pay and Apple Pay as direct buttons
- Added code examples for all SDK types

## Files Updated

1. **Lite SDK (Payment Web)** - `lite-web-sdk-payment.md`
   - Removed APPLE_PAY and GOOGLE_PAY from mountCheckoutLite payment method types
   - Added mountExternalButtons documentation
   - Added unmount methods documentation

2. **Full SDK (Web) Implementation** - `full-sdk-implementation.md`
   - Added mountExternalButtons documentation
   - Updated Google Pay and Apple Pay display information

3. **Seamless SDK (Payment Web)** - `seamless-sdk-payment-web.md`
   - Added mountExternalButtons documentation
   - Updated Google Pay and Apple Pay display information

4. **Lite SDK (Payment) Overview** - `the-ultimate-checkout-lite.md`
   - Updated to reflect SDK 1.5 changes

