### PR TITLE
[DM-43] [SDK-Android] Customize card number placeholder in card form

### DIFF
--- a/docs/SDKs/android-sdk-integrations/full-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/full-checkout-android.md
@@ -92,7 +92,8 @@ data class YunoConfig(
     val saveCardEnabled: Boolean = false,
     val cardFormDeployed: Boolean = false,
     val language: YunoLanguage? = null,
-    val styles: YunoStyles? = null
+    val styles: YunoStyles? = null,
+    val cardNumberPlaceholder: String? = null // Optional: Custom placeholder text for card number field
 )
 ```
 
@@ -106,6 +107,7 @@ The following table describes each customization available:
 | `saveCardEnabled`    | Enables the Save card checkbox on card flows. Check the [Save card](../docs/full-checkout-android#save-card-for-future-payments) section for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `cardFormDeployed`   | This option is only available for Full SDK. If `TRUE`, the system presents the card form deployed on the payment methods list. If `FALSE`, presents the normal card form on another screen.                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `language`           | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
+| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 | `styles`             | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, check the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                 |
 
 Update your manifest to use your application:

--- a/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
@@ -123,7 +123,8 @@ data class YunoConfig(
     val saveCardEnabled: Boolean = false,
     val cardFormDeployed: Boolean = false,
     val language: YunoLanguage? = null,
-    val styles: YunoStyles? = null
+    val styles: YunoStyles? = null,
+    val cardNumberPlaceholder: String? = null // Optional: Custom placeholder text for card number field
 )
 ```
 
@@ -135,6 +136,7 @@ The following table describes each customization option:
 | **saveCardEnabled**  | Enables the **Save card checkbox** on card flows. See the [Save card](#save-card-for-future-payments) section for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **language**         | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | **styles**           | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, see the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                   |
+| **cardNumberPlaceholder** | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 
 You also need to update your manifest to use your application:
 

--- a/docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md
+++ b/docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md
@@ -126,6 +126,7 @@ Use the `YunoConfig` data class to set additional configurations for the SDK. Th
 | **saveCardEnabled** | Enables the save card checkbox for card flows. Check the [Save card](#save-card-for-future-payments) section for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | **language**        | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | **styles**          | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, check the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                   |
+| **cardNumberPlaceholder** | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 
 The following code block shows an example of `YunoConfig`:
 
@@ -134,7 +135,8 @@ data class YunoConfig(
     val cardFlow: CardFormType = CardFormType.ONE_STEP,
     val saveCardEnabled: Boolean = false,
     val language: YunoLanguage? = null,
-  	val styles: YunoStyles? = null 
+  	val styles: YunoStyles? = null,
+    val cardNumberPlaceholder: String? = null // Optional: Custom placeholder text for card number field
 )
 ```
 


### PR DESCRIPTION
### Summary
This PR documents the new `cardNumberPlaceholder` configuration option for customizing the card number field placeholder text in Android SDK card forms (Full, Lite, and Seamless SDK). This feature allows merchants to adapt the checkout UI to their brand voice, UX style, and localization needs.

### Changes

#### Documentation Updates
- **Android Full SDK**: Added `cardNumberPlaceholder` parameter to `YunoConfig` data class definition and parameters table
- **Android Lite SDK**: Added `cardNumberPlaceholder` parameter to `YunoConfig` data class definition and parameters table
- **Android Seamless SDK**: Added `cardNumberPlaceholder` parameter to `YunoConfig` data class definition and parameters table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs for the `cardNumberPlaceholder` option in Android SDKs, updating `YunoConfig` examples and option tables across Full, Lite, and Seamless guides.
> 
> - **Docs (Android SDKs)**
>   - **Full SDK**:
>     - Add `cardNumberPlaceholder` to `YunoConfig` example and parameters table.
>   - **Lite SDK**:
>     - Add `cardNumberPlaceholder` to `YunoConfig` example and options table.
>   - **Seamless SDK**:
>     - Add `cardNumberPlaceholder` to options table and `YunoConfig` example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc29820a7f55a26c0a4537244ad653489e85ae1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->