### PR TITLE
docs: fix NuPay broken link and add APM installments reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -547,6 +547,7 @@
             "dropdown": "Installments",
             "icon": "layer-group",
             "pages": [
+              "reference/installments/apm-installments",
               "reference/installments/create-installments-plan",
               "reference/installments/get-installments-plan",
               "reference/installments/get-installments-plan-by-account",

--- a/docs/wallets/nupay.mdx
+++ b/docs/wallets/nupay.mdx
@@ -119,7 +119,7 @@ Depending on the flow, you'll need:
 
 ### Step 2: Get payment conditions
 
-Request available installment options for NuPay using the [APM installments](/reference/apm-installments) endpoint. The request parameters vary based on the integration flow.
+Request available installment options for NuPay using the [APM installments](/reference/installments/apm-installments) endpoint. The request parameters vary based on the integration flow.
 
 <Tabs>
   <Tab title="Enrollment Flow">

--- a/docs/wallets/nupay.mdx
+++ b/docs/wallets/nupay.mdx
@@ -235,5 +235,6 @@ You can use NuPay for recurring charges.
 * [Retrieve enrolled payment method by id](/reference/retrieve-enrolled-payment-method-by-id-api)
 * [Create payment](/reference/create-payment)
 * [Retrieve payment by id](/reference/retrieve-payment-by-id)
+* [APM installments](/reference/installments/apm-installments)
 * [Create subscription](/reference/create-subscription)
 * [Retrieve subscription](/reference/retrieve-subscription)

--- a/openapi/installments/apm-installments.json
+++ b/openapi/installments/apm-installments.json
@@ -1,0 +1,226 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "APM Installments",
+    "version": "1.0.0",
+    "description": "Retrieve available installment plans for specific Alternative Payment Methods (APMs), such as NuPay."
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "publicApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key"
+      },
+      "privateSecretKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key"
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Account-Code"
+      }
+    }
+  },
+  "security": [
+    {
+      "publicApiKey": [],
+      "privateSecretKey": [],
+      "accountCode": []
+    }
+  ],
+  "paths": {
+    "/apm-installments": {
+      "post": {
+        "summary": "Retrieve APM Installments",
+        "description": "Retrieve available installment plans for specific Alternative Payment Methods (APMs). This is useful for integrations like NuPay, where you may want to present installment options to the customer before finalizing the payment.",
+        "operationId": "retrieve-apm-installments",
+        "tags": [
+          "Installments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "country",
+                  "amount",
+                  "payment_method"
+                ],
+                "properties": {
+                  "country": {
+                    "type": "string",
+                    "description": "ISO 3166-1 alpha-2 country code (e.g., BR).",
+                    "example": "BR"
+                  },
+                  "amount": {
+                    "type": "object",
+                    "required": [
+                      "currency",
+                      "value"
+                    ],
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "description": "ISO 4217 currency code.",
+                        "example": "BRL"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "Amount in minor units.",
+                        "example": "25000"
+                      }
+                    }
+                  },
+                  "customer": {
+                    "type": "object",
+                    "description": "Customer data. Can include id or email and document details.",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Yuno customer ID.",
+                        "example": "c9d0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f"
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email",
+                        "example": "customer@example.com"
+                      },
+                      "document": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "CPF",
+                              "CNPJ"
+                            ],
+                            "example": "CPF"
+                          },
+                          "number": {
+                            "type": "string",
+                            "example": "00000000000"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "payment_method": {
+                    "type": "string",
+                    "description": "The specific NuPay method.",
+                    "enum": [
+                      "NU_PAY",
+                      "NU_PAY_ENROLLMENT"
+                    ],
+                    "example": "NU_PAY_ENROLLMENT"
+                  },
+                  "vaulted_token": {
+                    "type": "string",
+                    "description": "Required for enrollment flow.",
+                    "example": "vaulted_token_uuid"
+                  }
+                }
+              },
+              "examples": {
+                "EnrollmentFlow": {
+                  "summary": "Enrollment Flow",
+                  "value": {
+                    "country": "BR",
+                    "amount": {
+                      "currency": "BRL",
+                      "value": "25000"
+                    },
+                    "customer": {
+                      "id": "c9d0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f"
+                    },
+                    "payment_method": "NU_PAY_ENROLLMENT",
+                    "vaulted_token": "vaulted_token_uuid"
+                  }
+                },
+                "TwoFAMode": {
+                  "summary": "2FA Mode",
+                  "value": {
+                    "country": "BR",
+                    "payment_method": "NU_PAY",
+                    "amount": {
+                      "currency": "BRL",
+                      "value": "25000"
+                    },
+                    "customer": {
+                      "email": "customer@example.com",
+                      "document": {
+                        "type": "CPF",
+                        "number": "00000000000"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of available installment plans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "installment": {
+                        "type": "integer"
+                      },
+                      "amount": {
+                        "type": "object",
+                        "properties": {
+                          "currency": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "rate": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "installment": 1,
+                    "amount": {
+                      "currency": "BRL",
+                      "value": 25000
+                    },
+                    "rate": 1
+                  },
+                  {
+                    "installment": 3,
+                    "amount": {
+                      "currency": "BRL",
+                      "value": 25000
+                    },
+                    "rate": 1.05
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/installments/apm-installments.mdx
+++ b/reference/installments/apm-installments.mdx
@@ -1,0 +1,76 @@
+---
+title: "APM Installments"
+---
+
+The `apm-installments` endpoint allows you to retrieve available installment plans for specific Alternative Payment Methods (APMs). This is particularly useful for integrations like NuPay, where you may want to present installment options to the customer before finalizing the payment.
+
+### Usage Scenarios
+
+Depending on your integration flow, you will use this endpoint differently:
+
+*   **Enrollment Flow**: Used when a customer has already enrolled their NuPay account. You'll need to provide the `vaulted_token` and the customer `id`.
+*   **2FA Mode (Direct)**: Used for direct integrations where you collect customer details (email/document) to initiate a two-factor authentication flow.
+
+### Request Examples
+
+<Tabs>
+  <Tab title="Enrollment Flow">
+    ```bash
+    curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+    --header 'public-api-key: {{your_public_api_key}}' \
+    --header 'private-secret-key: {{your_secret_api_key}}' \
+    --header 'X-account-code: {{your_account_code}}' \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "country": "BR",
+      "amount": {
+        "currency": "BRL",
+        "value": "25000"
+      },
+      "customer": {
+        "id": "{{customer_id}}"
+      },
+      "payment_method": "NU_PAY_ENROLLMENT",
+      "vaulted_token": "{{vaulted_token}}"
+    }'
+    ```
+  </Tab>
+  <Tab title="2FA Mode">
+    ```bash
+    curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+    --header 'public-api-key: {{your_public_api_key}}' \
+    --header 'private-secret-key: {{your_secret_api_key}}' \
+    --header 'X-account-code: {{your_account_code}}' \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "country": "BR",
+      "payment_method": "NU_PAY",
+      "amount": {
+        "currency": "BRL",
+        "value": "25000"
+      },
+      "customer": {
+        "email": "customer@example.com",
+        "document": {
+          "type": "CPF",
+          "number": "00000000000"
+        }
+      }
+    }'
+    ```
+  </Tab>
+</Tabs>
+
+### Main Parameters
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `country` | `string` | ISO 3166-1 alpha-2 country code (e.g., `BR`). |
+| `amount` | `object` | Contains `currency` (ISO 4217) and `value` (amount in minor units). |
+| `customer` | `object` | Customer data. Can include `id` or `email` and `document` details. |
+| `payment_method` | `string` | The specific NuPay method: `NU_PAY` or `NU_PAY_ENROLLMENT`. |
+| `vaulted_token` | `string` | Required for enrollment flow. |
+
+<Note>
+This endpoint is currently specific to certain APMs. For standard credit card installments, please refer to the [Installments Plan](/reference/installments/get-installments-plan) documentation.
+</Note>

--- a/reference/installments/apm-installments.mdx
+++ b/reference/installments/apm-installments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "APM Installments"
+openapi: "/openapi/installments/apm-installments.json POST /apm-installments"
 ---
 
 The `apm-installments` endpoint allows you to retrieve available installment plans for specific Alternative Payment Methods (APMs). This is particularly useful for integrations like NuPay, where you may want to present installment options to the customer before finalizing the payment.
@@ -10,66 +11,6 @@ Depending on your integration flow, you will use this endpoint differently:
 
 *   **Enrollment Flow**: Used when a customer has already enrolled their NuPay account. You'll need to provide the `vaulted_token` and the customer `id`.
 *   **2FA Mode (Direct)**: Used for direct integrations where you collect customer details (email/document) to initiate a two-factor authentication flow.
-
-### Request Examples
-
-<Tabs>
-  <Tab title="Enrollment Flow">
-    ```bash
-    curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
-    --header 'public-api-key: {{your_public_api_key}}' \
-    --header 'private-secret-key: {{your_secret_api_key}}' \
-    --header 'X-account-code: {{your_account_code}}' \
-    --header 'Content-Type: application/json' \
-    --data '{
-      "country": "BR",
-      "amount": {
-        "currency": "BRL",
-        "value": "25000"
-      },
-      "customer": {
-        "id": "{{customer_id}}"
-      },
-      "payment_method": "NU_PAY_ENROLLMENT",
-      "vaulted_token": "{{vaulted_token}}"
-    }'
-    ```
-  </Tab>
-  <Tab title="2FA Mode">
-    ```bash
-    curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
-    --header 'public-api-key: {{your_public_api_key}}' \
-    --header 'private-secret-key: {{your_secret_api_key}}' \
-    --header 'X-account-code: {{your_account_code}}' \
-    --header 'Content-Type: application/json' \
-    --data '{
-      "country": "BR",
-      "payment_method": "NU_PAY",
-      "amount": {
-        "currency": "BRL",
-        "value": "25000"
-      },
-      "customer": {
-        "email": "customer@example.com",
-        "document": {
-          "type": "CPF",
-          "number": "00000000000"
-        }
-      }
-    }'
-    ```
-  </Tab>
-</Tabs>
-
-### Main Parameters
-
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `country` | `string` | ISO 3166-1 alpha-2 country code (e.g., `BR`). |
-| `amount` | `object` | Contains `currency` (ISO 4217) and `value` (amount in minor units). |
-| `customer` | `object` | Customer data. Can include `id` or `email` and `document` details. |
-| `payment_method` | `string` | The specific NuPay method: `NU_PAY` or `NU_PAY_ENROLLMENT`. |
-| `vaulted_token` | `string` | Required for enrollment flow. |
 
 <Note>
 This endpoint is currently specific to certain APMs. For standard credit card installments, please refer to the [Installments Plan](/reference/installments/get-installments-plan) documentation.


### PR DESCRIPTION

## PR description

## Summary

I identified that the `/reference/apm-installments` page was missing from the repository, so I created the missing MDX file and updated the navigation in `docs.json` to resolve the broken link in the NuPay guide.

**Changes:**
- **New Reference Page**: Created `reference/installments/apm-installments.mdx` with technical details for Enrollment and 2FA flows.
- **Navigation Update**: Added the new page to the "Installments" dropdown in `docs.json`.
- **Link Resolution**: Resolved the broken link in `docs/wallets/nupay.mdx` by providing the missing reference file.

**Note on Verification:**
I couldn't fully verify the 404 removal via `mint broken-links` because the tool is currently reporting over 400 unrelated errors caused by a malformed `openapi.json` file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change (new reference page/spec plus navigation/link updates) with no runtime or API behavior impact.
> 
> **Overview**
> Adds a new API reference page for `POST /apm-installments`, backed by a new OpenAPI spec (`openapi/installments/apm-installments.json`) describing request/response schemas and examples for NuPay enrollment and 2FA flows.
> 
> Updates docs navigation (`docs.json`) to include the new Installments page and fixes the NuPay guide (`docs/wallets/nupay.mdx`) to link to `/reference/installments/apm-installments` and list it in the related endpoints section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737181f1c60f5cb1e6acbb90a8b6f53f9f38ba9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->