### PR TITLE
docs(android): add 2.6.0 and 2.7.0 to Android Release Notes

### DIFF
--- a/docs/sdks/resources/release-notes/android.mdx
+++ b/docs/sdks/resources/release-notes/android.mdx
@@ -45,6 +45,9 @@ The Android SDK release notes offer a comprehensive overview of the updates, imp
 |           | **NEW**: Google Pay now supported in `startPayment` flow                                                                                                                    |
 | 2.8.1     | **IMPROVE**: Added new card type field (Google Pay)                                                                                                                         |
 | 2.8.0     | **NEW**: Card scanning (OCR) feature - scan credit or debit cards with device camera using Google Pay's OCR solution                                                        |
+| 2.7.0     | **IMPROVE**: Improvements in architecture                                                                                                                                    |
+|           | **FIX**: EdgeToEdge issue in WebView                                                                                                                                         |
+| 2.6.0     | **NEW**: Google Pay PIX direct                                                                                                                                               |
 | 2.5       | **NEW**: Brazil hybrid card support - process as credit by default, enable card saving                                                                                      |
 |           | **NEW**: Complete Chinese localization support (zh-CN) across payments, errors, loaders, and APMs                                                                           |
 |           | **IMPROVE**: Enrollment and payment flow updates                                                                                                                            |


### PR DESCRIPTION
## Summary
Fills a gap in the Android Release Notes table — the existing page jumped from 2.8.0 directly to 2.5. Adds the two missing versions in the right slot:

**2.7.0**
- **IMPROVE**: Improvements in architecture
- **FIX**: EdgeToEdge issue in WebView

**2.6.0**
- **NEW**: Google Pay PIX direct

## Test plan
- [ ] Mintlify preview deployment renders the table cleanly
- [ ] 2.7.0 and 2.6.0 rows appear between 2.8.0 and 2.5 in descending order
- [ ] No broken links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the Android release notes table; no runtime/code behavior is affected.
> 
> **Overview**
> Adds the missing Android SDK release notes entries for versions `2.7.0` and `2.6.0` (architecture improvements, a WebView Edge-to-Edge fix, and Google Pay PIX direct) in the correct position between `2.8.0` and `2.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7e99428f59f1b1b75000138df91f5ded30e04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->