### PR TITLE
docs: Standardise headings capitalization across tickets

### DIFF
--- a/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
+++ b/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
@@ -447,7 +447,7 @@ If a transaction is rejected, you can use the credit card form to retry a paymen
    2. Create a new checkout session and update the SDK with the new one by executing `yuno.updateCheckoutSession(checkoutsession)`
 3. Continue with the new checkout and one-time use token with the regular payment flow.
 
-### Hide Pay button
+### Hide pay button
 
 You can hide the Pay button when presenting the card or customer data form. Set `showPayButton` to `false` when starting the checkout with the `startCheckout` function:
 
@@ -529,7 +529,7 @@ Learn about the additional configurations from the Full SDK by accessing [Comple
 * [Payment Status](doc:payment-status): Update the user about the payment process
 * [3DS Setup SDK](doc:3d-secure): Integrate 3DS into your payment flow
 
-## Stay Updated
+## Stay updated
 
 Visit the [changelog](https://docs.y.uno/changelog) for the latest SDK updates and version history.
 


### PR DESCRIPTION
## Summary
Standardises headings and section titles across multiple docs so that only the first word is capitalised, except for proper nouns, acronyms, and product names (e.g. Yuno SDK, VTEX, API, BIN, ID, APMs).

## Changes

### Format standard
- Applied the rule **“only capitalise the first word”** for all headings (##, ###, ####), keeping:
  - Proper nouns (Yuno, VTEX, ClearSale, Pix, etc.)
  - Product names (Yuno SDK Web, SDK Lite, VTEXIO)
  - Acronyms (API, BIN, ID, APMs) in caps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes two headings to sentence case in the Full SDK (Web) implementation doc.
> 
> - **Docs** (`docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md`):
>   - Standardize heading capitalization to sentence case:
>     - `Hide Pay button` → `Hide pay button`
>     - `Stay Updated` → `Stay updated`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df719221d324470b9128818d61dd23ec4b3a20a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->