### PR TITLE
docs(api): remove events object from dry-run provider events response

### DIFF
--- a/openapi/dry-run/register-dry-run-provider-event.json
+++ b/openapi/dry-run/register-dry-run-provider-event.json
@@ -289,8 +289,7 @@
           "status",
           "merchant_reference",
           "provider_id",
-          "payment_method_type",
-          "events"
+          "payment_method_type"
         ],
         "properties": {
           "id": {
@@ -322,25 +321,6 @@
           },
           "payment_method_type": {
             "type": "string"
-          },
-          "events": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "type"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "REQUEST",
-                    "RESPONSE",
-                    "WEBHOOK"
-                  ]
-                }
-              }
-            }
           }
         }
       },


### PR DESCRIPTION
## Summary

This adjustment removes the `events` field from the response payload of the `POST /v1/dry-run/provider-events` endpoint to match the final API implementation.

**Changes:**
- Updated `openapi/dry-run/register-dry-run-provider-event.json`: Removed the `events` field from the `DryRunResponse` schema (both in `properties` and `required`).

**Pages:**
- /reference/dry-run/register-dry-run-provider-event

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/schema-only change that narrows the documented response shape, with no runtime logic changes.
> 
> **Overview**
> Updates the OpenAPI schema for `POST /v1/dry-run/provider-events` so `DryRunResponse` no longer includes an `events` field (removed from both `required` and `properties`), aligning the documented response with the implemented API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91293910b2de7fa7dd531cf74a9a9a4b569b7552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->