### PR TITLE
docs(release-notes): update android sdk release notes v2.13.0 - v2.13.4

### DIFF
--- a/docs/sdks/resources/release-notes/android.mdx
+++ b/docs/sdks/resources/release-notes/android.mdx
@@ -10,6 +10,11 @@ The Android SDK release notes offer a comprehensive overview of the updates, imp
 
 | Version   | Changes                                                                                                                                                                     |
 | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.13.4    | **IMPROVE**: Apply merchant custom `fontFamily` from `YunoConfig.styles` across all SDK components                                                                          |
+| 2.13.3    | **IMPROVE**: WebView loading state polish                                                                                                                                   |
+| 2.13.2    | **IMPROVE**: 3DS redirect handling for broader provider compatibility                                                                                                       |
+| 2.13.1    | **IMPROVE**: Loader timing behavior in extended payment flows                                                                                                               |
+| 2.13.0    | **NEW**: Support Keeploader                                                                                                                                                 |
 | 2.12.0    | **NEW**: Add dynamic base URL based on region prefix                                                                                                                       |
 |           | **NEW**: Add `payment_method` query param to issuers endpoint                                                                                                              |
 |           | **NEW**: Support alphanumeric CNPJ validation                                                                                                                              |


### PR DESCRIPTION
## Summary

This PR updates the Android SDK release notes to include versions **2.13.0** through **2.13.4**, documenting recent improvements in UI, provider compatibility, and new feature support.

**Changes:**
- Added 5 new entries to the Android release notes table in `docs/sdks/resources/release-notes/android.mdx`.
- Highlights include:
    - Support for merchant custom `fontFamily` from `YunoConfig.styles`.
    - WebView and loader UI polish.
    - Improved 3DS redirect handling.
    - New support for **Keeploader**.

**Pages:**
- `docs/sdks/resources/release-notes/android.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates release note text without affecting runtime behavior.
> 
> **Overview**
> Updates `docs/sdks/resources/release-notes/android.mdx` to add Android SDK release note entries for versions `2.13.0` through `2.13.4`, documenting the new Keeploader support plus UI/flow improvements (loader/WebView polish, broader 3DS redirect compatibility, and applying merchant `fontFamily` styling across SDK components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed532b0505930e4d933ec469133da8606274e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->