### PR TITLE
[DM-46] [SDK-Android] Hide cardholder name field in card form

### DIFF
--- a/docs/SDKs/android-sdk-integrations/full-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/full-checkout-android.md
@@ -93,7 +93,8 @@ data class YunoConfig(
     val cardFormDeployed: Boolean = false,
     val language: YunoLanguage? = null,
     val styles: YunoStyles? = null,
-    val cardNumberPlaceholder: String? = null // Optional: Custom placeholder text for card number field
+    val cardNumberPlaceholder: String? = null, // Optional: Custom placeholder text for card number field
+    val hideCardholderName: Boolean? = null // Optional: Set to true to hide cardholder name field
 )
 ```
 
@@ -108,6 +109,7 @@ The following table describes each customization available:
 | `cardFormDeployed`   | This option is only available for Full SDK. If `TRUE`, the system presents the card form deployed on the payment methods list. If `FALSE`, presents the normal card form on another screen.                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `language`           | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
+| `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 | `styles`             | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, check the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                 |
 
 Update your manifest to use your application:

--- a/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/lite-sdk-android/lite-checkout-android.md
@@ -124,7 +124,8 @@ data class YunoConfig(
     val cardFormDeployed: Boolean = false,
     val language: YunoLanguage? = null,
     val styles: YunoStyles? = null,
-    val cardNumberPlaceholder: String? = null // Optional: Custom placeholder text for card number field
+    val cardNumberPlaceholder: String? = null, // Optional: Custom placeholder text for card number field
+    val hideCardholderName: Boolean? = null // Optional: Set to true to hide cardholder name field
 )
 ```
 
@@ -137,6 +138,7 @@ The following table describes each customization option:
 | **language**         | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | **styles**           | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, see the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                   |
 | **cardNumberPlaceholder** | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
+| **hideCardholderName** | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 You also need to update your manifest to use your application:
 

--- a/docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md
+++ b/docs/SDKs/android-sdk-integrations/seamless-sdk-payment-android.md
@@ -127,6 +127,7 @@ Use the `YunoConfig` data class to set additional configurations for the SDK. Th
 | **language**        | Defines the language to be used in the payment forms. You can set it to one of the available language options: <ul><li>es (Spanish)</li><li>en (English)</li><li>pt (Portuguese)</li><li>fil (Filipino)</li><li>id (Indonesian)</li><li>ms (Malay)</li><li>th (Thai)</li><li>zh-TW (Chinese (Traditional, Taiwan))</li><li>zh-CN (Chinese (Simplified, China))</li><li>vi (Vietnamese)</li><li>fr (French)</li><li>pl (Polish)</li><li>it (Italian)</li><li>de (German)</li><li>ru (Russian)</li><li>tr (Turkish)</li><li>nl (Dutch)</li><li>sv (Swedish)</li><li>ko (Korean)</li><li>ja (Japanese)</li></ul> |
 | **styles**          | Enables SDK-wide UI customization. Use it to define global visual styles like font family and button appearance (color, padding, radius, typography) through a `YunoStyles` object. For more information, check the [`styles`](../docs/full-checkout-android#styles) section.                                                                                                                                                                                                                                                                                                                                   |
 | **cardNumberPlaceholder** | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
+| **hideCardholderName** | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 The following code block shows an example of `YunoConfig`:
 
@@ -136,7 +137,8 @@ data class YunoConfig(
     val saveCardEnabled: Boolean = false,
     val language: YunoLanguage? = null,
   	val styles: YunoStyles? = null,
-    val cardNumberPlaceholder: String? = null // Optional: Custom placeholder text for card number field
+    val cardNumberPlaceholder: String? = null, // Optional: Custom placeholder text for card number field
+    val hideCardholderName: Boolean? = null // Optional: Set to true to hide cardholder name field
 )
 ```
 


### PR DESCRIPTION
## PR Description

### Summary
This PR documents the new `hideCardholderName` configuration option for hiding the cardholder name field in Android SDK card forms (Full, Lite, and Seamless SDK). This feature allows merchants to streamline the checkout experience and reduce friction when the cardholder name field is not required.

### Changes

#### Documentation Updates
- **Android Full SDK**: Added `hideCardholderName` parameter to `YunoConfig` data class definition and parameters table
- **Android Lite SDK**: Added `hideCardholderName` parameter to `YunoConfig` data class definition and parameters table
- **Android Seamless SDK**: Added `hideCardholderName` parameter to `YunoConfig` data class definition and parameters table
