### PR TITLE
update header parameter name to lowercase private-secret-key 

### DIFF
--- a/openapi/sellers/sellers-api.json
+++ b/openapi/sellers/sellers-api.json
@@ -34,7 +34,7 @@
             }
           },
           {
-            "name": "PRIVATE-SECRET-KEY",
+            "name": "private-secret-key",
             "in": "header",
             "required": true,
             "schema": {
@@ -207,7 +207,7 @@
           }
         },
         {
-          "name": "PRIVATE-SECRET-KEY",
+          "name": "private-secret-key",
           "in": "header",
           "required": true,
           "schema": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes an API contract detail (required header name) in the OpenAPI spec, which can break generated clients or integrations that follow the spec literally. Scope is limited to documentation/spec updates only.
> 
> **Overview**
> Standardizes the Sellers OpenAPI documentation by renaming the required auth header from `PRIVATE-SECRET-KEY` to `private-secret-key` on the `POST /sellers` and `/sellers/{merchant_seller_id}` operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23bc6921b9e9b734c2fa09fcd78257f85f790e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->