### PR TITLE
docs: add valid icon for Sellers (Franchise) section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -440,7 +440,7 @@
           },
           {
             "dropdown": "Sellers (Franchise)",
-            "icon": "building-store",
+            "icon": "shopping-bag",
             "pages": [
               "reference/sellers/manage-sellers",
               "reference/sellers/the-seller-object",


### PR DESCRIPTION
## PR description

## Summary

I identified that the "Sellers (Franchise)" navigation section in `docs.json` was using an invalid icon name (`building-store`), which prevented it from rendering correctly in the sidebar. I've updated it to use `shopping-bag`.

**Changes:**
- **Navigation Update**: Changed `"icon": "building-store"` to `"icon": "shopping-bag"` for the Sellers dropdown in `docs.json`.
- **Consistency**: The new icon is visually distinct from the "Recipients" icon while maintaining a commerce-related theme.

**Verification:**
Validated the change using the local Mintlify development server to ensure the icon renders correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that only affects sidebar rendering for a single navigation item.
> 
> **Overview**
> Fixes the API Reference sidebar navigation by updating the `Sellers (Franchise)` dropdown icon in `docs.json` from an invalid value to `shopping-bag`, restoring correct icon rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2c6ab411d851a82b31563ce5f8632fb577132e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->