### PR TITLE
[DM-10] Pass VTEX Defense Mode to payment metadata

### DIFF
--- a/docs/PLUGINS/vtex/vtex-headless-integration-guide.md
+++ b/docs/PLUGINS/vtex/vtex-headless-integration-guide.md
@@ -60,7 +60,7 @@ For more details, refer to the [Configure Yuno as Provider](../docs/configure-yu
 
 <Image align="center" src="https://files.readme.io/4902cb86d6c26bee4ac69c17c8eccb5d05d97d59639d1420065f48af77623e10-Install_Yuno_Payment_App_.png" />
 
-### Install Yuno SDK Web for VTEX (Optional)
+### Install Yuno SDK Web for VTEX (optional)
 
 If your project requires **Yuno SDK Web VTEX**, install it using `npm`:
 
@@ -84,7 +84,7 @@ yunoVTEX.mount({...})
 
 For additional information, access [@yuno-payments/sdk-web-vtex](https://www.npmjs.com/package/@yuno-payments/sdk-web-vtex).
 
-## Payment Flows
+## Payment flows
 
 The following sections illustrate how payments are processed in VTEXIO and VTEX Headless using different payment methods:
 
@@ -96,7 +96,7 @@ The following sections illustrate how payments are processed in VTEXIO and VTEX 
 
 VTEXIO enables seamless payment processing for various methods, including credit cards and alternative payment methods (APMs) like Pix. Below is a step-by-step breakdown of how these payment flows work.  
 
-#### Credit Card Payment Flow in VTEXIO
+#### Credit card payment flow in VTEXIO
 
 This flow details how credit card payments are processed in VTEXIO, from user interaction to transaction completion.
 
@@ -196,7 +196,7 @@ To get TypeScript types, install the `npm` package:
 npm install @yuno-payments/sdk-web-vtex
 ```
 
-## Payment Response Payloads
+## Payment response payloads
 
 When processing payments through **Yuno and VTEX**, the `yunopartnerbr.yuno` connector generates a structured payload containing all the necessary transaction details. Below, we provide example payloads for credit card payments and Pix payments (APMs).  
 
@@ -208,7 +208,7 @@ When processing payments through **Yuno and VTEX**, the `yunopartnerbr.yuno` con
 >
 > For more details, access the [API reference](https://docs.y.uno/reference/create-payment).
 
-### Credit Card Payment Payload
+### Credit card payment payload
 
 The following JSON response represents a credit card payment authorization processed through Yuno.
 
@@ -224,7 +224,7 @@ The following JSON response represents a credit card payment authorization proce
 }
 ```
 
-### Pix Payment Payload
+### Pix payment payload
 
 This example shows a Pix payment response, where Yuno generates a QR code in both text format and base64 image format. 
 
@@ -246,7 +246,7 @@ This example shows a Pix payment response, where Yuno generates a QR code in bot
 
 ```
 
-## Payment Metadata
+## Payment metadata
 
 When processing payments through Yuno with VTEX, additional metadata is included in the payment details:
 


### PR DESCRIPTION
## Summary
Documents how the VTEX connector detects Defense Mode via metadata flag, routes payments correctly when Defense Mode is active, and bypasses external fraud providers when Defense Mode is active.

## Changes

### Documentation Updates
- Document Defense Mode detection via metadata flag
- Explain how Defense Mode affects payment routing
- Note metadata flag (defense_mode: true)
- Explain fraud provider bypass behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Payment metadata section to VTEX headless guide, detailing `vtex_account` and `defense_mode` flags and their handling; also normalizes several headings’ capitalization.
> 
> - **Docs (VTEX Headless Guide)** `docs/PLUGINS/vtex/vtex-headless-integration-guide.md`:
>   - **New: Payment metadata**
>     - Documents `metadata` entries: `vtex_account` and `defense_mode` with JSON examples.
>     - Explains Defense Mode behavior and recommendation to bypass fraud checks when `defense_mode=true`.
>   - **Consistency**
>     - Normalizes casing for section titles (e.g., “Install Yuno SDK Web for VTEX (optional)”, “Payment flows”, “Credit card payment flow”, “Payment response payloads”, “Pix payment payload”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bd406066422d1b157b2c149306ba9f6cb57807d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->