### PR TITLE
[DM-47] [iOS] Validate SDK statuses for Pix and ApplePay

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
@@ -204,7 +204,7 @@ You can obtain the one-time token to create the payment back-to-back at the end 
 func yunoCreatePayment(with token: String) { ... }
 ```
 
-## Step 7: Create the Payment
+## Step 7: Create the payment
 
 Once you have completed the steps described above, you can create a payment. The back-to-back payment creation must be carried out using the [Create Payment endpoint](https://docs.y.uno/reference/create-payment). The merchant should call their backend to create the payment within Yuno, using the one-time token and the checkout session.
 
@@ -220,7 +220,7 @@ Once you have completed the steps described above, you can create a payment. The
 Yuno.continuePayment()
 ```
 
-## Step 8: Handle Payment Status (Optional)
+## Step 8: Handle payment status (Optional)
 
 > 🚧 Deep Links and Mercado Pago Checkout Pro
 >
@@ -258,11 +258,11 @@ After the payment is completed, the SDK can return different transaction states:
 | `internalError`   | It means that an unexpected error occurred within the system or infrastructure handling the payment process. This state suggests a problem on the server or backend side rather than an issue with the user's input or request.     |
 | `userCancell`     | This state indicates that the user has voluntarily canceled or aborted the transaction or payment process. This state is typically used when there is an option for the user to cancel or abandon the payment process.              |
 
-### Payment Status Validation
+### Payment status validation
 
-The SDK provides consistent status handling for different payment method types to ensure clear communication between the SDK state and backend payment status.
+This section explains how the SDK handles payment status when users cancel or leave payment flows, and how the SDK status relates to the backend payment status in these scenarios.
 
-#### Sync Payment Methods (Apple Pay)
+#### Sync payment methods (Apple Pay)
 
 For synchronous payment methods like Apple Pay, when a user cancels or closes the wallet UI before a payment service provider (PSP) response is received:
 
@@ -272,7 +272,7 @@ For synchronous payment methods like Apple Pay, when a user cancels or closes th
 
 This ensures that the backend payment remains in a pending state and can be properly handled by the merchant's system.
 
-#### Async Payment Methods (PIX and QR-based methods)
+#### Async payment methods (PIX and QR-based methods)
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
@@ -283,7 +283,7 @@ For asynchronous payment methods like PIX, when a user closes the QR code window
 
 This behavior allows users to return to the payment flow and complete the transaction using the same QR code before it expires.
 
-#### Expired Async Payments
+#### Expired async payments
 
 If a PIX QR code expires naturally:
 
@@ -303,7 +303,7 @@ func yunoPaymentResult(_ result: Yuno.Result) { ... }
 func yunoEnrollmentResult(_ result: Yuno.Result) { ... }
 ```
 
-## Complementary Features
+## Complementary features
 
 Yuno iOS SDK provides additional services and configurations you can use to improve customers' experience. Use the [SDK Customizations](../docs/sdk-customizations-ios) to change the SDK appearance to match your brand or to configure the loader.
 

--- a/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
@@ -179,7 +179,7 @@ You can obtain the one-time token to create the payment back-to-back at the end 
 func yunoCreatePayment(with token: String) { ... }
 ```
 
-## Step 6: Create the Payment
+## Step 6: Create the payment
 
 Once you have completed the steps described before, you can create a payment. The back-to-back payment creation must be carried out using the [Create Payment endpoint](https://docs.y.uno/reference/create-payment). The merchant should call their backend to create the payment within Yuno, using the one-time token and the checkout session.
 
@@ -191,7 +191,7 @@ Once you have completed the steps described before, you can create a payment. Th
 Yuno.continuePayment()
 ```
 
-## Step 7: Handle Payment Status (Optional)
+## Step 7: Handle payment status (Optional)
 
 > ❗️ Deep Links and Mercado Pago Checkout Pro
 >
@@ -233,11 +233,11 @@ The SDK returns different transaction states after payment completion. The follo
 | `internalError`   | It means that an unexpected error occurred within the system or infrastructure handling the payment process. This state suggests that there was a problem on the server or backend side rather than an issue with the user's input or request. |
 | `userCancell`     | This state indicates that the user has voluntarily canceled or aborted the transaction or payment process. This state is typically used when there is an option for the user to cancel or abandon the payment process.                         |
 
-### Payment Status Validation
+### Payment status validation
 
-The SDK provides consistent status handling for different payment method types to ensure clear communication between the SDK state and backend payment status.
+This section explains how the SDK handles payment status when users cancel or leave payment flows, and how the SDK status relates to the backend payment status in these scenarios.
 
-#### Sync Payment Methods (Apple Pay)
+#### Sync payment methods (Apple Pay)
 
 For synchronous payment methods like Apple Pay, when a user cancels or closes the wallet UI before a payment service provider (PSP) response is received:
 
@@ -247,7 +247,7 @@ For synchronous payment methods like Apple Pay, when a user cancels or closes th
 
 This ensures that the backend payment remains in a pending state and can be properly handled by the merchant's system.
 
-#### Async Payment Methods (PIX and QR-based methods)
+#### Async payment methods (PIX and QR-based methods)
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
@@ -258,7 +258,7 @@ For asynchronous payment methods like PIX, when a user closes the QR code window
 
 This behavior allows users to return to the payment flow and complete the transaction using the same QR code before it expires.
 
-#### Expired Async Payments
+#### Expired async payments
 
 If a PIX QR code expires naturally:
 
@@ -278,7 +278,7 @@ func yunoPaymentResult(_ result: Yuno.Result) { ... }
 func yunoEnrollmentResult(_ result: Yuno.Result) { ... }
 ```
 
-## Complementary Features
+## Complementary features
 
 The Yuno iOS SDK provides additional features to enhance the customer experience. Use [SDK Customizations](../docs/sdk-customizations-ios) to match your brand appearance or configure the loader.
 

--- a/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
@@ -100,7 +100,7 @@ Before starting the payment process, you need to create a `checkout_session` usi
 | `workflow`           | Yes      | Set the value to `SDK_SEAMLESS` so the SDK can complete the payment flow correctly.                                                                                                                                                              |
 | `alternative_amount` | No       | An alternative currency representation of the transaction amount with the same structure as `amount` (`currency` and `value`). Useful for multi-currency scenarios, such as displaying prices to customers in their preferred currency (e.g., USD) while processing the payment in the local currency (e.g., COP). |
 
-## Step 3: Start the checkout and Payment process
+## Step 3: Start the checkout and payment process
 
 The seamless checkout and payment process is initiated with a single method `startPaymentSeamlessLite`. In the `ViewController`, where Yuno will be displayed, call the `Yuno.startPaymentSeamlessLite()` method. You can use the method with async/await or using callbacks:
 
@@ -157,7 +157,7 @@ The following table describes each parameter from `SeamlessParams`:
 >
 > If you're using Swift 6, you'll need to implement the `YunoPaymentDelegate` protocol with specific concurrency considerations. Swift 6 introduces stricter thread safety requirements that affect how you implement delegates. See the [Implementing `YunoPaymentDelegate` with Swift 6 Concurrency](#implementing-yunopaymentdelegate-with-swift-6-concurrency) section for detailed implementation options and best practices.
 
-## Step 4: Handle Payment Status (Optional)
+## Step 4: Handle payment status (Optional)
 
 > ❗️ Deep Links and Mercado Pago Checkout Pro
 >
@@ -195,11 +195,11 @@ After the payment is completed, the SDK can return different transaction states.
 | `internalError`   | It means that an unexpected error occurred within the system or infrastructure handling the payment process. This state suggests a problem on the server or backend side rather than an issue with the user's input or request.     |
 | `userCancell`     | This state indicates that the user has voluntarily canceled or aborted the transaction or payment process. It is typically used when the user has the option to cancel or abandon the payment process.                              |
 
-### Payment Status Validation
+### Payment status validation
 
-The SDK provides consistent status handling for different payment method types to ensure clear communication between the SDK state and backend payment status.
+This section explains how the SDK handles payment status when users cancel or leave payment flows, and how the SDK status relates to the backend payment status in these scenarios.
 
-#### Sync Payment Methods (Apple Pay)
+#### Sync payment methods (Apple Pay)
 
 For synchronous payment methods like Apple Pay, when a user cancels or closes the wallet UI before a payment service provider (PSP) response is received:
 
@@ -209,7 +209,7 @@ For synchronous payment methods like Apple Pay, when a user cancels or closes th
 
 This ensures that the backend payment remains in a pending state and can be properly handled by the merchant's system.
 
-#### Async Payment Methods (PIX and QR-based methods)
+#### Async payment methods (PIX and QR-based methods)
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
@@ -220,7 +220,7 @@ For asynchronous payment methods like PIX, when a user closes the QR code window
 
 This behavior allows users to return to the payment flow and complete the transaction using the same QR code before it expires.
 
-#### Expired Async Payments
+#### Expired async payments
 
 If a PIX QR code expires naturally:
 
@@ -242,7 +242,7 @@ enum Result {
 }
 ```
 
-## Complementary Features
+## Complementary features
 
 Yuno iOS SDK provides additional services and configurations you can use to improve customers' experience. Use the [SDK Customizations](../docs/sdk-customizations-ios) to change the SDK appearance to match your brand or to configure the loader.
 


### PR DESCRIPTION
## PR Description

### Summary
This PR documents the standardized payment status validation behavior for iOS SDK, specifically for Apple Pay (sync payment method) and PIX (async payment method). This ensures consistent status handling when users cancel or leave payment flows, clarifying the relationship between SDK status and backend payment status.

### Changes

#### Documentation Updates
- **iOS Full SDK**: Added "Payment Status Validation" section documenting behavior for Apple Pay and PIX
- **iOS Seamless SDK**: Added "Payment Status Validation" section documenting behavior for Apple Pay and PIX
- **iOS Lite SDK**: Added "Payment Status Validation" section documenting behavior for Apple Pay and PIX
