### PR TITLE
2026 04 01 update status badge colors

### DIFF
--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -3,6 +3,8 @@ title: "Payment Status and Response Codes"
 ---
 
 import { HTMLBlock } from "/snippets/HTMLBlock.jsx";
+import { StatusBadge } from "/snippets/StatusBadge.jsx";
+
 
 Payments have all the essential information about the order, including customer information, amount, currency, items, shipping info, etc. You can always refer to the transaction details for more details about the order and the payment interactions.
 
@@ -30,263 +32,263 @@ The payments can have the following status and sub status.
   </thead>
   <tbody>
     <tr>
-      <td class="status"><code>CREATED</code></td>
-      <td class="substatus"><code>CREATED</code></td>
+      <td class="status"><StatusBadge type="info" text="CREATED" /></td>
+      <td class="substatus"><StatusBadge type="info" text="CREATED" /></td>
       <td></td>
       <td></td>
       <td>Initial state at the time of creating a payment.</td>
     </tr>
     <tr>
-      <td class="status" rowspan="2"><code>READY_TO_PAY</code></td>
-      <td class="substatus"><code>CREATED</code></td>
+      <td class="status" rowspan="2"><StatusBadge type="info" text="READY_TO_PAY" /></td>
+      <td class="substatus"><StatusBadge type="info" text="CREATED" /></td>
       <td>Purchase</td>
-      <td>Created</td>
+      <td><StatusBadge type="info" text="Created" /></td>
       <td>Initial state at the time of creating a payment. Waiting for customer action</td>
     </tr>
     <tr>
-      <td class="substatus"><code>READY_TO_PAY</code></td>
+      <td class="substatus"><StatusBadge type="info" text="READY_TO_PAY" /></td>
       <td></td>
       <td></td>
       <td>Initial state at the time of creating a payment. Waiting for customer action</td>
     </tr>
     <tr>
-      <td class="status" rowspan="7"><code>PENDING</code></td>
-      <td class="substatus"><code>AUTHORIZED</code></td>
+      <td class="status" rowspan="7"><StatusBadge type="warning" text="PENDING" /></td>
+      <td class="substatus"><StatusBadge type="warning" text="AUTHORIZED" /></td>
       <td>Authorize</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Card authorizations</td>
     </tr>
     <tr>
-      <td class="substatus"><code>IN_PROCESS</code></td>
+      <td class="substatus"><StatusBadge type="warning" text="IN_PROCESS" /></td>
       <td>Purchase</td>
-      <td>Created</td>
+      <td><StatusBadge type="info" text="Created" /></td>
       <td>The client has been redirected to the provider and we are waiting for the completion of the payment.</td>
     </tr>
     <tr>
-      <td class="substatus" rowspan="2"><code>WAITING_ADDITIONAL_STEP</code></td>
+      <td class="substatus" rowspan="2"><StatusBadge type="warning" text="WAITING_ADDITIONAL_STEP" /></td>
       <td>Purchase</td>
-      <td>Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
       <td>3DS/Second factor</td>
     </tr>
     <tr>
       <td>Authorize</td>
-      <td>Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
       <td>3DS/Second factor for authorization flow</td>
     </tr>
     <tr>
-      <td class="substatus"><code>PENDING_PROVIDER_CONFIRMATION</code></td>
+      <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Purchase</td>
-      <td>Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
       <td>Wating for providers payment confirmation.</td>
     </tr>
     <tr>
-      <td class="substatus"><code>PENDING_FRAUD_REVIEW</code></td>
+      <td class="substatus"><StatusBadge type="warning" text="PENDING_FRAUD_REVIEW" /></td>
       <td>Fraud</td>
-      <td>Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
       <td>Transaction is being analyzed by fraud provider</td>
     </tr>
     <tr>
-      <td class="substatus"><code>PENDING_OTP_COMPLETION</code></td>
+      <td class="substatus"><StatusBadge type="warning" text="PENDING_OTP_COMPLETION" /></td>
       <td>Purchase</td>
-      <td>Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
       <td>Initial status upon payment creation</td>
     </tr>
     <tr>
-      <td class="status"><code>VERIFIED</code></td>
-      <td class="substatus"><code>VERIFIED</code></td>
+      <td class="status"><StatusBadge type="success" text="VERIFIED" /></td>
+      <td class="substatus"><StatusBadge type="success" text="VERIFIED" /></td>
       <td>Verify</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Zero amount card authorizations</td>
     </tr>
     <tr>
-      <td rowspan="2" class="status"><code>EXPIRED</code></td>
-      <td rowspan="2" class="substatus"><code>EXPIRED</code></td>
+      <td rowspan="2" class="status"><StatusBadge type="error" text="EXPIRED" /></td>
+      <td rowspan="2" class="substatus"><StatusBadge type="error" text="EXPIRED" /></td>
       <td>Purchase</td>
-      <td>Expired</td>
+      <td><StatusBadge type="error" text="Expired" /></td>
       <td>The offline payment method reaches its expiration date.</td>
     </tr>
     <tr>
       <td>Authorize</td>
-      <td>Expired</td>
+      <td><StatusBadge type="error" text="Expired" /></td>
       <td><br/>Authorization expires</td>
     </tr>
     <tr>
-      <td rowspan="2" class="status"><code>REJECTED</code></td>
-      <td rowspan="2" class="substatus"><code>REJECTED</code></td>
+      <td rowspan="2" class="status"><StatusBadge type="error" text="REJECTED" /></td>
+      <td rowspan="2" class="substatus"><StatusBadge type="error" text="REJECTED" /></td>
       <td>Purchase</td>
-      <td>Rejected</td>
-      <td>Rejected by Yuno</td>
+      <td><StatusBadge type="error" text="Rejected" /></td>
+      <td><StatusBadge type="error" text="Rejected" /> by Yuno</td>
     </tr>
     <tr>
       <td>Capture</td>
-      <td>Error</td>
+      <td><StatusBadge type="error" text="Error" /></td>
       <td>Capture rejection by Yuno</td>
     </tr>
     <tr>
-      <td rowspan="3" class="status"><code>DECLINED</code></td>
-      <td rowspan="2" class="substatus"><code>DECLINED</code></td>
+      <td rowspan="3" class="status"><StatusBadge type="error" text="DECLINED" /></td>
+      <td rowspan="2" class="substatus"><StatusBadge type="error" text="DECLINED" /></td>
       <td>Purchase</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Providers rejection</td>
     </tr>
     <tr>
       <td>Capture</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Providers capture rejection</td>
     </tr>
     <tr>
-      <td class="substatus"><code>FRAUD_DECLINED</code></td>
+      <td class="substatus"><StatusBadge type="error" text="FRAUD_DECLINED" /></td>
       <td>Fraud screening</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Declined fraud screening</td>
     </tr>
     <tr>
-      <td rowspan="13" class="status"><code>SUCCEEDED</code></td>
-      <td class="substatus"><code>PARTIALLY_APPROVED</code></td>
+      <td rowspan="12" class="status"><StatusBadge type="success" text="SUCCEEDED" /></td>
+      <td class="substatus"><StatusBadge type="success" text="PARTIALLY_APPROVED" /></td>
       <td>Purchase</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Partial payment (payment with 2 cards)</td>
     </tr>
     <tr>
-      <td class="substatus"><code>APPROVED</code></td>
+      <td class="substatus"><StatusBadge type="success" text="APPROVED" /></td>
       <td>Purchase</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful payment</td>
     </tr>
     <tr>
-      <td class="substatus"><code>CAPTURED</code></td>
+      <td class="substatus"><StatusBadge type="success" text="CAPTURED" /></td>
       <td>Capture</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful capture</td>
     </tr>
     <tr>
-      <td rowspan="4" class="substatus"><code>PARTIALLY_CAPTURED</code></td>
+      <td rowspan="3" class="substatus"><StatusBadge type="success" text="PARTIALLY_CAPTURED" /></td>
       <td>Capture</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful partial capture</td>
     </tr>
     <tr>
       <td>Refund</td>
-      <td>Error/Declined</td>
+      <td><StatusBadge type="error" text="Error" />/Declined</td>
       <td>Remains approved due to error in refund / cancellation</td>
     </tr>
     <tr>
       <td>Chargeback</td>
-      <td>Error/Declined</td>
+      <td><StatusBadge type="error" text="Error" />/Declined</td>
       <td>Remains approved due to rejection in chargeback</td>
     </tr>
     <tr>
-      <td class="substatus"><code>PARTIALLY_REFUNDED</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="PARTIALLY_REFUNDED" /></td>
       <td>Refund</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful partial refund</td>
     </tr>
     <tr>
-      <td class="substatus"><code>PARTIALLY_CHARGEBACKED</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="PARTIALLY_CHARGEBACKED" /></td>
       <td>Chargeback</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful partial chargeback</td>
     </tr>
     <tr>
-      <td class="substatus"><code>FRAUD_DECLINED</code></td>
+      <td class="substatus"><StatusBadge type="error" text="FRAUD_DECLINED" /></td>
       <td>Fraud screening</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Fraud screening declined. Can occur before or after provider authorization. Payment succeeded and funds have moved. </td>
     </tr>
     <tr>
-      <td class="substatus"><code>REFUND_RETRY_IN_PROCESS</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="REFUND_RETRY_IN_PROCESS" /></td>
       <td>Refund</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Transaction was declined and is waiting for retry.</td>
     </tr>
     <tr>
-      <td class="substatus"><code>CAPTURE_RETRY_IN_PROCESS</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="CAPTURE_RETRY_IN_PROCESS" /></td>
       <td>Capture</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Transaction was declined and is waiting for retry.</td>
     </tr>
     <tr>
-      <td class="substatus"><code>CAPTURE_RETRY_PROCESS_FAILED</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="CAPTURE_RETRY_PROCESS_FAILED" /></td>
       <td>Capture</td>
-      <td>Declined</td>
+      <td><StatusBadge type="error" text="Declined" /></td>
       <td>Transaction was declined and retry scheme it's finished.</td>
     </tr>
     <tr>
-      <td rowspan="2" class="status"><code>REFUNDED</code></td>
-      <td class="substatus"><code>PENDING_PROVIDER_CONFIRMATION</code></td>
+      <td rowspan="2" class="status"><StatusBadge type="secondary" text="REFUNDED" /></td>
+      <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Refund</td>
-      <td>Pending</td>
-      <td>Refund Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Refund <StatusBadge type="warning" text="Pending" /></td>
     </tr>
     <tr>
-      <td class="substatus"><code>REFUNDED</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="REFUNDED" /></td>
       <td>Refund</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful refund</td>
     </tr>
     <tr>
-      <td rowspan="2" class="status"><code>CANCELED</code></td>
-      <td class="substatus"><code>PENDING_PROVIDER_CONFIRMATION</code></td>
+      <td rowspan="2" class="status"><StatusBadge type="error" text="CANCELED" /></td>
+      <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Cancel</td>
-      <td>Pending</td>
-      <td>Cancel Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Cancel <StatusBadge type="warning" text="Pending" /></td>
     </tr>
     <tr>
-      <td class="substatus"><code>CANCELED</code></td>
+      <td class="substatus"><StatusBadge type="error" text="CANCELED" /></td>
       <td>Cancel</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Successful cancelation</td>
     </tr>
     <tr>
-      <td rowspan="2" class="status"><code>IN_DISPUTE</code></td>
-      <td class="substatus"><code>RECEIVED</code></td>
+      <td rowspan="2" class="status"><StatusBadge type="secondary" text="IN_DISPUTE" /></td>
+      <td class="substatus"><StatusBadge type="secondary" text="RECEIVED" /></td>
       <td>Chargeback</td>
-      <td>Created</td>
+      <td><StatusBadge type="info" text="Created" /></td>
       <td>Chargeback or Inquiry received. Decision or documentation must be provided</td>
     </tr>
     <tr>
-      <td class="substatus"><code>PENDING_REVIEW</code></td>
+      <td class="substatus"><StatusBadge type="secondary" text="PENDING_REVIEW" /></td>
       <td>Chargeback</td>
-      <td>Pending</td>
+      <td><StatusBadge type="warning" text="Pending" /></td>
       <td>In_review</td>
     </tr>
     <tr>
-      <td rowspan="1" class="status"><code>CHARGEBACK</code></td>
-      <td class="substatus"><code>LOST</code></td>
+      <td rowspan="1" class="status"><StatusBadge type="error" text="CHARGEBACK" /></td>
+      <td class="substatus"><StatusBadge type="error" text="LOST" /></td>
       <td>Chargeback</td>
       <td>Prevented</td>
       <td>Predispute deflected by provider/network. Payment reflects lost funds.</td>
     </tr>
     <tr>
-      <td rowspan="4" class="status"><code>ERROR</code></td>
-      <td class="substatus"><code>ERROR</code></td>
+      <td rowspan="4" class="status"><StatusBadge type="error" text="ERROR" /></td>
+      <td class="substatus"><StatusBadge type="error" text="ERROR" /></td>
       <td></td>
       <td>Example: timeout.</td>
       <td></td>
     </tr>
     <tr>
-      <td class="substatus"><code>TIMEOUT</code></td>
+      <td class="substatus"><StatusBadge type="error" text="TIMEOUT" /></td>
       <td></td>
       <td></td>
       <td></td>
     </tr>
     <tr>
-      <td class="substatus"><code>PENDING_REVERSE</code></td>
+      <td class="substatus"><StatusBadge type="warning" text="PENDING_REVERSE" /></td>
       <td></td>
       <td></td>
       <td></td>
     </tr>
     <tr>
-      <td class="substatus"><code>REVERSED_BY_TIMEOUT</code></td>
+      <td class="substatus"><StatusBadge type="warning" text="REVERSED_BY_TIMEOUT" /></td>
       <td></td>
       <td></td>
       <td></td>
     </tr>
     <tr>
-      <td rowspan="1" class="status"><code>FRAUD</code></td>
-      <td class="substatus"><code>FRAUD_VERIFIED</code></td>
+      <td rowspan="1" class="status"><StatusBadge type="success" text="FRAUD" /></td>
+      <td class="substatus"><StatusBadge type="success" text="FRAUD_VERIFIED" /></td>
       <td>Fraud</td>
-      <td>Succeeded</td>
+      <td><StatusBadge type="success" text="Succeeded" /></td>
       <td>Transaction verified by fraud provider during stand alone fraud verification</td>
     </tr>
   </tbody>

--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -265,18 +265,15 @@ The payments can have the following status and sub status.
       <td></td>
       <td></td>
       <td></td>
-      <td></td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_REVERSE" /></td>
       <td></td>
       <td></td>
       <td></td>
-      <td></td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="REVERSED_BY_TIMEOUT" /></td>
-      <td></td>
       <td></td>
       <td></td>
       <td></td>

--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -39,16 +39,10 @@ The payments can have the following status and sub status.
       <td>Initial state at the time of creating a payment.</td>
     </tr>
     <tr>
-      <td class="status" rowspan="2"><StatusBadge type="info" text="READY_TO_PAY" /></td>
+      <td class="status"><StatusBadge type="info" text="READY_TO_PAY" /></td>
       <td class="substatus"><StatusBadge type="info" text="CREATED" /></td>
       <td>Purchase</td>
       <td>Created</td>
-      <td>Initial state at the time of creating a payment. Waiting for customer action</td>
-    </tr>
-    <tr>
-      <td class="substatus"><StatusBadge type="info" text="READY_TO_PAY" /></td>
-      <td></td>
-      <td></td>
       <td>Initial state at the time of creating a payment. Waiting for customer action</td>
     </tr>
     <tr>
@@ -117,7 +111,7 @@ The payments can have the following status and sub status.
       <td rowspan="2" class="substatus"><StatusBadge type="error" text="REJECTED" /></td>
       <td>Purchase</td>
       <td>Rejected</td>
-      <td><StatusBadge type="error" text="Rejected" /> by Yuno</td>
+      <td>Rejected by Yuno</td>
     </tr>
     <tr>
       <td>Capture</td>
@@ -218,7 +212,7 @@ The payments can have the following status and sub status.
       <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Refund</td>
       <td>Pending</td>
-      <td>Refund <StatusBadge type="warning" text="Pending" /></td>
+      <td>Refund Pending</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="REFUNDED" /></td>
@@ -231,7 +225,7 @@ The payments can have the following status and sub status.
       <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Cancel</td>
       <td>Pending</td>
-      <td>Cancel <StatusBadge type="warning" text="Pending" /></td>
+      <td>Cancel Pending</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="error" text="CANCELED" /></td>

--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -265,15 +265,18 @@ The payments can have the following status and sub status.
       <td></td>
       <td></td>
       <td></td>
+      <td></td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_REVERSE" /></td>
       <td></td>
       <td></td>
       <td></td>
+      <td></td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="REVERSED_BY_TIMEOUT" /></td>
+      <td></td>
       <td></td>
       <td></td>
       <td></td>

--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -42,7 +42,7 @@ The payments can have the following status and sub status.
       <td class="status" rowspan="2"><StatusBadge type="info" text="READY_TO_PAY" /></td>
       <td class="substatus"><StatusBadge type="info" text="CREATED" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="info" text="Created" /></td>
+      <td>Created</td>
       <td>Initial state at the time of creating a payment. Waiting for customer action</td>
     </tr>
     <tr>
@@ -55,201 +55,201 @@ The payments can have the following status and sub status.
       <td class="status" rowspan="7"><StatusBadge type="warning" text="PENDING" /></td>
       <td class="substatus"><StatusBadge type="warning" text="AUTHORIZED" /></td>
       <td>Authorize</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Card authorizations</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="IN_PROCESS" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="info" text="Created" /></td>
+      <td>Created</td>
       <td>The client has been redirected to the provider and we are waiting for the completion of the payment.</td>
     </tr>
     <tr>
       <td class="substatus" rowspan="2"><StatusBadge type="warning" text="WAITING_ADDITIONAL_STEP" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>3DS/Second factor</td>
     </tr>
     <tr>
       <td>Authorize</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>3DS/Second factor for authorization flow</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>Wating for providers payment confirmation.</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_FRAUD_REVIEW" /></td>
       <td>Fraud</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>Transaction is being analyzed by fraud provider</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_OTP_COMPLETION" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>Initial status upon payment creation</td>
     </tr>
     <tr>
       <td class="status"><StatusBadge type="success" text="VERIFIED" /></td>
       <td class="substatus"><StatusBadge type="success" text="VERIFIED" /></td>
       <td>Verify</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Zero amount card authorizations</td>
     </tr>
     <tr>
       <td rowspan="2" class="status"><StatusBadge type="error" text="EXPIRED" /></td>
       <td rowspan="2" class="substatus"><StatusBadge type="error" text="EXPIRED" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="error" text="Expired" /></td>
+      <td>Expired</td>
       <td>The offline payment method reaches its expiration date.</td>
     </tr>
     <tr>
       <td>Authorize</td>
-      <td><StatusBadge type="error" text="Expired" /></td>
+      <td>Expired</td>
       <td><br/>Authorization expires</td>
     </tr>
     <tr>
       <td rowspan="2" class="status"><StatusBadge type="error" text="REJECTED" /></td>
       <td rowspan="2" class="substatus"><StatusBadge type="error" text="REJECTED" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="error" text="Rejected" /></td>
+      <td>Rejected</td>
       <td><StatusBadge type="error" text="Rejected" /> by Yuno</td>
     </tr>
     <tr>
       <td>Capture</td>
-      <td><StatusBadge type="error" text="Error" /></td>
+      <td>Error</td>
       <td>Capture rejection by Yuno</td>
     </tr>
     <tr>
       <td rowspan="3" class="status"><StatusBadge type="error" text="DECLINED" /></td>
       <td rowspan="2" class="substatus"><StatusBadge type="error" text="DECLINED" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Providers rejection</td>
     </tr>
     <tr>
       <td>Capture</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Providers capture rejection</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="error" text="FRAUD_DECLINED" /></td>
       <td>Fraud screening</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Declined fraud screening</td>
     </tr>
     <tr>
       <td rowspan="12" class="status"><StatusBadge type="success" text="SUCCEEDED" /></td>
       <td class="substatus"><StatusBadge type="success" text="PARTIALLY_APPROVED" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Partial payment (payment with 2 cards)</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="success" text="APPROVED" /></td>
       <td>Purchase</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful payment</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="success" text="CAPTURED" /></td>
       <td>Capture</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful capture</td>
     </tr>
     <tr>
       <td rowspan="3" class="substatus"><StatusBadge type="success" text="PARTIALLY_CAPTURED" /></td>
       <td>Capture</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful partial capture</td>
     </tr>
     <tr>
       <td>Refund</td>
-      <td><StatusBadge type="error" text="Error" />/Declined</td>
+      <td>Error/Declined</td>
       <td>Remains approved due to error in refund / cancellation</td>
     </tr>
     <tr>
       <td>Chargeback</td>
-      <td><StatusBadge type="error" text="Error" />/Declined</td>
+      <td>Error/Declined</td>
       <td>Remains approved due to rejection in chargeback</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="PARTIALLY_REFUNDED" /></td>
       <td>Refund</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful partial refund</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="PARTIALLY_CHARGEBACKED" /></td>
       <td>Chargeback</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful partial chargeback</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="error" text="FRAUD_DECLINED" /></td>
       <td>Fraud screening</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Fraud screening declined. Can occur before or after provider authorization. Payment succeeded and funds have moved. </td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="REFUND_RETRY_IN_PROCESS" /></td>
       <td>Refund</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Transaction was declined and is waiting for retry.</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="CAPTURE_RETRY_IN_PROCESS" /></td>
       <td>Capture</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Transaction was declined and is waiting for retry.</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="CAPTURE_RETRY_PROCESS_FAILED" /></td>
       <td>Capture</td>
-      <td><StatusBadge type="error" text="Declined" /></td>
+      <td>Declined</td>
       <td>Transaction was declined and retry scheme it's finished.</td>
     </tr>
     <tr>
       <td rowspan="2" class="status"><StatusBadge type="secondary" text="REFUNDED" /></td>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Refund</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>Refund <StatusBadge type="warning" text="Pending" /></td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="REFUNDED" /></td>
       <td>Refund</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful refund</td>
     </tr>
     <tr>
       <td rowspan="2" class="status"><StatusBadge type="error" text="CANCELED" /></td>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Cancel</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>Cancel <StatusBadge type="warning" text="Pending" /></td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="error" text="CANCELED" /></td>
       <td>Cancel</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Successful cancelation</td>
     </tr>
     <tr>
       <td rowspan="2" class="status"><StatusBadge type="secondary" text="IN_DISPUTE" /></td>
       <td class="substatus"><StatusBadge type="secondary" text="RECEIVED" /></td>
       <td>Chargeback</td>
-      <td><StatusBadge type="info" text="Created" /></td>
+      <td>Created</td>
       <td>Chargeback or Inquiry received. Decision or documentation must be provided</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="secondary" text="PENDING_REVIEW" /></td>
       <td>Chargeback</td>
-      <td><StatusBadge type="warning" text="Pending" /></td>
+      <td>Pending</td>
       <td>In_review</td>
     </tr>
     <tr>
@@ -288,7 +288,7 @@ The payments can have the following status and sub status.
       <td rowspan="1" class="status"><StatusBadge type="success" text="FRAUD" /></td>
       <td class="substatus"><StatusBadge type="success" text="FRAUD_VERIFIED" /></td>
       <td>Fraud</td>
-      <td><StatusBadge type="success" text="Succeeded" /></td>
+      <td>Succeeded</td>
       <td>Transaction verified by fraud provider during stand alone fraud verification</td>
     </tr>
   </tbody>

--- a/snippets/StatusBadge.jsx
+++ b/snippets/StatusBadge.jsx
@@ -1,0 +1,7 @@
+export const StatusBadge = ({ type = 'secondary', text }) => {
+  return (
+    <span className={`status-badge status-${type.toLowerCase()}`}>
+      {text}
+    </span>
+  );
+};

--- a/snippets/StatusBadge.jsx
+++ b/snippets/StatusBadge.jsx
@@ -1,7 +1,3 @@
 export const StatusBadge = ({ type = 'secondary', text }) => {
-  return (
-    <span className={`status-badge status-${type.toLowerCase()}`}>
-      {text}
-    </span>
-  );
+  return <span className={`status-badge status-${type.toLowerCase().trim()}`}>{text}</span>;
 };

--- a/style.css
+++ b/style.css
@@ -485,6 +485,10 @@ html.dark .status-success {
   background-color: #16a34a33 !important;
 }
 
+html.dark .status-success:hover {
+  background-color: rgba(74, 222, 128, 0.25) !important;
+}
+
 /* Error status — rose-600 */
 .status-error {
   color: #e11d48 !important;
@@ -498,6 +502,10 @@ html.dark .status-error {
 
 .status-error:hover {
   background-color: #e11d4833 !important;
+}
+
+html.dark .status-error:hover {
+  background-color: rgba(251, 113, 133, 0.25) !important;
 }
 
 /* Warning status — yellow-500 */
@@ -515,6 +523,10 @@ html.dark .status-warning {
   background-color: #eab30833 !important;
 }
 
+html.dark .status-warning:hover {
+  background-color: rgba(250, 204, 21, 0.25) !important;
+}
+
 /* Info status — blue-600 */
 .status-info {
   color: #2563eb !important;
@@ -528,6 +540,10 @@ html.dark .status-info {
 
 .status-info:hover {
   background-color: #2563eb33 !important;
+}
+
+html.dark .status-info:hover {
+  background-color: rgba(96, 165, 250, 0.25) !important;
 }
 
 /* Alert status — orange-600 */
@@ -545,6 +561,10 @@ html.dark .status-alert {
   background-color: #ea580c33 !important;
 }
 
+html.dark .status-alert:hover {
+  background-color: rgba(251, 146, 60, 0.25) !important;
+}
+
 /* Secondary status — generic gray / neutral */
 .status-secondary {
   color: #5c5e66 !important;
@@ -554,4 +574,12 @@ html.dark .status-alert {
 html.dark .status-secondary {
   color: #9899a3 !important;
   background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+.status-secondary:hover {
+  background-color: #5c5e6633 !important;
+}
+
+html.dark .status-secondary:hover {
+  background-color: rgba(255, 255, 255, 0.15) !important;
 }

--- a/style.css
+++ b/style.css
@@ -71,7 +71,7 @@ html.dark [data-component-part="code-block-root"] {
 }
 
 [data-component-part="code-block-header"],
-.code-block > div:first-child {
+.code-block>div:first-child {
   background-color: transparent !important;
   border-bottom: 1px solid #e2e5eb !important;
   border-radius: 6px 6px 0 0 !important;
@@ -79,7 +79,7 @@ html.dark [data-component-part="code-block-root"] {
 }
 
 html.dark [data-component-part="code-block-header"],
-html.dark .code-block > div:first-child {
+html.dark .code-block>div:first-child {
   border-bottom-color: #3a3c44 !important;
   color: #9899a3 !important;
 }
@@ -164,11 +164,12 @@ html.dark table th:first-child {
 
 /* Payment status table: continuation rows have no first-column cell due to rowspan.
    Their td:first-child is actually the Substatus column — undo the sticky from it. */
-.payment-status-table td:not(.status) {
+.payment-status-table td:first-child:not(.status) {
   position: static !important;
   background-color: transparent !important;
   box-shadow: none !important;
 }
+
 
 .payment-status-table td {
   vertical-align: top !important;
@@ -385,7 +386,7 @@ span[class*="line"] * {
 
 .code-block,
 .code-block:has([data-component-part="code-block-header"]),
-:not(.code-block) > [data-component-part="code-block-root"] {
+:not(.code-block)>[data-component-part="code-block-root"] {
   --code-padding-right: 48px;
 }
 
@@ -393,9 +394,7 @@ span[class*="line"] * {
    Border-radius — sharp corners
    ============================================ */
 
-*:not(a):not(.code-block):not(pre):not([data-component-part="code-block-root"]):not(
-    [data-component-part="code-block-header"]
-  ) {
+*:not(a):not(.code-block):not(pre):not([data-component-part="code-block-root"]):not([data-component-part="code-block-header"]) {
   border-radius: 2px !important;
 }
 
@@ -417,7 +416,7 @@ span[class*="line"] * {
   line-height: 20px;
 }
 
-#page-context-menu-button + button {
+#page-context-menu-button+button {
   border-radius: 0 2px 2px 0 !important;
 }
 
@@ -437,7 +436,7 @@ span[class*="line"] * {
   border-radius: 0 !important;
 }
 
-.company_card_wrapper .card > div {
+.company_card_wrapper .card>div {
   padding: 18px 20px;
 }
 
@@ -475,51 +474,63 @@ span[class*="line"] * {
 /* Success status — green-600 */
 .status-success {
   color: #16a34a !important;
-  background-color: #16a34a1a !important; /* 10% alpha */
+  background-color: #16a34a1a !important;
+  /* 10% alpha */
 }
 
 .status-success:hover {
-  background-color: #16a34a33 !important; /* 20% alpha */
+  background-color: #16a34a33 !important;
+  /* 20% alpha */
 }
 
 /* Error status — rose-600 */
 .status-error {
   color: #e11d48 !important;
-  background-color: #e11d481a !important; /* 10% alpha */
+  background-color: #e11d481a !important;
+  /* 10% alpha */
 }
 
 .status-error:hover {
-  background-color: #e11d4833 !important; /* 20% alpha */
+  background-color: #e11d4833 !important;
+  /* 20% alpha */
 }
 
 /* Warning status — yellow-500 */
 .status-warning {
   color: #eab308 !important;
-  background-color: #eab3081a !important; /* 10% alpha */
+  background-color: #eab3081a !important;
+  /* 10% alpha */
 }
 
 .status-warning:hover {
-  background-color: #eab30833 !important; /* 20% alpha */
+  background-color: #eab30833 !important;
+  /* 20% alpha */
 }
+
+
 
 /* Info status — blue-600 */
 .status-info {
   color: #2563eb !important;
-  background-color: #2563eb1a !important; /* 10% alpha */
+  background-color: #2563eb1a !important;
+  /* 10% alpha */
 }
 
 .status-info:hover {
-  background-color: #2563eb33 !important; /* 20% alpha */
+  background-color: #2563eb33 !important;
+  /* 20% alpha */
 }
 
 /* Alert status — orange-600 */
 .status-alert {
   color: #ea580c !important;
-  background-color: #ea580c1a !important; /* 10% alpha */
+  background-color: #ea580c1a !important;
+  /* 10% alpha */
 }
 
 .status-alert:hover {
-  background-color: #ea580c33 !important; /* 20% alpha */
+  background-color: #ea580c33 !important;
+  /* 20% alpha */
 }
 
 /* Secondary status — generic gray / neutral */
@@ -532,4 +543,3 @@ html.dark .status-secondary {
   color: #9899a3 !important;
   background-color: rgba(255, 255, 255, 0.08) !important;
 }
-

--- a/style.css
+++ b/style.css
@@ -470,73 +470,85 @@ span[class*="line"] * {
 }
 
 
-
 /* Success status — green-600 */
 .status-success {
   color: #16a34a !important;
   background-color: #16a34a1a !important;
-  /* 10% alpha */
+}
+
+html.dark .status-success {
+  color: #4ade80 !important;
+  background-color: rgba(74, 222, 128, 0.15) !important;
 }
 
 .status-success:hover {
   background-color: #16a34a33 !important;
-  /* 20% alpha */
 }
 
 /* Error status — rose-600 */
 .status-error {
   color: #e11d48 !important;
   background-color: #e11d481a !important;
-  /* 10% alpha */
+}
+
+html.dark .status-error {
+  color: #fb7185 !important;
+  background-color: rgba(251, 113, 133, 0.15) !important;
 }
 
 .status-error:hover {
   background-color: #e11d4833 !important;
-  /* 20% alpha */
 }
 
 /* Warning status — yellow-500 */
 .status-warning {
   color: #eab308 !important;
   background-color: #eab3081a !important;
-  /* 10% alpha */
+}
+
+html.dark .status-warning {
+  color: #facc15 !important;
+  background-color: rgba(250, 204, 21, 0.15) !important;
 }
 
 .status-warning:hover {
   background-color: #eab30833 !important;
-  /* 20% alpha */
 }
-
-
 
 /* Info status — blue-600 */
 .status-info {
   color: #2563eb !important;
   background-color: #2563eb1a !important;
-  /* 10% alpha */
+}
+
+html.dark .status-info {
+  color: #60a5fa !important;
+  background-color: rgba(96, 165, 250, 0.15) !important;
 }
 
 .status-info:hover {
   background-color: #2563eb33 !important;
-  /* 20% alpha */
 }
 
 /* Alert status — orange-600 */
 .status-alert {
   color: #ea580c !important;
   background-color: #ea580c1a !important;
-  /* 10% alpha */
+}
+
+html.dark .status-alert {
+  color: #fb923c !important;
+  background-color: rgba(251, 146, 60, 0.15) !important;
 }
 
 .status-alert:hover {
   background-color: #ea580c33 !important;
-  /* 20% alpha */
 }
 
 /* Secondary status — generic gray / neutral */
 .status-secondary {
   color: #5c5e66 !important;
-  background-color: #e8eaf5 !important;
+  background-color: #5c5e661a !important;
 }
 
 html.dark .status-secondary {

--- a/style.css
+++ b/style.css
@@ -164,11 +164,34 @@ html.dark table th:first-child {
 
 /* Payment status table: continuation rows have no first-column cell due to rowspan.
    Their td:first-child is actually the Substatus column — undo the sticky from it. */
-.payment-status-table td:first-child:not(.status) {
+.payment-status-table td:not(.status) {
   position: static !important;
   background-color: transparent !important;
   box-shadow: none !important;
 }
+
+.payment-status-table td {
+  vertical-align: top !important;
+  text-align: left;
+  padding: 12px 8px !important;
+}
+
+
+
+.payment-status-table th {
+  text-align: left;
+  padding: 12px 8px !important;
+}
+
+
+/* Ensure status and substatus columns are centered if desired, 
+   but left-aligned usually looks cleaner with badges. */
+.payment-status-table td.status,
+.payment-status-table td.substatus {
+  min-width: 110px;
+}
+
+
 
 /* ============================================
    API reference params
@@ -428,3 +451,85 @@ span[class*="line"] * {
   font-size: 16px !important;
   margin: 0 !important;
 }
+
+/* ============================================
+   Status Badges — Dashboard Sync
+   ============================================ */
+
+.status-badge {
+  padding: 2px 10px !important;
+  border-radius: 4px !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  white-space: nowrap !important;
+  line-height: 1.2 !important;
+  min-height: 24px !important;
+  margin-top: 2px !important;
+}
+
+
+
+/* Success status — green-600 */
+.status-success {
+  color: #16a34a !important;
+  background-color: #16a34a1a !important; /* 10% alpha */
+}
+
+.status-success:hover {
+  background-color: #16a34a33 !important; /* 20% alpha */
+}
+
+/* Error status — rose-600 */
+.status-error {
+  color: #e11d48 !important;
+  background-color: #e11d481a !important; /* 10% alpha */
+}
+
+.status-error:hover {
+  background-color: #e11d4833 !important; /* 20% alpha */
+}
+
+/* Warning status — yellow-500 */
+.status-warning {
+  color: #eab308 !important;
+  background-color: #eab3081a !important; /* 10% alpha */
+}
+
+.status-warning:hover {
+  background-color: #eab30833 !important; /* 20% alpha */
+}
+
+/* Info status — blue-600 */
+.status-info {
+  color: #2563eb !important;
+  background-color: #2563eb1a !important; /* 10% alpha */
+}
+
+.status-info:hover {
+  background-color: #2563eb33 !important; /* 20% alpha */
+}
+
+/* Alert status — orange-600 */
+.status-alert {
+  color: #ea580c !important;
+  background-color: #ea580c1a !important; /* 10% alpha */
+}
+
+.status-alert:hover {
+  background-color: #ea580c33 !important; /* 20% alpha */
+}
+
+/* Secondary status — generic gray / neutral */
+.status-secondary {
+  color: #5c5e66 !important;
+  background-color: #e8eaf5 !important;
+}
+
+html.dark .status-secondary {
+  color: #9899a3 !important;
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+


### PR DESCRIPTION
## Summary

This PR standardizes the visual representation of payment status and substatus badges in the Yuno Mintlify documentation to align with the Yuno dashboard's design. It introduces a reusable `StatusBadge` React component and defined brand-consistent CSS styles.

**Key Changes:**

- **Reusable Component**: Created `snippets/StatusBadge.jsx` for consistent, color-coded badges (Success, Error, Warning, Info, Alert, Secondary).
- **CSS Standardization**: Added new classes to `style.css` using brand-consistent hex codes with 10% alpha (background) and 20% alpha (hover).
- **Reference Table Update**: 
    - Replaced raw `<code>` tags in the **Status** and **Substatus** columns of `payment.mdx` with the new `<StatusBadge />` component.
    - Reverted "Transaction status" and "Description" columns to plain text as requested to maintain focus on primary payment states.
- **Layout & Bug Fixes**:
    - **Consolidated READY_TO_PAY**: Removed redundant rows in the `READY_TO_PAY` status section for better technical clarity.
    - **Rowspan Fixes**: Corrected `rowspan` mismatches (e.g., `SUCCEEDED` group) that were breaking the table structure.
    - **Alignment & Spacing**: Improved table alignment by setting `vertical-align: top` and optimized cell padding to prevent text clipping in the Description column.

**Impacted Pages:**
- [Payment Status and Response Codes](reference/payments/status-and-response-codes/payment.mdx)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that mainly affect styling and table markup; potential issues are limited to rendering/layout regressions in the payment status table.
> 
> **Overview**
> Updates the payment status reference table to render **Status** and **Substatus** values as consistent, color-coded badges via a new reusable `StatusBadge` snippet.
> 
> Adds dashboard-aligned badge styling in `style.css` (including dark-mode variants) and tweaks `.payment-status-table` spacing/alignment, while also cleaning up table structure (rowspan adjustments and removing a redundant `READY_TO_PAY` row) to avoid broken layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d843190bc81e7e6badcb145a7f90e9a3ec674b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->