### PR TITLE
docs(api): update discounts to array of objects

### DIFF
--- a/docs/payment-features/payment-amount-details.mdx
+++ b/docs/payment-features/payment-amount-details.mdx
@@ -242,7 +242,7 @@ curl --request POST \
 
 ## Discounts
 
-A dedicated array of object (`additional_data.order.discounts`) allows you to specify the discounts that are included in the transaction.
+A dedicated array of objects (`additional_data.order.discounts`) allows you to specify the discounts that are included in the transaction.
 
 In the following example you can see a request that clarifies that a 500 USD tip amount is part of a 5000 USD final transaction. This field is for informational purposes, the `discounts` is already included in the final transaction amount and is not added separately.
 

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -697,7 +697,7 @@
                           },
                           "discounts": {
                             "type": "array",
-                            "description": "Specifies the discounts array of object.",
+                            "description": "Specifies the discounts array of objects.",
                             "items": {
                               "properties": {
                                 "id": {

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -847,7 +847,7 @@
                           },
                           "discounts": {
                             "type": "array",
-                            "description": "Specifies the discounts array of object.",
+                            "description": "Specifies the discounts array of objects.",
                             "items": {
                               "properties": {
                                 "id": {
@@ -11255,7 +11255,7 @@
                                 "account_funding": {},
                                 "tickets": {},
                                 "fulfillment": {},
-                                "discounts": {}
+                                "discounts": []
                               }
                             },
                             "seller_details": {}

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -2144,7 +2144,7 @@ This object represents the payment created after generating the checkout session
           </Expandable>
         </ParamField>
 
-        <ParamField body="items" type="array of object">
+        <ParamField body="items" type="array of objects">
           Specifies the item's object.
 
           <Expandable title="properties">
@@ -2201,7 +2201,7 @@ This object represents the payment created after generating the checkout session
         </ParamField>
 
         <ParamField body="discounts" type="array of objects">
-          Specifies the order's discounts object.
+          Specifies the order's discounts array of objects.
 
           <Expandable title="properties">
 
@@ -2226,7 +2226,7 @@ This object represents the payment created after generating the checkout session
           </Expandable>
         </ParamField>
 
-        <ParamField body="tickets" type="array of object">
+        <ParamField body="tickets" type="array of objects">
           Specifies the tickets object.
 
           <Expandable title="properties">


### PR DESCRIPTION
## PR description

### Description

This PR standardizes the `additional_data.order.discounts` field documentation across the API specifications and Markdown documentation. It resolves inconsistencies where the array of objects structure for `discounts` was either incorrectly described as a singular object, contained grammatical errors, or had malformed example payloads (e.g., using `{}` instead of `[]`).

### Changes
* **openapi/payments/create-payment.json**: Corrected an example response payload where `discounts` was an empty object `{}` instead of an empty array `[]`. Updated the description from `Specifies the discounts array of object.` to `Specifies the discounts array of objects.`.
* **openapi/payments/authorize-payment.json**: Updated the parameter description from `Specifies the discounts array of object.` to `Specifies the discounts array of objects.`.
* **reference/payments/the-payment-object.mdx**: Updated the descriptions of the `discounts`, `items`, and `tickets` ParamFields to grammatically correct them from `array of object` and `discounts object` to `array of objects`.
* **docs/payment-features/payment-amount-details.mdx**: Fixed a grammatical typo changing `A dedicated array of object` to `A dedicated array of objects`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime code or API behavior is modified, but consumers may rely on the corrected examples/wording for integration.
> 
> **Overview**
> **Standardizes `additional_data.order.discounts` documentation** across payment docs and OpenAPI specs to consistently describe it as an *array of objects* (fixing “array of object”/“discounts object” wording).
> 
> Also corrects the `create-payment` OpenAPI example to show an empty `discounts` value as `[]` (not `{}`), aligning examples with the documented schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3333f537eb804fca7976a2a7c327889ef025fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->