### PR TITLE
docs: remove OTT step from direct integration guides

### DIFF
--- a/docs/direct-integration-use-cases/create-payment-basic.mdx
+++ b/docs/direct-integration-use-cases/create-payment-basic.mdx
@@ -24,6 +24,14 @@ Make sure to complete these requirements before following the create payment gui
 Yuno provides [Postman Collections](/reference/postman-collections) that you can use to replicate the use cases locally.
 </Note>
 
+<Warning>
+**Enable Yuno Test Payment Gateway**
+
+To test a simple card payment in the **sandbox environment**, you must first enable the [Yuno Test Payment Gateway](/docs/direct-integration-use-cases/yuno-testing-gateway). This connection simulates a provider and allows you to verify your direct integration without using real card data.
+</Warning>
+
+
+
 ## Steps summary
 
 The create payment process normally requires finishing the two steps listed below.

--- a/docs/direct-integration-use-cases/create-payment-basic.mdx
+++ b/docs/direct-integration-use-cases/create-payment-basic.mdx
@@ -14,9 +14,9 @@ Before starting following the steps described in this guide, you need to:
   * `account_id`
 * [Set up your connections](/docs/using-yuno/dashboard-overview/connections) on your Yuno Dashboard account.
 * [Build a route](/docs/using-yuno/dashboard-overview/routing) for the payment method to define how it will be processed.
-* [Configure the checkout builder](/docs/using-yuno/dashboard-overview/checkout-builder) to make your connected payments available.
 
 Make sure to complete these requirements before following the create payment guide.
+
 
 <Note>
 **Explore Yuno Postman Collections**
@@ -26,11 +26,12 @@ Yuno provides [Postman Collections](/reference/postman-collections) that you can
 
 ## Steps summary
 
-The create payment process normally requires finishing the four steps listed below.
+The create payment process normally requires finishing the two steps listed below.
+
 
 1. [Create a customer](/reference/customers/create-customer)
-2. [Create a checkout session](/reference/checkout-sessions/create-checkout-session)
-3. [Create the payment](#step-3-create-a-payment)
+2. [Create the payment](#step-2-create-a-payment)
+
 
 
 <Note>
@@ -56,37 +57,31 @@ If you add optional information, be aware of the required mandatory fields.
 At the end of the create a customer process, you will receive an `id`, which identifies the user within the Yuno system. Use the `id` to initialize the checkout.
 
 If you are creating a payment for an existing user who was previously created and already had an `id` you can skip this step.
+### Step 2: Create a payment
 
-### Step 2: Create a checkout session
-
-With a customer registered, you can create a checkout session. The checkout is when the customer finalizes their order and proceeds to pay for the products or services they wish to acquire. Therefore, at this stage, you will provide information regarding the payment amount and the location where it is being created.
-
-Use the [Create Checkout Session](/reference/create-checkout-session) endpoint. Notice that the `customer_id` required to perform the request is the `id` you received when creating the customer in [Step 1](/docs/create-payment-basic#1-create-a-customer).
-
-From the request response to the  [Create Checkout Session](/reference/checkout-sessions/create-checkout-session) endpoint, you will receive the `checkout_session` information. It will be used to create the payment on the next step.
-
-
-
-### Step 3: Create a payment
 
 You will create a payment using the endpoint [Create Payment](/reference/payments/create-payment). With Yuno, you can create payments with several payment methods, using 3DS or split payments. However, this guide focuses on a simple payment without additional authentication, validation, or enrollment requirements.
 
 Below, you find a deeper description of how to create a payment.
 
-#### 4.1 Provide the required attributes
+#### 2.1 Provide the required attributes
 
-Provide customer-related information, including the `checkout_session` from Step 2 through `checkout.session` and `customer_payer` object that contains the `id` from Step 1.
+
+Provide customer-related information, including the `customer_payer` object that contains the `id` from Step 1.
+
 
 Certain objects are not mandatory when creating a payment. However, if you provide this information, the user’s payment experience will be enhanced. Be aware of the mandatory fields if you wish to provide this information.
 
-#### 4.2 Choose the capture type
+#### 2.2 Choose the capture type
+
 
 Yuno provides two options for payment capture:
 
 * Single-step: Authorization and capture are performed simultaneously. You only need to create the payment. The authorization and capture are performed automatically. For the single-step option, you need to send the attribute `capture` as `true` on the request.
 * Two steps: Authorization and capture are performed at different moments. After creating the payment, you will need to perform an authorization request and a capture request.  If you wish to process the payment in Two Steps, send `capture` as `false` and after creating the payment, use the [Authorize Payment](/reference/payments/authorize-payment) and the [Capture Authorization](/reference/payments/capture-authorization) to complete the process.
 
-#### 4.3 Additional features
+#### 2.3 Additional features
+
 
 Yuno also lets you use some additional features that are supported in the basic payment creation process:
 
@@ -99,7 +94,7 @@ Both fields can be found in the payment\_method detail section of the payment.
   To generate and receive a <code>vaulted\_token</code> when <code>vault\_on\_success = true</code>, the payment must reference an existing Yuno customer through <code>customer\_payer.id</code>. Creating or sending the customer data inline inside the payment request does not create the customer on our side, so no vaulting will occur. When these conditions are met and the payment status is <code>SUCCEEDED</code>, the <code>vaulted\_token</code> will be returned in the payment response and can be used for future transactions.
 </Note>
 
-### Step 4: Check the payment status
+### Step 3: Check the payment status
 
 After performing the request to the [Create Payment](/reference/payments/create-payment) endpoint, you can check the payment status by analyzing the `status` and `sub_status` from the response. Check the page [Payment Status](/reference/payments/status-and-response-codes/payment) to see all options you can receive in response to the payment creation request.
 

--- a/docs/direct-integration-use-cases/create-payment-basic.mdx
+++ b/docs/direct-integration-use-cases/create-payment-basic.mdx
@@ -30,8 +30,8 @@ The create payment process normally requires finishing the four steps listed bel
 
 1. [Create a customer](/reference/customers/create-customer)
 2. [Create a checkout session](/reference/checkout-sessions/create-checkout-session)
-3. [Create a one-time token](#step-3-create-a-one-time-token-ott)
-4. [Create the payment](/reference/payments/create-payment)
+3. [Create the payment](#step-3-create-a-payment)
+
 
 <Note>
 **Additional payment methods and functionalities**
@@ -63,27 +63,11 @@ With a customer registered, you can create a checkout session. The checkout is w
 
 Use the [Create Checkout Session](/reference/create-checkout-session) endpoint. Notice that the `customer_id` required to perform the request is the `id` you received when creating the customer in [Step 1](/docs/create-payment-basic#1-create-a-customer).
 
-From the request response to the  [Create Checkout Session](/reference/checkout-sessions/create-checkout-session) endpoint, you will receive the `checkout_session` information. It will be used to create the one-time token (OTT) and the payment on the next steps.
+From the request response to the  [Create Checkout Session](/reference/checkout-sessions/create-checkout-session) endpoint, you will receive the `checkout_session` information. It will be used to create the payment on the next step.
 
-### Step 3: Create a one-time token (OTT)
 
-A one-time token is a unique identifier Yuno generates to protect your customer privacy and security. It serves as an identifier for payment details and prevents sensitive data from being stored on your servers. Therefore, you can use one-time tokens to make it simple for your customers to repeat payments without re-entering their payment information, making the process more secure and convenient.
 
-You will always get the one-time token from the Yuno SDK on your application. By using Yuno's SDK we take care of every particular scenario that different payment methods could have. This allows us to:
-
-* Ask for missing information for the enrolled payment method in case the selected provider in the CARD route needs some additional fields.
-* Support fraud screening
-* Support 3DS
-
-You can always use the list [Payment type](/reference/payment-type-list) to check all available payment types. In the response of the SDK, you will receive the `one-time-token`, which you will use to create the payment.
-
-<Note>
-**Testing credit card payments**
-
-Remember that for testing credit card payments you can set the [Yuno Test Payment Gateway](/docs/direct-integration-use-cases/yuno-testing-gateway) as a provider in your Card route.
-</Note>
-
-### Step 4: Create a payment
+### Step 3: Create a payment
 
 You will create a payment using the endpoint [Create Payment](/reference/payments/create-payment). With Yuno, you can create payments with several payment methods, using 3DS or split payments. However, this guide focuses on a simple payment without additional authentication, validation, or enrollment requirements.
 
@@ -115,7 +99,7 @@ Both fields can be found in the payment\_method detail section of the payment.
   To generate and receive a <code>vaulted\_token</code> when <code>vault\_on\_success = true</code>, the payment must reference an existing Yuno customer through <code>customer\_payer.id</code>. Creating or sending the customer data inline inside the payment request does not create the customer on our side, so no vaulting will occur. When these conditions are met and the payment status is <code>SUCCEEDED</code>, the <code>vaulted\_token</code> will be returned in the payment response and can be used for future transactions.
 </Note>
 
-### Step 5: Check the payment status
+### Step 4: Check the payment status
 
 After performing the request to the [Create Payment](/reference/payments/create-payment) endpoint, you can check the payment status by analyzing the `status` and `sub_status` from the response. Check the page [Payment Status](/reference/payments/status-and-response-codes/payment) to see all options you can receive in response to the payment creation request.
 

--- a/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
+++ b/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
@@ -75,8 +75,8 @@ The create payment process normally requires finishing the four steps listed bel
 
 1. [Create a customer](/reference/create-customer)
 2. [Create a checkout session](/reference/create-checkout-session)
-3. [Create a One-Time Token](#3-create-a-one-time-token-ott)
-4. [Create the payment](/reference/create-payment)
+3. [Create the payment](/reference/create-payment)
+
 
 ### Create a payment
 
@@ -106,15 +106,11 @@ When creating the route, you can define conditions that work as filters. If you 
 
 Use the [Create Checkout Session](/reference/create-checkout-session) endpoint. Notice that the `customer_id` required to perform the request is the `id` you received when creating the customer in [Step 1](/docs/yuno-testing-gateway#1-create-a-customer).
 
-From the request response to the  [Create Checkout Session](/reference/create-checkout-session) endpoint, you will receive the `checkout_session` information. It will be used to create the one-time token (OTT) and the payment on the next steps.
+From the request response to the  [Create Checkout Session](/reference/create-checkout-session) endpoint, you will receive the `checkout_session` information. It will be used to create the payment on the next steps.
 
-#### 3. Create a one-time token (OTT)
 
-An OTT is a unique identifier Yuno generates to protect your customer privacy and security. It serves as an identifier for payment details and prevents sensitive data from being stored on your servers. Therefore, you can use OTTs to make it simple for your customers to repeat payments without re-entering their payment information, making the process more secure and convenient.
 
-You will always get the OTT from the Yuno SDK on your production application. However, to make it easier for you to test the payment creation process, Yuno provides the [Create OTT]() endpoint. You will need to provide the  `checkout_session` received in [Step 2](/docs/yuno-testing-gateway#2-create-a-checkout-session) and define the payment type as `CARD` through the `type` parameter.  In the response, you will receive the `one-time-token`, which you will use to create the payment.
-
-#### 4. Create a payment
+#### 3. Create a payment
 
 You will create a payment using the [Create Payment endpoint](/reference/create-payment). Below you find a deeper description of how to create a payment.
 
@@ -139,9 +135,8 @@ When creating the payment, you need to inform which integration from Yuno you ar
 * `DIRECT`: If you are using a back-to-back integration. To use this workflow, you need to be PCI compliant.
 * `REDIRECT`: If you are using a back-to-back integration and provider redirection.
 
-#### 4.4 Provide the payment method information
+Inform the payment method information through the object `payment_method`. Select the payment `type` equal to `CARD` based on the [Payment type list](/reference/payment-type-list). In addition, you need to add the card information on the object `detail.card`.
 
-Inform the payment method information through the object `payment_method`. Here, you will provide the `one-time-token` through the attribute `token` and select the payment `type` equal to `CARD`, the one informed in  [Step 3](/docs/yuno-testing-gateway#3-create-a-one-time-token-ott), based on the [Payment type list](/reference/payment-type-list). In addition, you need to add the card information on the object `detail.card`.
 
 You can use the payment description or specific card data to get the desired result when you test payment with Yuno Test Payment Gateway. The following sections describe in detail each approach.
 

--- a/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
+++ b/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
@@ -69,13 +69,11 @@ Before starting following the steps described in this guide, you need to:
 * [Build a route](/docs/routing#configuring-the-dynamic-routing) for the Yuno Testing Gateway to define it as your card payment provider. You find a step-by-step guide on how to do it in the Set up the [Yuno Testing Gateway section](/docs/yuno-testing-gateway#set-up-the-yuno-test-payment-gateway).
 * [Configure the checkout builder](/docs/checkout-builder) to make the Yuno Testing Gateway available.
 
-### Steps summary
-
-The create payment process normally requires finishing the four steps listed below.
+The create payment process normally requires finishing the two steps listed below.
 
 1. [Create a customer](/reference/create-customer)
-2. [Create a checkout session](/reference/create-checkout-session)
-3. [Create the payment](/reference/create-payment)
+2. [Create the payment](/reference/create-payment)
+
 
 
 ### Create a payment
@@ -94,40 +92,26 @@ At the end of the create a customer process, you will receive an `id`, which ide
 
 If you are creating a payment for an existing user who was previously created and already has an `id`, you can skip this step.
 
-#### 2. Create a checkout session
-
-With a customer registered, you can create a checkout session. The checkout is when the customer finalizes their order and proceeds to pay for the products or services they wish to acquire. Therefore, at this stage, you will provide information regarding the payment amount and the location where it is being created.
-
-<Warning>
-**Route Conditions Filtering**
-
-When creating the route, you can define conditions that work as filters. If you have used country as a condition, check if the provided country when creating the checkout session is on the condition list. Otherwise, the card payment may not be processed by the Yuno Testing Gateway.
-</Warning>
-
-Use the [Create Checkout Session](/reference/create-checkout-session) endpoint. Notice that the `customer_id` required to perform the request is the `id` you received when creating the customer in [Step 1](/docs/yuno-testing-gateway#1-create-a-customer).
-
-From the request response to the  [Create Checkout Session](/reference/create-checkout-session) endpoint, you will receive the `checkout_session` information. It will be used to create the payment on the next steps.
 
 
 
-#### 3. Create a payment
+#### 2. Create a payment
 
 You will create a payment using the [Create Payment endpoint](/reference/create-payment). Below you find a deeper description of how to create a payment.
 
-#### 4.1 Provide the required attributes
+Provide customer-related information, including the `customer_payer` object that contains the `id` from Step 1.
 
-Provide customer-related information, including the `checkout_session` from Step 2 through `checkout.session` and `customer_payer` object that contains the `id` from Step 1.
 
 Certain objects are not mandatory when creating a payment. However, if you provide this information, the user’s payment experience will be enhanced. Be aware of the mandatory fields if you wish to provide this information.
 
-#### 4.2 Choose the capture type
+#### 2.1 Choose the capture type
 
 Yuno provides two options for payment capture:
 
 * Single-step: Authorization and capture are performed simultaneously. You only need to create the payment. The authorization and capture are performed automatically. For the single-step option, you need to send the `capture` attribute as `true` on the request.
 * Two steps: Authorization and capture are performed at different moments. After creating the payment, you will need to perform an authorization request and a capture request. If you wish to process the payment in Two Steps, send `capture` as `false` and after creating the payment, use the [Authorize Payment](/reference/authorize-payment) and the [Capture Authorization](/reference/capture-authorization) to complete the process.
 
-#### 4.3 Define the payment workflow
+#### 2.2 Define the payment workflow
 
 When creating the payment, you need to inform which integration from Yuno you are using. When creating a payment, you must inform it through the `workflow` attribute, which can be:
 
@@ -146,11 +130,11 @@ You can use the payment description or specific card data to get the desired res
 Yuno system follows a sequential process, initially examining card data and subsequently evaluating the provided description. Consequently, if there is a disparity in the status indicated by the card data and the description for a testing payment, Yuno will prioritize and reflect the status associated with the card data.
 </Note>
 
-##### 4.4.1 - Payment Description
+##### 2.2.1 - Payment Description
 
 To get the desired payment result using the payment description, you need to define the expected result as the description of the payment you create. For example, if you are testing a payment and expect a successful result, the payment description should be "SUCCEEDED". You will find all available options in the [Transaction Codes](/reference/transaction#transaction-codes) section.
 
-##### 4.4.2 - Card detail
+##### 2.2.2 - Card detail
 
 Another option to get the expected payment results is to use one of the testing cards provided by Yuno. In the tables below, you find a list of cards and their data details to use when using the Yuno Testing Gateway. The **Transaction Response Code** column defines the returned payment status when you use the corresponding card.
 
@@ -560,7 +544,7 @@ Another option to get the expected payment results is to use one of the testing 
 </Accordion>
 </AccordionGroup>
 
-#### 4.4.3 - 3DS Test Cards
+#### 2.2.3 - 3DS Test Cards
 
 Use these cards and OTP codes to test 3DS flows through our preview environment using a Netcetera Demo Merchant (NDM) Simulator, which is configured to mock a Directory Server and/or ACS with predefined schemes and testing card numbers. It does not reach external test DS/ACS, it only helps complete 3DS flows for testing purposes.
 

--- a/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
+++ b/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
@@ -6,7 +6,8 @@ While Yuno provides diverse payment options, the basic payment process always fo
 
 ## The Yuno payment process
 
-The payment process consists of four steps:
+The payment process consisting of the following steps:
+
 
 <Steps>
   <Step title="Create a customer">
@@ -17,20 +18,25 @@ The payment process consists of four steps:
     </Note>
   </Step>
   <Step title="Create a checkout session">
-    To process a payment, create a [checkout session](/docs/sessions#checkout-session). This session connects the customer to the payment and stores key transaction details. Yuno loads all available [payment methods](/docs/payment-methods) linked to your account.
+    To process a payment with Yuno SDK or Checkout, create a [checkout session](/docs/sessions#checkout-session). This session connects the customer to the payment and stores key transaction details. Yuno loads all available [payment methods](/docs/payment-methods) linked to your account.
     <Note>
-      If your customer wishes to enroll a payment method, you'll create a [customer session](/docs/sessions#customer-session) instead.
+      Direct/Server-to-server integrations normally skip this step and provide the transaction details directly during payment creation.
     </Note>
+
   </Step>
   <Step title="Collect payment details">
-    To process a payment, you need to collect the customer's payment information. This can be done by using Yuno's SDKs, which securely capture sensitive data and generate a one-time token (OTT), or by providing the payment details directly if you are using a server-to-server integration.
+    To process a payment, you need to collect the customer's payment information. 
+    * **SDK Integration**: Yuno's SDKs securely capture sensitive data and generate a one-time token (OTT).
+    * **Direct Integration**: You collect the payment details directly on your servers (requiring PCI compliance) and send them to the payment endpoint.
     <Note>
       An OTT is a temporary, single-use code used by Yuno SDKs to enhance security and simplify the integration for merchants.
     </Note>
   </Step>
 
+
   <Step title="Create the payment">
-    A [payment](/docs/payments-1) represents the final transaction. Use the data collected in the previous steps (connected customer and payment information) to process the payment within the checkout session.
+    A [payment](/docs/payments-1) represents the final transaction. Use the data collected in the previous steps (customer ID and payment information) to process the final transaction.
+
     <Note>
       Certain fields are optional but can enhance user experience. Consider mandatory fields if you decide to include this information.
     </Note>

--- a/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
+++ b/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
@@ -20,7 +20,7 @@ The payment process consisting of the following steps:
   <Step title="Create a checkout session">
     To process a payment with Yuno SDK or Checkout, create a [checkout session](/docs/sessions#checkout-session). This session connects the customer to the payment and stores key transaction details. Yuno loads all available [payment methods](/docs/payment-methods) linked to your account.
     <Note>
-      Direct/Server-to-server integrations normally skip this step and provide the transaction details directly during payment creation.
+      Direct/Server-to-server integrations skip this step and provide the transaction details directly during payment creation.
     </Note>
 
   </Step>

--- a/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
+++ b/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
@@ -22,14 +22,15 @@ The payment process consists of four steps:
       If your customer wishes to enroll a payment method, you'll create a [customer session](/docs/sessions#customer-session) instead.
     </Note>
   </Step>
-  <Step title="Create a one-time token">
-    A [one-time token](/docs/tokens) (OTT) enhances payment security by protecting sensitive information. To generate it, provide the customer identification, checkout session, and selected payment method.
+  <Step title="Collect payment details">
+    To process a payment, you need to collect the customer's payment information. This can be done by using Yuno's SDKs, which securely capture sensitive data and generate a one-time token (OTT), or by providing the payment details directly if you are using a server-to-server integration.
     <Note>
-      An OTT is a temporary, single-use code that prevents unauthorized reuse and blocking fraud.
+      An OTT is a temporary, single-use code used by Yuno SDKs to enhance security and simplify the integration for merchants.
     </Note>
   </Step>
+
   <Step title="Create the payment">
-    A [payment](/docs/payments-1) represents the final transaction. Use the data collected in the previous steps (connected customer and valid OTT) to process the payment within the checkout session.
+    A [payment](/docs/payments-1) represents the final transaction. Use the data collected in the previous steps (connected customer and payment information) to process the payment within the checkout session.
     <Note>
       Certain fields are optional but can enhance user experience. Consider mandatory fields if you decide to include this information.
     </Note>

--- a/snippets/GenericOrientation.mdx
+++ b/snippets/GenericOrientation.mdx
@@ -1,0 +1,5 @@
+<Warning>
+  **Looking for the fastest way to integrate?**
+  We recommend using our [Standard Integration (Full Checkout)](/checkout/full-checkout) for the best experience.
+  If you need a more customized checkout flow, you are in the right place!
+</Warning>

--- a/snippets/LegacyOrientation.mdx
+++ b/snippets/LegacyOrientation.mdx
@@ -1,0 +1,5 @@
+<Warning>
+  **This SDK is now Legacy.**
+  We recommend using our [Full Checkout](/checkout/full-checkout) for a more modern and supported integration.
+  If you are currently using this SDK and have questions, please contact our support team.
+</Warning>


### PR DESCRIPTION
## Summary

Following the latest feedback from the product team, this PR removes BOTH the **Checkout Session** and **One-Time Token (OTT)** steps from the Direct Integration (server-to-server) guides.

As confirmed by the team, Direct flows (Full API / PCI compliant) do not require these mechanisms, which are primarily designed for internal SDK usage. Removing them simplifies the integration path and prevents "endpoint fragmentation" and 404 errors for Full API customers.


**Changes:**
- **create-payment-basic.mdx**: Removed Steps 2 (Session) and 3 (OTT). Renumbered the guide to a streamlined 2-step process (Customer -> Payment).
- **yuno-testing-gateway.mdx**: Removed Session and OTT steps. Updated the payment creation example to remove `checkout.session` and `token` attributes.
- **how-yuno-payment-flow-works.mdx**: Broadened the high-level description for Steps 2 and 3, clarifying they are used for SDK/Checkout flows and can be skipped in Direct integrations.

**Pages:**
- [docs/direct-integration-use-cases/create-payment-basic.mdx](file:///home/damo/001-docs-repos/101-wc-internal-docs/0001-yuno-docs-project/005-yuno-mintlify-docs/docs/direct-integration-use-cases/create-payment-basic.mdx)
- [docs/direct-integration-use-cases/yuno-testing-gateway.mdx](file:///home/damo/001-docs-repos/101-wc-internal-docs/0001-yuno-docs-project/005-yuno-mintlify-docs/docs/direct-integration-use-cases/yuno-testing-gateway.mdx)
- [docs/how-yuno-works/how-yuno-payment-flow-works.mdx](file:///home/damo/001-docs-repos/101-wc-internal-docs/0001-yuno-docs-project/005-yuno-mintlify-docs/docs/how-yuno-works/how-yuno-payment-flow-works.mdx)
