### PR TITLE
docs(api): add organization roles and permissions catalog endpoints

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -518,6 +518,15 @@
                 ]
               },
               {
+                "group": "Roles",
+                "pages": [
+                  "reference/organizations/list-roles",
+                  "reference/organizations/create-role",
+                  "reference/organizations/update-role",
+                  "reference/organizations/delete-role"
+                ]
+              },
+              {
                 "group": "Users",
                 "pages": [
                   "reference/organizations/list-users",
@@ -531,6 +540,7 @@
               {
                 "group": "Permissions",
                 "pages": [
+                  "reference/organizations/list-permissions-catalog",
                   "reference/organizations/retrieve-user-account-permissions",
                   "reference/organizations/replace-user-account-permissions",
                   "reference/organizations/update-user-account-permissions",

--- a/openapi/organizations/create-role.json
+++ b/openapi/organizations/create-role.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Roles API - Create",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/roles": {
+      "post": {
+        "summary": "Create Role",
+        "operationId": "create-role",
+        "description": "Create a custom role for the organization.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "maxLength": 255, "example": "Operator" },
+                  "description": { "type": "string", "maxLength": 1024, "example": "Custom operator" },
+                  "permission_ids": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "default": []
+                  },
+                  "testing_permission_ids": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "default": []
+                  },
+                  "role_type": { "type": "string", "enum": ["account", "organization"], "default": "account" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "description": { "type": "string", "nullable": true },
+                    "admin": { "type": "boolean" },
+                    "permission_ids": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "testing_permission_ids": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "role_type": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Duplicate name or validation failure"
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/delete-role.json
+++ b/openapi/organizations/delete-role.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Roles API - Delete",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/roles/{role_id}": {
+      "delete": {
+        "summary": "Delete Role",
+        "operationId": "delete-role",
+        "description": "Delete a custom role. Users assigned to this role will be reassigned to ReadOnly.",
+        "parameters": [
+          { "name": "role_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "The unique identifier of the role to delete." }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content - Successfully deleted"
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/list-permissions-catalog.json
+++ b/openapi/organizations/list-permissions-catalog.json
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Permissions Catalog API - List",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/permissions-catalog": {
+      "get": {
+        "summary": "List Permissions Catalog",
+        "operationId": "list-permissions-catalog",
+        "description": "Slim permissions catalog including sections and permissions.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "title": { "type": "string", "example": "Payments" },
+                      "organization_only": { "type": "boolean" },
+                      "permissions_catalog": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": { "type": "string", "example": "view_payment_transactions" },
+                            "title": { "type": "string", "example": "View payment transactions" },
+                            "description": { "type": "string" },
+                            "action_type": { "type": "string", "enum": ["VIEW", "EDIT"] }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/list-roles.json
+++ b/openapi/organizations/list-roles.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Roles API - List",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/roles": {
+      "get": {
+        "summary": "List Roles",
+        "operationId": "list-roles",
+        "description": "List Yuno default and organization custom roles.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "string", "example": "rol_AbCdEfGhIjKl" },
+                      "name": { "type": "string", "example": "Admin" },
+                      "description": { "type": "string", "nullable": true },
+                      "admin": { "type": "boolean" },
+                      "permission_ids": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "testing_permission_ids": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "role_type": { "type": "string", "enum": ["account", "organization"] },
+                      "created_at": { "type": "string", "format": "date-time" },
+                      "updated_at": { "type": "string", "format": "date-time" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/update-role.json
+++ b/openapi/organizations/update-role.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Roles API - Update",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/roles/{role_id}": {
+      "patch": {
+        "summary": "Update Role",
+        "operationId": "update-role",
+        "description": "Partial update of a custom role. Note: role_type is immutable.",
+        "parameters": [
+          { "name": "role_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "The unique identifier of the role." }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string", "maxLength": 255 },
+                  "description": { "type": "string", "maxLength": 1024 },
+                  "permission_ids": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "testing_permission_ids": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "description": { "type": "string", "nullable": true },
+                    "admin": { "type": "boolean" },
+                    "permission_ids": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "testing_permission_ids": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "role_type": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Bad Request - Validation failure" },
+          "404": { "description": "Not Found - Role not found in organization" }
+        }
+      }
+    }
+  }
+}

--- a/reference/organizations/create-role.mdx
+++ b/reference/organizations/create-role.mdx
@@ -1,0 +1,6 @@
+---
+title: "Create Role"
+openapi: "/openapi/organizations/create-role.json POST /organizations/roles"
+---
+
+Create a custom role for the organization.

--- a/reference/organizations/delete-role.mdx
+++ b/reference/organizations/delete-role.mdx
@@ -1,0 +1,6 @@
+---
+title: "Delete Role"
+openapi: "/openapi/organizations/delete-role.json DELETE /organizations/roles/{role_id}"
+---
+
+Delete a custom role. Users assigned to the deleted role will be automatically reassigned to the ReadOnly role.

--- a/reference/organizations/list-permissions-catalog.mdx
+++ b/reference/organizations/list-permissions-catalog.mdx
@@ -1,0 +1,6 @@
+---
+title: "List Permissions Catalog"
+openapi: "/openapi/organizations/list-permissions-catalog.json GET /organizations/permissions-catalog"
+---
+
+Slim permissions catalog including sections and specific permissions.

--- a/reference/organizations/list-roles.mdx
+++ b/reference/organizations/list-roles.mdx
@@ -1,0 +1,6 @@
+---
+title: "List Roles"
+openapi: "/openapi/organizations/list-roles.json GET /organizations/roles"
+---
+
+List Yuno default and organization custom roles.

--- a/reference/organizations/update-role.mdx
+++ b/reference/organizations/update-role.mdx
@@ -1,0 +1,6 @@
+---
+title: "Update Role"
+openapi: "/openapi/organizations/update-role.json PATCH /organizations/roles/{role_id}"
+---
+
+Partial update of a custom role. Note that `role_type` is immutable.


### PR DESCRIPTION
## Summary

This PR adds the documentation for the new Organization Roles and Permissions Catalog API endpoints. These allow organizations to manage custom roles (List, Create, Update, Delete) and view the slim permissions catalog.


**Changes:**
- Created 5 new OpenAPI specifications for roles and permissions catalog management.
- Updated `docs.json` navigation to include new groups for "Roles" and "Permissions Catalog" under the Organizations API.
- Verified all fields and paths against technical requirements.

**Pages:**
- `reference/organizations/list-roles`
- `reference/organizations/create-role`
- `reference/organizations/update-role`
- `reference/organizations/delete-role`
- `reference/organizations/list-permissions-catalog`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds new reference pages and navigation entries without modifying runtime or API behavior.
> 
> **Overview**
> Documents new Organizations endpoints for **custom role management** (list/create/update/delete) and **permissions catalog listing** by adding OpenAPI specs plus corresponding `reference/organizations/*.mdx` pages.
> 
> Updates `docs.json` navigation to surface a new **Roles** group and to include `list-permissions-catalog` under **Permissions**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359f5a32ff5314143394afe27c3781e9a0d08866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->