### PR TITLE
apple-pay-cert-options

### DIFF
--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -13,6 +13,18 @@ Use this guide to prepare and configure Apple Pay with Yuno.
 
 When finished, you'll be ready to [choose your integration path](#next-steps)  (SDK or Direct) for one-time and recurring payments.
 
+## Apple Pay certificate options
+
+In the Yuno Dashboard, you will find two options for Apple Pay certificates:
+
+* **Yuno**: This option is for merchants who do not have an Apple Developer account or a mobile app (i.e., they are web-only). In these cases, you must register your domain via the API in order to use Yuno's certificates. Use the following endpoints to manage your domain registration:
+  * [Register domain](/reference/domains/register-domain)
+  * [Get domain](/reference/domains/get-domain)
+  * [Delete domain](/reference/domains/delete-domain)
+  * [Domain webhooks](/reference/domains/webhooks-domains)
+
+* **Own**: This option is for merchants who have mobile apps and an Apple Developer account. In this case, you can follow the steps in this document to upload your certificates to the Yuno Dashboard.
+
 ## Step 1: Register a merchant identifier
 
 <Note>
@@ -201,5 +213,3 @@ After completing the Dashboard setup, choose your path to integrate via SDK or D
 
 * **SDK Integration**: [one-time](/docs/apple-pay-sdk-integration#one-time-payments-with-sdk) and [recurring](/docs/apple-pay-sdk-integration#recurring-payments-with-sdk)
 * **Direct integration**: [one-time](/docs/apple-pay-direct-integration#one-time-payments-with-direct-api)  and [recurring](/docs/apple-pay-direct-integration#recurring-payments-with-direct-api)
-
-<br />


### PR DESCRIPTION
## Summary

Adds a new **Apple Pay certificate options** section to the Prerequisites (Apple Pay) page, explaining the two available certificate modes in the Yuno Dashboard.

**Changes:**
- Added "Apple Pay certificate options" section between the intro and Step 1 in `prerequisites-apple-pay.mdx`
- Explains the **Yuno** option (for web-only merchants without an Apple Developer account), with links to the four domain management API endpoints
- Explains the **Own** option (for merchants with a mobile app and Apple Developer account), pointing them to the existing certificate steps in the document

**Pages:**
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance and links; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a new **Apple Pay certificate options** section to the Apple Pay prerequisites doc, clarifying the two Dashboard certificate modes (*Yuno-managed* vs *own certificates*) and when to use each.
> 
> For the *Yuno* mode, it now points web-only merchants to the domain registration API endpoints needed to manage domains, and it removes a trailing `<br />` at the end of the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca69e9895d5a5750baaca1c136c22b08457fdce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->