### PR TITLE
docs(api): add missing fields and acquirer filter to reports

### DIFF
--- a/openapi/reports/create-a-report.json
+++ b/openapi/reports/create-a-report.json
@@ -93,6 +93,10 @@
                     "type": "string",
                     "description": "Account identifier(s). Omit to include all accounts. For multiple accounts, send a comma-separated list. <br> Example: `19d28762-c714-4fb0-9ef6-4e1953ed33tf, 91d82267-c714-4fb0-9ef6-4e1953ed33tf`."
                   },
+                  "acquirer": {
+                    "type": "string",
+                    "description": "Filters the Settlements report by acquirer. Accepts a single value (case-insensitive; conventionally uppercase). <br> Example: `BAC_CREDOMATIC`"
+                  },
                   "payment_status": {
                     "type": "string",
                     "description": "The status of the payment (MAX 255; MIN 3; [Payment status](/reference/payment#payments-status)). Don't send this parameter to request the creation of a report for all payment status. Otherwise, indicate all the status you want to include. <br> Example: `CREATED,READY_TO_PAY,DECLINED`"

--- a/reference/reports/reports-fields.mdx
+++ b/reference/reports/reports-fields.mdx
@@ -274,6 +274,12 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>25</td>
             </tr>
             <tr>
+              <td><code>authorization_code</code></td>
+              <td>string</td>
+              <td>Authorization code returned by the acquirer / issuer when the transaction is approved. May be numeric or alphanumeric. Already documented in Transactions.</td>
+              <td>T60375</td>
+            </tr>
+            <tr>
               <td><code>amount_value</code></td>
               <td>number</td>
               <td>The payment amount (multiple of 0.0001).</td>
@@ -290,6 +296,24 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>string</td>
               <td>Name of the beneficiary for the transaction or payment.</td>
               <td>Jane Doe</td>
+            </tr>
+            <tr>
+              <td><code>billing_cycles_current</code></td>
+              <td>integer</td>
+              <td>Current billing cycle number (1-indexed) for subscription-backed payments.</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td><code>billing_cycles_next_at</code></td>
+              <td>datetime</td>
+              <td>Timestamp of the next scheduled billing for subscription-backed payments.</td>
+              <td>2027-04-10T10:14:39.515Z</td>
+            </tr>
+            <tr>
+              <td><code>billing_cycles_total</code></td>
+              <td>integer</td>
+              <td>Total number of billing cycles configured. <code>2000000</code> is a sentinel for indefinite (unlimited) subscription.</td>
+              <td>12</td>
             </tr>
             <tr>
               <td><code>bnpl_installments</code></td>
@@ -407,6 +431,12 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>US</td>
             </tr>
             <tr>
+              <td><code>connection_name</code></td>
+              <td>string</td>
+              <td>Merchant-assigned label of the provider connection (<code>account_integration</code>) through which the transaction was routed.</td>
+              <td>Rappi MX (#30441) 866b71f2db 1_9V4FF82f</td>
+            </tr>
+            <tr>
               <td><code>created_at</code></td>
               <td>timestamp</td>
               <td>The payment creation date (MAX 27; MIN 27; <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO
@@ -517,6 +547,12 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>123456789</td>
             </tr>
             <tr>
+              <td><code>metadata_value</code></td>
+              <td>string (json)</td>
+              <td>Custom metadata attached to the payment by the merchant at creation time, serialized as a JSON array of <code>{key, value}</code> objects.</td>
+              <td>[{"key":"order_ref","value":"20260100186943"}]</td>
+            </tr>
+            <tr>
               <td><code>nationality</code></td>
               <td>string</td>
               <td>Nationality of the individual.</td>
@@ -533,6 +569,24 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>string</td>
               <td>Unique identifier assigned to a transaction by the card network. It is used to track and reference specific transactions, particularly in recurring payment scenarios, ensuring consistency and traceability across the payment lifecycle. (MAX 255; MIN 3)</td>
               <td>NTX123456789</td>
+            </tr>
+            <tr>
+              <td><code>network_token_iin</code></td>
+              <td>string</td>
+              <td>IIN/BIN of the network token (DPAN) used in the transaction. First 8 digits of the tokenized PAN; differs from <code>card_iin</code>. Populated on network-tokenized transactions (Apple Pay / Google Pay).</td>
+              <td>51884710</td>
+            </tr>
+            <tr>
+              <td><code>network_token_last4</code></td>
+              <td>string</td>
+              <td>Last 4 digits of the network token PAN (DPAN). Differs from <code>card_lfd</code>. Populated on network-tokenized transactions.</td>
+              <td>8394</td>
+            </tr>
+            <tr>
+              <td><code>network_token_type</code></td>
+              <td>string</td>
+              <td>Funding type or card brand of the network token (<code>CREDIT</code>, <code>DEBIT</code>, <code>VISA</code>, <code>MASTERCARD</code>, <code>AMEX</code>, etc.). Populated primarily on Apple Pay (~99.9%); may be empty on Google Pay. <b>Note:</b> this field does NOT contain the wallet identifier (APPLE_PAY/GOOGLE_PAY) — use <code>payment_method_type</code> for that.</td>
+              <td>CREDIT</td>
             </tr>
             <tr>
               <td><code>order_fee_amount</code></td>
@@ -605,6 +659,12 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>string</td>
               <td>A unique identifier assigned to a specific payment transaction.</td>
               <td>69ad0a39-b769-423c-b223-d7b8bf</td>
+            </tr>
+            <tr>
+              <td><code>payment_method_type</code></td>
+              <td>string</td>
+              <td>Specific payment method used (<code>CARD</code>, <code>APPLE_PAY</code>, <code>PIX</code>, <code>NEQUI</code>, <code>YAPE</code>, <code>MERCADO_PAGO_WALLET</code>, <code>BANK_TRANSFER</code>, <code>GCASH</code>, <code>BOLETO</code>, <code>OXXO</code>, etc.).</td>
+              <td>APPLE_PAY</td>
             </tr>
             <tr>
               <td><code>payment_seller_details_address_city</code></td>
@@ -775,6 +835,12 @@ The report fields are subject to modifications, and new fields can be added to t
               <td>111aaa222</td>
             </tr>
             <tr>
+              <td><code>transaction_id</code></td>
+              <td>string (uuid)</td>
+              <td>Yuno's internal transaction identifier associated with the payment.</td>
+              <td>67d2c9dc-69c6-45b0-b07e-34e869f4d471</td>
+            </tr>
+            <tr>
               <td><code>updated_at</code></td>
               <td>timestamp</td>
               <td>The date and time of the last update for the payment.</td>
@@ -870,6 +936,24 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>John Doe</td>
       </tr>
       <tr>
+        <td><code>billing_cycles_current</code></td>
+        <td>integer</td>
+        <td>Current billing cycle number (1-indexed) for subscription-backed payments.</td>
+        <td>3</td>
+      </tr>
+      <tr>
+        <td><code>billing_cycles_next_at</code></td>
+        <td>datetime</td>
+        <td>Timestamp of the next scheduled billing for subscription-backed payments.</td>
+        <td>2027-04-10T10:14:39.515Z</td>
+      </tr>
+      <tr>
+        <td><code>billing_cycles_total</code></td>
+        <td>integer</td>
+        <td>Total number of billing cycles configured. <code>2000000</code> is a sentinel for indefinite (unlimited) subscription.</td>
+        <td>12</td>
+      </tr>
+      <tr>
         <td><code>capture</code></td>
         <td>boolean</td>
         <td>Indicates if the transaction is captured.</td>
@@ -904,6 +988,12 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>string</td>
         <td>Code of the card issuer (MAX 50; MIN 2).</td>
         <td>BCO001</td>
+      </tr>
+      <tr>
+        <td><code>card_issuer_country</code></td>
+        <td>string</td>
+        <td>ISO Alpha-2 country code of the issuing bank, derived from the card IIN.</td>
+        <td>MX</td>
       </tr>
       <tr>
         <td><code>card_issuer_name</code></td>
@@ -952,6 +1042,12 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>enum</td>
         <td>Country where the transaction occurred (MAX 2; MIN 2).</td>
         <td>UY</td>
+      </tr>
+      <tr>
+        <td><code>connection_name</code></td>
+        <td>string</td>
+        <td>Merchant-assigned label of the provider connection (<code>account_integration</code>) through which the transaction was routed.</td>
+        <td>Rappi MX (#30441) 866b71f2db 1_9V4FF82f</td>
       </tr>
       <tr>
         <td><code>created_at</code></td>
@@ -1014,6 +1110,12 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>No deferral</td>
       </tr>
       <tr>
+        <td><code>fingerprint_code</code></td>
+        <td>string (uuid)</td>
+        <td>Unique fingerprint of the card, used by Yuno to identify the same card across transactions without exposing PAN data.</td>
+        <td>5aa1d176-7460-4ca4-8579-17d92b32fec1</td>
+      </tr>
+      <tr>
         <td><code>fraud_screening_provider_score</code></td>
         <td>number</td>
         <td>Fraud screening score provided by the fraud detection system (MAX 100; MIN 0).</td>
@@ -1036,6 +1138,18 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>string</td>
         <td>Type of installments plan (MAX 50; MIN 3).</td>
         <td>Single payment</td>
+      </tr>
+      <tr>
+        <td><code>iso_code</code></td>
+        <td>string</td>
+        <td>ISO 8583 response code returned by the acquirer / network. <code>00</code>/<code>000</code> indicate approval.</td>
+        <td>00</td>
+      </tr>
+      <tr>
+        <td><code>iso_message</code></td>
+        <td>string</td>
+        <td>Response message associated with the ISO 8583 response.</td>
+        <td>Approved</td>
       </tr>
       <tr>
         <td><code>merchant_order_id</code></td>
@@ -1084,6 +1198,24 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>string</td>
         <td>Unique identifier assigned to a transaction by the card network. It is used to track and reference specific transactions, particularly in recurring payment scenarios, ensuring consistency and traceability across the payment lifecycle. (MAX 255; MIN 3)</td>
         <td>NTX123456789</td>
+      </tr>
+      <tr>
+        <td><code>network_token_iin</code></td>
+        <td>string</td>
+        <td>IIN/BIN of the network token (DPAN) used in the transaction. First 8 digits of the tokenized PAN; differs from <code>card_iin</code>. Populated on network-tokenized transactions (Apple Pay / Google Pay).</td>
+        <td>51884710</td>
+      </tr>
+      <tr>
+        <td><code>network_token_last4</code></td>
+        <td>string</td>
+        <td>Last 4 digits of the network token PAN (DPAN). Differs from <code>card_lfd</code>. Populated on network-tokenized transactions.</td>
+        <td>8394</td>
+      </tr>
+      <tr>
+        <td><code>network_token_type</code></td>
+        <td>string</td>
+        <td>Funding type or card brand of the network token (<code>CREDIT</code>, <code>DEBIT</code>, <code>VISA</code>, <code>MASTERCARD</code>, <code>AMEX</code>, etc.). Populated primarily on Apple Pay (~99.9%); may be empty on Google Pay. <b>Note:</b> this field does NOT contain the wallet identifier (APPLE_PAY/GOOGLE_PAY) — use <code>payment_method_type</code> for that.</td>
+        <td>CREDIT</td>
       </tr>
       <tr>
         <td><code>payment_id</code></td>
@@ -1168,6 +1300,18 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>string</td>
         <td>Provider message that explains the meaning of the raw Merchant Advice Code.</td>
         <td>Issuer unavailable</td>
+      </tr>
+      <tr>
+        <td><code>provider_raw_notification</code></td>
+        <td>string (json)</td>
+        <td>Raw webhook notification payload received from the provider. Wrapped as <code>{"value":"<stringified-provider-json>"}</code>.</td>
+        <td>{"value":"{\"country\":\"Colombia\",\"ticketNumber\":\"...\"}"}</td>
+      </tr>
+      <tr>
+        <td><code>provider_raw_response</code></td>
+        <td>string (json)</td>
+        <td>Raw response body returned by the provider API. Wrapped as <code>{"value":"<stringified-provider-json>"}</code>.</td>
+        <td>{"value":"{\"bankId\":\"1051\",\"bankName\":\"BANCO DAVIVIENDA\"}"}</td>
       </tr>
       <tr>
         <td><code>provider_image</code></td>
@@ -1270,6 +1414,18 @@ The report fields are subject to modifications, and new fields can be added to t
         <td>string</td>
         <td>The soft descriptor shown on the customer's bank statement (MAX 22; MIN 3).</td>
         <td>MERCHANT ECOMMERCE</td>
+      </tr>
+      <tr>
+        <td><code>stored_credentials_reason</code></td>
+        <td>string</td>
+        <td>Business reason for which stored credentials were used. Values: <code>CARD_ON_FILE</code>, <code>SUBSCRIPTION</code>, <code>UNSCHEDULED_CARD_ON_FILE</code>.</td>
+        <td>CARD_ON_FILE</td>
+      </tr>
+      <tr>
+        <td><code>stored_credentials_usage</code></td>
+        <td>string</td>
+        <td>Usage classification. <code>FIRST</code> = initial capture, <code>USED</code> = subsequent use.</td>
+        <td>USED</td>
       </tr>
       <tr>
         <td><code>status</code></td>


### PR DESCRIPTION
## Summary

This PR adds 19 missing fields to the Payments and Transactions report documentation and introduces the `acquirer` filter for the Settlements report in the OpenAPI specification.


**Changes:**
- Added 19 missing fields to `reference/reports/reports-fields.mdx` (Payments, Transactions, and Both).
- Added `acquirer` (String) filter to `openapi/reports/create-a-report.json` for Settlements reports.

**Pages:**
- [Reports Fields](https://docs.y.uno/reference/reports/reports-fields)
- [Create a Report](https://docs.y.uno/reference/reports/create-a-report)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/spec-only change that expands report field listings and adds an optional request filter; no runtime logic is modified.
> 
> **Overview**
> Adds an optional `acquirer` parameter to `POST /reports` in `openapi/reports/create-a-report.json` to allow filtering **Settlements** reports by acquirer.
> 
> Expands `reference/reports/reports-fields.mdx` with additional documented fields across **Payment** and **Transaction** reports (e.g., authorization/billing cycle details, connection metadata, network token fields, stored credentials, and raw provider payload fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 665c507ebef9389c4021a219bbd7c5b521bdbfee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->