### PR TITLE
docs(api): update dry-run registration id example

### DIFF
--- a/openapi/dry-run/register-dry-run-provider-event.json
+++ b/openapi/dry-run/register-dry-run-provider-event.json
@@ -312,7 +312,7 @@
           "id": {
             "type": "string",
             "description": "Public identifier of the dry-run registration (nano_id, 21 chars).",
-            "example": "dry_run_01j5v8xpt2v0b"
+            "example": "drun_1209fnkw428ufwd"
           },
           "status": {
             "type": "string",


### PR DESCRIPTION
## Summary

This PR updates the example ID for dry-run registrations in the OpenAPI specification to align with the latest stakeholder feedback from Palo.


**Changes:**
- Updated `DryRunResponse.id.example` from `dry_run_01j5v8xpt2v0b` to `drun_1209fnkw428ufwd` in `register-dry-run-provider-event.json`.

**Pages:**
- /reference/dry-run/register-dry-run-provider-event

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change in the OpenAPI spec; no runtime behavior or validation logic is modified.
> 
> **Overview**
> Updates the OpenAPI spec for `DryRunResponse.id` in `register-dry-run-provider-event.json` to use the new example value `drun_1209fnkw428ufwd` instead of `dry_run_01j5v8xpt2v0b`, aligning the documented dry-run registration ID format with current expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918fcd7a05d12a672f79f187f30c6f7a1debfd90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->