### PR TITLE
docs(api): make payment_method_type and provider_id optional in dry-run request/response

### DIFF
--- a/openapi/dry-run/register-dry-run-provider-event.json
+++ b/openapi/dry-run/register-dry-run-provider-event.json
@@ -118,8 +118,6 @@
         "type": "object",
         "required": [
           "merchant_reference",
-          "provider_id",
-          "payment_method_type",
           "events"
         ],
         "properties": {
@@ -287,9 +285,7 @@
         "required": [
           "id",
           "status",
-          "merchant_reference",
-          "provider_id",
-          "payment_method_type"
+          "merchant_reference"
         ],
         "properties": {
           "id": {

--- a/reference/dry-run/register-dry-run-provider-event.mdx
+++ b/reference/dry-run/register-dry-run-provider-event.mdx
@@ -47,5 +47,4 @@ Use `X-Idempotency-Key` for safe retries. Same key + same payload returns the or
 
 - `merchant_reference` is always required and uniquely identifies the order on your side. Yuno uses it to resolve the event to a payment asynchronously when `payment_id` is not supplied.
 - `payment_id`, if supplied, is resolved immediately. If the id is unknown for your account the request returns `404 PAYMENT_NOT_FOUND`.
-- `provider_id` + `payment_method_type` together identify which integration surface the dry-run exercises (e.g. `stripe` + `CARD`).
-
+- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (e.g. `stripe` + `CARD`). if omitted, Yuno uses the information from the associated payment.


### PR DESCRIPTION
## Summary

This adjustment makes the `payment_method_type` and `provider_id` fields optional in both `DryRunRequest` and `DryRunResponse` schemas for the `POST /v1/dry-run/provider-events` endpoint, as requested by Palo.

**Changes:**
- Updated `openapi/dry-run/register-dry-run-provider-event.json`: Removed `payment_method_type` and `provider_id` from the `required` array in `DryRunRequest` and `DryRunResponse` schemas.

**Pages:**
- /reference/dry-run/register-dry-run-provider-event

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/OpenAPI schema change that only relaxes required fields for one endpoint. Main risk is client confusion if consumers assumed these fields are always returned/populated.
> 
> **Overview**
> Updates the `POST /v1/dry-run/provider-events` OpenAPI schemas so `provider_id` and `payment_method_type` are **no longer required** in `DryRunRequest` or `DryRunResponse`.
> 
> Documentation is adjusted to state these fields are *optional* and, when omitted, Yuno will infer them from the associated payment during correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d99a64911ce1c6d6108ba72197d3db7add63814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->