### PR TITLE
docs(wallets): document NuPay 2FA mode (non-enrollment flow)

### DIFF
--- a/docs/wallets/nupay.mdx
+++ b/docs/wallets/nupay.mdx
@@ -109,35 +109,65 @@ After the customer completes the authentication, use [Retrieve payment by id](/r
 
 ## Payments with payment conditions (installments)
 
-After enrollment, you can accept payments with NuPay using payment conditions.
+NuPay supports installments for both enrolled payment methods and one-time payments (2FA mode).
 
 ### Step 1: Ensure prerequisites
 
-Have a Yuno customer `id` and an enrolled NuPay `vaulted_token`.
+Depending on the flow, you'll need:
+*   **Enrollment Flow**: A Yuno customer `id` and an enrolled NuPay `vaulted_token`.
+*   **2FA Mode**: Customer details, specifically their tax ID (CPF) and email.
 
 ### Step 2: Get payment conditions
 
-Request available installment options for NuPay using the APM installments endpoint.
+Request available installment options for NuPay using the [APM installments](/reference/apm-installments) endpoint. The request parameters vary based on the integration flow.
 
-```bash
-curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
---header 'public-api-key: {{your_public_api_key}}' \
---header 'private-secret-key: {{your_secret_api_key}}' \
---header 'X-account-code: {{your_account_code}}' \
---header 'Content-Type: application/json' \
---data '{
-  "country": "BR",
-  "amount": {
-    "currency": "BRL",
-    "value": "250"
-  },
-  "customer": {
-    "id": "{{customer_id}}"
-  },
-  "payment_method": "NU_PAY_ENROLLMENT",
-  "vaulted_token": "{{vaulted_token}}"
-}'
-```
+<Tabs>
+  <Tab title="Enrollment Flow">
+    ```bash
+    curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+    --header 'public-api-key: {{your_public_api_key}}' \
+    --header 'private-secret-key: {{your_secret_api_key}}' \
+    --header 'X-account-code: {{your_account_code}}' \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "country": "BR",
+      "amount": {
+        "currency": "BRL",
+        "value": "250"
+      },
+      "customer": {
+        "id": "{{customer_id}}"
+      },
+      "payment_method": "NU_PAY_ENROLLMENT",
+      "vaulted_token": "{{vaulted_token}}"
+    }'
+    ```
+  </Tab>
+  <Tab title="2FA Mode">
+    ```bash
+    curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+    --header 'public-api-key: {{your_public_api_key}}' \
+    --header 'private-secret-key: {{your_secret_api_key}}' \
+    --header 'X-account-code: {{your_account_code}}' \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "country": "BR",
+      "payment_method": "NU_PAY",
+      "amount": {
+        "currency": "BRL",
+        "value": "250"
+      },
+      "customer": {
+        "document": {
+          "document_type": "CPF",
+          "document_number": "12345678900"
+        },
+        "email": "customer@email.com"
+      }
+    }'
+    ```
+  </Tab>
+</Tabs>
 
 The response returns an array of installment plans, including `id`, available `installments`, and amounts. Select a plan `id` and an allowed installments number.
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the NuPay "2FA mode" (non-enrollment flow) to the NuPay guide. This flow allows merchants to process payments without a prior enrollment step, authenticating each transaction individually.


**Changes:**
- Added "Payments without enrollment (2FA mode)" section to `docs/wallets/nupay.mdx`.
- Included request/response examples using the `NU_PAY` payment method type.
- Updated the installment flow documentation to include both the Enrollment flow (using `vaulted_token`) and the 2FA flow (using CPF/Email).
- Updated the guide introduction to include the new capability.

**Pages:**
- [NuPay](https://docs.y.uno/docs/wallets/nupay)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies supported NuPay flows and request parameters; no runtime or API behavior changes.
> 
> **Overview**
> Documents NuPay *2FA mode* (non-enrollment) for one-time payments, including the `Create payment` request using `NU_PAY` and the expected `REDIRECT_URL` action/fields.
> 
> Updates the installments section to state support for both enrollment and 2FA flows, clarifies prerequisites, and replaces the single APM installments example with tabbed `apm-installments` request examples for `NU_PAY_ENROLLMENT` (with `vaulted_token`) vs `NU_PAY` (with CPF/email).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 744cde50f44a8c172023e2b649eafbf8c775e715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->