### PR TITLE
[DM-42] [SDK-iOS] Customize card number placeholder in card form

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
@@ -86,7 +86,8 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool
+    let keepLoader: Bool,
+    let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
 }
 ```
 
@@ -98,6 +99,7 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                          |
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
+| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 
 > 📘 Access Your API Key
 >

--- a/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
@@ -82,7 +82,8 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool
+    let keepLoader: Bool,
+    let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
 }
 ```
 
@@ -94,6 +95,7 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                          |
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
+| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 
 > 📘 Accessing Your API Key
 >

--- a/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
@@ -71,7 +71,8 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool
+    let keepLoader: Bool,
+    let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
 }
 ```
 
@@ -83,6 +84,7 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                        |
 | `saveCardEnabled` | This optional field lets you choose whether the **Save Card** checkbox is shown on card flows. It is false by default.                                                              |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to false. |
+| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 
 > 📘 Accessing Your API Key
 >


### PR DESCRIPTION
## PR Description

### Summary
This PR documents the new `cardNumberPlaceholder` configuration option for customizing the card number field placeholder text in iOS SDK card forms (Full, Lite, and Seamless SDK). This feature allows merchants to adapt the checkout UI to their brand voice, UX style, and localization needs.

### Changes

#### Documentation Updates
- **iOS Full SDK**: Added `cardNumberPlaceholder` parameter to `YunoConfig` class definition and parameters table
- **iOS Lite SDK**: Added `cardNumberPlaceholder` parameter to `YunoConfig` class definition and parameters table
- **iOS Seamless SDK**: Added `cardNumberPlaceholder` parameter to `YunoConfig` class definition and parameters table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for the new optional `cardNumberPlaceholder` in `YunoConfig` (Full, Lite, Seamless), including code samples and option table descriptions.
> 
> - **iOS SDK Docs**:
>   - **Config option added**: Document new optional `YunoConfig.cardNumberPlaceholder` for customizing the card number field placeholder.
>     - Updated code samples to include trailing comma after `keepLoader` and new `cardNumberPlaceholder` property.
>     - Added option descriptions to parameter tables in:
>       - `docs/SDKs/ios-sdk-integrations/full-checkout-ios.md`
>       - `docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md`
>       - `docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aded0c33f7eb2b5d9ac7d3d4c7a2c6a8d3c081fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->