### PR TITLE
Update iOS SDK release notes for version 2.9.0

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/ios-release-notes.md
+++ b/docs/SDKs/ios-sdk-integrations/ios-release-notes.md
@@ -9,6 +9,12 @@ The iOS SDK release notes provide a comprehensive overview of the updates, impro
 
 | Version | Changes                                                                                                                                                                                                           |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.9.0    | **NEW**: Allow cards expiring in the current month and year. |
+|         | **FIX**: Various bug fixes and improvements. |
+|         | **NEW**: Reduce character limit for full list and payment button. |
+|         | **NEW**: Add support for Click to Pay passkey. |
+|         | **NEW**: Implement PayPal Installments. |
+|         | **NEW**: Support dark mode. |
 | 2.8.1   | **IMPROVE**: Hide debit cards when only credit is enabled.                                                                                                                                                       |
 |         | **NEW**: Enable Click to Pay passkey for render mode.                                                                                                                                                            |
 | 2.8.0   | **FIX**: Various bug fixes and improvements.                                                                                                                                                                      |


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.9.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `2.9.0` iOS SDK release notes highlighting new features, improvements, and fixes.
> 
> - **Docs**:
>   - Update `docs/SDKs/ios-sdk-integrations/ios-release-notes.md` with `2.9.0` entry:
>     - NEW: Allow cards expiring in current month/year.
>     - NEW: Reduce character limit for full list and payment button.
>     - NEW: Support Click to Pay passkey.
>     - NEW: Implement PayPal Installments.
>     - NEW: Support dark mode.
>     - FIX: Various bug fixes and improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e23246c23cf99b03dbd2d93ca0d188c657f6ae7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->