### PR TITLE
docs(ai): add mcp support docs and discoverability callouts

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -208,6 +208,7 @@
             "anchor": "AI Capabilities",
             "icon": "robot",
             "pages": [
+              "mcp",
               "docs/ai-capabilities/aida-ai-agent",
               "docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp",
               "docs/ai-capabilities/remote-yuno-mcp-server",

--- a/docs/how-yuno-works/what-is-yuno.mdx
+++ b/docs/how-yuno-works/what-is-yuno.mdx
@@ -2,6 +2,10 @@
 title: "What is Yuno?"
 ---
 
+<Info>
+  **Pro-tip for Developers**: You can connect your AI agent (Cursor, Windsurf, Claude) directly to these docs for real-time assistance. [Learn how to setup MCP](/mcp).
+</Info>
+
 Yuno allows businesses to accept all available payment methods and manage fraud detection and prevention through a single integration. It solves common challenges in payment performance and customer experience, such as:
 
 * Low approval rates

--- a/index.mdx
+++ b/index.mdx
@@ -7,4 +7,27 @@ import {HeroSection} from '/snippets/homepage/HeroSection.jsx';
 import {FeatureCards} from '/snippets/homepage/FeatureCards.jsx';
 
 <HeroSection />
+
+<div className="bg-[#f8f9fa] dark:bg-[#1a1b20] pt-10 pb-0 px-5 -mb-10 relative z-10">
+  <div className="max-w-[1200px] mx-auto">
+    <div className="bg-white dark:bg-[#282a30] border border-gray-200 dark:border-[#3a3c44] rounded-xl p-6 flex flex-col sm:flex-row items-center justify-between shadow-[0_4px_20px_rgba(0,0,0,0.04)] hover:shadow-[0_4px_25px_rgba(61,79,223,0.1)] transition-shadow">
+      <div className="flex items-center gap-4 mb-4 sm:mb-0">
+        <div className="bg-[#3d4fdf]/10 dark:bg-[#3d4fdf]/20 p-3 rounded-xl text-[#3d4fdf] dark:text-[#7a8aef]">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7">
+            <path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM6.166 18.894a.75.75 0 0 0 1.06 1.06l1.59-1.591a.75.75 0 1 0-1.06-1.061l-1.59 1.59ZM2.25 12a.75.75 0 0 1 .75-.75H5.25a.75.75 0 0 1 0 1.5H3a.75.75 0 0 1-.75-.75ZM6.166 5.106a.75.75 0 0 0-1.06 1.06l1.59 1.591a.75.75 0 1 0 1.06-1.061l-1.59-1.59Z" />
+          </svg>
+        </div>
+        <div>
+          <div className="font-bold text-[#111827] dark:text-[#ededf0] text-lg">AI-Powered Coding</div>
+          <div className="text-[#6b7280] dark:text-[#9899a3] text-[15px] mt-1">
+            Link Yuno's documentation directly to your local AI agent (Cursor, Windsurf) for real-time assistance.
+          </div>
+        </div>
+      </div>
+      <a href="/mcp" className="inline-flex items-center gap-2 px-6 py-3 bg-[#3d4fdf] hover:bg-[#3242b8] text-white text-sm font-semibold rounded-lg transition-colors no-underline whitespace-nowrap shadow-sm dark:bg-[#3d4fdf] dark:hover:bg-[#4d60ef]">
+        Setup MCP →
+      </a>
+    </div>
+  </div>
+</div>
 <FeatureCards />

--- a/mcp.mdx
+++ b/mcp.mdx
@@ -1,0 +1,52 @@
+---
+title: "Model Context Protocol (MCP)"
+description: "Connect your AI coding agents directly to Yuno's documentation."
+---
+
+The Model Context Protocol (MCP) allows AI tools like **Cursor**, **Windsurf**, and **Claude** to browse, search, and read Yuno's documentation in real-time. This ensures your AI assistant always has the latest context when helping you integrate Yuno.
+
+## Documentation MCP URL
+Use the following URL to connect your tools to the Yuno documentation:
+
+[https://docs.y.uno/mcp](https://docs.y.uno/mcp)  
+
+---
+
+## Connecting to AI Tools
+
+### Cursor
+1. Open **Cursor Settings** (`Cmd+Shift+P` or `Ctrl+Shift+P` -> "Open MCP Settings").
+2. Click on **+ Add New MCP Server**.
+3. Fill in the details:
+   - **Name**: Yuno Docs
+   - **Type**: `http`
+   - **URL**: `https://docs.y.uno/mcp`
+4. Click **Save**.
+
+### Claude Desktop
+1. Open your Claude Desktop configuration file (usually `~/Library/Application Support/Claude/claude_desktop_config.json` or `%APPDATA%\Claude\claude_desktop_config.json`).
+2. Add the Yuno Docs connector to the `mcpServers` section:
+
+```json
+{
+  "mcpServers": {
+    "yuno-docs": {
+      "url": "https://docs.y.uno/mcp"
+    }
+  }
+}
+```
+
+### Windsurf / VS Code Copilot  
+For tools that support native MCP via folder configuration, create a `.vscode/mcp.json` file in your project:  
+
+```json
+{
+  "servers": {
+    "yuno-docs": {
+      "type": "http",
+      "url": "https://docs.y.uno/mcp"
+    }
+  }
+}
+```


### PR DESCRIPTION

## PR description

## Summary

Adds documentation and discoverability callouts for connecting local AI agents (Cursor, Windsurf, Claude) to the Yuno documentation via the Model Context Protocol (MCP).

**Changes:**
- **New Page**: Added `mcp.mdx` with connection instructions (Cursor, Claude, Windsurf).
- **Discoverability**: 
  - Added `<Info>` block to `what-is-yuno.mdx` for Pro-tip setup.
  - Implemented a custom styled Tailwind card banner in `index.mdx` (between the Hero section and Feature Cards) for maximum visibility without layout breakage.
- **Navigation**: Updated `docs.json` to include the MCP page under "AI Capabilities".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; main risk is minor navigation/homepage layout regressions due to the new custom banner markup.
> 
> **Overview**
> Adds a new `mcp.mdx` page documenting how to connect AI coding tools (Cursor/Claude/Windsurf) to Yuno docs via the MCP endpoint.
> 
> Improves discoverability by linking to `/mcp` from both the `What is Yuno?` intro page (new `<Info>` callout) and the homepage (new styled banner card), and registers `mcp` in `docs.json` navigation under **AI Capabilities**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130e16f0c94e9b7bc3a45defa3bbbcdbf5b74516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->