### PR TITLE
docs: add backend integration examples to native enrollment guides

### DIFF
--- a/docs/sdks/card-enrollment/android-enrollment.mdx
+++ b/docs/sdks/card-enrollment/android-enrollment.mdx
@@ -81,9 +81,49 @@ For the full list of parameters, see the [Android SDK Common Reference](/docs/sd
 
 Yuno full-checkout for Android provides enrollment with pre-built UI, card enrollment, status handling, and basic error management. See [Requirements](#requirements) above.
 
-### Step 1: Create a customer
+### Step 1: Create a customer session and an enrollment payment method object
 
-Create a customer in Yuno's system using the [Create customer endpoint](/reference/customers/create-customer) before enrolling payment methods. This endpoint returns a `customer_id`. Then create a customer session using the [Create Customer Session](/reference/customer-sessions-enrollment/create-customer-session) endpoint; use the returned `customer_session` when calling the enrollment methods.
+Create a [customer session](/reference/customer-sessions-enrollment/create-customer-session) and an [enrollment payment method object](/reference/payment-methods-checkout/enroll-payment-method-checkout) on your **server-side** to keep private API keys secure; define which payment method the customer can enroll when creating the payment method object.
+
+#### Server-side example
+
+Create a customer session and enrollment payment method on your backend. This keeps your private API keys secure.
+
+```javascript
+// 1. Create customer session
+const customerSession = await fetch(
+  "https://api-sandbox.y.uno/v1/customers/sessions",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${PRIVATE_SECRET_KEY}`,
+    },
+    body: JSON.stringify({
+      customer_id: "your-customer-id",
+      country: "US",
+    }),
+  }
+).then((res) => res.json());
+
+// 2. Create enrollment payment method
+const enrollment = await fetch(
+  `https://api-sandbox.y.uno/v1/customers/sessions/${customerSession.id}/payment-methods`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${PRIVATE_SECRET_KEY}`,
+    },
+    body: JSON.stringify({
+      type: "CARD",
+    }),
+  }
+).then((res) => res.json());
+
+// Return customerSession to your client
+return customerSession;
+```
 
 ### Step 2: Include the library in your project
 

--- a/docs/sdks/card-enrollment/ios-enrollment.mdx
+++ b/docs/sdks/card-enrollment/ios-enrollment.mdx
@@ -41,22 +41,49 @@ For the full list of parameters, see the [iOS SDK Common Reference](/docs/sdks/r
 
 The Yuno full-checkout iOS SDK provides enrollment with pre-built UI, card enrollment, status handling, and basic error management. See [Requirements](#requirements) above.
 
-### Step 1: Create a customer and customer session
+### Step 1: Create a customer session and an enrollment payment method object
 
-Create a customer in Yuno's system using the [Create customer endpoint](/reference/customers/create-customer) before enrolling payment methods. This endpoint will return a `customer_id` that you'll use to associate enrolled payment methods with the specific customer.
+Create a [customer session](/reference/customer-sessions-enrollment/create-customer-session) and an [enrollment payment method object](/reference/payment-methods-checkout/enroll-payment-method-checkout) on your **server-side** to keep private API keys secure; define which payment method the customer can enroll when creating the payment method object.
 
-Then create a customer session using the [Create Customer Session](/reference/customer-sessions-enrollment/create-customer-session) endpoint. The session information will be used when calling the enrollment methods.
+#### Server-side example
 
-```json
-POST /v1/customer-session
+Create a customer session and enrollment payment method on your backend. This keeps your private API keys secure.
 
-{
-  "country": "BR",
-  "customer_id": "6c85a4e3-0a6c-423d-a12a-10045320ab4a"
-}
+```javascript
+// 1. Create customer session
+const customerSession = await fetch(
+  "https://api-sandbox.y.uno/v1/customers/sessions",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${PRIVATE_SECRET_KEY}`,
+    },
+    body: JSON.stringify({
+      customer_id: "your-customer-id",
+      country: "US",
+    }),
+  }
+).then((res) => res.json());
+
+// 2. Create enrollment payment method
+const enrollment = await fetch(
+  `https://api-sandbox.y.uno/v1/customers/sessions/${customerSession.id}/payment-methods`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${PRIVATE_SECRET_KEY}`,
+    },
+    body: JSON.stringify({
+      type: "CARD",
+    }),
+  }
+).then((res) => res.json());
+
+// Return customerSession to your client
+return customerSession;
 ```
-
-The response includes a `customer_session` ID that you'll use in the next step.
 
 ### Step 2: Include the library in your project
 


### PR DESCRIPTION
## PR description

## Summary

This PR brings the Android and iOS enrollment guides into parity with the Web guide by adding detailed server-side integration examples and correcting inconsistent endpoint paths.

**Changes:**
- **Android Enrollment**: Added Step 1 "Create a customer session and an enrollment payment method object" with a full backend code example.
- **iOS Enrollment**: Corrected the endpoint path to `/v1/customers/sessions` and added the missing enrollment payment method object creation step.
- **Consistency**: Unified the enrollment flow documentation across all platforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that adjust described API endpoints/flow but do not affect runtime behavior.
> 
> **Overview**
> Adds a new Step 1 in both Android and iOS enrollment guides that instructs integrators to create a `customer session` and an `enrollment payment method` **server-side**, including a concrete JavaScript backend example.
> 
> Replaces/updates the previous iOS Step 1 content to align with the new flow and endpoint usage, bringing the native enrollment docs into parity with the web guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f84da8c3d152a02906035a987b3abbde1c03fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->