### PR TITLE
Add Android 2.15.0 and iOS 2.16.0 releases 

### DIFF
--- a/changelog/source/android.json
+++ b/changelog/source/android.json
@@ -2,6 +2,32 @@
   "sdk": "android",
   "releases": [
     {
+      "version": "2.15.0",
+      "release_date": "2026-05-08",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.15.0'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Flexible Actions in Enrollment",
+          "description": "Enrollment now supports the same dynamic action screens used in payments, including PIN, image, payment code, OTP, and info screens.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Installment Details on Tokenization",
+          "description": "When a card is tokenized with installments selected, the installment information — plan, rate, amount, and selected option — is now returned alongside the one-time token. ",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.13.4",
       "release_date": "2026-04-20",
       "upgrade": {

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,79 +2,279 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.16.0",
+      "release_date": "2026-05-08",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.16.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.16.0'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Flexible Actions in Enrollment",
+          "description": "Enrollment now supports the same dynamic action screens used in payments, including PIN, image, payment code, OTP, and info screens.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.15.0",
       "release_date": "2026-04-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.15.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.15.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.15.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.15.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Optional Delegate viewController", "description": "`delegate.viewController` is now optional, simplifying integrations that do not need to provide a presenting controller. No changes required if you are already setting it.", "group": "Form Experience", "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Apple Pay Contact Fields", "description": "The Apple Pay sheet now requests billing/shipping address, name, email, and phone based on the merchant's required fields configuration. Driven by Dashboard settings — no code changes required.", "group": "Address & Contact Collection", "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Shipping Address Support", "description": "Card and APM forms now support shipping address entry, including a billing/shipping toggle and field validation.", "group": "Address & Contact Collection", "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Auto-advance", "description": "The form now auto-advances to the next field when input is valid, reducing keystrokes during checkout. No configuration required.", "group": "Form Experience", "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Glass Keyboard Toolbar", "description": "Added a keyboard toolbar with a glass effect for iOS 26. The toolbar appears automatically on iOS 26 and has no effect on earlier versions.", "group": "Form Experience", "migration_guide": null, "links": [] },
-        { "type": "FIXED", "title": "CVV Length for Enrolled Cards", "description": "Fixed the CVV field character limit for enrolled cards: the field now enforces the correct length from `securityCodeLength` in the enrollment data. Previously the default 3-digit limit was always applied.", "group": "Enrollment & Validation Fixes", "migration_guide": null, "links": [] },
-        { "type": "FIXED", "title": "Validate IIN Session Header", "description": "The validate IIN endpoint now sends `customer_session` instead of `checkout_session` during enrollment. This fixes a validation error that occurred when the session type was mismatched.", "group": "Enrollment & Validation Fixes", "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Expiration Date Single Source", "description": "Removed redundant `@Published` `expirationMonth` and `expirationYear` properties. Expiration date now has a single canonical source, eliminating potential state inconsistencies.", "group": "Form Experience", "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Optional Delegate viewController",
+          "description": "`delegate.viewController` is now optional, simplifying integrations that do not need to provide a presenting controller. No changes required if you are already setting it.",
+          "group": "Form Experience",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Apple Pay Contact Fields",
+          "description": "The Apple Pay sheet now requests billing/shipping address, name, email, and phone based on the merchant's required fields configuration. Driven by Dashboard settings — no code changes required.",
+          "group": "Address & Contact Collection",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Shipping Address Support",
+          "description": "Card and APM forms now support shipping address entry, including a billing/shipping toggle and field validation.",
+          "group": "Address & Contact Collection",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Auto-advance",
+          "description": "The form now auto-advances to the next field when input is valid, reducing keystrokes during checkout. No configuration required.",
+          "group": "Form Experience",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Glass Keyboard Toolbar",
+          "description": "Added a keyboard toolbar with a glass effect for iOS 26. The toolbar appears automatically on iOS 26 and has no effect on earlier versions.",
+          "group": "Form Experience",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "CVV Length for Enrolled Cards",
+          "description": "Fixed the CVV field character limit for enrolled cards: the field now enforces the correct length from `securityCodeLength` in the enrollment data. Previously the default 3-digit limit was always applied.",
+          "group": "Enrollment & Validation Fixes",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Validate IIN Session Header",
+          "description": "The validate IIN endpoint now sends `customer_session` instead of `checkout_session` during enrollment. This fixes a validation error that occurred when the session type was mismatched.",
+          "group": "Enrollment & Validation Fixes",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Expiration Date Single Source",
+          "description": "Removed redundant `@Published` `expirationMonth` and `expirationYear` properties. Expiration date now has a single canonical source, eliminating potential state inconsistencies.",
+          "group": "Form Experience",
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.13.0",
       "release_date": "2026-01-30",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.13.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.13.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.13.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.13.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Dynamic CVV Max Length", "description": "The CVV field now enforces a dynamic maximum length based on the `securityCodeLength` value returned by the API. Previously the field always used a fixed 3-digit limit.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Card IIN Endpoint Migration", "description": "Migrated card IIN lookups to the `card-info` endpoint with checkout session headers. Dynamic co-badged card brand selection is now supported. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Platform Identification API", "description": "Added a public `setPlatform` method and sub-platform header to all requests. Use `setPlatform` when integrating the SDK inside a wrapper framework.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Punto Pago Warning Banner", "description": "Added a warning banner for the Punto Pago kiosk disclaimer. Activated automatically for eligible payment methods — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Cardholder Name Max Length", "description": "Increased the cardholder name field maximum length from 50 to 255 characters. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Alphanumeric CNPJ Validation", "description": "The CNPJ field now accepts alphanumeric input to support the updated Brazilian tax ID format. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "API Key Region Support", "description": "Added region parsing from the API key. The SDK now routes requests to the correct regional endpoint automatically.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Dynamic CVV Max Length",
+          "description": "The CVV field now enforces a dynamic maximum length based on the `securityCodeLength` value returned by the API. Previously the field always used a fixed 3-digit limit.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Card IIN Endpoint Migration",
+          "description": "Migrated card IIN lookups to the `card-info` endpoint with checkout session headers. Dynamic co-badged card brand selection is now supported. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Platform Identification API",
+          "description": "Added a public `setPlatform` method and sub-platform header to all requests. Use `setPlatform` when integrating the SDK inside a wrapper framework.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Punto Pago Warning Banner",
+          "description": "Added a warning banner for the Punto Pago kiosk disclaimer. Activated automatically for eligible payment methods — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Cardholder Name Max Length",
+          "description": "Increased the cardholder name field maximum length from 50 to 255 characters. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Alphanumeric CNPJ Validation",
+          "description": "The CNPJ field now accepts alphanumeric input to support the updated Brazilian tax ID format. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "API Key Region Support",
+          "description": "Added region parsing from the API key. The SDK now routes requests to the correct regional endpoint automatically.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.12.3",
       "release_date": "2026-01-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.3\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.12.3'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.3\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.12.3'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Cardholder Name Now Optional", "description": "The cardholder name field is now optional in card forms. Forms no longer block submission when this field is empty.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Cardholder Name Now Optional",
+          "description": "The cardholder name field is now optional in card forms. Forms no longer block submission when this field is empty.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.12.2",
       "release_date": "2026-01-08",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.12.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.12.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Data Race in Payment Methods List", "description": "Resolved a data race condition in the payment methods list loading function. This fix eliminates intermittent crashes on devices running concurrent background tasks.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Data Race in Payment Methods List",
+          "description": "Resolved a data race condition in the payment methods list loading function. This fix eliminates intermittent crashes on devices running concurrent background tasks.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.12.1",
       "release_date": "2025-12-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.12.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.12.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Apple Pay in Render Mode", "description": "Fixed an Apple Pay initialization issue that prevented the payment sheet from appearing in render mode. Apple Pay now initializes correctly in all integration modes.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Apple Pay in Render Mode",
+          "description": "Fixed an Apple Pay initialization issue that prevented the payment sheet from appearing in render mode. Apple Pay now initializes correctly in all integration modes.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.12.0",
       "release_date": "2025-12-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.12.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.12.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.12.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
         {
@@ -98,726 +298,2150 @@
       "version": "2.11.1",
       "release_date": "2025-11-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.11.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.11.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.11.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.11.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Bug Fixes and Stability", "description": "Various bug fixes and stability improvements. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Bug Fixes and Stability",
+          "description": "Various bug fixes and stability improvements. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.11.0",
       "release_date": "2025-11-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.11.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.11.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.11.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.11.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Podspec Configuration Updates", "description": "Updated podspec configuration for improved CocoaPods compatibility. No API changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "FIXED", "title": "Bug Fixes and Stability", "description": "Various bug fixes and stability improvements. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Podspec Configuration Updates",
+          "description": "Updated podspec configuration for improved CocoaPods compatibility. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Bug Fixes and Stability",
+          "description": "Various bug fixes and stability improvements. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.10.1",
       "release_date": "2025-10-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.10.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.10.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.10.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.10.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Updated Package Checksum", "description": "Updated the Swift Package Manager checksum. Re-resolve your package dependencies after upgrading.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Updated Package Checksum",
+          "description": "Updated the Swift Package Manager checksum. Re-resolve your package dependencies after upgrading.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.10.0",
       "release_date": "2025-10-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.10.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.10.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.10.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.10.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Bug Fixes and Stability", "description": "Various bug fixes and stability improvements. No API changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Architecture Improvements", "description": "Internal architecture refactoring for improved maintainability. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Bug Fixes and Stability",
+          "description": "Various bug fixes and stability improvements. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Architecture Improvements",
+          "description": "Internal architecture refactoring for improved maintainability. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.9.0",
       "release_date": "2025-09-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.9.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.9.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.9.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.9.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Cards Expiring This Month Allowed", "description": "Cards expiring in the current month and year are now accepted at checkout. Previously these cards were incorrectly rejected as expired.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Click to Pay Passkey Support", "description": "Added Click to Pay passkey authentication support. Activated automatically for eligible transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "PayPal Installments", "description": "Added support for PayPal installments payment flow. Activated automatically when PayPal installments is configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Dark Mode Support", "description": "The SDK UI now adapts to the system dark mode setting. No configuration required; the SDK follows the device appearance automatically.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Cards Expiring This Month Allowed",
+          "description": "Cards expiring in the current month and year are now accepted at checkout. Previously these cards were incorrectly rejected as expired.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Click to Pay Passkey Support",
+          "description": "Added Click to Pay passkey authentication support. Activated automatically for eligible transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "PayPal Installments",
+          "description": "Added support for PayPal installments payment flow. Activated automatically when PayPal installments is configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dark Mode Support",
+          "description": "The SDK UI now adapts to the system dark mode setting. No configuration required; the SDK follows the device appearance automatically.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.8.1",
       "release_date": "2025-08-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.8.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.8.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.8.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.8.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Hide Debit Cards When Credit Only", "description": "Debit cards are now hidden from the payment methods list when the merchant has enabled credit-only mode. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Click to Pay Passkey for Render Mode", "description": "Click to Pay passkey authentication is now supported in render mode. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Traditional Chinese Date Format", "description": "Added Traditional Chinese (zh-TW) date format for the MM/YY expiration field. Activated automatically based on the device locale.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Hide Debit Cards When Credit Only",
+          "description": "Debit cards are now hidden from the payment methods list when the merchant has enabled credit-only mode. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Click to Pay Passkey for Render Mode",
+          "description": "Click to Pay passkey authentication is now supported in render mode. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Traditional Chinese Date Format",
+          "description": "Added Traditional Chinese (zh-TW) date format for the MM/YY expiration field. Activated automatically based on the device locale.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.8.0",
       "release_date": "2025-08-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.8.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.8.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.8.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.8.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "ACH Field Enrollment", "description": "Added ACH bank account fields to the enrollment form. No integration changes required; the fields appear automatically when ACH enrollment is configured.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Settings Migration v1 to v2", "description": "SDK settings have been migrated from the v1 schema to v2. Existing settings are migrated automatically on first launch after upgrading.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Secondary Background Color in Flexible Actions", "description": "Flexible actions now support a secondary background color for improved UI customization. Configure via the `YunoConfig.styles` object.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Full Payment List Styling", "description": "Added styling support to the full payment list view. Configure appearance via the `YunoConfig.styles` object.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "ACH Field Enrollment",
+          "description": "Added ACH bank account fields to the enrollment form. No integration changes required; the fields appear automatically when ACH enrollment is configured.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Settings Migration v1 to v2",
+          "description": "SDK settings have been migrated from the v1 schema to v2. Existing settings are migrated automatically on first launch after upgrading.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Secondary Background Color in Flexible Actions",
+          "description": "Flexible actions now support a secondary background color for improved UI customization. Configure via the `YunoConfig.styles` object.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Full Payment List Styling",
+          "description": "Added styling support to the full payment list view. Configure appearance via the `YunoConfig.styles` object.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.7.1",
       "release_date": "2025-07-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.7.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.7.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.7.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.7.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Click to Pay with Passkey", "description": "Added Click to Pay authentication with passkey support. Activated automatically for eligible transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Pending Status Enrollment Notification", "description": "The SDK now notifies the host app of pending status during enrollment when redirecting to a deeplink. Listen for the `pending` status in your enrollment callback.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Click to Pay with Passkey",
+          "description": "Added Click to Pay authentication with passkey support. Activated automatically for eligible transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Pending Status Enrollment Notification",
+          "description": "The SDK now notifies the host app of pending status during enrollment when redirecting to a deeplink. Listen for the `pending` status in your enrollment callback.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.7.0",
       "release_date": "2025-07-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.7.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.7.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.7.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.7.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "ClearSale Web Integration", "description": "Integrated ClearSale fraud prevention via web integration. Activated automatically when ClearSale is configured for your account — no integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "ClearSale Web Integration",
+          "description": "Integrated ClearSale fraud prevention via web integration. Activated automatically when ClearSale is configured for your account — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.6.0",
       "release_date": "2025-06-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.6.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.6.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.6.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.6.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Navigation Toolbar for Keyboard", "description": "Added a navigation toolbar that appears above the keyboard in payment and enrollment forms. The toolbar provides previous/next field navigation and a dismiss button.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Navigation Toolbar for Keyboard",
+          "description": "Added a navigation toolbar that appears above the keyboard in payment and enrollment forms. The toolbar provides previous/next field navigation and a dismiss button.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.5.0",
       "release_date": "2025-06-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.5.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.5.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.5.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.5.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Recurring Apple Pay Support", "description": "Added support for recurring Apple Pay subscriptions. The SDK handles the recurring payment sheet automatically when the checkout is configured for subscriptions.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Simplified Chinese and Traditional Chinese", "description": "Added Simplified Chinese (zh-CN) and Traditional Chinese (zh-TW) language support. Activated automatically based on the device language setting.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "iPad Screen Support", "description": "The payment forms now adapt to iPad screen sizes with an optimized layout. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "OCR Card Scanning", "description": "Added OCR card scanning to automatically populate card number, expiry, and cardholder name fields from the device camera. The button appears automatically in the card form when the device supports it.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "ELO Card Icon", "description": "Added the ELO brand icon to card form and payment list. Displayed automatically when an ELO card is detected.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Coinflow Chargeback Protection", "description": "Integrated Coinflow chargeback protection. Activated automatically for eligible transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Recurring Apple Pay Support",
+          "description": "Added support for recurring Apple Pay subscriptions. The SDK handles the recurring payment sheet automatically when the checkout is configured for subscriptions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Simplified Chinese and Traditional Chinese",
+          "description": "Added Simplified Chinese (zh-CN) and Traditional Chinese (zh-TW) language support. Activated automatically based on the device language setting.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "iPad Screen Support",
+          "description": "The payment forms now adapt to iPad screen sizes with an optimized layout. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "OCR Card Scanning",
+          "description": "Added OCR card scanning to automatically populate card number, expiry, and cardholder name fields from the device camera. The button appears automatically in the card form when the device supports it.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "ELO Card Icon",
+          "description": "Added the ELO brand icon to card form and payment list. Displayed automatically when an ELO card is detected.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Coinflow Chargeback Protection",
+          "description": "Integrated Coinflow chargeback protection. Activated automatically for eligible transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.4.2",
       "release_date": "2025-05-28",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.4.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.4.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.4.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.4.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Call Settings in Enrollment", "description": "The SDK now calls the settings service during enrollment initialization. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Credit-Only Enrollment Mode", "description": "Added support for restricting enrollment to credit cards only. Configure via your Dashboard payment method settings.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Call Settings in Enrollment",
+          "description": "The SDK now calls the settings service during enrollment initialization. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Credit-Only Enrollment Mode",
+          "description": "Added support for restricting enrollment to credit cards only. Configure via your Dashboard payment method settings.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.4.0",
       "release_date": "2025-05-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.4.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.4.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.4.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.4.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "REMOVED", "title": "Deprecated startCheckout Method", "description": "Removed the deprecated `startCheckout(with: self)` method. Use the async `startCheckout` API instead. See the migration guide for details.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "getPaymentMethodView Async Replacement", "description": "Replaced `getPaymentMethodView` with an async version that returns the view via a completion handler. Update call sites to use the new async signature.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "startPaymentRender Replacement", "description": "Replaced `startPaymentRender` with a new render flow method. Update call sites to use the new method name.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "startPaymentLite Replacement", "description": "Replaced `startPaymentLite` with an updated version. Update call sites to use the new method name.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "FIXED", "title": "Missing Apple Pay Values", "description": "Added missing values in the `/payment/complete` service call for Apple Pay. This resolves payment failures that occurred for some Apple Pay transactions.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Nuvei 3DS Support", "description": "Integrated Nuvei 3DS challenge handling. Activated automatically for eligible Nuvei transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Styling Object Update", "description": "Updated the `YunoConfig.styles` object structure. Review the styling documentation if you customize SDK appearance.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Banner View Payment Action", "description": "Added banner view support within the payment action view for flexible actions. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "REMOVED",
+          "title": "Deprecated startCheckout Method",
+          "description": "Removed the deprecated `startCheckout(with: self)` method. Use the async `startCheckout` API instead. See the migration guide for details.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "getPaymentMethodView Async Replacement",
+          "description": "Replaced `getPaymentMethodView` with an async version that returns the view via a completion handler. Update call sites to use the new async signature.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "startPaymentRender Replacement",
+          "description": "Replaced `startPaymentRender` with a new render flow method. Update call sites to use the new method name.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "startPaymentLite Replacement",
+          "description": "Replaced `startPaymentLite` with an updated version. Update call sites to use the new method name.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Missing Apple Pay Values",
+          "description": "Added missing values in the `/payment/complete` service call for Apple Pay. This resolves payment failures that occurred for some Apple Pay transactions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Nuvei 3DS Support",
+          "description": "Integrated Nuvei 3DS challenge handling. Activated automatically for eligible Nuvei transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Styling Object Update",
+          "description": "Updated the `YunoConfig.styles` object structure. Review the styling documentation if you customize SDK appearance.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Banner View Payment Action",
+          "description": "Added banner view support within the payment action view for flexible actions. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.3.0",
       "release_date": "2025-05-18",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.3.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.3.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.3.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.3.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Text Component Identifier Separation", "description": "Separated view block identifiers into specific text components for improved customization. Review custom text configurations if your integration overrides identifier labels.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "NuPay Banner Text Weight", "description": "NuPay banner messages are now displayed in bold for improved readability. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "CVV and Expiry Field Proportions", "description": "Adjusted the width proportions of the CVV and expiration date fields in the card form for a more balanced layout. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "External Browser Redirect", "description": "Redirects now open in the external browser when the backend flag is set, instead of always using an in-app web view. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Text Component Identifier Separation",
+          "description": "Separated view block identifiers into specific text components for improved customization. Review custom text configurations if your integration overrides identifier labels.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "NuPay Banner Text Weight",
+          "description": "NuPay banner messages are now displayed in bold for improved readability. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "CVV and Expiry Field Proportions",
+          "description": "Adjusted the width proportions of the CVV and expiration date fields in the card form for a more balanced layout. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "External Browser Redirect",
+          "description": "Redirects now open in the external browser when the backend flag is set, instead of always using an in-app web view. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.2.2",
       "release_date": "2025-05-16",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.2.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.2.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.2.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.2.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Luhn Validation", "description": "Added Luhn algorithm validation to the card number field. Cards with invalid Luhn checksums are now rejected before submission, reducing server-side errors.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Luhn Validation",
+          "description": "Added Luhn algorithm validation to the card number field. Cards with invalid Luhn checksums are now rejected before submission, reducing server-side errors.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.2.1",
       "release_date": "2025-05-17",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.2.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.2.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.2.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.2.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Bug Fixes and Stability", "description": "Various bug fixes and stability improvements. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Bug Fixes and Stability",
+          "description": "Various bug fixes and stability improvements. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.2.0",
       "release_date": "2025-05-16",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.2.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.2.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.2.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.2.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "PayPal Enrollment", "description": "Added PayPal enrollment support. Users can now save their PayPal account during the enrollment flow.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "PayPal Enrollment",
+          "description": "Added PayPal enrollment support. Users can now save their PayPal account during the enrollment flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.1.0",
       "release_date": "2025-05-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.1.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.1.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.1.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.1.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Color Codable Initializers Hidden", "description": "Color `Codable` initializers are no longer part of the public API. If you were using these initializers directly, switch to the documented color configuration methods.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Sodexo Expiration Date Validation", "description": "Added expiration date validation specific to Sodexo brand cards. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Redirect Payment Action Support", "description": "Added support for the redirect payment action type, enabling redirect-based APMs to operate through the flexible actions flow.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Color Codable Initializers Hidden",
+          "description": "Color `Codable` initializers are no longer part of the public API. If you were using these initializers directly, switch to the documented color configuration methods.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Sodexo Expiration Date Validation",
+          "description": "Added expiration date validation specific to Sodexo brand cards. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Redirect Payment Action Support",
+          "description": "Added support for the redirect payment action type, enabling redirect-based APMs to operate through the flexible actions flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "2.0.0",
       "release_date": "2025-05-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.0.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '2.0.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.0.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.0.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "NuPay Installments", "description": "Added support for NuPay installments payment flow.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Flexible Actions Migration", "description": "Migrated legacy Alternative Payment Methods (APMs) to the flexible actions architecture. Merchants using APMs should verify their payment flows after upgrading.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Mercado Pago 3DS", "description": "Integrated Mercado Pago 3DS for enhanced fraud protection. Activated automatically for eligible transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Socket Connection Support", "description": "Added WebSocket connection support based on a backend feature flag. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Airwallex Anti-fraud Integration", "description": "Integrated Airwallex anti-fraud detection. Activated automatically for eligible transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "3DS Unlimit Support", "description": "Added 3DS challenge support for Unlimit payment method. Activated automatically — no integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "NuPay Installments",
+          "description": "Added support for NuPay installments payment flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Flexible Actions Migration",
+          "description": "Migrated legacy Alternative Payment Methods (APMs) to the flexible actions architecture. Merchants using APMs should verify their payment flows after upgrading.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Mercado Pago 3DS",
+          "description": "Integrated Mercado Pago 3DS for enhanced fraud protection. Activated automatically for eligible transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Socket Connection Support",
+          "description": "Added WebSocket connection support based on a backend feature flag. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Airwallex Anti-fraud Integration",
+          "description": "Integrated Airwallex anti-fraud detection. Activated automatically for eligible transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "3DS Unlimit Support",
+          "description": "Added 3DS challenge support for Unlimit payment method. Activated automatically — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.25.0",
       "release_date": "2025-04-01",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.25.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.25.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.25.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.25.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Astropay Enrollment Support", "description": "Added support for Astropay card enrollment. Users can now save their Astropay account during the enrollment flow.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Redirect-Type Enrollment", "description": "Added support for redirect-type enrollment flows. The SDK now handles the redirect and returns the enrollment result to the host app.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Astropay Enrollment Support",
+          "description": "Added support for Astropay card enrollment. Users can now save their Astropay account during the enrollment flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Redirect-Type Enrollment",
+          "description": "Added support for redirect-type enrollment flows. The SDK now handles the redirect and returns the enrollment result to the host app.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.24.2",
       "release_date": "2025-03-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.24.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.24.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.24.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.24.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Loader Recursive Presentation", "description": "Enhanced loader display with recursive view controller presentation for more reliable loading indicators in complex navigation stacks.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Loader Recursive Presentation",
+          "description": "Enhanced loader display with recursive view controller presentation for more reliable loading indicators in complex navigation stacks.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.24.1",
       "release_date": "2025-03-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.24.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.24.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.24.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.24.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Full Payment View Size Notification", "description": "Added a notification for the full payment view size. Use this to adjust your container layout when the SDK view changes height.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Full Payment View Size Notification",
+          "description": "Added a notification for the full payment view size. Use this to adjust your container layout when the SDK view changes height.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.24.0",
       "release_date": "2025-03-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.24.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.24.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.24.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.24.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Mercado Pago Checkout Pro Browser", "description": "Mercado Pago Checkout Pro now opens in an in-app browser instead of a web view. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Preselected Payment Methods", "description": "Added support for preselecting a payment method programmatically. Pass the payment method token when starting checkout to skip the payment list.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Full Payment List Migrated to SwiftUI", "description": "The full payment list UI has been migrated to SwiftUI for improved performance and customization. No API changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Flexible Actions Styling and QR Button", "description": "Added styling support and a QR button to flexible actions. Configure via `YunoConfig.styles`.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "3DS Loading URL Support", "description": "Added support for loading external URLs during 3DS challenges. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Mercado Pago Checkout Pro Browser",
+          "description": "Mercado Pago Checkout Pro now opens in an in-app browser instead of a web view. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Preselected Payment Methods",
+          "description": "Added support for preselecting a payment method programmatically. Pass the payment method token when starting checkout to skip the payment list.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Full Payment List Migrated to SwiftUI",
+          "description": "The full payment list UI has been migrated to SwiftUI for improved performance and customization. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Flexible Actions Styling and QR Button",
+          "description": "Added styling support and a QR button to flexible actions. Configure via `YunoConfig.styles`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "3DS Loading URL Support",
+          "description": "Added support for loading external URLs during 3DS challenges. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.23.2",
       "release_date": "2025-02-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.23.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.23.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.23.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.23.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "cancelByUser Notification for Enrollment", "description": "The SDK now sends a `cancelByUser` notification when the user closes enrollment forms. Handle this event in your enrollment callback to update your UI accordingly.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "cancelByUser Notification for Enrollment",
+          "description": "The SDK now sends a `cancelByUser` notification when the user closes enrollment forms. Handle this event in your enrollment callback to update your UI accordingly.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.23.1",
       "release_date": "2025-02-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.23.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.23.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.23.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.23.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "cancelByUser Notification for Apple Pay", "description": "The SDK now sends a `cancelByUser` notification when the user closes the Apple Pay modal. Handle this event in your payment callback to update your UI accordingly.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "cancelByUser Notification for Apple Pay",
+          "description": "The SDK now sends a `cancelByUser` notification when the user closes the Apple Pay modal. Handle this event in your payment callback to update your UI accordingly.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.23.0",
       "release_date": "2025-02-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.23.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.23.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.23.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.23.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Generic Enrollment Forms and WebSocket", "description": "Added support for generic enrollment forms and WebSocket connectivity. Tested with Bancolombia button integration.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Generic Enrollment Forms and WebSocket",
+          "description": "Added support for generic enrollment forms and WebSocket connectivity. Tested with Bancolombia button integration.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.22.1",
       "release_date": "2025-01-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.22.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.22.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.22.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.22.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Embedded Web View Publisher", "description": "Fixed an issue where embedded web views did not return `anyPublisher` directly. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Embedded Web View Publisher",
+          "description": "Fixed an issue where embedded web views did not return `anyPublisher` directly. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.22.0",
       "release_date": "2025-01-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.22.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.22.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.22.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.22.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Nationality Removed from Required Fields", "description": "Nationality has been removed from the required fields list. Forms no longer request this field during enrollment.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "OTP View in Flexible Actions", "description": "Added an OTP (one-time password) input view within the flexible actions flow. Activated automatically for payment methods requiring OTP verification.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "x-sdk-type Request Header", "description": "Added `x-sdk-type` to all outbound request headers for improved platform telemetry. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Enrolled Card Support in Dynamic SDK", "description": "Added enrolled card handling to the dynamic SDK. Enrolled cards can now be used in dynamic payment flows.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Authorized Substatus Notification", "description": "Added notification for the authorized payment substatus. Handle this event to take action when a payment is authorized but not yet captured.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Nationality Removed from Required Fields",
+          "description": "Nationality has been removed from the required fields list. Forms no longer request this field during enrollment.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "OTP View in Flexible Actions",
+          "description": "Added an OTP (one-time password) input view within the flexible actions flow. Activated automatically for payment methods requiring OTP verification.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "x-sdk-type Request Header",
+          "description": "Added `x-sdk-type` to all outbound request headers for improved platform telemetry. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Enrolled Card Support in Dynamic SDK",
+          "description": "Added enrolled card handling to the dynamic SDK. Enrolled cards can now be used in dynamic payment flows.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Authorized Substatus Notification",
+          "description": "Added notification for the authorized payment substatus. Handle this event to take action when a payment is authorized but not yet captured.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.21.2",
       "release_date": "2024-12-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.21.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.21.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.21.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.21.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Enrollment Cancellables Memory Leak", "description": "Added `anyCancellables` to `YunoEnrollmentHeadlessImpl` to prevent memory leaks in long-running enrollment sessions.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Enrollment Cancellables Memory Leak",
+          "description": "Added `anyCancellables` to `YunoEnrollmentHeadlessImpl` to prevent memory leaks in long-running enrollment sessions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.21.1",
       "release_date": "2024-12-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.21.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.21.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.21.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.21.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "REMOVED", "title": "Koin Dependency Removed", "description": "Removed the Koin dependency from the SDK package. This reduces binary size and eliminates potential conflicts with apps that include Koin independently.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "REMOVED",
+          "title": "Koin Dependency Removed",
+          "description": "Removed the Koin dependency from the SDK package. This reduces binary size and eliminates potential conflicts with apps that include Koin independently.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.21.0",
       "release_date": "2024-12-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.21.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.21.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.21.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.21.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Xendit Indoramart Payment Method", "description": "Added support for Xendit - Indoramart payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "MetricKit Performance Monitoring", "description": "Integrated MetricKit and `URLSessionTaskMetrics` for performance monitoring and diagnostics. Metrics are collected automatically — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Combined Payment and Enrollment Flow", "description": "Added support for a combined payment and enrollment flow. Users can enroll a payment method and complete a payment in a single session.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Dynamic Actions Image Support", "description": "Added IMAGE action type support to the dynamic actions framework. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Xendit Indoramart Payment Method",
+          "description": "Added support for Xendit - Indoramart payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "MetricKit Performance Monitoring",
+          "description": "Integrated MetricKit and `URLSessionTaskMetrics` for performance monitoring and diagnostics. Metrics are collected automatically — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Combined Payment and Enrollment Flow",
+          "description": "Added support for a combined payment and enrollment flow. Users can enroll a payment method and complete a payment in a single session.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dynamic Actions Image Support",
+          "description": "Added IMAGE action type support to the dynamic actions framework. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.20.0",
       "release_date": "2024-11-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.20.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.20.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.20.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.20.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Koin SDK Integration", "description": "Integrated the Koin SDK package for Koin PIX Parcelado support. Add the Koin dependency to your project if you plan to use Koin payment methods.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Koin PIX Parcelado", "description": "Added Koin PIX Parcelado installment payment support including socket-based status updates, OTP handling, and in-review status display.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Click to Pay Token Storage", "description": "Added saving and sending of Click to Pay (C2P) tokens in user defaults. C2P is activated via a feature flag — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Delayed Provider Response Screen", "description": "Added a delayed provider response screen for payment methods that take additional time to confirm. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Koin SDK Integration",
+          "description": "Integrated the Koin SDK package for Koin PIX Parcelado support. Add the Koin dependency to your project if you plan to use Koin payment methods.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Koin PIX Parcelado",
+          "description": "Added Koin PIX Parcelado installment payment support including socket-based status updates, OTP handling, and in-review status display.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Click to Pay Token Storage",
+          "description": "Added saving and sending of Click to Pay (C2P) tokens in user defaults. C2P is activated via a feature flag — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Delayed Provider Response Screen",
+          "description": "Added a delayed provider response screen for payment methods that take additional time to confirm. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.19.3",
       "release_date": "2024-11-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.3\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.19.3'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.3\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.19.3'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "NuPay Redirect Payment", "description": "Added NuPay redirect payment flow support. The SDK now handles the redirect and returns the payment result to the host app.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "NuPay Redirect Payment",
+          "description": "Added NuPay redirect payment flow support. The SDK now handles the redirect and returns the payment result to the host app.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.19.2",
       "release_date": "2024-10-28",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.19.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.19.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Socket on Authorized Substatus", "description": "The SDK now opens a socket connection when the payment substatus is `authorized`, enabling real-time status updates for authorized-but-pending payments.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Socket on Authorized Substatus",
+          "description": "The SDK now opens a socket connection when the payment substatus is `authorized`, enabling real-time status updates for authorized-but-pending payments.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.19.1",
       "release_date": "2024-10-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.1\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.19.1'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.19.1'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Document Required Field in Enrollment", "description": "Added document number as a required field in enrollment forms when specified by the payment method configuration. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Document Required Field in Enrollment",
+          "description": "Added document number as a required field in enrollment forms when specified by the payment method configuration. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.19.0",
       "release_date": "2024-10-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.19.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.19.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.19.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Inswitch Cash Payment", "description": "Added support for Inswitch cash payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Inswitch Bank Transfer", "description": "Added support for Inswitch bank transfer payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Xendit QRIS Payment Method", "description": "Added support for Xendit QRIS payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Inswitch Cash Payment",
+          "description": "Added support for Inswitch cash payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Inswitch Bank Transfer",
+          "description": "Added support for Inswitch bank transfer payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Xendit QRIS Payment Method",
+          "description": "Added support for Xendit QRIS payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.18.0",
       "release_date": "2024-09-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.18.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.18.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.18.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.18.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "SDK Seamless Integration", "description": "Added SDK seamless integration mode for a frictionless checkout experience. Contact your Yuno technical account manager to enable this feature.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "RUT Validation and Masks", "description": "Added Chilean RUT validation and input mask to document fields. Activated automatically for CLP transactions.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Dynamic SDK Cleanup", "description": "Removed `OptionalStateValue` and `YunoDynamicConnection` class from the dynamic SDK. Internal refactoring — no API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "SDK Seamless Integration",
+          "description": "Added SDK seamless integration mode for a frictionless checkout experience. Contact your Yuno technical account manager to enable this feature.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "RUT Validation and Masks",
+          "description": "Added Chilean RUT validation and input mask to document fields. Activated automatically for CLP transactions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Dynamic SDK Cleanup",
+          "description": "Removed `OptionalStateValue` and `YunoDynamicConnection` class from the dynamic SDK. Internal refactoring — no API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.17.0",
       "release_date": "2024-08-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.17.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.17.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.17.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.17.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Copy Voucher in Enrollment Flow", "description": "Added a copy button for voucher codes in the enrollment flow. Users can now copy the voucher code directly from the enrollment screen.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Dynamic SDK Conditional Dependencies", "description": "Added dependencies for dynamic SDK condition evaluation. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Dynamic SDK Text Field Restrictions", "description": "Restricted allowed characters in dynamic SDK text fields for CARD and APM types to improve input validation. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Copy Voucher in Enrollment Flow",
+          "description": "Added a copy button for voucher codes in the enrollment flow. Users can now copy the voucher code directly from the enrollment screen.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dynamic SDK Conditional Dependencies",
+          "description": "Added dependencies for dynamic SDK condition evaluation. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Dynamic SDK Text Field Restrictions",
+          "description": "Restricted allowed characters in dynamic SDK text fields for CARD and APM types to improve input validation. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.16.0",
       "release_date": "2024-07-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.16.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.16.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.16.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.16.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "FAC 3DS Action", "description": "Added FAC 3DS action support. Activated automatically for eligible FAC transactions — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Enrolled Card Form in Dynamic SDK", "description": "Added enrolled card form support to the dynamic SDK. Enrolled cards can now be managed through dynamic SDK flows.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Step-by-Step Card Form in Dynamic SDK", "description": "Implemented step-by-step card form in the dynamic SDK. The multi-step card entry flow is now available in dynamic integrations.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Backend-Driven Icons and View Names", "description": "Icons and view names in the dynamic SDK are now fetched from the backend. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "FAC 3DS Action",
+          "description": "Added FAC 3DS action support. Activated automatically for eligible FAC transactions — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Enrolled Card Form in Dynamic SDK",
+          "description": "Added enrolled card form support to the dynamic SDK. Enrolled cards can now be managed through dynamic SDK flows.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Step-by-Step Card Form in Dynamic SDK",
+          "description": "Implemented step-by-step card form in the dynamic SDK. The multi-step card entry flow is now available in dynamic integrations.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Backend-Driven Icons and View Names",
+          "description": "Icons and view names in the dynamic SDK are now fetched from the backend. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.15.0",
       "release_date": "2024-06-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.15.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.15.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.15.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.15.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Step-by-Step Dynamic SDK", "description": "Implemented step-by-step card form functionality in the dynamic SDK. The multi-step flow guides users through card entry one field at a time.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "RUT Validation", "description": "Added Chilean RUT document validation. Validation is applied automatically to RUT fields in payment and enrollment forms.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Dynamic SDK Analytics", "description": "Added analytics event tracking for dynamic SDK flows. Events are sent automatically — no integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Accessibility Identifiers for Automation", "description": "Added accessibility identifiers to the sample app for UI automation testing. No production integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Step-by-Step Dynamic SDK",
+          "description": "Implemented step-by-step card form functionality in the dynamic SDK. The multi-step flow guides users through card entry one field at a time.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "RUT Validation",
+          "description": "Added Chilean RUT document validation. Validation is applied automatically to RUT fields in payment and enrollment forms.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dynamic SDK Analytics",
+          "description": "Added analytics event tracking for dynamic SDK flows. Events are sent automatically — no integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Accessibility Identifiers for Automation",
+          "description": "Added accessibility identifiers to the sample app for UI automation testing. No production integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.9.0",
       "release_date": "2024-04-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.9.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.9.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.9.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.9.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Loader and Service Timeout", "description": "Added loader display during service calls and configurable service timeout. No integration changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Analytics Event Flow", "description": "Improved the analytics event flow for more accurate and complete event reporting. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Loader and Service Timeout",
+          "description": "Added loader display during service calls and configurable service timeout. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Analytics Event Flow",
+          "description": "Improved the analytics event flow for more accurate and complete event reporting. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.6.2",
       "release_date": "2024-02-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.6.2\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.6.2'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.6.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.6.2'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Background Payment Status Query", "description": "Added automatic payment status query when the app returns from background. This ensures the SDK has the latest payment state after the user completes a redirect flow.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Background Payment Status Query",
+          "description": "Added automatic payment status query when the app returns from background. This ensures the SDK has the latest payment state after the user completes a redirect flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.19",
       "release_date": "2024-01-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.19\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.19'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.19\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.19'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Mercado Pago Checkout Pro Caching", "description": "Resolved a caching issue in Mercado Pago Checkout Pro that caused stale payment sessions to be reused. The SDK now always fetches a fresh session.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Daviplata Document Type Filtering", "description": "Implemented document type filtering in the Daviplata enrollment form. Only supported document types are shown, reducing user errors.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Mercado Pago Checkout Pro Caching",
+          "description": "Resolved a caching issue in Mercado Pago Checkout Pro that caused stale payment sessions to be reused. The SDK now always fetches a fresh session.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Daviplata Document Type Filtering",
+          "description": "Implemented document type filtering in the Daviplata enrollment form. Only supported document types are shown, reducing user errors.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.18",
       "release_date": "2023-12-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.18\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.18'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.18\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.18'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Loader Persistence Support", "description": "Added support for persisting the loader between navigation steps. No integration changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Loader Persistence Support",
+          "description": "Added support for persisting the loader between navigation steps. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.17",
       "release_date": "2023-12-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.17\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.17'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.17\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.17'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Terms and Conditions Opening Bug", "description": "Fixed a bug that prevented the terms and conditions link from opening correctly. The link now opens in the in-app browser as expected.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "CheckboxColor in Yuno Appearance", "description": "Added a `checkboxColor` field to the `Yuno.Appearance` object. Use this to customize the checkbox color in forms.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Payment Method Form Improvements", "description": "Improved the payment method form layout and usability. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Terms and Conditions Opening Bug",
+          "description": "Fixed a bug that prevented the terms and conditions link from opening correctly. The link now opens in the in-app browser as expected.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "CheckboxColor in Yuno Appearance",
+          "description": "Added a `checkboxColor` field to the `Yuno.Appearance` object. Use this to customize the checkbox color in forms.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Payment Method Form Improvements",
+          "description": "Improved the payment method form layout and usability. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.16",
       "release_date": "2023-11-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.16\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.16'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.16\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.16'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Card Form Improvements", "description": "Multiple improvements to the card form UI and validation. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Card Form Improvements",
+          "description": "Multiple improvements to the card form UI and validation. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.15",
       "release_date": "2023-11-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.15\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.15'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.15\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.15'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Required Fields in Card Form", "description": "Added required field enforcement to the card form. Fields marked as required by the payment method configuration now block form submission when empty.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Required Fields in Card Form",
+          "description": "Added required field enforcement to the card form. Fields marked as required by the payment method configuration now block form submission when empty.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.14",
       "release_date": "2023-10-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.14\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.14'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.14\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.14'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Openpay Payment Method", "description": "Added support for Openpay payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "One-Step Card Form Customization", "description": "Added customization options for the one-step card form. Configure appearance via the `Yuno.Appearance` object.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Openpay Payment Method",
+          "description": "Added support for Openpay payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "One-Step Card Form Customization",
+          "description": "Added customization options for the one-step card form. Configure appearance via the `Yuno.Appearance` object.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.13",
       "release_date": "2023-10-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.13\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.13'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.13\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.13'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "New Payment Method Types", "description": "Added support for additional payment method types. New methods are activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "New Payment Method Types",
+          "description": "Added support for additional payment method types. New methods are activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.12",
       "release_date": "2023-09-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.12\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.12'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.12\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.12'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "PagSeguro Checkout Support", "description": "Added support for PagSeguro checkout payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "UNLIMINT Checkout Support", "description": "Added support for UNLIMINT checkout payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "PagSeguro Checkout Support",
+          "description": "Added support for PagSeguro checkout payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "UNLIMINT Checkout Support",
+          "description": "Added support for UNLIMINT checkout payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.11",
       "release_date": "2023-09-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.11\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.11'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.11\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.11'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Multistep Card Form Improvements", "description": "Multiple improvements to the multistep card form flow and validation. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Multistep Card Form Improvements",
+          "description": "Multiple improvements to the multistep card form flow and validation. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.9",
       "release_date": "2023-08-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.9\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.9'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.9\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.9'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "FIXED", "title": "Yuno Appearance Initialization Bug", "description": "Fixed a bug where `Yuno.Appearance` object initialization could fail under certain configurations. The object now initializes correctly in all cases.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Dlocal Redirect Payment Method", "description": "Added support for Dlocal redirect payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Khipu Payment Method", "description": "Added support for Khipu payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Dlocal PSE Payment Method", "description": "Added support for Dlocal PSE payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Multiple Step Card Form Improvements", "description": "Multiple improvements to the multiple-step card form validation and navigation. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "FIXED",
+          "title": "Yuno Appearance Initialization Bug",
+          "description": "Fixed a bug where `Yuno.Appearance` object initialization could fail under certain configurations. The object now initializes correctly in all cases.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dlocal Redirect Payment Method",
+          "description": "Added support for Dlocal redirect payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Khipu Payment Method",
+          "description": "Added support for Khipu payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dlocal PSE Payment Method",
+          "description": "Added support for Dlocal PSE payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Multiple Step Card Form Improvements",
+          "description": "Multiple improvements to the multiple-step card form validation and navigation. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.8",
       "release_date": "2023-07-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.8\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.8'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.8\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.8'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Multiple Step Card Form Improvements", "description": "Multiple improvements to the multiple-step card entry flow. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Multiple Step Card Form Improvements",
+          "description": "Multiple improvements to the multiple-step card entry flow. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.7",
       "release_date": "2023-07-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.7\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.7'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.7\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.7'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Tarjeta Clave Payment Method", "description": "Added support for Tarjeta Clave payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Kushki Payment Method", "description": "Added support for Kushki payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Daviplata UX Improvements", "description": "Improved the Daviplata payment form user experience. No API changes required.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "CHANGED", "title": "Diners Card Form Improvements", "description": "Improved the Diners card entry experience in the card form. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Tarjeta Clave Payment Method",
+          "description": "Added support for Tarjeta Clave payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Kushki Payment Method",
+          "description": "Added support for Kushki payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Daviplata UX Improvements",
+          "description": "Improved the Daviplata payment form user experience. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Diners Card Form Improvements",
+          "description": "Improved the Diners card entry experience in the card form. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.3",
       "release_date": "2023-05-15",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.3\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.3'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.3\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.3'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Multi-Step Card Form Option", "description": "Added multi-step card form as an alternative to the single-step form. Configure via `cardFormType` in SDK initialization.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Multi-Step Card Form Option",
+          "description": "Added multi-step card form as an alternative to the single-step form. Configure via `cardFormType` in SDK initialization.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.1.0",
       "release_date": "2023-04-10",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.0\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.1.0'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.1.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.1.0'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "Swift Package Manager Support", "description": "Added Swift Package Manager distribution. You can now integrate the SDK using either Swift Package Manager or CocoaPods.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "Swift Package Manager Support",
+          "description": "Added Swift Package Manager distribution. You can now integrate the SDK using either Swift Package Manager or CocoaPods.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.0.17",
       "release_date": "2023-03-20",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.0.17\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.0.17'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.0.17\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.0.17'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Card Form General Improvements", "description": "General improvements to the card form including layout, validation, and accessibility. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Card Form General Improvements",
+          "description": "General improvements to the card form including layout, validation, and accessibility. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.0.16",
       "release_date": "2023-03-05",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.0.16\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.0.16'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.0.16\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.0.16'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "CHANGED", "title": "Card Form Wording Improvements", "description": "Updated card form field labels and error messages for clarity. No API changes required.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "CHANGED",
+          "title": "Card Form Wording Improvements",
+          "description": "Updated card form field labels and error messages for clarity. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     },
     {
       "version": "1.0.9",
       "release_date": "2023-02-01",
       "upgrade": [
-        { "label": "Swift Package Manager", "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.0.9\")", "language": "swift" },
-        { "label": "CocoaPods", "snippet": "pod 'YunoSDK', '1.0.9'", "language": "ruby" }
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"1.0.9\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '1.0.9'",
+          "language": "ruby"
+        }
       ],
       "entries": [
-        { "type": "ADDED", "title": "PIX and NuPay Async Payments", "description": "Added async payment support for PIX and NuPay. The SDK now polls for status and notifies the host app when the payment completes.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Card Enrollment Support", "description": "Added card enrollment to allow users to save cards for future payments.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "Wibond Payment Method", "description": "Added support for Wibond payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] },
-        { "type": "ADDED", "title": "MercadoPago Wallet Support", "description": "Added support for MercadoPago Wallet payment method. Activated automatically when configured for your account.", "group": null, "migration_guide": null, "links": [] }
+        {
+          "type": "ADDED",
+          "title": "PIX and NuPay Async Payments",
+          "description": "Added async payment support for PIX and NuPay. The SDK now polls for status and notifies the host app when the payment completes.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Card Enrollment Support",
+          "description": "Added card enrollment to allow users to save cards for future payments.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Wibond Payment Method",
+          "description": "Added support for Wibond payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "MercadoPago Wallet Support",
+          "description": "Added support for MercadoPago Wallet payment method. Activated automatically when configured for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
       ]
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates changelog JSON with new release entries and reformats existing iOS entries without affecting runtime code.
> 
> **Overview**
> Adds new changelog releases for **Android `2.15.0`** and **iOS `2.16.0`**, documenting new enrollment support for flexible/dynamic action screens (and Android tokenization now returning installment details).
> 
> Also reformats many existing entries in `changelog/source/ios.json` from single-line objects to multi-line JSON (content unchanged), plus minor file-ending newline adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30672a8e734ffc41b6a0df1585a34ba0a9e8b6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->