### PR TITLE
docs(sdk): fix method names, async patterns, and version refs across all platforms

### DIFF
--- a/docs/sdks/customization/secure-fields/enrollment-secure-fields.mdx
+++ b/docs/sdks/customization/secure-fields/enrollment-secure-fields.mdx
@@ -113,7 +113,7 @@ const secureNumber = secureFields.create({
   },
 })
 
-secureNumber.render('#pan')
+await secureNumber.render('#pan')
 
 const secureExpiration = secureFields.create({
   name: 'expiration',
@@ -141,7 +141,7 @@ const secureExpiration = secureFields.create({
   },
 })
 
-secureExpiration.render('#expiration')
+await secureExpiration.render('#expiration')
 
 const secureCvv = secureFields.create({
   name: 'cvv',
@@ -169,7 +169,7 @@ const secureCvv = secureFields.create({
   },
 })
 
-secureCvv.render('#cvv')
+await secureCvv.render('#cvv')
 
 ```
 

--- a/docs/sdks/customization/secure-fields/payment-secure-fields.mdx
+++ b/docs/sdks/customization/secure-fields/payment-secure-fields.mdx
@@ -127,7 +127,7 @@ const secureNumber = secureFields.create({
     },
   })
 
-  secureNumber.render('#pan')
+  await secureNumber.render('#pan')
 
   const secureExpiration = secureFields.create({
     name: 'expiration',
@@ -156,7 +156,7 @@ const secureNumber = secureFields.create({
     },
   })
 
-  secureExpiration.render('#expiration')
+  await secureExpiration.render('#expiration')
 
 
   const secureCvv = secureFields.create({
@@ -186,7 +186,7 @@ const secureNumber = secureFields.create({
     },
   })
 
-  secureCvv.render('#cvv')
+  await secureCvv.render('#cvv')
 ```
 
 Below, you can see a GIF showing how you can configure the secure-fields:

--- a/docs/sdks/headless-android/checkout.mdx
+++ b/docs/sdks/headless-android/checkout.mdx
@@ -109,7 +109,7 @@ Add the Yuno SDK dependency to your application in the `build.gradle` file:
 
 ```kotlin
 dependencies {
-    implementation 'com.yuno.payments:android-sdk:{last_version}'
+    implementation 'com.yuno.payments:android-sdk:2.11.0'
 }
 ```
 

--- a/docs/sdks/headless-android/enrollment.mdx
+++ b/docs/sdks/headless-android/enrollment.mdx
@@ -107,7 +107,7 @@ maven { url "https://yunopayments.jfrog.io/artifactory/snapshots-libs-release" }
 
 ```kotlin
 dependencies {
-    implementation 'com.yuno.payments:android-sdk:{last_version}'
+    implementation 'com.yuno.payments:android-sdk:2.11.0'
 }
 ```
 

--- a/docs/sdks/headless-ios/checkout.mdx
+++ b/docs/sdks/headless-ios/checkout.mdx
@@ -31,7 +31,7 @@ You can install Yuno SDK in two ways:
 
 * **Cocoapods**: If you do not have a Podfile, follow the [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html) guide to create one. After creating the Podfile, you will integrate the Yuno SDK with Cocoapods by adding the line below to your Podfile:
   ```ruby
-  pod 'YunoSDK', '~> 2.11.1'
+  pod 'YunoSDK', '~> 2.14.2'
   ```
 * **[Swift Package Manager](https://www.swift.org/package-manager/)**: Set up the Swift package, and then add Yuno SDK as a dependency, as presented in the following code block:
   ```swift

--- a/docs/sdks/headless-ios/checkout.mdx
+++ b/docs/sdks/headless-ios/checkout.mdx
@@ -31,12 +31,12 @@ You can install Yuno SDK in two ways:
 
 * **Cocoapods**: If you do not have a Podfile, follow the [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html) guide to create one. After creating the Podfile, you will integrate the Yuno SDK with Cocoapods by adding the line below to your Podfile:
   ```ruby
-  pod 'YunoSDK', '~> {last_version}'
+  pod 'YunoSDK', '~> 2.11.1'
   ```
 * **[Swift Package Manager](https://www.swift.org/package-manager/)**: Set up the Swift package, and then add Yuno SDK as a dependency, as presented in the following code block:
   ```swift
   dependencies: [
-      .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "{last_version}"))
+      .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.11.1"))
   ]
   ```
 

--- a/docs/sdks/headless-ios/enrollment.mdx
+++ b/docs/sdks/headless-ios/enrollment.mdx
@@ -33,7 +33,7 @@ You can install Yuno SDK in two ways:
 
 * **Cocoapods**: If you do not have a Podfile, follow the [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html) guide to create one. After creating the Podfile, you will integrate the Yuno SDK with Cocoapods by adding the line below to your Podfile:
   ```ruby
-  pod 'YunoSDK', '~> 2.11.1'
+  pod 'YunoSDK', '~> 2.14.2'
   ```
 * **[Swift Package Manager](https://www.swift.org/package-manager/)**: Set up the Swift package, and then add Yuno SDK as a dependency, as presented in the following code block:
   ```swift

--- a/docs/sdks/headless-ios/enrollment.mdx
+++ b/docs/sdks/headless-ios/enrollment.mdx
@@ -33,12 +33,12 @@ You can install Yuno SDK in two ways:
 
 * **Cocoapods**: If you do not have a Podfile, follow the [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html) guide to create one. After creating the Podfile, you will integrate the Yuno SDK with Cocoapods by adding the line below to your Podfile:
   ```ruby
-  pod 'YunoSDK', '~> {last_version}'
+  pod 'YunoSDK', '~> 2.11.1'
   ```
 * **[Swift Package Manager](https://www.swift.org/package-manager/)**: Set up the Swift package, and then add Yuno SDK as a dependency, as presented in the following code block:
   ```swift
   dependencies: [
-      .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "{last_version}"))
+      .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.11.1"))
   ]
   ```
 

--- a/docs/sdks/lite-android/checkout.mdx
+++ b/docs/sdks/lite-android/checkout.mdx
@@ -55,7 +55,7 @@ Include the following code in the `build.gradle` file to add the Yuno SDK depend
 
 ```kotlin
 dependencies {
-    implementation 'com.yuno.payments:android-sdk:{last_version}'
+    implementation 'com.yuno.payments:android-sdk:2.11.0'
 }
 ```
 

--- a/docs/sdks/lite-ios/checkout.mdx
+++ b/docs/sdks/lite-ios/checkout.mdx
@@ -20,7 +20,7 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 Add the following line to your Podfile:
 
 ```ruby
-pod 'YunoSDK', '~> 2.11.1'
+pod 'YunoSDK', '~> 2.14.2'
 ```
 
 ### Swift Package Manager

--- a/docs/sdks/lite-ios/checkout.mdx
+++ b/docs/sdks/lite-ios/checkout.mdx
@@ -20,7 +20,7 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 Add the following line to your Podfile:
 
 ```ruby
-pod 'YunoSDK', '~> 1.1.22'
+pod 'YunoSDK', '~> 2.11.1'
 ```
 
 ### Swift Package Manager
@@ -28,7 +28,7 @@ pod 'YunoSDK', '~> 1.1.22'
 Add `YunoSDK` as a dependency:
 
 ```swift
-.package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "1.1.17"))
+.package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.11.1"))
 ```
 
 ## Step 2: Initialize SDK

--- a/docs/sdks/lite-web/enrollment.mdx
+++ b/docs/sdks/lite-web/enrollment.mdx
@@ -58,7 +58,7 @@ After creating the customer, you can create the customer session. Use the custom
 Use the configuration below to provide a lite and user-friendly enrollment experience for your customers:
 
 ```javascript
-await yuno.mountEnrollment({
+await yuno.mountEnrollmentLite({
   customerSession: "438413b7-4921-41e4-b8f3-28a5a0141638",
   elementSelector: "#root",
   countryCode: "US",
@@ -82,7 +82,7 @@ await yuno.mountEnrollment({
 });
 ```
 
-When using `mountEnrollment`, specify the callbacks to handle enrollment. You can also customize the interface using the `texts` objects.
+When using `mountEnrollmentLite`, specify the callbacks to handle enrollment. You can also customize the interface using the `texts` objects.
 
 ### Parameters
 
@@ -110,7 +110,7 @@ Common status values include `ENROLLED`, `DECLINED`, `CANCELED`, and `ERROR`.
 
 ## Step 5: Initiate the enrollment (Required)
 
-After mounting the SDK using `await yuno.mountEnrollment()`, the form will be displayed in the specified element. The user can then proceed with entering their payment method details to complete the enrollment.
+After mounting the SDK using `await yuno.mountEnrollmentLite()`, the form will be displayed in the specified element. The user can then proceed with entering their payment method details to complete the enrollment.
 
 <Note>
 **Demo App**

--- a/docs/sdks/lite-web/enrollment.mdx
+++ b/docs/sdks/lite-web/enrollment.mdx
@@ -77,7 +77,7 @@ await yuno.mountEnrollmentLite({
   },
   yunoError(error, data) {
     console.error("An error occurred:", error);
-    await yuno.hideLoader();
+    yuno.hideLoader();
   },
 });
 ```

--- a/docs/sdks/overview/quickstart.mdx
+++ b/docs/sdks/overview/quickstart.mdx
@@ -184,7 +184,7 @@ Choose your platform and follow the steps to start process your first payments w
     }
 
     dependencies {
-        implementation 'com.yuno.payments:android-sdk:2.9.0'
+        implementation 'com.yuno.payments:android-sdk:2.11.0'
     }
     ```
 

--- a/docs/sdks/seamless-sdk/android-payments.mdx
+++ b/docs/sdks/seamless-sdk/android-payments.mdx
@@ -136,7 +136,7 @@ Include the following code in the `build.gradle` file to add the Yuno SDK depend
 
 ```kotlin
 dependencies {
-    implementation 'com.yuno.payments:android-sdk:{last_version}'
+    implementation 'com.yuno.payments:android-sdk:2.11.0'
 }
 ```
 

--- a/docs/sdks/seamless-sdk/ios-payments.mdx
+++ b/docs/sdks/seamless-sdk/ios-payments.mdx
@@ -31,7 +31,7 @@ You can add the library using CocoaPods or Swift Package Manager.
 To add the Yuno SDK to your iOS project, you need to install the Yuno SDK. If you do not have a Podfile, follow the [CocoaPods guide](https://guides.cocoapods.org/using/using-cocoapods.html) to create one. After creating the Podfile, you will integrate the Yuno SDK with Cocoapods by adding the line below to your Podfile.
 
 ```ruby
-pod 'YunoSDK', '~> 2.11.1'
+pod 'YunoSDK', '~> 2.14.2'
 ```
 
 After, you need to run the installation:
@@ -46,7 +46,7 @@ If you are using the [Swift Package Manager](https://www.swift.org/package-manag
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.11.1"))
+    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.14.2"))
 ]
 ```
 

--- a/docs/sdks/seamless-sdk/ios-payments.mdx
+++ b/docs/sdks/seamless-sdk/ios-payments.mdx
@@ -31,7 +31,7 @@ You can add the library using CocoaPods or Swift Package Manager.
 To add the Yuno SDK to your iOS project, you need to install the Yuno SDK. If you do not have a Podfile, follow the [CocoaPods guide](https://guides.cocoapods.org/using/using-cocoapods.html) to create one. After creating the Podfile, you will integrate the Yuno SDK with Cocoapods by adding the line below to your Podfile.
 
 ```ruby
-pod 'YunoSDK', '~> 1.19.0'
+pod 'YunoSDK', '~> 2.11.1'
 ```
 
 After, you need to run the installation:
@@ -46,7 +46,7 @@ If you are using the [Swift Package Manager](https://www.swift.org/package-manag
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "1.1.17"))
+    .package(url: "https://github.com/yuno-payments/yuno-sdk-ios.git", .upToNextMajor(from: "2.11.1"))
 ]
 ```
 


### PR DESCRIPTION
## Summary

Cross-platform SDK documentation audit (CORECM-16997) — fixes discrepancies found by comparing public documentation against SDK source of truth (published types, READMEs, and sample apps) across all six SDK platforms.

### Changes by Platform

**Web SDK (3 files)**
- Fixed `mountEnrollment` → `mountEnrollmentLite` in Lite enrollment docs (method name mismatch — would break integration)
- Added missing `await` on `SecureField.render()` calls in both Secure Fields payment and enrollment guides (`render()` returns `Promise<void>` per `types.ts`)

**iOS SDK (4 files)**
- Updated severely outdated SDK versions:
  - Lite iOS: `1.1.22` → `2.11.1` (CocoaPods), `1.1.17` → `2.11.1` (SPM)
  - Seamless iOS: `1.19.0` → `2.11.1` (CocoaPods), `1.1.17` → `2.11.1` (SPM)
  - Headless iOS (payment + enrollment): replaced `{last_version}` placeholders with `2.11.1`

**Android SDK (4 files)**
- Updated Quickstart guide from `2.9.0` → `2.11.0` (matching Full Checkout docs)
- Replaced `{last_version}` placeholders with `2.11.0` in Headless (payment + enrollment), Lite, and Seamless SDK docs

**Audit Methodology:**
- Web: compared all code snippets against `yuno-sdk-web/typescript/types.ts` and vanilla sample apps
- iOS: compared against `yuno-ios` podspec, README, and latest release tags
- Android: compared against `android-sdk` README and production release tags
- Follows the established fix pattern from PR #294

### Files Changed (12)

| Category | File | Fix |
|----------|------|-----|
| Web — Secure Fields | `customization/secure-fields/payment-secure-fields.mdx` | Add `await` to `render()` |
| Web — Secure Fields | `customization/secure-fields/enrollment-secure-fields.mdx` | Add `await` to `render()` |
| Web — Lite Enrollment | `lite-web/enrollment.mdx` | `mountEnrollment` → `mountEnrollmentLite` |
| iOS — Lite | `lite-ios/checkout.mdx` | Version `1.1.22` → `2.11.1` |
| iOS — Seamless | `seamless-sdk/ios-payments.mdx` | Version `1.19.0` → `2.11.1` |
| iOS — Headless Payment | `headless-ios/checkout.mdx` | Replace `{last_version}` → `2.11.1` |
| iOS — Headless Enrollment | `headless-ios/enrollment.mdx` | Replace `{last_version}` → `2.11.1` |
| Android — Quickstart | `overview/quickstart.mdx` | Version `2.9.0` → `2.11.0` |
| Android — Headless Payment | `headless-android/checkout.mdx` | Replace `{last_version}` → `2.11.0` |
| Android — Headless Enrollment | `headless-android/enrollment.mdx` | Replace `{last_version}` → `2.11.0` |
| Android — Lite | `lite-android/checkout.mdx` | Replace `{last_version}` → `2.11.0` |
| Android — Seamless | `seamless-sdk/android-payments.mdx` | Replace `{last_version}` → `2.11.0` |

## Test plan

- [x] Verify `mountEnrollmentLite` method name matches `types.ts` line 682 in `yuno-sdk-web`
- [x] Verify `SecureField.render()` returns `Promise<void>` (types.ts line 279) justifying `await`
- [x] Verify iOS SDK version 2.11.1 is a valid release tag in `yuno-ios`
- [x] Verify Android SDK version 2.11.0 is a valid production release in `android-sdk`
- [ ] Confirm no remaining `{last_version}` placeholders in SDK docs
- [ ] Check that code snippets in modified files are syntactically valid

Refs: CORECM-16997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this PR only updates documentation, but it can affect integrators if the updated method names/async usage or pinned SDK versions are incorrect.
> 
> **Overview**
> Updates SDK docs to match current SDK APIs and version references across platforms.
> 
> Web docs now `await` `SecureField.render()` in Secure Fields enrollment/payment examples and correct Lite Web enrollment to use `mountEnrollmentLite` (and removes an unnecessary `await` on `hideLoader()`). Mobile docs replace `{last_version}`/outdated values with pinned versions (Android `2.11.0`; iOS pod `2.14.2` and SPM `2.11.1`/`2.14.2`) including the Android quickstart and headless/lite/seamless install snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb7cfb8634aa8a136937ac86789cf22a507f43d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->