### PR TITLE
docs: Add callback_url requirement for Android CTP Passkey integration

### DIFF
--- a/docs/SDKs/android-sdk-integrations/full-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/full-checkout-android.md
@@ -454,6 +454,18 @@ The Yuno Android SDK provides additional services and configurations you can use
 
 Unlike other processes, when a user completes a payment using CTP Passkey, the _One-Time Token_ (`OTT`) will not be received through the usual callback methods. The OTT will be delivered via the **deeplink URL** in the Intent. Your app must read it from the `Intent`, create the payment on your backend, and then continue the flow with the SDK.
 
+> ⚠️ Important
+>
+> It is **essential** to include a `callback_url` when creating the checkout session for CTP Passkey payments. This URL must match the deeplink scheme configured in your AndroidManifest. For example:
+>
+> ```json
+> {
+>   "callback_url": "myapp://pay/ctp"
+> }
+> ```
+>
+> The `callback_url` is used to redirect the customer back to your app after the Passkey authentication process completes.
+
 #### 1. AndroidManifest (deeplink)
 
 Add an `intent-filter` to your main activity in `AndroidManifest.xml`:
@@ -570,6 +582,7 @@ You can test the CTP Passkey flow using these sample deeplink URLs:
 
 Use this checklist to ensure proper CTP Passkey integration:
 
+* ✅ `callback_url` included when creating the checkout session (must match deeplink scheme)
 * ✅ `intent-filter` configured correctly (scheme/host/path)
 * ✅ `handleDeeplink` implemented in both `onCreate()` and `onNewIntent()`
 * ✅ Extract both `one_time_token` and `checkout_session` parameters

--- a/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
@@ -268,6 +268,18 @@ Send `FALSE` in the `showPaymentStatus` parameter to show your payment status sc
 
 Unlike other processes, when a user completes a payment using CTP Passkey, the *One-Time Token* (`OTT`) will not be received through the usual callback methods. The OTT will be delivered via the **deeplink URL** in the Intent. Your app must read it from the `Intent`, create the payment on your backend, and then continue the flow with the SDK.
 
+> ⚠️ Important
+>
+> It is **essential** to include a `callback_url` when creating the checkout session for CTP Passkey payments. This URL must match the deeplink scheme configured in your AndroidManifest. For example:
+>
+> ```json
+> {
+>   "callback_url": "myapp://pay/ctp"
+> }
+> ```
+>
+> The `callback_url` is used to redirect the customer back to your app after the Passkey authentication process completes.
+
 ### 1. AndroidManifest (deeplink)
 
 Add an `intent-filter` to your main activity in `AndroidManifest.xml`:
@@ -382,6 +394,7 @@ You can test the CTP Passkey flow using these sample deeplink URLs:
 
 Use this checklist to ensure proper CTP Passkey integration:
 
+* ✅ `callback_url` included when creating the checkout session (must match deeplink scheme)
 * ✅ `intent-filter` configured correctly (scheme/host/path)
 * ✅ `handleDeeplink` implemented in both `onCreate()` and `onNewIntent()`
 * ✅ Extract both `one_time_token` and `checkout_session` parameters


### PR DESCRIPTION
## Summary
Adds essential information about the `callback_url` requirement when creating checkout sessions for Click to Pay (CTP) Passkey payments on Android. This ensures developers include the necessary callback URL that matches their deeplink scheme configuration.

## Changes

### Full SDK (Android) - `full-checkout-android.md`
- Added an "Important" callout after the CTP Passkey introduction explaining that `callback_url` is essential when creating the checkout session
- Included example JSON showing the callback_url format: `"callback_url": "myapp://pay/ctp"`
- Updated the checklist to include `callback_url` as the first item, emphasizing it must match the deeplink scheme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document `callback_url` requirement (with example) for Android CTP Passkey deeplinks and add it to the integration checklists in Full and Lite SDK docs.
> 
> - **Docs (Android CTP Passkey)**
>   - **Requirement**: Add `callback_url` requirement with example JSON; must match AndroidManifest deeplink scheme.
>   - **Files**:
>     - `docs/SDKs/android-sdk-integrations/full-checkout-android.md`
>     - `docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md`
>   - **Checklists**: Add `callback_url` item to CTP integration checklists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f345e68ca110a5ed03e8145759542e6af20501de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->