### PR TITLE
[DM-45]	[SDK-iOS] Hide cardholder name field in card form

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
@@ -88,6 +88,7 @@ final class YunoConfig {
     let saveCardEnabled: Bool,
     let keepLoader: Bool,
     let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
+    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
 }
 ```
 
@@ -100,6 +101,7 @@ Configure the SDK with the following options:
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
 | `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Access Your API Key
 >

--- a/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
@@ -84,6 +84,7 @@ final class YunoConfig {
     let saveCardEnabled: Bool,
     let keepLoader: Bool,
     let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
+    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
 }
 ```
 
@@ -96,6 +97,7 @@ Configure the SDK with the following options:
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
 | `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Accessing Your API Key
 >

--- a/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
@@ -73,6 +73,7 @@ final class YunoConfig {
     let saveCardEnabled: Bool,
     let keepLoader: Bool,
     let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
+    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
 }
 ```
 
@@ -85,6 +86,7 @@ Configure the SDK with the following options:
 | `saveCardEnabled` | This optional field lets you choose whether the **Save Card** checkbox is shown on card flows. It is false by default.                                                              |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to false. |
 | `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Accessing Your API Key
 >


### PR DESCRIPTION
## PR Description

### Summary
This PR documents the new `hideCardholderName` configuration option for hiding the cardholder name field in iOS SDK card forms (Full, Lite, and Seamless SDK). This feature allows merchants to streamline the checkout experience and reduce friction when the cardholder name field is not required.

### Changes

#### Documentation Updates
- **iOS Full SDK**: Added `hideCardholderName` parameter to `YunoConfig` class definition and parameters table
- **iOS Lite SDK**: Added `hideCardholderName` parameter to `YunoConfig` class definition and parameters table
- **iOS Seamless SDK**: Added `hideCardholderName` parameter to `YunoConfig` class definition and parameters table
