### PR TITLE
docs(wallets): document NuPay 2FA mode (non-enrollment flow)

### DIFF
--- a/docs/wallets/nupay.mdx
+++ b/docs/wallets/nupay.mdx
@@ -1,10 +1,12 @@
 ---
 title: "NuPay"
+description: "Accept payments with NuPay, the digital payment method from NuBank, using the Direct workflow for one-time payments, enrollment, and 2FA mode."
 ---
 
 This guide explores Yuno's NuPay integration using the Direct workflow. You'll learn how to:
 
 * Enroll NuPay as a customer payment method
+* Make payments without enrollment (2FA mode)
 * Make payments with installments (payment conditions)
 * Set up subscriptions
 
@@ -62,6 +64,48 @@ Use [Retrieve Enrolled Payment Method by id](/reference/retrieve-enrolled-paymen
 <Warning>
   The enrollment is only complete after Yuno receives Nu’s confirmation.
 </Warning>
+
+## Payments without enrollment (2FA mode)
+
+You can accept one-time payments with NuPay without requiring the customer to enroll their payment method. This is often referred to as **2FA mode**, as the customer authenticates each transaction individually.
+
+### Step 1: Create a payment
+
+Use [Create payment](/reference/create-payment) with the Direct workflow and the `NU_PAY` payment method type. In this mode, you don't need a `vaulted_token`.
+
+```json
+{
+  "description": "One-time NuPay Payment",
+  "account_id": "{{account_id}}",
+  "merchant_order_id": "0000024",
+  "country": "BR",
+  "amount": {
+    "currency": "BRL",
+    "value": 150
+  },
+  "customer_payer": {
+    "id": "{{customer_id}}"
+  },
+  "workflow": "DIRECT",
+  "callback_url": "https://your-callback.com",
+  "payment_method": {
+    "type": "NU_PAY"
+  }
+}
+```
+
+### Step 2: Handle the response
+
+Since this mode requires customer authentication, the response will return an action to redirect the user.
+
+*   **status**: `READY_TO_PAY`
+*   **sub_status**: `WAITING_ADDITIONAL_STEP`
+*   **action**: `REDIRECT_URL`
+*   **redirect_url**: URL to redirect the customer to Nu for 2FA authentication.
+
+### Step 3: Confirm payment
+
+After the customer completes the authentication, use [Retrieve payment by id](/reference/retrieve-payment-by-id) to confirm the final status.
 
 ## Payments with payment conditions (installments)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the NuPay "2FA mode" (non-enrollment flow) to the NuPay guide. This flow allows merchants to process payments without a prior enrollment step, authenticating each transaction individually.


**Changes:**
- Added "Payments without enrollment (2FA mode)" section to `docs/wallets/nupay.mdx`.
- Included request/response examples using the `NU_PAY` payment method type.
- Updated the guide introduction to include the new capability.

**Pages:**
- [NuPay](https://docs.y.uno/docs/wallets/nupay)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for an additional NuPay payment flow without affecting any runtime code paths.
> 
> **Overview**
> Adds documentation for NuPay **payments without enrollment (2FA mode)**, including a Direct-workflow `Create payment` example using `NU_PAY`, expected redirect-based response fields, and a final confirmation step via `Retrieve payment by id`.
> 
> Updates the guide metadata and intro list to reflect the new 2FA capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6ad102094f48eabf6830a8818e622b55185176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->