### PR TITLE
[DM-28]	Vaulted token not returned when vault_on_success is true - v2

### DIFF
--- a/docs/DIRECT INTEGRATION USE CASES/create-payment-basic.md
+++ b/docs/DIRECT INTEGRATION USE CASES/create-payment-basic.md
@@ -118,7 +118,7 @@ Yuno also lets you use some additional features that are supported in the basic 
 Both fields can be found in the payment_method detail section of the payment.
 
 <Callout icon="ℹ️" theme="warning">
-  To generate and receive a <code>vaulted_token</code> when <code>vault_on_success = true</code>, the payment must reference an existing Yuno customer through <code>customer_payer.id</code>. Creating or sending the customer data inline inside the payment request does not create the customer on our side, so no vaulting will occur.
+  To generate and receive a <code>vaulted_token</code> when <code>vault_on_success = true</code>, the payment must reference an existing Yuno customer through <code>customer_payer.id</code>. Creating or sending the customer data inline inside the payment request does not create the customer on our side, so no vaulting will occur. When these conditions are met and the payment status is <code>SUCCEEDED</code>, the <code>vaulted_token</code> will be returned in the payment response and can be used for future transactions.
 </Callout>
 
 ### Step 5: Check the payment status

--- a/reference/Yuno API Reference/manage-payments/the-payment-object.md
+++ b/reference/Yuno API Reference/manage-payments/the-payment-object.md
@@ -199,6 +199,7 @@ This object represents the payment created after generating the checkout session
         <br />The vaulted_token represents a securely stored payment_method associated with a previous transaction. When
         utilizing a vaulted_token for creating a payment, there is no need to send an additional token; it can be set as
         null (MAX: 64; MIN: 36).
+        <br /><small> This field is returned in the payment response when <code>vault_on_success = true</code> and the payment status is <code>SUCCEEDED</code>, provided the payment references an existing Yuno customer through <code>customer_payer.id</code>. </small>
         <br /><small> Example: 8604911d-5ds9-229e-8468-bd41abear14s </small>
       </p>
 
@@ -210,7 +211,7 @@ This object represents the payment created after generating the checkout session
 
       <p><strong><code>vault_on_success</code></strong> <small>boolean</small>
         <br />Flag to enroll the card after a successful payment. Requires the payment to reference an existing Yuno customer through <code>customer_payer.id</code>.
-        <br /><small> Without a customer ID no vaulting occurs and no <code>vaulted_token</code> is returned, even if customer details are included inline. </small>
+        <br /><small> When set to <code>true</code> and the payment status is <code>SUCCEEDED</code>, the payment response will include a <code>vaulted_token</code> that can be used for future transactions. Without a customer ID no vaulting occurs and no <code>vaulted_token</code> is returned, even if customer details are included inline. </small>
         <br /><small> Possible values: <code>True</code> or <code>False</code> </small>
       </p>
 


### PR DESCRIPTION
## PR Description

### Summary
This PR updates the documentation to clearly state that `vaulted_token` is returned in the payment response when `vault_on_success = true` and the payment status is `SUCCEEDED`. This addresses a bug fix where `vaulted_token` was not being returned, and now it is correctly returned in the response.

### Changes

#### Documentation Updates
- **Payment Object API Reference**: Updated `vaulted_token` field description to clarify it's returned when `vault_on_success = true` and payment succeeds
- **Payment Object API Reference**: Updated `vault_on_success` field description to explicitly mention that `vaulted_token` is returned in the response
- **Create Payment Basic Guide**: Enhanced callout to clarify that `vaulted_token` is returned in the payment response when conditions are met
