### PR TITLE
docs(changelog): add iOS SDK v2.15.0 release notes

### DIFF
--- a/changelog/ios-sdk-v2.15-changelog.mdx
+++ b/changelog/ios-sdk-v2.15-changelog.mdx
@@ -1,0 +1,66 @@
+---
+title: "Updates for May, 2026: iOS SDK v2.15.0"
+---
+
+* **Release Date**: May 2026
+* **Status**: Latest Version
+
+## What's New in v2.15.0
+
+This version expands address and contact data collection, polishes the form-input experience on iOS 26, and tightens enrollment-flow correctness.
+
+### Address & Contact Collection
+
+Capture richer customer information during checkout.
+
+1. **Apple Pay contact fields**: The Apple Pay sheet now requests billing/shipping address, name, email, and phone based on the merchant's required fields configuration.
+2. **Shipping address in forms**: Card and APM forms now support shipping address entry, including a billing/shipping toggle and validation.
+
+### Form Experience
+
+Smoother input flow across card and APM forms.
+
+3. **Auto-advance**: The form auto-advances to the next field when input is valid, with safeguards against spurious advances and field skipping driven by `validate_fields` flags.
+4. **iOS 26 keyboard toolbar**: New keyboard toolbar with glass effect, optimized for iOS 26.
+5. **Optional delegate `viewController`**: `delegate.viewController` is now optional, simplifying integrations that don't need to provide a presenting controller.
+
+### Enrollment & Validation Fixes
+
+Correctness improvements for enrollment-related flows.
+
+6. **CVV length for enrolled cards**: The CVV field character limit for enrolled cards now applies the correct `securityCodeLength` from the enrollment data.
+7. **Validate IIN session header**: The Validate IIN endpoint now sends `customer_session` instead of `checkout_session` during the enrollment flow.
+
+### Internal Refactor
+
+8. **Expiration date single source of truth**: Removed redundant `@Published` month/year properties on the expiration-date model to prevent stale intermediate values.
+
+## Implementation
+
+Upgrade to v2.15.0 by updating your dependency in Swift Package Manager or CocoaPods.
+
+### Swift Package Manager
+
+Update your `Package.swift` to point to `2.15.0`:
+
+```swift
+.package(url: "https://github.com/yuno-payments/yuno-ios-sdk", from: "2.15.0")
+```
+
+### CocoaPods
+
+Update your `Podfile`:
+
+```ruby
+pod 'YunoSDK', '2.15.0'
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+<Note>
+See the [iOS Release Notes](/docs/sdks/resources/release-notes/ios) for the full version history.
+</Note>

--- a/docs.json
+++ b/docs.json
@@ -756,6 +756,7 @@
               {
                 "group": "2026",
                 "pages": [
+                  "changelog/ios-sdk-v2.15-changelog",
                   "changelog/web-sdk-v1.6-8-changelog",
                   "changelog/web-sdk-v1.6-changelog",
                   "changelog/web-sdk-v1.5-changelog"

--- a/docs/sdks/resources/release-notes/ios.mdx
+++ b/docs/sdks/resources/release-notes/ios.mdx
@@ -10,6 +10,14 @@ The iOS SDK release notes provide a comprehensive overview of the updates, impro
 
 | Version | Changes                                                                                                                                                                                                           |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.15.0  | **CHANGE**: Make `delegate.viewController` optional. |
+|         | **NEW**: Apple Pay contact field support — requests billing/shipping address, name, email, and phone based on required fields. |
+|         | **NEW**: Shipping address support in card and APM forms with billing/shipping toggle and validation. |
+|         | **NEW**: Auto-advance to the next field on valid input, with safeguards against spurious advances and field skipping based on `validate_fields` flags. |
+|         | **NEW**: iOS 26 keyboard toolbar with glass effect. |
+|         | **FIX**: CVV field character limit for enrolled cards now applies the correct `securityCodeLength` from enrollment data. |
+|         | **CHANGE**: Validate IIN endpoint now sends `customer_session` instead of `checkout_session` during the enrollment flow. |
+|         | **IMPROVE**: Refactored expiration date to a single source of truth, removing redundant `@Published` month/year properties to prevent stale intermediate values. |
 | 2.14.2  | **FIX**: Addressed issue causing render flow to hang on formView when isFormEnable is false. |
 | 2.14.0 | **CHANGE**: Move Apple Pay flow before OTT. |
 |        | **NEW**: Add free trial support. |


### PR DESCRIPTION
## Summary
- Adds **iOS SDK v2.15.0** release notes to two places on `main`:
  - `changelog/ios-sdk-v2.15-changelog.mdx` — new dedicated page (first iOS entry under the Changelog tab; mirrors the web-SDK page format)
  - `docs/sdks/resources/release-notes/ios.mdx` — new 2.15.0 row at the top of the iOS Release Notes table
- Wires the new page into `docs.json` under the `2026` group.

## What's in v2.15.0
- **CHANGE**: \`delegate.viewController\` is now optional
- **NEW**: Apple Pay contact field support (billing/shipping address, name, email, phone)
- **NEW**: Shipping address support in card and APM forms with billing/shipping toggle
- **NEW**: Auto-advance to next field on valid input (respects \`validate_fields\`)
- **NEW**: iOS 26 keyboard toolbar with glass effect
- **FIX**: CVV length for enrolled cards uses correct \`securityCodeLength\` from enrollment data
- **CHANGE**: Validate IIN endpoint now sends \`customer_session\` instead of \`checkout_session\` during enrollment
- **IMPROVE**: Expiration date refactored to a single source of truth (removed redundant \`@Published\` month/year)

## Test plan
- [ ] \`mint dev\` — verify new changelog page renders, navigation entry shows under 2026
- [ ] iOS Release Notes table renders cleanly with 2.15.0 row at top
- [ ] No broken links (\`mint broken-links\`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new changelog page and updates navigation; main risk is broken links or formatting issues in rendered docs.
> 
> **Overview**
> Adds a new `changelog/ios-sdk-v2.15-changelog.mdx` page documenting iOS SDK `v2.15.0` (Apple Pay contact field collection, shipping address support in forms, input auto-advance and iOS 26 keyboard toolbar updates, enrollment/validation fixes, and an expiration-date refactor).
> 
> Updates the iOS release notes table (`docs/sdks/resources/release-notes/ios.mdx`) with a new `2.15.0` entry, and wires the new changelog page into the `Changelog` tab navigation for the `2026` group via `docs.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd5c1b29d2b7e5a3bbcce708ea818b352adb88a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->