### PR TITLE
[DM-46] [SDK-Android] Hide cardholder name field in card form

### DIFF
--- a/docs/SDKs/android-sdk-integrations/full-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/full-checkout-android.md
@@ -92,7 +92,8 @@ data class YunoConfig(
     val saveCardEnabled: Boolean = false,
     val cardFormDeployed: Boolean = false,
     val language: YunoLanguage? = null,
-    val styles: YunoStyles? = null
+    val styles: YunoStyles? = null,
+    val hideCardholderName: Boolean? = null // Optional: Set to true to hide cardholder name field
 )
 ```
 
@@ -107,6 +108,7 @@ The following table describes each customization available:
 | `cardFormDeployed`   | This option is only available for Full SDK. If `TRUE`, the system presents the card form deployed on the payment methods list. If `FALSE`, presents the normal card form on another screen.                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `language`           | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | `styles`             | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, check the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                 |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 Update your manifest to use your application:
 

--- a/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
@@ -123,7 +123,8 @@ data class YunoConfig(
     val saveCardEnabled: Boolean = false,
     val cardFormDeployed: Boolean = false,
     val language: YunoLanguage? = null,
-    val styles: YunoStyles? = null
+    val styles: YunoStyles? = null,
+    val hideCardholderName: Boolean? = null // Optional: Set to true to hide cardholder name field
 )
 ```
 
@@ -135,6 +136,7 @@ The following table describes each customization option:
 | **saveCardEnabled**  | Enables the **Save card checkbox** on card flows. See the [Save card](#save-card-for-future-payments) section for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **language**         | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | **styles**           | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, see the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                   |
+| **hideCardholderName** | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 You also need to update your manifest to use your application:
 

--- a/docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md
+++ b/docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md
@@ -126,6 +126,7 @@ Use the `YunoConfig` data class to set additional configurations for the SDK. Th
 | **saveCardEnabled** | Enables the save card checkbox for card flows. Check the [Save card](#save-card-for-future-payments) section for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | **language**        | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | **styles**          | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, check the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                   |
+| **hideCardholderName** | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 The following code block shows an example of `YunoConfig`:
 
@@ -134,7 +135,8 @@ data class YunoConfig(
     val cardFlow: CardFormType = CardFormType.ONE_STEP,
     val saveCardEnabled: Boolean = false,
     val language: YunoLanguage? = null,
-  	val styles: YunoStyles? = null 
+  	val styles: YunoStyles? = null,
+    val hideCardholderName: Boolean? = null // Optional: Set to true to hide cardholder name field
 )
 ```
 


### PR DESCRIPTION
## PR Description

### Summary
This PR documents the new `hideCardholderName` configuration option for hiding the cardholder name field in Android SDK card forms (Full, Lite, and Seamless SDK). This feature allows merchants to streamline the checkout experience and reduce friction when the cardholder name field is not required.

### Changes

#### Documentation Updates
- **Android Full SDK**: Added `hideCardholderName` parameter to `YunoConfig` data class definition and parameters table
- **Android Lite SDK**: Added `hideCardholderName` parameter to `YunoConfig` data class definition and parameters table
- **Android Seamless SDK**: Added `hideCardholderName` parameter to `YunoConfig` data class definition and parameters table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents the new `YunoConfig.hideCardholderName` option across Android Full, Lite, and Seamless SDK docs to allow hiding the cardholder name field.
> 
> - **Docs (Android SDKs)**:
>   - **YunoConfig**: Add `hideCardholderName` optional flag to hide the cardholder name field in card forms.
>     - Updates code examples and parameter tables in:
>       - `docs/SDKs/android-sdk-integrations/full-checkout-android.md`
>       - `docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md`
>       - `docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c4c1753a78ba6556e357db7a9997eb11b64aea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->