### PR TITLE
docs(payments): expand currency_conversion request parameters

### DIFF
--- a/docs/additional-services/currency-conversion.mdx
+++ b/docs/additional-services/currency-conversion.mdx
@@ -87,3 +87,70 @@ Also, the merchant can use directly the [currency conversion service of Yuno](/r
 ```
 
 In order to use this, please **contact your technical account manager** to make sure that the information is set properly.
+
+## Request parameters
+
+The following fields are sent inside `amount.currency_conversion` on `POST /v1/payments`.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `cardholder_currency` | `string` | Yes | Currency the cardholder is charged in. ISO 4217 alpha-3 code. Must differ from `amount.currency`. |
+| `cardholder_amount` | `decimal` | Yes | Total amount billed to the cardholder in `cardholder_currency`. Range: `0.0001` – `9,999,999,999`. |
+| `cardholder_accepted` | `boolean` | Yes | Cardholder's explicit consent to the DCC offer. `true` = accepted (charge in `cardholder_currency`). `false` = declined (payment proceeds in merchant currency). |
+| `rate` | `decimal` | Yes | Applied FX rate (markup included). Must be `> 0`. |
+| `rate_margin_percentage` | `decimal` | Yes | Markup added over the wholesale rate, expressed as a percentage. Range: `0` – `100`. |
+| `rate_source` | `string` | Conditional | Wholesale benchmark used for the quote. Required when `rate_margin_percentage > 0`. Free text, max 50 chars. Examples: `ECB`, `REUTERS`, `BLOOMBERG`, `PROVIDER_INTERNAL`. |
+| `provider` | `string` (enum) | Yes | DCC provider that issued the quote. See [Provider values](#provider-values). |
+| `description` | `string` | Optional | Verbatim disclosure text shown to the cardholder at the point of sale. Stored unchanged for audit. Max 4096 chars. |
+| `created_at` | `string` (ISO 8601) | Yes | Timestamp when the DCC provider issued the quote. Must be `≤ now()`. |
+| `expires_at` | `string` (ISO 8601) | Optional | Timestamp when the quote expires. Must be `> created_at`. The payment is rejected if `expires_at < now()` at validation time. |
+
+### Provider values
+
+`provider` accepts one of:
+
+| Value | DCC provider | Typical market |
+| --- | --- | --- |
+| `FEXCO` | Fexco Merchant Services | Universal — largest DCC provider; supported natively by MPGS |
+| `GLOBAL_BLUE` | Global Blue | Retail, tax-free shopping, tourism |
+| `PLANET` | Planet Payment | Retail, hospitality, tourism |
+| `EURONET` | Euronet / Pure Commerce | ATM DCC, LatAm, APAC |
+| `CURRENCYFAIR` | Currencyfair | E-commerce, digital |
+| `EUROPEAN_PAYMENT_SERVICES` | European Payment Services (EPS) | EU regional |
+| `OTHER` | Any provider not listed above | Long-tail or emerging-market providers |
+
+### Validation rules
+
+* All required fields must be present.
+* `provider` must match one of the allowed enum values exactly.
+* `cardholder_currency` must be a valid ISO 4217 alpha-3 code and must differ from `amount.currency`.
+* `created_at` and `expires_at` must be valid ISO 8601 timestamps.
+* `expires_at`, when provided, must be strictly greater than `created_at`.
+* `rate_source` is required whenever `rate_margin_percentage > 0`.
+
+### Request example
+
+```json
+POST /v1/payments
+
+{
+  "account_id": "4b8f9c10-5c6a-4b2d-9b7e-2c8d3a1b4f55",
+  "merchant_order_id": "order-2026-04-24-0001",
+  "amount": {
+    "value": 1000.00,
+    "currency": "USD",
+    "currency_conversion": {
+      "cardholder_currency": "QAR",
+      "cardholder_amount": 3640.00,
+      "cardholder_accepted": true,
+      "rate": 3.6400,
+      "rate_margin_percentage": 3.75,
+      "rate_source": "ECB",
+      "provider": "FEXCO",
+      "description": "You have chosen to pay in QAR. Amount: 3640.00 QAR. Rate: 3.6400.",
+      "created_at": "2026-04-24T14:30:00Z",
+      "expires_at": "2026-04-24T15:30:00Z"
+    }
+  }
+}
+```

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -96,7 +96,7 @@
                       },
                       "currency_conversion": {
                         "type": "object",
-                        "description": "The currency conversion object",
+                        "description": "The currency conversion (DCC) object. Used when the cardholder pays in their home currency at the point of sale while the merchant settles in their own. `cardholder_currency` must differ from `amount.currency`.",
                         "properties": {
                           "id": {
                             "type": "string",
@@ -108,12 +108,57 @@
                           },
                           "cardholder_currency": {
                             "type": "string",
-                            "description": "The currency to make the conversion (ISO 4217 MAX 3; MIN 3). This field is required if the 'currency_conversion' object is included in the request."
+                            "description": "The currency to make the conversion (ISO 4217 MAX 3; MIN 3). Must differ from `amount.currency`. This field is required if the 'currency_conversion' object is included in the request."
                           },
                           "cardholder_amount": {
                             "type": "number",
-                            "description": "Amount of the payment before conversion (multiple of 0.0001). This field is required if the 'currency_conversion' object is included in the request.",
+                            "description": "Total amount billed to the cardholder in `cardholder_currency` (multiple of 0.0001). Range: 0.0001 – 9,999,999,999. This field is required if the 'currency_conversion' object is included in the request.",
                             "format": "float"
+                          },
+                          "cardholder_accepted": {
+                            "type": "boolean",
+                            "description": "Cardholder's explicit consent to the DCC offer. `true` = accepted (charge in `cardholder_currency`); `false` = declined (payment proceeds in merchant currency)."
+                          },
+                          "rate": {
+                            "type": "number",
+                            "description": "Applied FX rate (markup included). Must be greater than 0.",
+                            "format": "float"
+                          },
+                          "rate_margin_percentage": {
+                            "type": "number",
+                            "description": "Markup added over the wholesale rate, expressed as a percentage. Range: 0 – 100.",
+                            "format": "float"
+                          },
+                          "rate_source": {
+                            "type": "string",
+                            "description": "Wholesale benchmark used for the quote. Required when `rate_margin_percentage > 0`. Free text, max 50 chars. Examples: `ECB`, `REUTERS`, `BLOOMBERG`, `PROVIDER_INTERNAL`."
+                          },
+                          "provider": {
+                            "type": "string",
+                            "description": "DCC provider that issued the quote.",
+                            "enum": [
+                              "FEXCO",
+                              "GLOBAL_BLUE",
+                              "PLANET",
+                              "EURONET",
+                              "CURRENCYFAIR",
+                              "EUROPEAN_PAYMENT_SERVICES",
+                              "OTHER"
+                            ]
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Verbatim disclosure text shown to the cardholder at the point of sale. Stored unchanged for audit. Max 4096 chars."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Timestamp when the DCC provider issued the quote (ISO 8601). Must be ≤ now()."
+                          },
+                          "expires_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Timestamp when the quote expires (ISO 8601). Must be greater than `created_at`. The payment is rejected if `expires_at` is in the past at validation time."
                           }
                         }
                       }


### PR DESCRIPTION
## Summary
Expands the `amount.currency_conversion` (DCC) object on `POST /v1/payments` to document the full set of request fields merchants can send.

**OpenAPI (`openapi/payments/create-payment.json`)** — adds 8 fields to the existing `currency_conversion` object (preserves existing `id`, `provider_currency_conversion_id`, `cardholder_currency`, `cardholder_amount`):
- `cardholder_accepted` (boolean)
- `rate` (decimal)
- `rate_margin_percentage` (decimal, 0–100)
- `rate_source` (string, conditional — required when `rate_margin_percentage > 0`)
- `provider` (enum: FEXCO, GLOBAL_BLUE, PLANET, EURONET, CURRENCYFAIR, EUROPEAN_PAYMENT_SERVICES, OTHER)
- `description` (string, max 4096)
- `created_at` (ISO 8601 date-time)
- `expires_at` (ISO 8601 date-time)

**Guide page (`docs/additional-services/currency-conversion.mdx`)** — adds a new **Request parameters** section with:
- Full field table (10 fields)
- Provider enum values table
- Validation rules
- Full request example

Scope is intentionally limited to **request fields only**; webhook fields (`code`, `status`, `error_reason`, `provider_data`) and their enums are not included in this PR.

## Test plan
- [ ] `mint dev` — verify the new section renders cleanly on the Currency Conversion page
- [ ] OpenAPI reference for `POST /v1/payments` shows all 12 properties on `amount.currency_conversion`
- [ ] `mint broken-links` — no new broken links
- [ ] JSON validates (already verified locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/spec changes only: expands the documented `amount.currency_conversion` (DCC) request shape in the guide and OpenAPI without altering runtime code.
> 
> **Overview**
> Expands the documented `amount.currency_conversion` (DCC) request payload for `POST /v1/payments` by adding fields for cardholder consent, FX rate details, provider identification, disclosure text, and quote timestamps.
> 
> Updates the Currency Conversion guide with a **Request parameters** section (field table, provider enum values, validation rules, and a full request example) and updates the OpenAPI schema to include the same new properties plus stronger descriptions/constraints (including a `provider` enum and `cardholder_currency` must differ from `amount.currency`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e9c38d67b58b71595a5bb391bb9218c72f027c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->