### PR TITLE
docs(api): fix register provider example consistency

### DIFF
--- a/openapi/dry-run/register-dry-run-provider-event.json
+++ b/openapi/dry-run/register-dry-run-provider-event.json
@@ -125,21 +125,25 @@
             "type": "string",
             "minLength": 3,
             "maxLength": 255,
-            "description": "Merchant-assigned identifier (MAX 255; MIN 3). Unique per account."
+            "description": "Merchant-assigned identifier (MAX 255; MIN 3). Unique per account.",
+            "example": "ORD-12345"
           },
           "payment_id": {
             "type": "string",
             "format": "uuid",
-            "description": "Yuno payment UUID. If supplied, resolved immediately."
+            "description": "Yuno payment UUID. If supplied, resolved immediately.",
+            "example": "fb9e5fa4-684c-4747-9755-9d332617f16f"
           },
           "account_id": {
             "type": "string",
             "format": "uuid",
-            "description": "Yuno account UUID — same shape as account_id in POST /v1/payments."
+            "description": "Yuno account UUID — same shape as account_id in POST /v1/payments.",
+            "example": "a389f417-ecd1-4355-89f5-7489564f264d"
           },
           "provider_id": {
             "type": "string",
             "description": "Provider identifier. Allowed values aligned to the Yuno catalog.",
+            "example": "STRIPE",
             "enum": [
               "STRIPE",
               "ADYEN",
@@ -197,6 +201,7 @@
           "payment_method_type": {
             "type": "string",
             "description": "Payment method exercised by this dry-run. Same vocabulary as payment_method.type in POST /v1/payments.",
+            "example": "CARD",
             "enum": [
               "",
               "CARD",
@@ -219,7 +224,17 @@
             "description": "1–10 HTTP exchange entries for this dry-run (MAX 10; MIN 1).",
             "items": {
               "$ref": "#/components/schemas/Event"
-            }
+            },
+            "example": [
+              {
+                "type": "REQUEST",
+                "http_method": "POST",
+                "base_url": "https://api.stripe.com",
+                "endpoint": "/v1/charges",
+                "headers": "eyBDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24gfQ==",
+                "body": "eyBhbW91bnQ6IDIwMDAsIGN1cnJlbmN5OiAidXNkIiB9"
+              }
+            ]
           }
         }
       },
@@ -238,7 +253,8 @@
               "RESPONSE",
               "WEBHOOK"
             ],
-            "description": "Which leg of the exchange this entry captures."
+            "description": "Which leg of the exchange this entry captures.",
+            "example": "REQUEST"
           },
           "http_method": {
             "type": "string",
@@ -248,16 +264,19 @@
               "PUT",
               "PATCH",
               "DELETE"
-            ]
+            ],
+            "example": "POST"
           },
           "base_url": {
             "type": "string",
             "format": "uri",
-            "description": "Required for REQUEST and WEBHOOK. Origin of the provider endpoint — scheme + host + port (e.g. https://api.stripe.com)."
+            "description": "Required for REQUEST and WEBHOOK. Origin of the provider endpoint — scheme + host + port (e.g. https://api.stripe.com).",
+            "example": "https://api.stripe.com"
           },
           "endpoint": {
             "type": "string",
-            "description": "Required for REQUEST and WEBHOOK. Path and query portion (e.g. /v1/charges?expand=customer)."
+            "description": "Required for REQUEST and WEBHOOK. Path and query portion (e.g. /v1/charges?expand=customer).",
+            "example": "/v1/charges"
           },
           "http_status_code": {
             "type": "integer",
@@ -270,13 +289,15 @@
             "type": "string",
             "format": "byte",
             "maxLength": 87400,
-            "description": "Base64-encoded header payload. Decoded content may be a JSON-serialized\n`{header-name: header-value}` map or the raw HTTP header block. Hard\ncap: 64 KB of decoded bytes per event.\n"
+            "description": "Base64-encoded header payload. Decoded content may be a JSON-serialized\n`{header-name: header-value}` map or the raw HTTP header block. Hard\ncap: 64 KB of decoded bytes per event.\n",
+            "example": "eyBDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24gfQ=="
           },
           "body": {
             "type": "string",
             "format": "byte",
             "maxLength": 1398000,
-            "description": "Base64-encoded body payload. Omit for empty bodies. Hard cap: 1 MB of\ndecoded bytes per event. For non-UTF-8 bodies (protobuf, gzip),\nbase64-encode the raw bytes directly.\n"
+            "description": "Base64-encoded body payload. Omit for empty bodies. Hard cap: 1 MB of\ndecoded bytes per event. For non-UTF-8 bodies (protobuf, gzip),\nbase64-encode the raw bytes directly.\n",
+            "example": "eyBhbW91bnQ6IDIwMDAsIGN1cnJlbmN5OiAidXNkIiB9"
           }
         }
       },
@@ -290,33 +311,40 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Public identifier of the dry-run registration (nano_id, 21 chars)."
+            "description": "Public identifier of the dry-run registration (nano_id, 21 chars).",
+            "example": "dry_run_01j5v8xpt2v0b"
           },
           "status": {
             "type": "string",
             "enum": [
               "REGISTERED"
             ],
-            "description": "Lifecycle state."
+            "description": "Lifecycle state.",
+            "example": "REGISTERED"
           },
           "merchant_reference": {
-            "type": "string"
+            "type": "string",
+            "example": "ORD-12345"
           },
           "payment_id": {
             "type": "string",
             "format": "uuid",
-            "nullable": true
+            "nullable": true,
+            "example": "fb9e5fa4-684c-4747-9755-9d332617f16f"
           },
           "account_id": {
             "type": "string",
             "format": "uuid",
-            "nullable": true
+            "nullable": true,
+            "example": "a389f417-ecd1-4355-89f5-7489564f264d"
           },
           "provider_id": {
-            "type": "string"
+            "type": "string",
+            "example": "STRIPE"
           },
           "payment_method_type": {
-            "type": "string"
+            "type": "string",
+            "example": "CARD"
           }
         }
       },


### PR DESCRIPTION
## Summary

This PR addresses technical inconsistencies in the "Register provider" API examples identified via internal feedback. 

**Changes:**
- Updated `payment_id` and `account_id` in request/response examples to use distinct UUIDs to reflect realistic data.
- Refined the `events` array in the request example to properly demonstrate provider event "echoing".
- General cleanup of the example JSON structure for better readability.

**Pages:**
- Register provider (API Reference)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates OpenAPI schema examples/metadata and does not change runtime behavior or validation rules.
> 
> **Overview**
> Improves the `POST /dry-run/provider-events` OpenAPI spec by adding concrete `example` values across `DryRunRequest`, `Event`, and `DryRunResponse` fields (UUIDs, `provider_id`, `payment_method_type`, and base64-encoded payloads).
> 
> Refines the request `events` example to show a realistic provider request entry, making the documentation more consistent and usable for integrators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92e84537c9e6afe87f6f59ec6bfbb72ea42a5d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->