### PR TITLE
add public-api-key header seller api

### DIFF
--- a/openapi/sellers/sellers-api.json
+++ b/openapi/sellers/sellers-api.json
@@ -26,6 +26,14 @@
         "description": "Creates a new franchise seller mapping.",
         "parameters": [
           {
+            "name": "public-api-key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "PRIVATE-SECRET-KEY",
             "in": "header",
             "required": true,
@@ -185,6 +193,14 @@
         {
           "name": "merchant_seller_id",
           "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "public-api-key",
+          "in": "header",
           "required": true,
           "schema": {
             "type": "string"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is an API contract change that marks `public-api-key` as a required header for seller create and seller-by-id operations, which can break existing clients and generated SDKs if they don’t send it.
> 
> **Overview**
> Adds a new **required** `public-api-key` header parameter to the Sellers OpenAPI spec for `POST /sellers` and for `/sellers/{merchant_seller_id}` (therefore applying to its `GET`/`PUT`/`DELETE` operations) alongside the existing `PRIVATE-SECRET-KEY` header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df0c5d4d5b02993af5ab7642140baf0c930e75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->