### PR TITLE
docs: Fix async payment status and substatus values in Android Full SDK

### DIFF
--- a/docs/SDKs/android-sdk-integrations/full-checkout-android.md
+++ b/docs/SDKs/android-sdk-integrations/full-checkout-android.md
@@ -190,7 +190,7 @@ This ensures that the backend payment remains in a pending state and can be prop
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
-- **SDK Status**: Returns `CANCELED` (CANCELLED_BY_USER), optionally with a sub-status such as `USER_LEFT_FLOW`
+- **SDK Status**: Returns `PROCESSING`, optionally with a sub-status such as `CLOSED_BY_USER`
 - **Backend Payment Status**: Remains `PENDING` and the QR code remains valid until expiry
 - **Checkout Session Reuse**: Re-opening the same checkout session can display the same valid QR code
 - **No Automatic Cancellation**: The PIX payment is not automatically cancelled when the user closes the QR window


### PR DESCRIPTION
## PR Description

### Summary
This PR fixes incorrect status and substatus values documented for async payment methods (PIX and QR-based methods) in the Android Full SDK documentation.

### Issue
The documentation incorrectly stated that when a user closes the QR code window, the SDK returns:
- Status: `CANCELED` (CANCELLED_BY_USER)
- Sub-status: `USER_LEFT_FLOW`

### Correction
The correct values are:
- Status: `PROCESSING`
- Sub-status: `CLOSED_BY_USER`