### PR TITLE
Add docs bot to the docs

### DIFF
--- a/scripts/docsbot.js
+++ b/scripts/docsbot.js
@@ -1,0 +1,37 @@
+window.DocsBotAI = window.DocsBotAI || {};
+
+DocsBotAI.init = function (e) {
+  return new Promise((t, r) => {
+    var n = document.createElement("script");
+    n.type = "text/javascript";
+    n.async = true;
+    n.src = "https://widget.docsbot.ai/chat.js";
+    let o = document.getElementsByTagName("script")[0];
+    o.parentNode.insertBefore(n, o);
+    n.addEventListener("load", () => {
+      let n;
+      Promise.all([
+        new Promise((t, r) => {
+          window.DocsBotAI.mount(Object.assign({}, e)).then(t).catch(r);
+        }),
+        (n = function e(t) {
+          return new Promise((e) => {
+            if (document.querySelector(t)) return e(document.querySelector(t));
+            let r = new MutationObserver((n) => {
+              if (document.querySelector(t))
+                return e(document.querySelector(t)), r.disconnect();
+            });
+            r.observe(document.body, { childList: true, subtree: true });
+          });
+        })("#docsbotai-root"),
+      ])
+        .then(() => t())
+        .catch(r);
+    });
+    n.addEventListener("error", (e) => {
+      r(e.message);
+    });
+  });
+};
+
+DocsBotAI.init({ id: "kt3kQQ36OPdxGR171DX9/Rn7KueLwOWNLimA1gKYM" });

--- a/scripts/docsbot.js
+++ b/scripts/docsbot.js
@@ -1,37 +1,49 @@
-window.DocsBotAI = window.DocsBotAI || {};
 
-DocsBotAI.init = function (e) {
-  return new Promise((t, r) => {
-    var n = document.createElement("script");
-    n.type = "text/javascript";
-    n.async = true;
-    n.src = "https://widget.docsbot.ai/chat.js";
-    let o = document.getElementsByTagName("script")[0];
-    o.parentNode.insertBefore(n, o);
-    n.addEventListener("load", () => {
-      let n;
-      Promise.all([
-        new Promise((t, r) => {
-          window.DocsBotAI.mount(Object.assign({}, e)).then(t).catch(r);
-        }),
-        (n = function e(t) {
-          return new Promise((e) => {
-            if (document.querySelector(t)) return e(document.querySelector(t));
-            let r = new MutationObserver((n) => {
-              if (document.querySelector(t))
-                return e(document.querySelector(t)), r.disconnect();
-            });
-            r.observe(document.body, { childList: true, subtree: true });
-          });
-        })("#docsbotai-root"),
-      ])
-        .then(() => t())
-        .catch(r);
-    });
-    n.addEventListener("error", (e) => {
-      r(e.message);
-    });
-  });
-};
+(function () {
+  function setup() {
+    window.DocsBotAI = window.DocsBotAI || {};
 
-DocsBotAI.init({ id: "kt3kQQ36OPdxGR171DX9/Rn7KueLwOWNLimA1gKYM" });
+    DocsBotAI.init = function (e) {
+      return new Promise((t, r) => {
+        var n = document.createElement("script");
+        n.type = "text/javascript";
+        n.async = true;
+        n.src = "https://widget.docsbot.ai/chat.js";
+        let o = document.getElementsByTagName("script")[0];
+        o.parentNode.insertBefore(n, o);
+        n.addEventListener("load", () => {
+          Promise.all([
+            new Promise((t, r) => {
+              window.DocsBotAI.mount(Object.assign({}, e)).then(t).catch(r);
+            }),
+            (function e(t) {
+              return new Promise((e) => {
+                if (document.querySelector(t)) return e(document.querySelector(t));
+                let r = new MutationObserver((n) => {
+                  if (document.querySelector(t))
+                    return e(document.querySelector(t)), r.disconnect();
+                });
+                r.observe(document.body, { childList: true, subtree: true });
+              });
+            })("#docsbotai-root"),
+          ])
+            .then(() => t())
+            .catch(r);
+        });
+        n.addEventListener("error", (e) => {
+          r(e.message);
+        });
+      });
+    };
+
+    DocsBotAI.init({ id: "kt3kQQ36OPdxGR171DX9/Rn7KueLwOWNLimA1gKYM" });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setup);
+  } else {
+    setup();
+  }
+})();
+
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new third-party widget loader that injects remote JavaScript into the docs site, which can affect security, privacy, and page performance. Risk is limited in scope to the docs runtime but depends on the external `widget.docsbot.ai` script behavior and availability.
> 
> **Overview**
> Adds a new `scripts/docsbot.js` initializer that injects the DocsBot AI chat widget (`https://widget.docsbot.ai/chat.js`) on page load.
> 
> The script defines `DocsBotAI.init()` to load the remote widget, wait for `#docsbotai-root` to appear (via `MutationObserver`), then mount the widget with the configured bot `id`, surfacing load errors via Promise rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef229825d3056a3d370eabdb4aadf27427960ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->