### PR TITLE
docs(sdks): clarify lack of continue payment support in headless mobile

### DIFF
--- a/docs/sdks/headless-android/checkout.mdx
+++ b/docs/sdks/headless-android/checkout.mdx
@@ -468,6 +468,16 @@ You can change the SDK appearance to match your brand. For more information, see
 In addition to the code examples provided, you can see the [Yuno repository](https://github.com/yuno-payments/yuno-sdk-android/tree/master) to complete Yuno Android SDKs implementation.
 </Info>
 
+## Step 9: Continue payment (Not supported)
+
+<Warning>
+**Missing Mobile Support**
+
+The `getContinuePaymentAction` method and the "Continue Payment" settings (required for features like Passkey SCOF) are currently **not supported** in the Headless Android SDK. 
+
+If your integration requires these features, consider using the [Full Checkout SDK](/docs/sdks/full-checkout/android-payments) or the [Web Headless SDK](/docs/sdks/headless-web/payment) as an alternative.
+</Warning>
+
 ## Error handling
 
 Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.

--- a/docs/sdks/headless-ios/checkout.mdx
+++ b/docs/sdks/headless-ios/checkout.mdx
@@ -364,6 +364,16 @@ Make sure the `url.scheme` in this code matches the `callback_url` you provided 
 In addition to the code examples provided, you can access the [Yuno repository](https://github.com/yuno-payments/yuno-sdk-ios) for a complete implementation of Yuno iOS SDKs.
 </Info>
 
+## Step 8: Continue payment (Not supported)
+
+<Warning>
+**Missing Mobile Support**
+
+The `getContinuePaymentAction` method and the "Continue Payment" settings (required for features like Passkey SCOF) are currently **not supported** in the Headless iOS SDK. 
+
+If your integration requires these features, consider using the [Full Checkout SDK](/docs/sdks/full-checkout/ios-payments) or the [Web Headless SDK](/docs/sdks/headless-web/payment) as an alternative.
+</Warning>
+
 ## Error handling
 
 Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.


### PR DESCRIPTION
## Summary

Clarifies that "Continue Payment" configurations (required for features like Passkey SCOF) are currently not supported in Headless Android and iOS SDKs. This aligns the mobile documentation with current technical capabilities and prevents developer confusion when comparing with the Web SDK.

**Changes:**
- **Headless Android**: Added Step 9 Warning explicitly stating `getContinuePaymentAction` is not supported.
- **Headless iOS**: Added Step 8 Warning explicitly stating `getContinuePaymentAction` is not supported.

**Pages:**
- Headless SDK (Payment Android)
- Headless SDK (Payment iOS)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds warnings about unsupported functionality; no runtime or API behavior changes.
> 
> **Overview**
> Adds an explicit *“Continue payment (Not supported)”* step to the Headless Android and Headless iOS checkout docs, warning that `getContinuePaymentAction` / “Continue Payment” settings (needed for Passkey SCOF) aren’t available on mobile headless.
> 
> Guides integrators who need these flows to use the Full Checkout mobile SDKs or the Web Headless SDK instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39776062ebf4182afd436ba23a12504946c56cb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->