### PR TITLE
docs: Fix async payment status and substatus values in iOS SDK

### DIFF
--- a/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/full-checkout-ios.md
@@ -277,7 +277,7 @@ This ensures that the backend payment remains in a pending state and can be prop
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
-- **SDK Status**: Returns `userCancell` (CANCELLED_BY_USER), optionally with a sub-status such as `USER_LEFT_FLOW`
+- **SDK Status**: Returns `PENDING`, optionally with a sub-status such as `CLOSED_BY_USER`
 - **Backend Payment Status**: Remains `PENDING` and the QR code remains valid until expiry
 - **Checkout Session Reuse**: Re-opening the same checkout session can display the same valid QR code
 - **No Automatic Cancellation**: The PIX payment is not automatically cancelled when the user closes the QR window

--- a/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/lite-sdk-ios/lite-checkout-ios.md
@@ -252,7 +252,7 @@ This ensures that the backend payment remains in a pending state and can be prop
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
-- **SDK Status**: Returns `userCancell` (CANCELLED_BY_USER), optionally with a sub-status such as `USER_LEFT_FLOW`
+- **SDK Status**: Returns `PENDING`, optionally with a sub-status such as `CLOSED_BY_USER`
 - **Backend Payment Status**: Remains `PENDING` and the QR code remains valid until expiry
 - **Checkout Session Reuse**: Re-opening the same checkout session can display the same valid QR code
 - **No Automatic Cancellation**: The PIX payment is not automatically cancelled when the user closes the QR window

--- a/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
+++ b/docs/SDKs/ios-sdk-integrations/seamless-sdk-payment-ios.md
@@ -214,7 +214,7 @@ This ensures that the backend payment remains in a pending state and can be prop
 
 For asynchronous payment methods like PIX, when a user closes the QR code window (clicks X) before completing the payment:
 
-- **SDK Status**: Returns `userCancell` (CANCELLED_BY_USER), optionally with a sub-status such as `USER_LEFT_FLOW`
+- **SDK Status**: Returns `PENDING`, optionally with a sub-status such as `CLOSED_BY_USER`
 - **Backend Payment Status**: Remains `PENDING` and the QR code remains valid until expiry
 - **Checkout Session Reuse**: Re-opening the same checkout session can display the same valid QR code
 - **No Automatic Cancellation**: The PIX payment is not automatically cancelled when the user closes the QR window


### PR DESCRIPTION
### Summary
This PR fixes incorrect status and substatus values documented for async payment methods (PIX and QR-based methods) in the iOS SDK documentation. This is the iOS equivalent of the Android SDK fix.

### Issue
The documentation incorrectly stated that when a user closes the QR code window, the SDK returns:
- Status: `userCancell` (CANCELLED_BY_USER)
- Sub-status: `USER_LEFT_FLOW`

### Correction
The correct values are:
- Status: `PENDING`
- Sub-status: `CLOSED_BY_USER`