### PR TITLE
docs: add card verification results (AVS & CVV)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -150,6 +150,7 @@
                 ]
               },
               "docs/payment-features/stored-credentials",
+              "docs/payment-features/card-verification-results",
               "docs/payment-features/transaction-retries",
               "docs/payment-features/split-payments-marketplace",
               "docs/payment-features/account-funding-transactions-afts",

--- a/docs/payment-features/card-verification-results.mdx
+++ b/docs/payment-features/card-verification-results.mdx
@@ -1,0 +1,123 @@
+---
+title: "Card verification results (AVS & CVV)"
+description: "Understand how Yuno surfaces issuer-side address (AVS), postal code, cardholder name, and CVV/CVC check results on every card payment."
+---
+
+When a card payment is authorized, the issuer can return the result of several verification checks the network ran against the card data the customer provided — most importantly **AVS** (Address Verification Service) and the **CVV / CVC** match. Yuno relays those results back to you on every card transaction so you can use them in your own risk, reconciliation, or retry logic.
+
+This guide covers:
+
+- What each verification result means
+- Where to find them in the API response and webhooks
+- How to interpret the codes
+- How to use them in your decision flow
+
+---
+
+## What gets checked
+
+| Check | What it verifies | Field |
+|---|---|---|
+| Street address (AVS) | First line of the billing address the customer entered matches what the issuer has on file. | `address_line_1_check` |
+| Postal / ZIP code (AVS) | The billing postal code matches the issuer's record. | `zip_code_check` |
+| Cardholder name | The cardholder name on the request matches the issuer's record. Coverage varies widely by network and country. | `card_holder_name_check` |
+| Card security code (CVV / CVC / CVV2) | The 3- or 4-digit security code on the card matches. | `card_security_code_check` |
+
+All four are issuer-driven: Yuno does not compute them, it forwards exactly what the acquirer / card network returns.
+
+---
+
+## Where to find them in the response
+
+The block lives on the **card detail** of the payment method, and is duplicated on each transaction that ran a verification:
+
+```
+payment.payment_method.payment_method_detail.card.verification_services
+payment.transactions.payment_method.detail.card.verification_services
+payment.transactions_history[].payment_method.detail.card.verification_services
+```
+
+It appears on the response of:
+
+- `POST /v1/payments` — Create payment
+- `GET /v1/payments/{id}` — Retrieve payment
+- `POST /v1/payments/{id}/capture`, `/refund`, `/cancel`, etc.
+
+It is also included in **payment webhook events** (`payment.created`, `payment.updated`, …), inside the same `payment_method.detail.card` path.
+
+### Example response (excerpt)
+
+```json
+{
+  "id": "p_01HZK3TJX5W8R7Q2V4N6Y8M1B3",
+  "status": "SUCCEEDED",
+  "payment_method": {
+    "type": "CARD",
+    "payment_method_detail": {
+      "card": {
+        "authorization_code": "123456",
+        "card_data": {
+          "brand": "VISA",
+          "iin": "411111",
+          "lfd": "1111"
+        },
+        "verification_services": {
+          "address_line_1_check":     "PASS",
+          "zip_code_check":           "PASS",
+          "card_holder_name_check":   "UNAVAILABLE",
+          "card_security_code_check": "PASS"
+        }
+      }
+    }
+  }
+}
+```
+
+If none of the checks were performed, the entire `verification_services` object is omitted from the response.
+
+---
+
+## Result values
+
+Yuno normalizes the result of every check returned by the issuer / acquirer into one of four canonical values. Each of the four fields takes the same enum:
+
+| Value | Meaning |
+|---|---|
+| `PASS` | The check ran and the value matched the issuer's record. |
+| `FAIL` | The check ran and the value did **not** match. |
+| `UNAVAILABLE` | The check could not be completed — the issuer is not certified, did not respond, or does not support the check in this region. |
+| `UNCHECKED` | The check was not performed for this transaction (e.g. the merchant did not send a CVV, or the provider does not run AVS). |
+
+---
+
+## How to use these results
+
+AVS and CVV results are **not** authorization decisions — the transaction can be approved even when the checks fail. They are advisory signals you can fold into your own risk strategy.
+
+A simple decision matrix many merchants use:
+
+| AVS (`address_line_1_check` / `zip_code_check`) | CVV (`card_security_code_check`) | Suggested action |
+|---|---|---|
+| `PASS` | `PASS` | Accept. |
+| `PASS` | `FAIL` | Soft decline / step-up — billing data looks right but the security code is wrong. |
+| `FAIL` | `PASS` | Review — billing-data mismatch is a strong fraud signal even with a correct CVV. |
+| `FAIL` | `FAIL` | Decline. |
+| `UNAVAILABLE` / `UNCHECKED` | any | Treat as unknown — fall back to other risk signals (3DS result, fraud-screening score). |
+
+Because verification coverage varies by issuer and region, any decisioning you build on top should:
+
+1. **Default to the authorization decision.** A `SUCCEEDED` transaction should ship unless your risk policy says otherwise.
+2. **Combine signals.** Pair CVV / AVS with `fraud_screening`, the `three_d_secure` result, and `provider_data.iso8583_response_code`.
+3. **Tolerate `UNAVAILABLE` and `UNCHECKED`.** Many cards in Latin America and EMEA do not run AVS at all.
+
+---
+
+## Sending verification data on the request
+
+You can also pass `verification_services` **into** Yuno on the create-payment request — for example, when relaying upstream auth results from a system of record. The same four fields are accepted under:
+
+```
+payment_method.payment_method_detail.card.verification_services
+```
+
+When provided on the request, Yuno forwards the values to the downstream provider where supported.

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -10664,7 +10664,7 @@
                                   "description": "Acquirer round-trip data returned by the underlying provider adapter."
                                 }
                               }
-                            }
+                            },
                             "refunded": {
                               "type": "integer",
                               "example": 0,

--- a/reference/reports/reports-fields.mdx
+++ b/reference/reports/reports-fields.mdx
@@ -549,8 +549,8 @@ The report fields are subject to modifications, and new fields can be added to t
             <tr>
               <td><code>metadata_value</code></td>
               <td>string (json)</td>
-              <td>Custom metadata attached to the payment by the merchant at creation time, serialized as a JSON array of <code>{key, value}</code> objects.</td>
-              <td>[{"key":"order_ref","value":"20260100186943"}]</td>
+              <td>{'Custom metadata attached to the payment by the merchant at creation time, serialized as a JSON array of {key, value} objects.'}</td>
+              <td>{'[{"key":"order_ref","value":"20260100186943"}]'}</td>
             </tr>
             <tr>
               <td><code>nationality</code></td>
@@ -1304,14 +1304,14 @@ The report fields are subject to modifications, and new fields can be added to t
       <tr>
         <td><code>provider_raw_notification</code></td>
         <td>string (json)</td>
-        <td>Raw webhook notification payload received from the provider. Wrapped as <code>{"value":"<stringified-provider-json>"}</code>.</td>
-        <td>{"value":"{\"country\":\"Colombia\",\"ticketNumber\":\"...\"}"}</td>
+        <td>{'Raw webhook notification payload received from the provider. Wrapped as {"value":"<stringified-provider-json>"}.'}</td>
+        <td>{'{"value":"{\\"country\\":\\"Colombia\\",\\"ticketNumber\\":\\"...\\"}"}'}</td>
       </tr>
       <tr>
         <td><code>provider_raw_response</code></td>
         <td>string (json)</td>
-        <td>Raw response body returned by the provider API. Wrapped as <code>{"value":"<stringified-provider-json>"}</code>.</td>
-        <td>{"value":"{\"bankId\":\"1051\",\"bankName\":\"BANCO DAVIVIENDA\"}"}</td>
+        <td>{'Raw response body returned by the provider API. Wrapped as {"value":"<stringified-provider-json>"}.'}</td>
+        <td>{'{"value":"{\\"bankId\\":\\"1051\\",\\"bankName\\":\\"BANCO DAVIVIENDA\\"}"}'}</td>
       </tr>
       <tr>
         <td><code>provider_image</code></td>
@@ -2269,7 +2269,7 @@ The settlement report has two types of reports:
       <td><code>reconciliation</code></td>
       <td>struct</td>
       <td>Reconciliation information structure containing status, date, and ID details.</td>
-      <td>`{"status": "RECONCILED", "date": "2022-05-09"}`</td>
+      <td>{'{"status": "RECONCILED", "date": "2022-05-09"}'}</td>
     </tr>
     <tr>
       <td><code>reconciliation_status</code></td>
@@ -2423,7 +2423,7 @@ The communications report provides detailed information about all communications
               <td><code>messages</code></td>
               <td>array</td>
               <td>Array of messages exchanged during the communication.</td>
-              <td>`[{"content": "Hello", "timestamp": "2024-03-15 14:30:00"}]`</td>
+              <td>{'[{"content": "Hello", "timestamp": "2024-03-15 14:30:00"}]'}</td>
             </tr>
             <tr>
               <td><code>summary</code></td>


### PR DESCRIPTION
## PR description

## Summary

Adds a new documentation page explaining how Yuno surfaces issuer-side verification results (AVS & CVV) in card payments. This PR also includes critical fixes for both build-time parsing errors and runtime UI stability.

**Changes:**
- **New Page**: Added `docs/payment-features/card-verification-results.mdx` covering AVS and CVV check results.
- **Navigation**: Updated `docs.json` to include the new page under the "Payment Features" section.
- **Bug Fix (OpenAPI)**: Fixed a missing comma in `openapi/payments/create-payment.json` (line 10667) that was blocking the build.
- **UI Stability Fix**: Resolved a React hydration crash ("ReferenceError: key is not defined") on the Reports Fields page. 
  - **Action**: Wrapped literal curly braces `{key, value}` and JSON snippets in JSX string literals `{'...'}` to prevent the MDX parser from incorrectly executing them as JavaScript code.
  - **Affected lines**: 552-553, 1307-1314, 2272, 2426 in `reference/reports/reports-fields.mdx`.

**Key Topics:**
- Verification checks covered (AVS, CVV, Cardholder name)
- API path to find results in responses and webhooks
- Normalized result values (PASS, FAIL, UNAVAILABLE, UNCHECKED)
- Recommended decision matrix for merchants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and content-rendering fixes; the only functional impact is correcting a JSON syntax error in the OpenAPI spec that could affect doc/build generation.
> 
> **Overview**
> Adds a new `card-verification-results` docs page explaining where AVS/CVV (and related) verification results appear in payment responses/webhooks and how to interpret/use the normalized values.
> 
> Updates site navigation (`docs.json`) to surface the new page, fixes a JSON syntax issue in `openapi/payments/create-payment.json` that could break spec parsing/builds, and adjusts `reference/reports/reports-fields.mdx` to wrap literal `{...}`/JSON examples as strings to prevent MDX/React hydration runtime errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d72655122318afde681938f76909474b9cfd8ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->