### PR TITLE
[DM-29]	Eliminate extra click in PayPal UX in SDK Lite + Full - v2

### DIFF
--- a/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
+++ b/docs/SDKs/web-sdk-integrations/full-checkout-sdk/full-sdk-implementation.md
@@ -111,6 +111,8 @@ yuno.startCheckout({
 >
 > For all APMs, including Google Pay, Apple Pay, and PayPal, `onPaymentMethodSelected` is triggered as soon as the customer chooses the payment method (before the payment flow begins). Define `onPaymentMethodSelected` in `startCheckout` before `mountCheckout`.
 
+For PayPal, the payment sheet now opens immediately after the shopper selects PayPal—no extra confirmation click required.
+
 > 📘 Google Pay and Apple Pay Display
 >
 > From SDK version 1.5, Google Pay and Apple Pay appear as direct buttons instead of radio buttons in the payment methods list. They are displayed separately from other payment methods.

--- a/docs/SDKs/web-sdk-integrations/lite-checkout-sdk/lite-web-sdk-payment.md
+++ b/docs/SDKs/web-sdk-integrations/lite-checkout-sdk/lite-web-sdk-payment.md
@@ -109,6 +109,8 @@ yuno.mountCheckoutLite({
 
 After mounting the SDK, the selected payment method flow will start automatically.
 
+For PayPal, the PayPal payment sheet now opens immediately after the shopper selects PayPal—no extra confirmation click required.
+
 > 📘 Google Pay and Apple Pay in Lite SDK
 >
 > Google Pay and Apple Pay are not available as built-in payment options in the Lite SDK. To use these payment methods, you must use the `mountExternalButtons` method. See [Mount external buttons](#mount-external-buttons) for more information.


### PR DESCRIPTION
### Summary
This PR documents the UX improvement for PayPal payments in SDK Lite and Full SDK, where the PayPal frame now opens immediately after selecting PayPal from the payment method list, eliminating the need for an extra confirmation click.

### Changes

#### Documentation Updates
- **Lite SDK Payment**: Added note about improved PayPal UX flow
- **Full SDK**: Added note about improved PayPal UX flow