### PR TITLE
[DM-45] [SDK-iOS] Hide cardholder name field in card form

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
@@ -86,7 +86,8 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool
+    let keepLoader: Bool,
+    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
 }
 ```
 
@@ -98,6 +99,7 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                          |
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Access Your API Key
 >

--- a/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
@@ -82,7 +82,8 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool
+    let keepLoader: Bool,
+    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
 }
 ```
 
@@ -94,6 +95,7 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                          |
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Accessing Your API Key
 >

--- a/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
@@ -71,7 +71,8 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool
+    let keepLoader: Bool,
+    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
 }
 ```
 
@@ -83,6 +84,7 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                        |
 | `saveCardEnabled` | This optional field lets you choose whether the **Save Card** checkbox is shown on card flows. It is false by default.                                                              |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to false. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Accessing Your API Key
 >


### PR DESCRIPTION
## PR Description

### Summary

This PR documents the new `hideCardholderName` configuration option for hiding the cardholder name field in iOS SDK card forms (Full, Lite, and Seamless SDK). This feature allows merchants to streamline the checkout experience and reduce friction when the cardholder name field is not required.

### Changes

#### Documentation Updates
- **iOS Full SDK**: Added `hideCardholderName` parameter to `YunoConfig` class definition and parameters table
- **iOS Lite SDK**: Added `hideCardholderName` parameter to `YunoConfig` class definition and parameters table
- **iOS Seamless SDK**: Added `hideCardholderName` parameter to `YunoConfig` class definition and parameters table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents the new optional `hideCardholderName` config to hide the cardholder name field in iOS card forms (Full, Lite, Seamless).
> 
> - **Docs (iOS SDKs)**:
>   - **Config option added**: Document `hideCardholderName` in `YunoConfig` to optionally hide the cardholder name field.
>   - **Pages updated**:
>     - `docs/SDKs/ios-sdk-integrations/full-checkout-ios.md`
>     - `docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md`
>     - `docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md`
>   - **Details**:
>     - Added to `YunoConfig` code samples and parameter tables.
>     - Notes that hiding the field doesn’t affect PAN/expiry/CVV, BIN, or 3DS/provider validations; merchant must supply name if required.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87e6b854509576fad77e07c8ea7eea6c61c5a884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->