### PR TITLE
docs: Fix VTEX provider page heading hierarchy

### DIFF
--- a/docs/PLUGINS/vtex/configure-yuno-as-provider.md
+++ b/docs/PLUGINS/vtex/configure-yuno-as-provider.md
@@ -1,5 +1,5 @@
 ---
-title: Configure Yuno as Provider
+title: Configure Yuno as provider
 excerpt: ''
 deprecated: false
 hidden: false
@@ -177,3 +177,26 @@ If you want to add or change certain UX aspects of the checkout, VTEX lets the m
 ### Available options
 
 For more information on the custom auto capture feature, [refer to the VTEX documentation](https://developers.vtex.com/docs/guides/custom-auto-capture-feature).
+
+
+## ClearSale field mappings
+
+When using ClearSale fraud detection with the VTEX connector, Yuno automatically maps VTEX order data to ClearSale's required fields. This ensures that all necessary information is correctly passed to ClearSale for fraud analysis.
+
+### Delivery type mapping
+
+The `deliveryType` field from VTEX orders is automatically extracted and mapped to ClearSale. This field is mandatory for merchants using ClearSale's Chargeback Guarantee product.
+
+**VTEX to ClearSale Mapping:**
+
+The VTEX connector extracts the `deliveryType` value from VTEX order logs (available in `AdditionalData.Order.Shipping.Type`) and correctly maps it to ClearSale. Common delivery type values include:
+
+* `Normal` → Mapped as `NORMAL`
+* `ECONOMY` → Mapped as `ECONOMY`
+* Other delivery types are mapped according to ClearSale's field requirements
+
+The delivery type is automatically included in the payload sent to ClearSale, ensuring compliance with ClearSale's mandatory field requirements for Chargeback Guarantee products.
+
+> 📘 ClearSale Integration
+>
+> For merchants using ClearSale's Chargeback Guarantee product, the `deliveryType` field is mandatory. The VTEX connector ensures this field is correctly extracted from VTEX orders and properly formatted for ClearSale.


### PR DESCRIPTION
## Summary

Adjust the heading hierarchy in the VTEX connector page to follow the style guide (sentence case, consistent heading levels).

## Changes

### Documentation Updates
- Update heading levels/titles in `configure-yuno-as-provider.md` to correct hierarchy.
- Keep callouts and tables unchanged; only adjust headings.
