### PR TITLE
docs(api): add store_credentials.usage to subscriptions

### DIFF
--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -249,6 +249,20 @@
                           "network_transaction_id": {
                             "type": "string",
                             "description": "The ID provided by Visa/Mastercard in the response of the initial payment (MAX 256; MIN 1)."
+                          },
+                          "store_credentials": {
+                            "type": "object",
+                            "description": "Specifies the credential usage for the card.",
+                            "properties": {
+                              "usage": {
+                                "type": "string",
+                                "description": "Indicates whether this is the first or a subsequent use. Required if a CIT payment was created before the subscription.",
+                                "enum": [
+                                  "FIRST",
+                                  "USED"
+                                ]
+                              }
+                            }
                           }
                         }
                       }

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -195,6 +195,20 @@
                                 "description": "Cardholder’s full name as it appears on the card (MAX 26; MIN 3) - only available for PCI certified merchants"
                               }
                             }
+                          },
+                          "store_credentials": {
+                            "type": "object",
+                            "description": "Specifies the credential usage for the card.",
+                            "properties": {
+                              "usage": {
+                                "type": "string",
+                                "description": "Indicates whether this is the first or a subsequent use. Required if a CIT payment was created before the subscription.",
+                                "enum": [
+                                  "FIRST",
+                                  "USED"
+                                ]
+                              }
+                            }
                           }
                         }
                       },

--- a/reference/subscriptions/create-subscription.mdx
+++ b/reference/subscriptions/create-subscription.mdx
@@ -9,4 +9,26 @@ openapi: "/openapi/subscriptions/create-subscription.json POST /subscriptions"
 The fields `billing_cycles` and `availability.finish_at` have an impact on each other. If both are completed during the subscription creation, it will transition to the `COMPLETED` state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`.
 </Warning>
 
+<Warning>
+**Credential Usage for Previous CIT**
+
+If you create a CIT payment (e.g. Apple Pay or card) *before* creating the subscription and pass the resulting vaulted token into the subscription, you **must** include `store_credentials.usage` to indicate whether this is the first or a subsequent use. Without this, rebills will be treated as CITs and declined by the provider.
+
+Required payload for new subscriptions:
+
+```json
+{
+  "payment_method": {
+    "type": "CARD",
+    "vaulted_token": "{{vaulted_token}}",
+    "card": {
+      "store_credentials": {
+        "usage": "USED"
+      }
+    }
+  }
+}
+```
+</Warning>
+
 Refer to the [HTTP Response Codes](/reference/response-codes) section for details on possible error outcomes.

--- a/reference/subscriptions/update-subscription.mdx
+++ b/reference/subscriptions/update-subscription.mdx
@@ -8,3 +8,9 @@ openapi: "/openapi/subscriptions/update-subscription.json PATCH /subscriptions/{
 
 The fields `billing_cycles` and `availability.finish_at` have an impact on each other. If both are completed during the subscription creation, it will transition to the `COMPLETED` state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`.
 </Warning>
+
+<Note>
+**Retroactive Credential Update**
+
+If you have existing subscriptions that are failing rebills because of missing credential usage (e.g. from an initial CIT payment), you can use this `PATCH` endpoint to add the `store_credentials` object retroactively to fix the issue.
+</Note>


### PR DESCRIPTION
## Summary

Updated the Subscriptions API documentation to highlight the requirement of `store_credentials.usage` when using a vaulted token from a previous Customer Initiated Transaction (CIT).

**Changes:**
- Added prominent Warning blocks to `Create Subscription` and `Update Subscription` pages.
- Updated `create-subscription.json` and `update-subscription.json` OpenAPI schemas to include the `store_credentials` object in the `card` parameter.
- Explained rationale for avoiding rebill failures by correctly identifying subsequent uses.

**Pages:**
- [Create Subscription](/reference/subscriptions/create-subscription)
- [Update Subscription](/reference/subscriptions/update-subscription)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/schema-only change; no runtime logic is modified. Main risk is client confusion or validation mismatches if the new field is interpreted as required everywhere.
> 
> **Overview**
> **Subscriptions API docs/schema now support credential usage metadata for card rebills.** The `create-subscription` and `update-subscription` OpenAPI schemas add a `payment_method.card.store_credentials.usage` field (enum `FIRST`/`USED`) to indicate first vs subsequent credential use.
> 
> Documentation adds a prominent warning on *Create Subscription* explaining that when a vaulted token comes from a prior CIT, `store_credentials.usage` must be included to prevent providers treating rebills as CITs (with an example payload), and a note on *Update Subscription* that `PATCH` can be used to add `store_credentials` retroactively for failing subscriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 488b108f78f7ba42f67050fbe676001648295813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->