### PR TITLE
update sellet api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ openapi.zip
 postman-collection.json
 postman-environment.json
 openapi/merged.json
+resources

--- a/openapi/sellers/sellers-api.json
+++ b/openapi/sellers/sellers-api.json
@@ -123,6 +123,47 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Seller"
+                },
+                "examples": {
+                  "CardProvider": {
+                    "summary": "Seller created with card provider",
+                    "value": {
+                      "seller_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "merchant_seller_id": "FRANCHISE_STORE_001",
+                      "name": "Franchise Store New York",
+                      "email": "store001@franchise.com",
+                      "phone": {
+                        "code": "+1",
+                        "number": "2125550100"
+                      },
+                      "document": {
+                        "type": "EIN",
+                        "number": "12-3456789"
+                      },
+                      "address": {
+                        "line_1": "350 Fifth Avenue",
+                        "line_2": "Suite 101",
+                        "city": "New York",
+                        "state": "NY",
+                        "country": "US",
+                        "zip_code": "10118"
+                      },
+                      "country": "US",
+                      "website": null,
+                      "industry": null,
+                      "merchant_category_code": "5812",
+                      "payment_methods": [
+                        {
+                          "provider_id": "STRIPE",
+                          "payment_method_type": "CARD",
+                          "merchant_id": "acct_1A2B3C4D5E",
+                          "wallet_details": null
+                        }
+                      ],
+                      "created_at": "2026-05-07T10:00:00Z",
+                      "updated_at": "2026-05-07T10:00:00Z"
+                    }
+                  }
                 }
               }
             }
@@ -172,6 +213,47 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Seller"
+                },
+                "examples": {
+                  "CardProvider": {
+                    "summary": "Seller with card provider",
+                    "value": {
+                      "seller_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "merchant_seller_id": "FRANCHISE_STORE_001",
+                      "name": "Franchise Store New York",
+                      "email": "store001@franchise.com",
+                      "phone": {
+                        "code": "+1",
+                        "number": "2125550100"
+                      },
+                      "document": {
+                        "type": "EIN",
+                        "number": "12-3456789"
+                      },
+                      "address": {
+                        "line_1": "350 Fifth Avenue",
+                        "line_2": "Suite 101",
+                        "city": "New York",
+                        "state": "NY",
+                        "country": "US",
+                        "zip_code": "10118"
+                      },
+                      "country": "US",
+                      "website": null,
+                      "industry": null,
+                      "merchant_category_code": "5812",
+                      "payment_methods": [
+                        {
+                          "provider_id": "STRIPE",
+                          "payment_method_type": "CARD",
+                          "merchant_id": "acct_1A2B3C4D5E",
+                          "wallet_details": null
+                        }
+                      ],
+                      "created_at": "2026-05-07T10:00:00Z",
+                      "updated_at": "2026-05-07T10:00:00Z"
+                    }
+                  }
                 }
               }
             }
@@ -208,6 +290,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Seller"
+                },
+                "examples": {
+                  "MultipleProviders": {
+                    "summary": "Updated seller with multiple providers",
+                    "value": {
+                      "seller_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "merchant_seller_id": "FRANCHISE_STORE_001",
+                      "name": "Franchise Store Los Angeles",
+                      "email": null,
+                      "phone": {
+                        "code": null,
+                        "number": null
+                      },
+                      "document": {
+                        "type": null,
+                        "number": null
+                      },
+                      "address": {
+                        "line_1": null,
+                        "line_2": null,
+                        "city": null,
+                        "state": null,
+                        "country": null,
+                        "zip_code": null
+                      },
+                      "country": "US",
+                      "website": null,
+                      "industry": null,
+                      "merchant_category_code": "5812",
+                      "payment_methods": [
+                        {
+                          "provider_id": "STRIPE",
+                          "payment_method_type": "CARD",
+                          "merchant_id": "acct_1A2B3C4D5E",
+                          "wallet_details": null
+                        },
+                        {
+                          "provider_id": "APPLE_PAY",
+                          "payment_method_type": "APPLE_PAY",
+                          "merchant_id": null,
+                          "wallet_details": {
+                            "payment_processing_key": "<base64-encoded .pem content>",
+                            "payment_processing_certificate": "<base64-encoded .pem content>",
+                            "merchant_identity_key": "<base64-encoded .pem content>",
+                            "merchant_identity_certificate": "<base64-encoded .pem content>",
+                            "merchant_identity_password": "password123"
+                          }
+                        }
+                      ],
+                      "created_at": "2026-05-07T10:00:00Z",
+                      "updated_at": "2026-05-07T14:30:00Z"
+                    }
+                  }
                 }
               }
             }

--- a/openapi/sellers/sellers-api.json
+++ b/openapi/sellers/sellers-api.json
@@ -26,37 +26,11 @@
         "description": "Creates a new franchise seller mapping.",
         "parameters": [
           {
-            "name": "public-api-key",
+            "name": "PRIVATE-SECRET-KEY",
             "in": "header",
             "required": true,
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "private-secret-key",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "X-account-code",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "X-Idempotency-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
             }
           }
         ],
@@ -71,39 +45,33 @@
                 "CardProvider": {
                   "summary": "Seller with card provider",
                   "value": {
-                    "account_code": "11111111-2222-3333-4444-555555555555",
+                    "account_id": "8a1c0e7f-4f2d-4bc7-9e1a-2c4d6f8a1b22",
                     "merchant_seller_id": "FRANCHISE_STORE_001",
-                    "name": "Franchise Store São Paulo",
+                    "name": "Franchise Store New York",
                     "email": "store001@franchise.com",
                     "phone": {
-                      "country_code": "55",
-                      "number": "11999999999"
+                      "code": "+1",
+                      "number": "2125550100"
                     },
                     "document": {
-                      "type": "CNPJ",
-                      "number": "12345678000199"
+                      "type": "EIN",
+                      "number": "12-3456789"
                     },
                     "address": {
-                      "street": "Av Paulista",
-                      "number": "1000",
-                      "city": "São Paulo",
-                      "state": "SP",
-                      "country": "BR",
-                      "zip_code": "01310-100"
+                      "line_1": "350 Fifth Avenue",
+                      "line_2": "Suite 101",
+                      "city": "New York",
+                      "state": "NY",
+                      "country": "US",
+                      "zip_code": "10118"
                     },
-                    "country": "BR",
+                    "country": "US",
                     "merchant_category_code": "5812",
-                    "payment_method": [
+                    "payment_methods": [
                       {
+                        "provider_id": "STRIPE",
                         "payment_method_type": "CARD",
-                        "detail": {
-                          "card": {
-                            "provider": {
-                              "id": "CIELO",
-                              "merchant_id": "CIELO_CC_12345"
-                            }
-                          }
-                        }
+                        "merchant_id": "acct_1A2B3C4D5E"
                       }
                     ]
                   }
@@ -111,37 +79,26 @@
                 "MultipleProviders": {
                   "summary": "Seller with multiple providers (card + wallet)",
                   "value": {
-                    "account_code": "11111111-2222-3333-4444-555555555555",
+                    "account_id": "8a1c0e7f-4f2d-4bc7-9e1a-2c4d6f8a1b22",
                     "merchant_seller_id": "FRANCHISE_STORE_001",
-                    "name": "Franchise Store São Paulo",
-                    "country": "BR",
+                    "name": "Franchise Store Los Angeles",
+                    "country": "US",
                     "merchant_category_code": "5812",
-                    "payment_method": [
+                    "payment_methods": [
                       {
+                        "provider_id": "STRIPE",
                         "payment_method_type": "CARD",
-                        "detail": {
-                          "card": {
-                            "provider": {
-                              "id": "CIELO",
-                              "merchant_id": "CIELO_CC_12345"
-                            }
-                          }
-                        }
+                        "merchant_id": "acct_1A2B3C4D5E"
                       },
                       {
+                        "provider_id": "APPLE_PAY",
                         "payment_method_type": "APPLE_PAY",
-                        "detail": {
-                          "wallet": {
-                            "provider": {
-                              "id": "APPLE_PAY",
-                              "merchant_id": "APPLE_PAY_12345",
-                              "payment_processing_key": "<base64-encoded .pem content>",
-                              "payment_processing_certificate": "<base64-encoded .pem content>",
-                              "merchant_identity_key": "<base64-encoded .pem content>",
-                              "merchant_identity_certificate": "<base64-encoded .pem content>",
-                              "merchant_identity_password": "password123"
-                            }
-                          }
+                        "wallet_details": {
+                          "payment_processing_key": "<base64-encoded .pem content>",
+                          "payment_processing_certificate": "<base64-encoded .pem content>",
+                          "merchant_identity_key": "<base64-encoded .pem content>",
+                          "merchant_identity_certificate": "<base64-encoded .pem content>",
+                          "merchant_identity_password": "password123"
                         }
                       }
                     ]
@@ -150,9 +107,9 @@
                 "MinimalSeller": {
                   "summary": "Minimal seller (no payment methods yet)",
                   "value": {
-                    "account_code": "11111111-2222-3333-4444-555555555555",
+                    "account_id": "8a1c0e7f-4f2d-4bc7-9e1a-2c4d6f8a1b22",
                     "merchant_seller_id": "FRANCHISE_STORE_002",
-                    "name": "Franchise Store Campinas"
+                    "name": "Franchise Store Chicago"
                   }
                 }
               }
@@ -173,6 +130,9 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "409": {
             "$ref": "#/components/responses/Conflict"
           }
@@ -190,28 +150,11 @@
           }
         },
         {
-          "name": "public-api-key",
+          "name": "PRIVATE-SECRET-KEY",
           "in": "header",
           "required": true,
           "schema": {
             "type": "string"
-          }
-        },
-        {
-          "name": "private-secret-key",
-          "in": "header",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "X-account-code",
-          "in": "header",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
           }
         }
       ],
@@ -233,6 +176,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
@@ -244,7 +190,7 @@
         "tags": [
           "Sellers"
         ],
-        "description": "Fully replaces the seller details and payment method configurations.",
+        "description": "Fully replaces the seller details and payment method configurations. `merchant_seller_id` is taken from the URL path; `account_id` must be provided in the request body.",
         "requestBody": {
           "required": true,
           "content": {
@@ -269,6 +215,9 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
@@ -285,6 +234,9 @@
           "204": {
             "description": "No Content"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
@@ -298,10 +250,6 @@
         "type": "object",
         "properties": {
           "seller_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "account_code": {
             "type": "string",
             "format": "uuid"
           },
@@ -325,6 +273,7 @@
           },
           "country": {
             "type": "string",
+            "minLength": 2,
             "maxLength": 2
           },
           "website": {
@@ -335,9 +284,10 @@
           },
           "merchant_category_code": {
             "type": "string",
+            "minLength": 4,
             "maxLength": 4
           },
-          "payment_method": {
+          "payment_methods": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PaymentMethodConfig"
@@ -356,11 +306,11 @@
       "SellerCreate": {
         "type": "object",
         "required": [
-          "account_code",
+          "account_id",
           "merchant_seller_id"
         ],
         "properties": {
-          "account_code": {
+          "account_id": {
             "type": "string",
             "format": "uuid"
           },
@@ -371,6 +321,7 @@
           },
           "name": {
             "type": "string",
+            "minLength": 1,
             "maxLength": 255
           },
           "email": {
@@ -388,20 +339,22 @@
           },
           "country": {
             "type": "string",
-            "maxLength": 2
+            "minLength": 2,
+            "maxLength": 2,
+            "description": "ISO 3166-1 alpha-2 country code."
           },
           "website": {
             "type": "string"
           },
           "industry": {
-            "type": "string",
-            "maxLength": 255
+            "type": "string"
           },
           "merchant_category_code": {
             "type": "string",
+            "minLength": 4,
             "maxLength": 4
           },
-          "payment_method": {
+          "payment_methods": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PaymentMethodConfig"
@@ -411,12 +364,22 @@
       },
       "SellerUpdate": {
         "type": "object",
+        "required": [
+          "account_id"
+        ],
         "properties": {
+          "account_id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "name": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "format": "email"
           },
           "phone": {
             "$ref": "#/components/schemas/Phone"
@@ -428,15 +391,20 @@
             "$ref": "#/components/schemas/Address"
           },
           "country": {
-            "type": "string"
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 2,
+            "description": "ISO 3166-1 alpha-2 country code."
           },
           "industry": {
             "type": "string"
           },
           "merchant_category_code": {
-            "type": "string"
+            "type": "string",
+            "minLength": 4,
+            "maxLength": 4
           },
-          "payment_method": {
+          "payment_methods": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PaymentMethodConfig"
@@ -447,8 +415,9 @@
       "Phone": {
         "type": "object",
         "properties": {
-          "country_code": {
-            "type": "string"
+          "code": {
+            "type": "string",
+            "description": "Country dialing code (e.g. +1, +57)."
           },
           "number": {
             "type": "string"
@@ -469,10 +438,10 @@
       "Address": {
         "type": "object",
         "properties": {
-          "street": {
+          "line_1": {
             "type": "string"
           },
-          "number": {
+          "line_2": {
             "type": "string"
           },
           "city": {
@@ -491,24 +460,43 @@
       },
       "PaymentMethodConfig": {
         "type": "object",
+        "description": "Each (provider_id, payment_method_type) pair must be unique within the array.",
         "required": [
-          "payment_method_type",
-          "detail"
+          "provider_id",
+          "payment_method_type"
         ],
         "properties": {
+          "provider_id": {
+            "type": "string"
+          },
           "payment_method_type": {
             "type": "string"
           },
-          "detail": {
-            "type": "object",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/CardDetail"
-              },
-              {
-                "$ref": "#/components/schemas/ApplePayDetail"
-              }
-            ]
+          "merchant_id": {
+            "type": "string"
+          },
+          "wallet_details": {
+            "$ref": "#/components/schemas/WalletDetails"
+          }
+        }
+      },
+      "WalletDetails": {
+        "type": "object",
+        "properties": {
+          "payment_processing_key": {
+            "type": "string"
+          },
+          "payment_processing_certificate": {
+            "type": "string"
+          },
+          "merchant_identity_key": {
+            "type": "string"
+          },
+          "merchant_identity_certificate": {
+            "type": "string"
+          },
+          "merchant_identity_password": {
+            "type": "string"
           }
         }
       },
@@ -586,6 +574,24 @@
     "responses": {
       "BadRequest": {
         "description": "Bad Request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized",
         "content": {
           "application/json": {
             "schema": {


### PR DESCRIPTION
Request from Palo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a breaking OpenAPI contract change (renamed fields, header requirements, and request/response shapes) that will impact client integrations, though it’s documentation/spec-only.
> 
> **Overview**
> Updates the `openapi/sellers/sellers-api.json` contract for the franchise Sellers API, including **breaking schema renames** (`account_code`→`account_id`, `payment_method`→`payment_methods`, phone `country_code`→`code`, address `street/number`→`line_1/line_2`) and additional validation constraints (min/max lengths, email format). It also reshapes payment method configuration to require `provider_id` and use `merchant_id`/`wallet_details` instead of nested `detail`, and adds `401 Unauthorized` responses plus updated request/response examples.
> 
> Separately, `.gitignore` now ignores the `resources` directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448b85955eb0474ce6dc3fe9619fb5adacdb6040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->