### PR TITLE
docs(api): set additional_data as optional in create payment

### DIFF
--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -60,8 +60,7 @@
                   "merchant_order_id",
                   "amount",
                   "payment_method",
-                  "checkout",
-                  "additional_data"
+                  "checkout"
                 ],
                 "properties": {
                   "account_id": {

--- a/openapi/yuno_sandbox_tested.json
+++ b/openapi/yuno_sandbox_tested.json
@@ -2387,8 +2387,7 @@
           "merchant_order_id",
           "amount",
           "payment_method",
-          "checkout",
-          "additional_data"
+          "checkout"
         ],
         "properties": {
           "account_id": {


### PR DESCRIPTION
## Summary

Updated the OpenAPI specifications for the "Create Payment" endpoint to mark the `additional_data` field as optional. It was previously incorrectly listed as a required field in the request schema, despite its description stating it was not mandatory.

**Changes:**
- **Modified**: `openapi/payments/create-payment.json` -> Removed `additional_data` from the `required` array in the request schema for the `create-payment` operation.
- **Modified**: `openapi/yuno_sandbox_tested.json` -> Synchronized the change in the sandbox-tested specification for consistency across environments.

**Verification:**
- Validated JSON syntax using `jq`.
- Verified using `grep` that `additional_data` is no longer in the `required` list for the relevant schemas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/spec-only change that relaxes request validation in the OpenAPI schemas by removing `additional_data` from required fields.
> 
> **Overview**
> Updates the OpenAPI specs for **Create Payment** so `additional_data` is no longer listed as a required field in the request body schema.
> 
> Applies the same required-field change in both `openapi/payments/create-payment.json` and `openapi/yuno_sandbox_tested.json` to keep the published and sandbox-tested specs consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97d376ab0d2e0369369c3d9fc2f3c80ccb93e20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->