### PR TITLE
[DM-54] [SDK-VTEX] Pagaleve / Pix Parcelado open in a modal

### DIFF
--- a/docs/PLUGINS/vtex/index.md
+++ b/docs/PLUGINS/vtex/index.md
@@ -18,7 +18,9 @@ Yuno and VTEX have joined forces to simplify payment processes for merchants wor
 
 ![](https://files.readme.io/64caa7b-vtex1.png)
 
-By integrating Yuno's payment orchestration platform with VTEX's e-commerce solution, merchants can easily manage payments and offer diverse payment options. Yuno ensures customers can choose their preferred payment method from local cards to digital wallets. Yuno's plugin allows your store to accept payments seamlessly without redirecting customers to external pages, enhancing the shopping experience and increasing the conversion rate.
+By integrating Yuno's payment orchestration platform with VTEX's e-commerce solution, merchants can easily manage payments and offer diverse payment options. Yuno ensures customers can choose their preferred payment method from local cards to digital wallets. Yuno's plugin allows your store to accept payments seamlessly without redirecting customers to external pages, enhancing the shopping experience and increasing the conversion rate. 
+
+Some payment methods like Pagaleve and Pix Parcelado open in a modal window, providing a seamless checkout experience within the VTEX storefront.
 
 > ❗️ Payments with two cards
 >

--- a/docs/PLUGINS/vtex/vtex-headless-integration-guide.md
+++ b/docs/PLUGINS/vtex/vtex-headless-integration-guide.md
@@ -123,6 +123,10 @@ This flow explains how Pix and other APMs are handled in VTEXIO, including payme
 4. Yuno generates a QR code and additional payment details and returns them to VTEX.
 5. VTEXIO opens the Pix application or redirects the user to complete the payment.
 
+> 📘 Modal Payment Methods
+>
+> Pagaleve and Pix Parcelado open in a modal window instead of redirecting to an external page. This provides a seamless checkout experience without leaving the VTEX storefront.
+
 <Image align="center" src="https://files.readme.io/89ce5296e6a38d163c1e5c9936b689477545556e7c42fd2d57561db069d09e06-Diagrama_-_Pix_APM_payment_flow_VTEXIO.png" />
 
 ### VTEX headless


### PR DESCRIPTION
## PR Description

### Summary
This PR documents that Pagaleve and Pix Parcelado payment methods open in a modal window instead of redirecting to an external page in the VTEX connector. This provides a seamless checkout experience without leaving the VTEX storefront.

### Changes

#### Documentation Updates
- **VTEX Index**: Updated introduction to mention modal behavior for Pagaleve and Pix Parcelado
- **VTEX Headless Integration Guide**: Added callout in Pix (APMs) payment flow section explaining modal behavior for Pagaleve and Pix Parcelado