### PR TITLE
[DM-42] [SDK-iOS] Customize card number placeholder in card formt

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
@@ -86,9 +86,7 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool,
-    let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
-    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
+    let keepLoader: Bool
 }
 ```
 
@@ -100,7 +98,6 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                          |
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
-| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 | `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Access Your API Key

--- a/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
@@ -82,9 +82,7 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool,
-    let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
-    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
+    let keepLoader: Bool
 }
 ```
 
@@ -96,7 +94,6 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                          |
 | `saveCardEnabled` | This optional field can be used to choose if the **Save Card** checkbox is shown on card flows. It is false by default.                                                               |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to `false`. |
-| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 | `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Accessing Your API Key

--- a/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
@@ -71,9 +71,7 @@ final class YunoConfig {
     let cardFormType: CardFormType,
     let appearance: Yuno.Appearance,
     let saveCardEnabled: Bool,
-    let keepLoader: Bool,
-    let cardNumberPlaceholder: String? // Optional: Custom placeholder text for card number field
-    let hideCardholderName: Bool? // Optional: Set to true to hide cardholder name field
+    let keepLoader: Bool
 }
 ```
 
@@ -85,7 +83,6 @@ Configure the SDK with the following options:
 | `appearance`      | This optional field defines the appearance of the checkout. By default, it uses Yuno styles.                                                                                        |
 | `saveCardEnabled` | This optional field lets you choose whether the **Save Card** checkbox is shown on card flows. It is false by default.                                                              |
 | `keepLoader`      | This optional field provides control over when to hide the loader. If set to `true`, the `hideLoader()` function must be called to hide the loader. By default, it is set to false. |
-| `cardNumberPlaceholder` | This optional field allows you to customize the placeholder text for the card number field. Supports alphanumeric characters, spaces, and UTF-8 characters for localization. If not provided, the SDK uses the default placeholder ("Card number"). This customization does not affect card formatting, masking, BIN logic, or validation. |
 | `hideCardholderName` | This optional field allows you to hide the cardholder name field in the card form. When set to `true`, the cardholder name field is not rendered. When not specified or set to `false`, the cardholder name field is displayed (default behavior). Hiding the field does not affect PAN, expiry, CVV collection, BIN logic, or 3DS/provider validations. The merchant is responsible for ensuring cardholder name is provided when required by their payment provider. |
 
 > 📘 Accessing Your API Key


### PR DESCRIPTION
## PR Description

### Summary
This PR originally documented a `cardNumberPlaceholder` configuration option for customizing the card number field placeholder text in iOS SDK card forms (Full, Lite, and Seamless SDK).

After confirming with **@Vivi Amezquita**, we verified that this configuration **does not apply to the iOS SDK**, so all related documentation changes have been **reverted**.

### Changes

#### Documentation Updates
- **Reverted**: Any references to `cardNumberPlaceholder` in the iOS SDK docs have been removed.
- **iOS Full SDK**: `YunoConfig` now only documents `hideCardholderName` as the additional optional field.
- **iOS Lite SDK**: `YunoConfig` now only documents `hideCardholderName` as the additional optional field.
- **iOS Seamless SDK**: `YunoConfig` now only documents `hideCardholderName` as the additional optional field.