### PR TITLE
docs(api): add payment_method_type to installment plans

### DIFF
--- a/openapi/installments/create-installments-plan.json
+++ b/openapi/installments/create-installments-plan.json
@@ -185,6 +185,14 @@
                         "format": "date-time"
                       }
                     }
+                  },
+                  "payment_method_type": {
+                    "type": "string",
+                    "description": "Allows specifying the payment method type when creating an installment plan.",
+                    "enum": [
+                      "CARD",
+                      "NU_PAY_ENROLLMENT"
+                    ]
                   }
                 }
               },
@@ -237,7 +245,8 @@
                     "availability": {
                       "start_at": "2023-09-12T00:00:00Z",
                       "finish_at": "2030-09-20T00:00:00Z"
-                    }
+                    },
+                    "payment_method_type": "NU_PAY_ENROLLMENT"
                   }
                 }
               }
@@ -318,6 +327,7 @@
                         "start_at": "2023-09-12T00:00:00Z",
                         "finish_at": "2030-09-20T00:00:00Z"
                       },
+                      "payment_method_type": "NU_PAY_ENROLLMENT",
                       "created_at": "2023-10-11T17:52:31.886178246Z",
                       "updated_at": "2023-10-11T17:52:31.886178246Z"
                     }
@@ -471,6 +481,10 @@
                     "updated_at": {
                       "type": "string",
                       "example": "2023-10-11T17:52:31.886178246Z"
+                    },
+                    "payment_method_type": {
+                      "type": "string",
+                      "example": "NU_PAY_ENROLLMENT"
                     }
                   }
                 }

--- a/openapi/installments/get-installments-plan-by-account.json
+++ b/openapi/installments/get-installments-plan-by-account.json
@@ -70,6 +70,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "payment_method_type",
+            "in": "query",
+            "description": "[Optional] - Filter by payment method type (CARD | NU_PAY_ENROLLMENT).",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -164,7 +172,8 @@
                           "finish_at": "2030-09-20T00:00:00Z"
                         },
                         "created_at": "2023-10-11T17:52:31.886178Z",
-                        "updated_at": "2023-10-11T17:52:31.886178Z"
+                        "updated_at": "2023-10-11T17:52:31.886178Z",
+                        "payment_method_type": "NU_PAY_ENROLLMENT"
                       }
                     ]
                   }
@@ -305,6 +314,10 @@
                       "updated_at": {
                         "type": "string",
                         "example": "2023-10-11T17:52:31.886178Z"
+                      },
+                      "payment_method_type": {
+                        "type": "string",
+                        "example": "NU_PAY_ENROLLMENT"
                       }
                     }
                   }

--- a/openapi/installments/get-installments-plan.json
+++ b/openapi/installments/get-installments-plan.json
@@ -140,7 +140,8 @@
                           "finish_at": "2030-09-20T00:00:00Z"
                         },
                         "created_at": "2023-10-11T17:52:31.886178Z",
-                        "updated_at": "2023-10-11T17:52:31.886178Z"
+                        "updated_at": "2023-10-11T17:52:31.886178Z",
+                        "payment_method_type": "NU_PAY_ENROLLMENT"
                       }
                     ]
                   }
@@ -257,6 +258,10 @@
                       "updated_at": {
                         "type": "string",
                         "example": "2023-10-11T17:52:31.886178Z"
+                      },
+                      "payment_method_type": {
+                        "type": "string",
+                        "example": "NU_PAY_ENROLLMENT"
                       }
                     }
                   }


### PR DESCRIPTION
## Summary

This PR adds the optional field `payment_method_type` to the Installment Plans API documentation to allow users to specify or filter by specific payment method types (e.g., `CARD`, `NU_PAY_ENROLLMENT`).


**Changes:**
- **POST /v1/installments-plans**: Added field to request body, response body, and updated examples.
- **GET /v1/installments-plans/{id}**: Added field to response body and updated examples.
- **GET /v1/installments-plans**: Added query parameter and response body field. Updated examples.

**Pages:**
- `openapi/installments/create-installments-plan.json`
- `openapi/installments/get-installments-plan.json`
- `openapi/installments/get-installments-plan-by-account.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI/documentation-only updates that add an optional field and filter; no runtime logic changes.
> 
> **Overview**
> Documents a new optional `payment_method_type` field for installment plans across the OpenAPI specs.
> 
> `POST /installments-plans` now accepts `payment_method_type` (enum: `CARD`, `NU_PAY_ENROLLMENT`) and returns it in the 200 response schema/examples. The `GET` endpoints (`/installments-plans/{installment_code}` and `/installments-plans` by account) now include `payment_method_type` in response schemas/examples, and the account-scoped list adds an optional `payment_method_type` query filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e9c37c295e5872813b3142c3307710dd48a8370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->