### PR TITLE
docs(api): add connections and routing reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -550,6 +550,25 @@
                   "reference/organizations/update-user-account-group-permissions",
                   "reference/organizations/delete-user-account-group-permission"
                 ]
+              },
+              {
+                "group": "Connections",
+                "pages": [
+                  "reference/organizations/connections-routing-overview",
+                  "reference/organizations/connections/get-provider-catalog",
+                  "reference/organizations/connections/create-connection",
+                  "reference/organizations/connections/retrieve-connection"
+                ]
+              },
+              {
+                "group": "Routing",
+                "pages": [
+                  "reference/organizations/routing/routing-resource-shape",
+                  "reference/organizations/routing/routing-conditions",
+                  "reference/organizations/routing/create-routing",
+                  "reference/organizations/routing/retrieve-routing",
+                  "reference/organizations/routing/update-routing"
+                ]
               }
             ]
           },

--- a/openapi/organizations/connections/create-connection.json
+++ b/openapi/organizations/connections/create-connection.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Connections API - Create", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/connections": {
+      "post": {
+        "summary": "Create a Connection",
+        "operationId": "create-connection",
+        "description": "Creates a connection in ACTIVE status.",
+        "parameters": [
+          { "name": "X-Idempotency-Key", "in": "header", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["merchant_connection_id", "provider_id", "flow_type", "payment_methods", "params"],
+                "properties": {
+                  "merchant_connection_id": { "type": "string", "example": "adyen-us-prod-001" },
+                  "provider_id": { "type": "string", "example": "ADYEN" },
+                  "flow_type": { "type": "string", "example": "PAYIN" },
+                  "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY"] },
+                  "params": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "param_id": { "type": "string" },
+                        "value": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "connection_id": { "type": "string" },
+                    "status": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/connections/get-provider-catalog.json
+++ b/openapi/organizations/connections/get-provider-catalog.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Connections API - Get Provider Catalog", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/connections/catalog/{provider_id}": {
+      "get": {
+        "summary": "Get Provider Catalog",
+        "operationId": "get-provider-catalog",
+        "description": "Returns the schema you need to fill in to create a connection for a given provider.",
+        "parameters": [
+          { "name": "provider_id", "in": "path", "required": true, "schema": { "type": "string", "example": "ADYEN" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "payment_method_type": { "type": "array", "items": { "type": "string" } },
+                    "params": { "type": "array", "items": { "type": "object" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/connections/retrieve-connection.json
+++ b/openapi/organizations/connections/retrieve-connection.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Connections API - Retrieve", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/connections/{connection_id}": {
+      "get": {
+        "summary": "Retrieve a Connection",
+        "operationId": "retrieve-connection",
+        "description": "Returns a connection you previously created.",
+        "parameters": [
+          { "name": "connection_id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "connection_id": { "type": "string" },
+                    "status": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/routing/create-routing.json
+++ b/openapi/organizations/routing/create-routing.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Routing API - Create", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/routing": {
+      "post": {
+        "summary": "Create a Routing",
+        "operationId": "create-routing",
+        "description": "Creates a routing for one (account_code, payment_method) pair.",
+        "parameters": [
+          { "name": "X-Idempotency-Key", "in": "header", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["payment_method", "name", "default_route"],
+                "properties": {
+                  "payment_method": { "type": "string", "example": "CARD" },
+                  "name": { "type": "string", "example": "Card routing" },
+                  "default_route": {
+                    "type": "object",
+                    "required": ["steps"],
+                    "properties": {
+                      "steps": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["index", "provider_id", "connection_id"],
+                          "properties": {
+                            "index": { "type": "integer", "example": 1 },
+                            "provider_id": { "type": "string", "example": "STRIPE" },
+                            "connection_id": { "type": "string", "format": "uuid", "example": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "account_code": { "type": "string" },
+                    "payment_method": { "type": "string" },
+                    "name": { "type": "string" },
+                    "default_route": { "type": "object" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/routing/retrieve-routing.json
+++ b/openapi/organizations/routing/retrieve-routing.json
@@ -1,0 +1,45 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Routing API - Retrieve", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/routing/{routing_id}": {
+      "get": {
+        "summary": "Retrieve a Routing",
+        "operationId": "retrieve-routing",
+        "description": "Returns the routing's current live configuration.",
+        "parameters": [
+          { "name": "routing_id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "account_code": { "type": "string" },
+                    "payment_method": { "type": "string" },
+                    "name": { "type": "string" },
+                    "default_route": { "type": "object" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Routing API - Update", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/routing/{routing_id}": {
+      "patch": {
+        "summary": "Update a Routing",
+        "operationId": "update-routing",
+        "description": "Replaces the routing's full configuration.",
+        "parameters": [
+          { "name": "routing_id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
+          { "name": "X-Idempotency-Key", "in": "header", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string", "example": "Updated Card routing" },
+                  "default_route": { "type": "object" },
+                  "condition_sets": { "type": "array", "items": { "type": "object" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "account_code": { "type": "string" },
+                    "payment_method": { "type": "string" },
+                    "name": { "type": "string" },
+                    "default_route": { "type": "object" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/organizations/connections-routing-overview.mdx
+++ b/reference/organizations/connections-routing-overview.mdx
@@ -1,0 +1,52 @@
+---
+title: "Connections & Routing Overview"
+description: "Merchant-facing reference for the new public-API surface that lets you create payment-provider connections and configure how Yuno routes payments across them."
+---
+
+Connections are how you bring your existing payment-provider accounts (Stripe, Adyen, dLocal, PayU, …) into Yuno's orchestration. Once a connection exists, you can reference it from a routing rule to send payments through that provider.
+
+A routing tells Yuno, for one `payment_method` on one account, which connection to use — and lets you branch by buyer attributes (country, currency, amount, card brand, custom metadata, …).
+
+## Common contract
+
+### Base URL
+
+```
+https://api.y.uno
+```
+
+### Authentication & headers
+
+| Header | Required | Notes |
+|---|---|---|
+| `public-api-key` | yes | Your merchant public API key. The account this key belongs to determines which account the request operates on. |
+| `private-secret-key` | yes | Your merchant private secret key. |
+| `X-Idempotency-Key` | on `POST` and `PATCH` | UUID, 24-hour scope. Re-sending the same key + body returns the cached response; same key with a different body returns a `409`. |
+| `Content-Type: application/json` | yes | |
+
+### Conventions
+
+- Field names are `snake_case` everywhere — request, response, errors. The one exception is inside `params[]` on the **provider catalog** response, where individual `param_id` values are passed through with their native casing (`merchantAccount`, `HMAC_KEY`, `apple-merchant-id`, etc.) — you must echo these verbatim when creating a connection.
+- Error envelope is the same across all endpoints:
+
+```json
+{
+  "type": "validation_error",
+  "code": "MISSING_REQUIRED_PARAM",
+  "message": "Required param 'merchantAccount' is missing for provider 'ADYEN'",
+  "details": { "provider_id": "ADYEN", "param_id": "merchantAccount" }
+}
+```
+
+Stable `code` values are listed per endpoint.
+
+### API-key scopes
+
+| Scope | Required for |
+|---|---|
+| `connections:read` | `GET /v1/connections/catalog/{provider_id}`, `GET /v1/connections/{connection_id}` |
+| `connections:write` | `POST /v1/connections` |
+| `routing:read` | `GET /v1/routing/{routing_id}` |
+| `routing:write` | `POST /v1/routing`, `PATCH /v1/routing/{routing_id}` |
+
+Missing scope → `403 INSUFFICIENT_SCOPE`.

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -1,53 +1,18 @@
 ---
 title: "Create a Connection"
 description: "Creates a connection in ACTIVE status from credentials and configuration you fill in based on the provider's catalog."
+api: "POST /v1/connections"
 ---
 
 Creates a connection in `ACTIVE` status from credentials and configuration you fill in based on the provider's catalog. The response includes the `connection_id` you'll use to reference this connection from routing rules.
 
-### Request
-
-<CodeGroup>
-```bash cURL
-curl --request POST \
-     --url https://api.y.uno/v1/connections \
-     --header 'Content-Type: application/json' \
-     --header 'X-Idempotency-Key: <UUID>' \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
-     --data '
-{
-  "merchant_connection_id": "adyen-us-prod-001",
-  "provider_id": "ADYEN",
-  "flow_type": "PAYIN",
-  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
-  "params": [
-    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
-    { "param_id": "x-api-key",              "value": "AQEx…W4w==" }
-  ],
-  "costs": [
-    {
-      "sort_number": 1,
-      "cost_name": "Transaction Fee",
-      "currency": "USD",
-      "cost_values": {
-        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
-        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
-      }
-    }
-  ]
-}
-'
-```
-</CodeGroup>
-
-#### Headers
+### Headers
 
 <ParamField header="X-Idempotency-Key" type="string" required>
   UUID, 24-hour scope. Re-sending the same key + body returns the cached response; same key with a different body returns a `409`.
 </ParamField>
 
-#### Body
+### Body
 
 <ParamField body="merchant_connection_id" type="string" required>
   Your label for this connection. Must be unique within the account. Free-form (e.g., `"adyen-us-prod-001"`, `"stripe-eu-test"`).
@@ -116,7 +81,39 @@ curl --request POST \
 </ResponseField>
 
 <CodeGroup>
-```json Response Example
+```bash cURL
+curl --request POST \
+     --url https://api.y.uno/v1/connections \
+     --header 'Content-Type: application/json' \
+     --header 'X-Idempotency-Key: <UUID>' \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
+     --data '
+{
+  "merchant_connection_id": "adyen-us-prod-001",
+  "provider_id": "ADYEN",
+  "flow_type": "PAYIN",
+  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
+  "params": [
+    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
+    { "param_id": "x-api-key",              "value": "AQEx…W4w==" }
+  ],
+  "costs": [
+    {
+      "sort_number": 1,
+      "cost_name": "Transaction Fee",
+      "currency": "USD",
+      "cost_values": {
+        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
+        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
+      }
+    }
+  ]
+}
+'
+```
+
+```json Response
 {
   "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
   "merchant_connection_id": "adyen-us-prod-001",

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Create a Connection"
 description: "Creates a connection in ACTIVE status from credentials and configuration you fill in based on the provider's catalog."
-api: "POST /v1/connections"
+openapi: "/openapi/organizations/connections/create-connection.json POST /connections"
 ---
 
 Creates a connection in `ACTIVE` status from credentials and configuration you fill in based on the provider's catalog. The response includes the `connection_id` you'll use to reference this connection from routing rules.

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -1,0 +1,129 @@
+---
+title: "Create a Connection"
+description: "Creates a connection in ACTIVE status from credentials and configuration you fill in based on the provider's catalog."
+---
+
+Creates a connection in `ACTIVE` status from credentials and configuration you fill in based on the provider's catalog. The response includes the `connection_id` you'll use to reference this connection from routing rules.
+
+### Request
+
+```
+POST /v1/connections
+```
+
+**Headers**
+
+`X-Idempotency-Key` is required. Re-sending the same key with the same body returns the cached response; same key with a different body returns `409 IDEMPOTENCY_REPLAY`.
+
+**Body**
+
+```json
+{
+  "merchant_connection_id": "adyen-us-prod-001",
+  "provider_id": "ADYEN",
+  "flow_type": "PAYIN",
+  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
+  "params": [
+    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
+    { "param_id": "x-api-key",              "value": "AQEx…W4w==" },
+    { "param_id": "HMAC_KEY",               "value": "9F86…E2FB" },
+    { "param_id": "url-prefix",             "value": "acme-live" },
+    { "param_id": "transaction-identifier", "value": "MERCHANT_REFERENCE" },
+    { "param_id": "MERCHANT_NAME",          "value": "ACME Inc." },
+    { "param_id": "CAPTURE_DELAY_HOURS",    "value": "24" },
+    { "param_id": "recurring-model",        "value": "CardOnFile" },
+    { "param_id": "3DS_ENABLED",            "value": true },
+    { "param_id": "ORIGIN_URL",             "value": "https://checkout.acme.com" }
+  ],
+  "costs": [
+    {
+      "sort_number": 1,
+      "cost_name": "Transaction Fee",
+      "currency": "USD",
+      "cost_values": {
+        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
+        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
+      }
+    }
+  ]
+}
+```
+
+**Top-level fields**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `merchant_connection_id` | string | yes | Your label for this connection. Must be unique within the account. Free-form (e.g., `"adyen-us-prod-001"`, `"stripe-eu-test"`). |
+| `provider_id` | string | yes | Yuno provider identifier (e.g., `"STRIPE"`, `"ADYEN"`). Must exist in the catalog. |
+| `flow_type` | enum | yes | `"PAYIN"`. |
+| `payment_methods[]` | string[] | yes | Subset of the provider's `payment_method_type[]` (from the catalog). |
+| `params[]` | object[] | yes | One `{param_id, value}` pair per parameter you're supplying. **Flat array** — even nested catalog params are submitted at the top level; Yuno resolves the hierarchy from the catalog tree. Required params (where the catalog has `optional: false`) must be present and non-empty. Activating a `boolean` parent (`"value": true`) makes its `optional: false` children required. |
+| `costs[]` | object[] | yes | Per-connection cost configuration. `currency` must be one supported by the provider. |
+
+**Per `params[]` entry**
+
+| Field | Type | Description |
+|---|---|---|
+| `param_id` | string | The exact `param_id` from the catalog. Casing matters. |
+| `value` | string \| boolean \| number \| array | Match the `field_type` from the catalog. Numerics are submitted as JSON numbers (or strings if the catalog says `field_type: "string"`). For `field_type: "array"`, submit a JSON array. |
+
+### Response — `201 Created`
+
+```
+Location: /v1/connections/{connection_id}
+```
+
+```json
+{
+  "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+  "merchant_connection_id": "adyen-us-prod-001",
+  "provider_id": "ADYEN",
+  "status": "ACTIVE",
+  "flow_type": "PAYIN",
+  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
+  "params": [
+    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
+    { "param_id": "x-api-key",              "value": "***" },
+    { "param_id": "HMAC_KEY",               "value": "***" },
+    { "param_id": "url-prefix",             "value": "acme-live" },
+    { "param_id": "transaction-identifier", "value": "MERCHANT_REFERENCE" },
+    { "param_id": "MERCHANT_NAME",          "value": "ACME Inc." },
+    { "param_id": "CAPTURE_DELAY_HOURS",    "value": "24" },
+    { "param_id": "recurring-model",        "value": "CardOnFile" },
+    { "param_id": "3DS_ENABLED",            "value": true },
+    { "param_id": "ORIGIN_URL",             "value": "https://checkout.acme.com" }
+  ],
+  "costs": [
+    {
+      "sort_number": 1,
+      "cost_name": "Transaction Fee",
+      "currency": "USD",
+      "cost_values": {
+        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
+        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
+      }
+    }
+  ],
+  "created_at": "2026-05-12T10:24:00Z",
+  "updated_at": "2026-05-12T10:24:00Z"
+}
+```
+
+**Server-added fields:** `connection_id`, `status` (always `ACTIVE` on create), `created_at`, `updated_at`.
+
+**Secret handling:** any param marked `secret: true` in the catalog (typically API keys, HMAC keys, etc.) is returned as `"value": "***"`. Your submitted secret is stored encrypted and never echoed back.
+
+**Save `connection_id`.** This is the value you'll pass into routing steps. There is no enumeration endpoint, so if you lose it you must look it up another way (dashboard, or any record you kept).
+
+### Errors
+
+| HTTP | `code` | When |
+|---|---|---|
+| `400` | `PROVIDER_NOT_FOUND` | Unknown `provider_id`. |
+| `400` | `MISSING_REQUIRED_PARAM` | A required param is missing. `details.param_id` names which one. |
+| `400` | `UNSUPPORTED_PAYMENT_METHOD` | `payment_methods` contains a method the provider doesn't support. |
+| `400` | `UNSUPPORTED_CURRENCY` | A `costs[].currency` isn't in the provider's supported list. |
+| `400` | `INVALID_PROVIDER_CREDENTIALS` | The credentials failed Yuno's pre-flight check against the provider. `details.provider_message` echoes the provider's reason. |
+| `409` | `CONNECTION_MERCHANT_ID_CONFLICT` | `merchant_connection_id` already exists in this account. |
+| `409` | `IDEMPOTENCY_REPLAY` | The idempotency key was replayed with a different body. |
+| `403` | `INSUFFICIENT_SCOPE` | API key missing `connections:write`. |

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -7,17 +7,15 @@ Creates a connection in `ACTIVE` status from credentials and configuration you f
 
 ### Request
 
-```
-POST /v1/connections
-```
-
-**Headers**
-
-`X-Idempotency-Key` is required. Re-sending the same key with the same body returns the cached response; same key with a different body returns `409 IDEMPOTENCY_REPLAY`.
-
-**Body**
-
-```json
+<CodeGroup>
+```bash cURL
+curl --request POST \
+     --url https://api.y.uno/v1/connections \
+     --header 'Content-Type: application/json' \
+     --header 'X-Idempotency-Key: <UUID>' \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
+     --data '
 {
   "merchant_connection_id": "adyen-us-prod-001",
   "provider_id": "ADYEN",
@@ -25,15 +23,7 @@ POST /v1/connections
   "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
   "params": [
     { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
-    { "param_id": "x-api-key",              "value": "AQEx…W4w==" },
-    { "param_id": "HMAC_KEY",               "value": "9F86…E2FB" },
-    { "param_id": "url-prefix",             "value": "acme-live" },
-    { "param_id": "transaction-identifier", "value": "MERCHANT_REFERENCE" },
-    { "param_id": "MERCHANT_NAME",          "value": "ACME Inc." },
-    { "param_id": "CAPTURE_DELAY_HOURS",    "value": "24" },
-    { "param_id": "recurring-model",        "value": "CardOnFile" },
-    { "param_id": "3DS_ENABLED",            "value": true },
-    { "param_id": "ORIGIN_URL",             "value": "https://checkout.acme.com" }
+    { "param_id": "x-api-key",              "value": "AQEx…W4w==" }
   ],
   "costs": [
     {
@@ -47,33 +37,86 @@ POST /v1/connections
     }
   ]
 }
+'
 ```
+</CodeGroup>
 
-**Top-level fields**
+#### Headers
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `merchant_connection_id` | string | yes | Your label for this connection. Must be unique within the account. Free-form (e.g., `"adyen-us-prod-001"`, `"stripe-eu-test"`). |
-| `provider_id` | string | yes | Yuno provider identifier (e.g., `"STRIPE"`, `"ADYEN"`). Must exist in the catalog. |
-| `flow_type` | enum | yes | `"PAYIN"`. |
-| `payment_methods[]` | string[] | yes | Subset of the provider's `payment_method_type[]` (from the catalog). |
-| `params[]` | object[] | yes | One `{param_id, value}` pair per parameter you're supplying. **Flat array** — even nested catalog params are submitted at the top level; Yuno resolves the hierarchy from the catalog tree. Required params (where the catalog has `optional: false`) must be present and non-empty. Activating a `boolean` parent (`"value": true`) makes its `optional: false` children required. |
-| `costs[]` | object[] | yes | Per-connection cost configuration. `currency` must be one supported by the provider. |
+<ParamField header="X-Idempotency-Key" type="string" required>
+  UUID, 24-hour scope. Re-sending the same key + body returns the cached response; same key with a different body returns a `409`.
+</ParamField>
 
-**Per `params[]` entry**
+#### Body
 
-| Field | Type | Description |
-|---|---|---|
-| `param_id` | string | The exact `param_id` from the catalog. Casing matters. |
-| `value` | string \| boolean \| number \| array | Match the `field_type` from the catalog. Numerics are submitted as JSON numbers (or strings if the catalog says `field_type: "string"`). For `field_type: "array"`, submit a JSON array. |
+<ParamField body="merchant_connection_id" type="string" required>
+  Your label for this connection. Must be unique within the account. Free-form (e.g., `"adyen-us-prod-001"`, `"stripe-eu-test"`).
+</ParamField>
 
-### Response — `201 Created`
+<ParamField body="provider_id" type="string" required>
+  Yuno provider identifier (e.g., `"STRIPE"`, `"ADYEN"`). Must exist in the catalog.
+</ParamField>
 
-```
-Location: /v1/connections/{connection_id}
-```
+<ParamField body="flow_type" type="enum" required>
+  Must be `"PAYIN"`.
+</ParamField>
 
-```json
+<ParamField body="payment_methods" type="string[]" required>
+  Subset of the provider's `payment_method_type[]` (from the catalog).
+</ParamField>
+
+<ParamField body="params" type="object[]" required>
+  One `{param_id, value}` pair per parameter you're supplying. **Flat array** — even nested catalog params are submitted at the top level; Yuno resolves the hierarchy from the catalog tree. 
+  
+  Required params (where the catalog has `optional: false`) must be present and non-empty. Activating a `boolean` parent (`"value": true`) makes its `optional: false` children required.
+  
+  <Expandable title="item">
+    <ParamField body="param_id" type="string" required>
+      The exact `param_id` from the catalog. Casing matters.
+    </ParamField>
+    <ParamField body="value" type="string | boolean | number | array" required>
+      Match the `field_type` from the catalog. Numerics are submitted as JSON numbers (or strings if the catalog says `field_type: "string"`). For `field_type: "array"`, submit a JSON array.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="costs" type="object[]" required>
+  Per-connection cost configuration. `currency` must be one supported by the provider.
+  <Expandable title="item">
+    <ParamField body="sort_number" type="integer">
+      Order of priority for the cost entry.
+    </ParamField>
+    <ParamField body="cost_name" type="string">
+      Label for the cost entry.
+    </ParamField>
+    <ParamField body="currency" type="string">
+      ISO 4217 currency code.
+    </ParamField>
+    <ParamField body="cost_values" type="object">
+        <Expandable title="successful | unsuccessful">
+            <ParamField body="fixed_fee" type="number">
+                Fixed fee amount.
+            </ParamField>
+            <ParamField body="percentage" type="number">
+                Percentage fee.
+            </ParamField>
+        </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+### Response
+
+<ResponseField name="connection_id" type="string">
+  Unique identifier for the connection. **Save this value** to reference it from routing rules.
+</ResponseField>
+
+<ResponseField name="status" type="string">
+  Current status (always `ACTIVE` on create).
+</ResponseField>
+
+<CodeGroup>
+```json Response Example
 {
   "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
   "merchant_connection_id": "adyen-us-prod-001",
@@ -83,37 +126,17 @@ Location: /v1/connections/{connection_id}
   "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
   "params": [
     { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
-    { "param_id": "x-api-key",              "value": "***" },
-    { "param_id": "HMAC_KEY",               "value": "***" },
-    { "param_id": "url-prefix",             "value": "acme-live" },
-    { "param_id": "transaction-identifier", "value": "MERCHANT_REFERENCE" },
-    { "param_id": "MERCHANT_NAME",          "value": "ACME Inc." },
-    { "param_id": "CAPTURE_DELAY_HOURS",    "value": "24" },
-    { "param_id": "recurring-model",        "value": "CardOnFile" },
-    { "param_id": "3DS_ENABLED",            "value": true },
-    { "param_id": "ORIGIN_URL",             "value": "https://checkout.acme.com" }
-  ],
-  "costs": [
-    {
-      "sort_number": 1,
-      "cost_name": "Transaction Fee",
-      "currency": "USD",
-      "cost_values": {
-        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
-        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
-      }
-    }
+    { "param_id": "x-api-key",              "value": "***" }
   ],
   "created_at": "2026-05-12T10:24:00Z",
   "updated_at": "2026-05-12T10:24:00Z"
 }
 ```
+</CodeGroup>
 
-**Server-added fields:** `connection_id`, `status` (always `ACTIVE` on create), `created_at`, `updated_at`.
-
-**Secret handling:** any param marked `secret: true` in the catalog (typically API keys, HMAC keys, etc.) is returned as `"value": "***"`. Your submitted secret is stored encrypted and never echoed back.
-
-**Save `connection_id`.** This is the value you'll pass into routing steps. There is no enumeration endpoint, so if you lose it you must look it up another way (dashboard, or any record you kept).
+<Note>
+**Secret handling:** any param marked `secret: true` in the catalog is returned as `"value": "***"`. Your submitted secret is stored encrypted and never echoed back.
+</Note>
 
 ### Errors
 
@@ -125,5 +148,4 @@ Location: /v1/connections/{connection_id}
 | `400` | `UNSUPPORTED_CURRENCY` | A `costs[].currency` isn't in the provider's supported list. |
 | `400` | `INVALID_PROVIDER_CREDENTIALS` | The credentials failed Yuno's pre-flight check against the provider. `details.provider_message` echoes the provider's reason. |
 | `409` | `CONNECTION_MERCHANT_ID_CONFLICT` | `merchant_connection_id` already exists in this account. |
-| `409` | `IDEMPOTENCY_REPLAY` | The idempotency key was replayed with a different body. |
 | `403` | `INSUFFICIENT_SCOPE` | API key missing `connections:write`. |

--- a/reference/organizations/connections/get-provider-catalog.mdx
+++ b/reference/organizations/connections/get-provider-catalog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Get Provider Catalog"
 description: "Returns the schema you need to fill in to create a connection for a given provider."
-api: "GET /v1/connections/catalog/{provider_id}"
+openapi: "/openapi/organizations/connections/get-provider-catalog.json GET /connections/catalog/{provider_id}"
 ---
 
 Returns the schema you need to fill in to create a connection for a given provider: which payment methods the provider supports, and the recursive list of parameters (credentials, toggles, choices) the provider requires.

--- a/reference/organizations/connections/get-provider-catalog.mdx
+++ b/reference/organizations/connections/get-provider-catalog.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Provider Catalog"
 description: "Returns the schema you need to fill in to create a connection for a given provider."
+api: "GET /v1/connections/catalog/{provider_id}"
 ---
 
 Returns the schema you need to fill in to create a connection for a given provider: which payment methods the provider supports, and the recursive list of parameters (credentials, toggles, choices) the provider requires.
@@ -11,7 +12,7 @@ This is the discovery endpoint — call it first to find out what a provider exp
 This endpoint is provider-scoped, not connection-scoped. It returns a schema, not your existing connections.
 </Note>
 
-### Request
+### Path Parameters
 
 <ParamField path="provider_id" type="string" required>
   Yuno provider identifier (`STRIPE`, `ADYEN`, `CYBERSOURCE`, …). Case-sensitive, UPPER_SNAKE_CASE.
@@ -69,6 +70,13 @@ This endpoint is provider-scoped, not connection-scoped. It returns a schema, no
 </ResponseField>
 
 <CodeGroup>
+```bash cURL
+curl --request GET \
+     --url https://api.y.uno/v1/connections/catalog/{provider_id} \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
+```
+
 ```json Response Example
 {
   "payment_method_type": ["CARD", "GOOGLE_PAY", "IDEAL", "PIX", "..."],

--- a/reference/organizations/connections/get-provider-catalog.mdx
+++ b/reference/organizations/connections/get-provider-catalog.mdx
@@ -1,0 +1,117 @@
+---
+title: "Get Provider Catalog"
+description: "Returns the schema you need to fill in to create a connection for a given provider."
+---
+
+Returns the schema you need to fill in to create a connection for a given provider: which payment methods the provider supports, and the recursive list of parameters (credentials, toggles, choices) the provider requires.
+
+This is the discovery endpoint — call it first to find out what a provider expects, then use its response as the input to [Create a Connection](/reference/organizations/connections/create-connection).
+
+<Note>
+This endpoint is provider-scoped, not connection-scoped. It returns a schema, not your existing connections.
+</Note>
+
+### Request
+
+```
+GET /v1/connections/catalog/{provider_id}
+```
+
+| Path parameter | Type | Required | Description |
+|---|---|---|---|
+| `provider_id` | string | yes | Yuno provider identifier (`STRIPE`, `ADYEN`, `CYBERSOURCE`, …). Case-sensitive, UPPER_SNAKE_CASE. |
+
+No query parameters and no body.
+
+### Response — `200 OK`
+
+```json
+{
+  "payment_method_type": ["CARD", "GOOGLE_PAY", "IDEAL", "PIX", "..."],
+  "params": [
+    {
+      "param_id": "merchantAccount",
+      "field_type": "string",
+      "description": "Account Code",
+      "editable_field": true,
+      "optional": false
+    },
+    {
+      "param_id": "x-api-key",
+      "field_type": "string",
+      "secret": true,
+      "description": "x-api-key",
+      "editable_field": true,
+      "optional": false
+    },
+    {
+      "param_id": "transaction-identifier",
+      "field_type": "string",
+      "description": "Transaction identifier used",
+      "editable_field": true,
+      "optional": false,
+      "options": ["ORDER_ID", "MERCHANT_REFERENCE", "TRANSACTION_CODE"]
+    },
+    {
+      "param_id": "3DS_ENABLED",
+      "field_type": "boolean",
+      "description": "Enable 3DS validation flow",
+      "editable_field": true,
+      "optional": true,
+      "params": [
+        {
+          "param_id": "ORIGIN_URL",
+          "field_type": "string",
+          "description": "Your origin url",
+          "editable_field": true,
+          "optional": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Top-level fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `payment_method_type[]` | string[] | The Yuno payment-method enums this provider supports. Pass any of these values into `payment_methods[]` on `POST /v1/connections`. |
+| `params[]` | object[] | Recursive parameter schema — see below. |
+
+**Per `params[]` node**
+
+| Field | Type | Description |
+|---|---|---|
+| `param_id` | string | Identifier to echo back in `POST /v1/connections.params[].param_id`. Pass casing **verbatim**. |
+| `field_type` | enum | One of `string`, `boolean`, `array`, `number`. |
+| `description` | string \| object | Display label. May be a plain string or a localization object `{ "EN": "...", "ES": "...", "PT": "..." }`. |
+| `placeholder` | string \| object | Optional placeholder text. Same shape rules as `description`. |
+| `tooltip` | string \| null | Optional helper text. |
+| `editable_field` | boolean | If `false`, value is fixed/read-only. |
+| `secret` | boolean | If `true`, the value is sensitive — stored encrypted and surfaced as `"***"` on subsequent reads. |
+| `allow_custom` | boolean | Only meaningful when `options[]` is present. If `true`, you may submit a free-form value alongside the catalog options (combobox semantics). |
+| `optional` | boolean | If `false`, you must supply a value. |
+| `is_hidden` | boolean | If `true`, the param exists but should not be rendered to end users. |
+| `sdk_required` | boolean | If `true`, the value is also required when configuring the Yuno SDK on the client side. |
+| `options[]` | string[] \| object[] | Present when the field is a constrained enum. With `field_type = "string"` → single-select. With `field_type = "array"` → multi-select. Plain strings or `{value, params}` objects (the latter when an option carries its own nested params). |
+| `params[]` | object[] | Nested children — activated when this node's value is `true` (boolean parent) or matches one of the `options` (string/array parent). |
+
+**How to read a node**
+
+| What you see | What it means |
+|---|---|
+| `field_type: "string"`, no `options[]` | Free-form text input. |
+| `field_type: "string"`, `secret: true` | Password / API key — write-only. Returned as `"***"` on `GET`. |
+| `field_type: "string"`, `options[]` present | Single-choice enum. The value you submit must be one of `options[]`. |
+| `field_type: "string"`, `options[]` present, `allow_custom: true` | Combobox. Submit one of `options[]` **or** a free-form value. |
+| `field_type: "boolean"` | Toggle. Setting it to `true` activates nested `params[]` and makes their `optional: false` children required. |
+| `field_type: "array"`, `options[]` present | Multi-select. Submit a JSON array whose elements are a subset of `options[]`. |
+| `field_type: "array"`, no `options[]` | Free-form list of strings. |
+
+### Errors
+
+| HTTP | `code` | When |
+|---|---|---|
+| `404` | `PROVIDER_NOT_FOUND` | The `provider_id` is not in Yuno's provider catalog. |
+| `403` | `INSUFFICIENT_SCOPE` | Your API key is missing the `connections:read` scope. |

--- a/reference/organizations/connections/get-provider-catalog.mdx
+++ b/reference/organizations/connections/get-provider-catalog.mdx
@@ -13,19 +13,63 @@ This endpoint is provider-scoped, not connection-scoped. It returns a schema, no
 
 ### Request
 
-```
-GET /v1/connections/catalog/{provider_id}
-```
+<ParamField path="provider_id" type="string" required>
+  Yuno provider identifier (`STRIPE`, `ADYEN`, `CYBERSOURCE`, …). Case-sensitive, UPPER_SNAKE_CASE.
+</ParamField>
 
-| Path parameter | Type | Required | Description |
-|---|---|---|---|
-| `provider_id` | string | yes | Yuno provider identifier (`STRIPE`, `ADYEN`, `CYBERSOURCE`, …). Case-sensitive, UPPER_SNAKE_CASE. |
+### Response
 
-No query parameters and no body.
+<ResponseField name="payment_method_type" type="string[]">
+  The Yuno payment-method enums this provider supports. Pass any of these values into `payment_methods[]` on [Create a Connection](/reference/organizations/connections/create-connection).
+</ResponseField>
 
-### Response — `200 OK`
+<ResponseField name="params" type="object[]">
+  Recursive parameter schema.
+  <Expandable title="item">
+    <ResponseField name="param_id" type="string">
+      Identifier to echo back in `POST /v1/connections.params[].param_id`. Pass casing **verbatim**.
+    </ResponseField>
+    <ResponseField name="field_type" type="enum">
+      One of `string`, `boolean`, `array`, `number`.
+    </ResponseField>
+    <ResponseField name="description" type="string | object">
+      Display label. May be a plain string or a localization object `{ "EN": "...", "ES": "...", "PT": "..." }`.
+    </ResponseField>
+    <ResponseField name="placeholder" type="string | object">
+      Optional placeholder text. Same shape rules as `description`.
+    </ResponseField>
+    <ResponseField name="tooltip" type="string | null">
+      Optional helper text.
+    </ResponseField>
+    <ResponseField name="editable_field" type="boolean">
+      If `false`, value is fixed/read-only.
+    </ResponseField>
+    <ResponseField name="secret" type="boolean">
+      If `true`, the value is sensitive — stored encrypted and surfaced as `"***"` on subsequent reads.
+    </ResponseField>
+    <ResponseField name="allow_custom" type="boolean">
+      Only meaningful when `options[]` is present. If `true`, you may submit a free-form value alongside the catalog options (combobox semantics).
+    </ResponseField>
+    <ResponseField name="optional" type="boolean">
+      If `false`, you must supply a value.
+    </ResponseField>
+    <ResponseField name="is_hidden" type="boolean">
+      If `true`, the param exists but should not be rendered to end users.
+    </ResponseField>
+    <ResponseField name="sdk_required" type="boolean">
+      If `true`, the value is also required when configuring the Yuno SDK on the client side.
+    </ResponseField>
+    <ResponseField name="options" type="string[] | object[]">
+      Present when the field is a constrained enum. With `field_type = "string"` → single-select. With `field_type = "array"` → multi-select. Plain strings or `{value, params}` objects (the latter when an option carries its own nested params).
+    </ResponseField>
+    <ResponseField name="params" type="object[]">
+      Nested children — activated when this node's value is `true` (boolean parent) or matches one of the `options` (string/array parent).
+    </ResponseField>
+  </Expandable>
+</ResponseField>
 
-```json
+<CodeGroup>
+```json Response Example
 {
   "payment_method_type": ["CARD", "GOOGLE_PAY", "IDEAL", "PIX", "..."],
   "params": [
@@ -43,14 +87,6 @@ No query parameters and no body.
       "description": "x-api-key",
       "editable_field": true,
       "optional": false
-    },
-    {
-      "param_id": "transaction-identifier",
-      "field_type": "string",
-      "description": "Transaction identifier used",
-      "editable_field": true,
-      "optional": false,
-      "options": ["ORDER_ID", "MERCHANT_REFERENCE", "TRANSACTION_CODE"]
     },
     {
       "param_id": "3DS_ENABLED",
@@ -71,33 +107,9 @@ No query parameters and no body.
   ]
 }
 ```
+</CodeGroup>
 
-**Top-level fields**
-
-| Field | Type | Description |
-|---|---|---|
-| `payment_method_type[]` | string[] | The Yuno payment-method enums this provider supports. Pass any of these values into `payment_methods[]` on `POST /v1/connections`. |
-| `params[]` | object[] | Recursive parameter schema — see below. |
-
-**Per `params[]` node**
-
-| Field | Type | Description |
-|---|---|---|
-| `param_id` | string | Identifier to echo back in `POST /v1/connections.params[].param_id`. Pass casing **verbatim**. |
-| `field_type` | enum | One of `string`, `boolean`, `array`, `number`. |
-| `description` | string \| object | Display label. May be a plain string or a localization object `{ "EN": "...", "ES": "...", "PT": "..." }`. |
-| `placeholder` | string \| object | Optional placeholder text. Same shape rules as `description`. |
-| `tooltip` | string \| null | Optional helper text. |
-| `editable_field` | boolean | If `false`, value is fixed/read-only. |
-| `secret` | boolean | If `true`, the value is sensitive — stored encrypted and surfaced as `"***"` on subsequent reads. |
-| `allow_custom` | boolean | Only meaningful when `options[]` is present. If `true`, you may submit a free-form value alongside the catalog options (combobox semantics). |
-| `optional` | boolean | If `false`, you must supply a value. |
-| `is_hidden` | boolean | If `true`, the param exists but should not be rendered to end users. |
-| `sdk_required` | boolean | If `true`, the value is also required when configuring the Yuno SDK on the client side. |
-| `options[]` | string[] \| object[] | Present when the field is a constrained enum. With `field_type = "string"` → single-select. With `field_type = "array"` → multi-select. Plain strings or `{value, params}` objects (the latter when an option carries its own nested params). |
-| `params[]` | object[] | Nested children — activated when this node's value is `true` (boolean parent) or matches one of the `options` (string/array parent). |
-
-**How to read a node**
+### How to read a node
 
 | What you see | What it means |
 |---|---|

--- a/reference/organizations/connections/retrieve-connection.mdx
+++ b/reference/organizations/connections/retrieve-connection.mdx
@@ -1,0 +1,29 @@
+---
+title: "Retrieve a Connection"
+description: "Returns a connection you previously created. Secrets are masked."
+---
+
+Returns a connection you previously created. Secrets are masked.
+
+### Request
+
+```
+GET /v1/connections/{connection_id}
+```
+
+| Path parameter | Type | Required | Description |
+|---|---|---|---|
+| `connection_id` | UUID | yes | The id returned by [Create a Connection](/reference/organizations/connections/create-connection). Must belong to the account your API key is scoped to. |
+
+No query parameters and no body.
+
+### Response — `200 OK`
+
+Same shape as the `POST /v1/connections` response. Secret values are returned as `"***"`.
+
+### Errors
+
+| HTTP | `code` | When |
+|---|---|---|
+| `404` | `CONNECTION_NOT_FOUND` | Unknown `connection_id`, or the id belongs to a different account. (Yuno returns the same code in both cases so the existence of other accounts' connections isn't leaked.) |
+| `403` | `INSUFFICIENT_SCOPE` | API key missing `connections:read`. |

--- a/reference/organizations/connections/retrieve-connection.mdx
+++ b/reference/organizations/connections/retrieve-connection.mdx
@@ -1,24 +1,16 @@
 ---
 title: "Retrieve a Connection"
 description: "Returns a connection you previously created. Secrets are masked."
+api: "GET /v1/connections/{connection_id}"
 ---
 
 Returns a connection you previously created. Secrets are masked.
 
-### Request
+### Path Parameters
 
 <ParamField path="connection_id" type="string" required>
   The id returned by [Create a Connection](/reference/organizations/connections/create-connection). Must belong to the account your API key is scoped to.
 </ParamField>
-
-<CodeGroup>
-```bash cURL
-curl --request GET \
-     --url https://api.y.uno/v1/connections/{connection_id} \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
-```
-</CodeGroup>
 
 ### Response
 
@@ -27,6 +19,13 @@ curl --request GET \
 </ResponseField>
 
 <CodeGroup>
+```bash cURL
+curl --request GET \
+     --url https://api.y.uno/v1/connections/{connection_id} \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
+```
+
 ```json Response Example
 {
   "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",

--- a/reference/organizations/connections/retrieve-connection.mdx
+++ b/reference/organizations/connections/retrieve-connection.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Retrieve a Connection"
 description: "Returns a connection you previously created. Secrets are masked."
-api: "GET /v1/connections/{connection_id}"
+openapi: "/openapi/organizations/connections/retrieve-connection.json GET /connections/{connection_id}"
 ---
 
 Returns a connection you previously created. Secrets are masked.

--- a/reference/organizations/connections/retrieve-connection.mdx
+++ b/reference/organizations/connections/retrieve-connection.mdx
@@ -7,23 +7,47 @@ Returns a connection you previously created. Secrets are masked.
 
 ### Request
 
+<ParamField path="connection_id" type="string" required>
+  The id returned by [Create a Connection](/reference/organizations/connections/create-connection). Must belong to the account your API key is scoped to.
+</ParamField>
+
+<CodeGroup>
+```bash cURL
+curl --request GET \
+     --url https://api.y.uno/v1/connections/{connection_id} \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
 ```
-GET /v1/connections/{connection_id}
+</CodeGroup>
+
+### Response
+
+<ResponseField name="connection_id" type="string">
+  Unique identifier for the connection.
+</ResponseField>
+
+<CodeGroup>
+```json Response Example
+{
+  "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+  "merchant_connection_id": "adyen-us-prod-001",
+  "provider_id": "ADYEN",
+  "status": "ACTIVE",
+  "flow_type": "PAYIN",
+  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
+  "params": [
+    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
+    { "param_id": "x-api-key",              "value": "***" }
+  ],
+  "created_at": "2026-05-12T10:24:00Z",
+  "updated_at": "2026-05-12T10:24:00Z"
+}
 ```
-
-| Path parameter | Type | Required | Description |
-|---|---|---|---|
-| `connection_id` | UUID | yes | The id returned by [Create a Connection](/reference/organizations/connections/create-connection). Must belong to the account your API key is scoped to. |
-
-No query parameters and no body.
-
-### Response — `200 OK`
-
-Same shape as the `POST /v1/connections` response. Secret values are returned as `"***"`.
+</CodeGroup>
 
 ### Errors
 
 | HTTP | `code` | When |
 |---|---|---|
-| `404` | `CONNECTION_NOT_FOUND` | Unknown `connection_id`, or the id belongs to a different account. (Yuno returns the same code in both cases so the existence of other accounts' connections isn't leaked.) |
+| `404` | `CONNECTION_NOT_FOUND` | Unknown `connection_id`, or the id belongs to a different account. |
 | `403` | `INSUFFICIENT_SCOPE` | API key missing `connections:read`. |

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -1,0 +1,148 @@
+---
+title: "Create a Routing"
+description: "Creates a routing for one (account_code, payment_method) pair. Always live on success."
+---
+
+Creates a routing for one `(account_code, payment_method)` pair. Always live on success.
+
+### Request
+
+```
+POST /v1/routing
+```
+
+**Headers**
+
+`X-Idempotency-Key` is required.
+
+**Body**
+
+Full routing per [Resource shape](/reference/organizations/routing/routing-resource-shape), **without** `id`, `account_code`, `created_at`, `updated_at`.
+
+##### Example — routing by metadata
+
+A common pattern: route by a custom metadata key the merchant attaches at checkout. The two condition sets below pick different connections based on `metadata.merchant_connection_id`; anything unmatched falls through to the default. Each route is a single terminal step, so `output[]` is omitted.
+
+```json
+{
+  "payment_method": "CARD",
+  "name": "Card routing by metadata.merchant_connection_id",
+  "default_route": {
+    "steps": [
+      {
+        "index": 1,
+        "provider_id": "STRIPE",
+        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
+      }
+    ]
+  },
+  "condition_sets": [
+    {
+      "sort_number": 1,
+      "name": "Route via Stripe connection",
+      "description": "Payments where metadata.merchant_connection_id = 'stripe-us-prod' use the Stripe connection",
+      "conditions": [
+        {
+          "condition_type": "METADATA",
+          "key": "merchant_connection_id",
+          "conditional": "EQUAL",
+          "values": ["stripe-us-prod"]
+        }
+      ],
+      "route": {
+        "steps": [
+          {
+            "index": 1,
+            "provider_id": "STRIPE",
+            "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
+          }
+        ]
+      }
+    },
+    {
+      "sort_number": 2,
+      "name": "Route via Adyen connection",
+      "description": "Payments where metadata.merchant_connection_id = 'adyen-eu-prod' use the Adyen connection",
+      "conditions": [
+        {
+          "condition_type": "METADATA",
+          "key": "merchant_connection_id",
+          "conditional": "EQUAL",
+          "values": ["adyen-eu-prod"]
+        }
+      ],
+      "route": {
+        "steps": [
+          {
+            "index": 1,
+            "provider_id": "ADYEN",
+            "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Response — `201 Created`
+
+```
+Location: /v1/routing/{routing_id}
+```
+
+```json
+{
+  "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
+  "account_code": "acc-uuid",
+  "payment_method": "CARD",
+  "name": "Card routing by metadata.merchant_connection_id",
+  "default_route": {
+    "steps": [
+      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" }
+    ]
+  },
+  "condition_sets": [
+    {
+      "sort_number": 1,
+      "name": "Route via Stripe connection",
+      "description": "Payments where metadata.merchant_connection_id = 'stripe-us-prod' use the Stripe connection",
+      "conditions": [
+        { "condition_type": "METADATA", "key": "merchant_connection_id", "conditional": "EQUAL", "values": ["stripe-us-prod"] }
+      ],
+      "route": {
+        "steps": [
+          { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" }
+        ]
+      }
+    },
+    {
+      "sort_number": 2,
+      "name": "Route via Adyen connection",
+      "description": "Payments where metadata.merchant_connection_id = 'adyen-eu-prod' use the Adyen connection",
+      "conditions": [
+        { "condition_type": "METADATA", "key": "merchant_connection_id", "conditional": "EQUAL", "values": ["adyen-eu-prod"] }
+      ],
+      "route": {
+        "steps": [
+          { "index": 1, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f" }
+        ]
+      }
+    }
+  ],
+  "created_at": "2026-05-12T14:30:00Z",
+  "updated_at": "2026-05-12T14:30:00Z"
+}
+```
+
+**Save `id`.** It is the value you'll use in `GET /v1/routing/{routing_id}` and `PATCH /v1/routing/{routing_id}`.
+
+### Errors
+
+| HTTP | `code` | When |
+|---|---|---|
+| `400` | `ROUTING_VALIDATION_FAILED` | Schema or rule violation. `details` names the offending field/path. |
+| `400` | `ROUTING_PROVIDER_NOT_AVAILABLE` | A step references a `(provider_id, connection_id)` not active for the account on this `payment_method`. |
+| `409` | `ROUTING_ALREADY_EXISTS` | A routing already exists for this `(account, payment_method)`. Use `PATCH` to update it. |
+| `409` | `ROUTING_IDEMPOTENCY_REPLAY` | Idempotency key replayed with different body. |
+| `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:write`. |

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Create a Routing"
 description: "Creates a routing for one (account_code, payment_method) pair. Always live on success."
-api: "POST /v1/routing"
+openapi: "/openapi/organizations/routing/create-routing.json POST /routing"
 ---
 
 Creates a routing for one `(account_code, payment_method)` pair. Each routing references **connections** by their `connection_id`. Make sure your connections are created and `ACTIVE` for the requested `payment_method` *before* you call routing.

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -1,45 +1,12 @@
 ---
 title: "Create a Routing"
 description: "Creates a routing for one (account_code, payment_method) pair. Always live on success."
+api: "POST /v1/routing"
 ---
 
 Creates a routing for one `(account_code, payment_method)` pair. Each routing references **connections** by their `connection_id`. Make sure your connections are created and `ACTIVE` for the requested `payment_method` *before* you call routing.
 
-### Request
-
-<CodeGroup>
-```bash cURL
-curl --request POST \
-     --url https://api.y.uno/v1/routing \
-     --header 'Content-Type: application/json' \
-     --header 'X-Idempotency-Key: <UUID>' \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
-     --data '
-{
-  "payment_method": "CARD",
-  "name": "Card routing",
-  "default_route": {
-    "steps": [
-      {
-        "index": 1,
-        "provider_id": "STRIPE",
-        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
-      }
-    ]
-  }
-}
-'
-```
-</CodeGroup>
-
-#### Headers
-
-<ParamField header="X-Idempotency-Key" type="string" required>
-  UUID, 24-hour scope.
-</ParamField>
-
-#### Body
+### Body
 
 <ParamField body="payment_method" type="enum" required>
   E.g., `CARD`, `PIX`, `WALLET`. Immutable per routing — to route a different method, create a new routing.
@@ -94,6 +61,30 @@ curl --request POST \
 </ResponseField>
 
 <CodeGroup>
+```bash cURL
+curl --request POST \
+     --url https://api.y.uno/v1/routing \
+     --header 'Content-Type: application/json' \
+     --header 'X-Idempotency-Key: <UUID>' \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
+     --data '
+{
+  "payment_method": "CARD",
+  "name": "Card routing",
+  "default_route": {
+    "steps": [
+      {
+        "index": 1,
+        "provider_id": "STRIPE",
+        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
+      }
+    ]
+  }
+}
+'
+```
+
 ```json Response Example
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -3,30 +3,22 @@ title: "Create a Routing"
 description: "Creates a routing for one (account_code, payment_method) pair. Always live on success."
 ---
 
-Creates a routing for one `(account_code, payment_method)` pair. Always live on success.
+Creates a routing for one `(account_code, payment_method)` pair. Each routing references **connections** by their `connection_id`. Make sure your connections are created and `ACTIVE` for the requested `payment_method` *before* you call routing.
 
 ### Request
 
-```
-POST /v1/routing
-```
-
-**Headers**
-
-`X-Idempotency-Key` is required.
-
-**Body**
-
-Full routing per [Resource shape](/reference/organizations/routing/routing-resource-shape), **without** `id`, `account_code`, `created_at`, `updated_at`.
-
-##### Example — routing by metadata
-
-A common pattern: route by a custom metadata key the merchant attaches at checkout. The two condition sets below pick different connections based on `metadata.merchant_connection_id`; anything unmatched falls through to the default. Each route is a single terminal step, so `output[]` is omitted.
-
-```json
+<CodeGroup>
+```bash cURL
+curl --request POST \
+     --url https://api.y.uno/v1/routing \
+     --header 'Content-Type: application/json' \
+     --header 'X-Idempotency-Key: <UUID>' \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
+     --data '
 {
   "payment_method": "CARD",
-  "name": "Card routing by metadata.merchant_connection_id",
+  "name": "Card routing",
   "default_route": {
     "steps": [
       {
@@ -35,107 +27,89 @@ A common pattern: route by a custom metadata key the merchant attaches at checko
         "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
       }
     ]
-  },
-  "condition_sets": [
-    {
-      "sort_number": 1,
-      "name": "Route via Stripe connection",
-      "description": "Payments where metadata.merchant_connection_id = 'stripe-us-prod' use the Stripe connection",
-      "conditions": [
-        {
-          "condition_type": "METADATA",
-          "key": "merchant_connection_id",
-          "conditional": "EQUAL",
-          "values": ["stripe-us-prod"]
-        }
-      ],
-      "route": {
-        "steps": [
-          {
-            "index": 1,
-            "provider_id": "STRIPE",
-            "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
-          }
-        ]
-      }
-    },
-    {
-      "sort_number": 2,
-      "name": "Route via Adyen connection",
-      "description": "Payments where metadata.merchant_connection_id = 'adyen-eu-prod' use the Adyen connection",
-      "conditions": [
-        {
-          "condition_type": "METADATA",
-          "key": "merchant_connection_id",
-          "conditional": "EQUAL",
-          "values": ["adyen-eu-prod"]
-        }
-      ],
-      "route": {
-        "steps": [
-          {
-            "index": 1,
-            "provider_id": "ADYEN",
-            "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
-          }
-        ]
-      }
-    }
-  ]
+  }
 }
+'
 ```
+</CodeGroup>
 
-### Response — `201 Created`
+#### Headers
 
-```
-Location: /v1/routing/{routing_id}
-```
+<ParamField header="X-Idempotency-Key" type="string" required>
+  UUID, 24-hour scope.
+</ParamField>
 
-```json
+#### Body
+
+<ParamField body="payment_method" type="enum" required>
+  E.g., `CARD`, `PIX`, `WALLET`. Immutable per routing — to route a different method, create a new routing.
+</ParamField>
+
+<ParamField body="name" type="string" required>
+  Free-form label.
+</ParamField>
+
+<ParamField body="default_route" type="object" required>
+  The route used when no `condition_sets[]` matches.
+  <Expandable title="properties">
+    <ParamField body="steps" type="object[]" required>
+      Each step is one provider attempt. `index` values are contiguous starting at 1.
+      <Expandable title="item">
+        <ParamField body="index" type="integer" required>
+            Step ordinal.
+        </ParamField>
+        <ParamField body="provider_id" type="string" required>
+            Must match the provider of the connection.
+        </ParamField>
+        <ParamField body="connection_id" type="UUID" required>
+            Must be `ACTIVE` and support the `payment_method`.
+        </ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="condition_sets" type="object[]">
+  Optional. Ordered by `sort_number` — first matching set wins.
+  <Expandable title="item">
+    <ParamField body="sort_number" type="integer" required>
+        Priority of the condition set.
+    </ParamField>
+    <ParamField body="name" type="string" required>
+        Label for the set.
+    </ParamField>
+    <ParamField body="conditions" type="object[]" required>
+        List of [Conditions](/reference/organizations/routing/routing-conditions) that must match.
+    </ParamField>
+    <ParamField body="route" type="object" required>
+        The steps to execute if this set matches.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+### Response
+
+<ResponseField name="id" type="string">
+  Unique identifier for the routing.
+</ResponseField>
+
+<CodeGroup>
+```json Response Example
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
   "account_code": "acc-uuid",
   "payment_method": "CARD",
-  "name": "Card routing by metadata.merchant_connection_id",
+  "name": "Card routing",
   "default_route": {
     "steps": [
-      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" }
+      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-..." }
     ]
   },
-  "condition_sets": [
-    {
-      "sort_number": 1,
-      "name": "Route via Stripe connection",
-      "description": "Payments where metadata.merchant_connection_id = 'stripe-us-prod' use the Stripe connection",
-      "conditions": [
-        { "condition_type": "METADATA", "key": "merchant_connection_id", "conditional": "EQUAL", "values": ["stripe-us-prod"] }
-      ],
-      "route": {
-        "steps": [
-          { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" }
-        ]
-      }
-    },
-    {
-      "sort_number": 2,
-      "name": "Route via Adyen connection",
-      "description": "Payments where metadata.merchant_connection_id = 'adyen-eu-prod' use the Adyen connection",
-      "conditions": [
-        { "condition_type": "METADATA", "key": "merchant_connection_id", "conditional": "EQUAL", "values": ["adyen-eu-prod"] }
-      ],
-      "route": {
-        "steps": [
-          { "index": 1, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f" }
-        ]
-      }
-    }
-  ],
   "created_at": "2026-05-12T14:30:00Z",
   "updated_at": "2026-05-12T14:30:00Z"
 }
 ```
-
-**Save `id`.** It is the value you'll use in `GET /v1/routing/{routing_id}` and `PATCH /v1/routing/{routing_id}`.
+</CodeGroup>
 
 ### Errors
 
@@ -144,5 +118,4 @@ Location: /v1/routing/{routing_id}
 | `400` | `ROUTING_VALIDATION_FAILED` | Schema or rule violation. `details` names the offending field/path. |
 | `400` | `ROUTING_PROVIDER_NOT_AVAILABLE` | A step references a `(provider_id, connection_id)` not active for the account on this `payment_method`. |
 | `409` | `ROUTING_ALREADY_EXISTS` | A routing already exists for this `(account, payment_method)`. Use `PATCH` to update it. |
-| `409` | `ROUTING_IDEMPOTENCY_REPLAY` | Idempotency key replayed with different body. |
 | `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:write`. |

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -1,24 +1,16 @@
 ---
 title: "Retrieve a Routing"
 description: "Returns the routing's current live configuration."
+api: "GET /v1/routing/{routing_id}"
 ---
 
 Returns the routing's current live configuration.
 
-### Request
+### Path Parameters
 
 <ParamField path="routing_id" type="string" required>
   The id returned by [Create a Routing](/reference/organizations/routing/create-routing). Must belong to the account your API key is scoped to.
 </ParamField>
-
-<CodeGroup>
-```bash cURL
-curl --request GET \
-     --url https://api.y.uno/v1/routing/{routing_id} \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
-```
-</CodeGroup>
 
 ### Response
 
@@ -27,6 +19,13 @@ curl --request GET \
 </ResponseField>
 
 <CodeGroup>
+```bash cURL
+curl --request GET \
+     --url https://api.y.uno/v1/routing/{routing_id} \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
+```
+
 ```json Response Example
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -7,23 +7,46 @@ Returns the routing's current live configuration.
 
 ### Request
 
+<ParamField path="routing_id" type="string" required>
+  The id returned by [Create a Routing](/reference/organizations/routing/create-routing). Must belong to the account your API key is scoped to.
+</ParamField>
+
+<CodeGroup>
+```bash cURL
+curl --request GET \
+     --url https://api.y.uno/v1/routing/{routing_id} \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
 ```
-GET /v1/routing/{routing_id}
+</CodeGroup>
+
+### Response
+
+<ResponseField name="id" type="string">
+  Unique identifier for the routing.
+</ResponseField>
+
+<CodeGroup>
+```json Response Example
+{
+  "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
+  "account_code": "acc-uuid",
+  "payment_method": "CARD",
+  "name": "Card routing",
+  "default_route": {
+    "steps": [
+      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-..." }
+    ]
+  },
+  "created_at": "2026-05-12T14:30:00Z",
+  "updated_at": "2026-05-12T14:30:00Z"
+}
 ```
-
-| Path parameter | Type | Required | Description |
-|---|---|---|---|
-| `routing_id` | UUID | yes | The id returned by [Create a Routing](/reference/organizations/routing/create-routing). Must belong to the account your API key is scoped to. |
-
-No query parameters and no body.
-
-### Response — `200 OK`
-
-Full routing — same shape as the `POST /v1/routing` response.
+</CodeGroup>
 
 ### Errors
 
 | HTTP | `code` | When |
 |---|---|---|
-| `404` | `ROUTING_NOT_FOUND` | Unknown `routing_id`, or id belongs to a different account. (Same code in both cases to avoid leaking the existence of other accounts' routings.) |
+| `404` | `ROUTING_NOT_FOUND` | Unknown `routing_id`, or id belongs to a different account. |
 | `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:read`. |

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Retrieve a Routing"
 description: "Returns the routing's current live configuration."
-api: "GET /v1/routing/{routing_id}"
+openapi: "/openapi/organizations/routing/retrieve-routing.json GET /routing/{routing_id}"
 ---
 
 Returns the routing's current live configuration.

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -1,0 +1,29 @@
+---
+title: "Retrieve a Routing"
+description: "Returns the routing's current live configuration."
+---
+
+Returns the routing's current live configuration.
+
+### Request
+
+```
+GET /v1/routing/{routing_id}
+```
+
+| Path parameter | Type | Required | Description |
+|---|---|---|---|
+| `routing_id` | UUID | yes | The id returned by [Create a Routing](/reference/organizations/routing/create-routing). Must belong to the account your API key is scoped to. |
+
+No query parameters and no body.
+
+### Response — `200 OK`
+
+Full routing — same shape as the `POST /v1/routing` response.
+
+### Errors
+
+| HTTP | `code` | When |
+|---|---|---|
+| `404` | `ROUTING_NOT_FOUND` | Unknown `routing_id`, or id belongs to a different account. (Same code in both cases to avoid leaking the existence of other accounts' routings.) |
+| `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:read`. |

--- a/reference/organizations/routing/routing-conditions.mdx
+++ b/reference/organizations/routing/routing-conditions.mdx
@@ -1,0 +1,55 @@
+---
+title: "Routing Conditions"
+description: "A condition matches against an attribute of the incoming payment."
+---
+
+A condition matches against an attribute of the incoming payment.
+
+```jsonc
+{
+  "condition_type": "<ENUM>",
+  "conditional":    "<OPERATOR>",
+  "values":         ["..."],
+
+  // Required only on specific condition_types — see "Special cases" below
+  "key":      "<string>",   // METADATA only
+  "currency": "<ISO 4217>"  // AMOUNT only
+}
+```
+
+Conditions inside the same `condition_sets[].conditions[]` are combined with **logical AND**. For OR semantics, split into multiple condition sets ordered by `sort_number`.
+
+#### `condition_type` catalog
+
+| `condition_type` | Matches against | Value shape | Applicable `conditional`s | Card-only? |
+|---|---|---|---|---|
+| `COUNTRY` | Buyer's billing country | ISO 3166-1 alpha-2 (e.g. `"US"`, `"BR"`) | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | no |
+| `ISSUER_COUNTRY` | Card-issuing bank's country | ISO 3166-1 alpha-2 | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | yes |
+| `CURRENCY` | Transaction currency | ISO 4217 (e.g. `"USD"`) | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | no |
+| `AMOUNT` | Transaction amount | Decimal as **string** (e.g. `"100.00"`); requires sibling `currency` | `EQUAL`, `NOT_EQUAL`, `GREATER_THAN`, `LESS_THAN`, `BETWEEN`, `NOT_BETWEEN` | no |
+| `CARD_TYPE` | Card funding source | `CREDIT`, `DEBIT`, `PREPAID` | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | yes |
+| `CARD_BRAND` | Card scheme | `VISA`, `MASTERCARD`, `AMEX`, `ELO`, `HIPERCARD`, `DINERS`, `DISCOVER`, `JCB`, `UNIONPAY`, `MAESTRO`, `CB` | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | yes |
+| `CARD_BIN` | First 6–8 digits of the PAN | 6–8 digit numeric string | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | yes |
+| `INSTALLMENTS` | Number of installments requested | Integer as string | `EQUAL`, `NOT_EQUAL`, `GREATER_THAN`, `LESS_THAN`, `BETWEEN`, `NOT_BETWEEN` | no |
+| `TRANSACTION_TYPE` | Payment intent type | `PURCHASE`, `AUTHORIZATION`, `RECURRING`, `MIT`, `CIT` | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | no |
+| `METADATA` | `payment.metadata[<key>]` | Any string the merchant sets; requires sibling `key` | `EQUAL`, `NOT_EQUAL`, `ONE_OF`, `NOT_ONE_OF` | no |
+
+#### `conditional` operators
+
+| Operator | Cardinality of `values[]` | Semantics |
+|---|---|---|
+| `EQUAL` | exactly 1 | `attribute == values[0]` |
+| `NOT_EQUAL` | exactly 1 | `attribute != values[0]` |
+| `ONE_OF` | ≥ 1 | `attribute ∈ values` |
+| `NOT_ONE_OF` | ≥ 1 | `attribute ∉ values` |
+| `GREATER_THAN` | exactly 1 | numeric `attribute > values[0]` |
+| `LESS_THAN` | exactly 1 | numeric `attribute < values[0]` |
+| `BETWEEN` | exactly 2 | inclusive on both ends |
+| `NOT_BETWEEN` | exactly 2 | inverse of `BETWEEN` |
+
+#### Special cases
+
+- **`AMOUNT` requires `currency`.** Comparisons are FX-naive; only payments whose currency matches the rule's `currency` are evaluated.
+- **`METADATA` requires `key`.** Compares `payment.metadata[key]`. If the key is absent on the payment, the condition does **not** match — absence is not equality.
+- **Card-only condition types** (`ISSUER_COUNTRY`, `CARD_TYPE`, `CARD_BRAND`, `CARD_BIN`) are only valid when `payment_method = "CARD"`.
+- **Numeric values are submitted as strings** to match the `values: string[]` schema. Yuno parses them based on the `condition_type`.

--- a/reference/organizations/routing/routing-resource-shape.mdx
+++ b/reference/organizations/routing/routing-resource-shape.mdx
@@ -1,0 +1,92 @@
+---
+title: "Routing Resource Shape"
+description: "Each routing is a single atomic resource on the public API: one HTTP call creates or replaces the full configuration."
+---
+
+A routing tells Yuno, for one `payment_method` on one account, which connection to use — and lets you branch by buyer attributes (country, currency, amount, card brand, custom metadata, …).
+
+### Resource shape
+
+```json
+{
+  "id": "r_8f2c1d3e-…",
+  "account_code": "acc-uuid",
+  "payment_method": "CARD",
+  "name": "Card routing",
+  "default_route": {
+    "steps": [
+      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-…" }
+    ]
+  },
+  "condition_sets": [
+    {
+      "sort_number": 1,
+      "name": "US & Canada — high value",
+      "description": "Route US/CA credit card transactions over $500",
+      "conditions": [
+        { "condition_type": "COUNTRY", "conditional": "ONE_OF",       "values": ["US", "CA"] },
+        { "condition_type": "AMOUNT",  "conditional": "GREATER_THAN", "values": ["500"], "currency": "USD" }
+      ],
+      "route": {
+        "steps": [
+          { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-…",
+            "output": [{ "status": "DECLINED", "next": 2 }] },
+          { "index": 2, "provider_id": "ADYEN",  "connection_id": "b2c4d5e6-…" }
+        ]
+      }
+    }
+  ],
+  "created_at": "2026-05-12T12:00:00Z",
+  "updated_at": "2026-05-12T12:00:00Z"
+}
+```
+
+**Top-level fields**
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | UUID | Server-assigned. The same value is referenced as `routing_id` in URL paths. |
+| `account_code` | string | Inferred from your API key. Not supplied in request bodies. |
+| `payment_method` | enum | E.g., `CARD`, `PIX`, `WALLET`. Immutable per routing — to route a different method, create a new routing. |
+| `name` | string | Free-form label. |
+| `default_route` | object | The route used when no `condition_sets[]` matches. **Required.** |
+| `condition_sets[]` | object[] | Optional. Ordered by `sort_number` — first matching set wins. Each has one `route`. |
+| `created_at`, `updated_at` | ISO-8601 timestamps | Server-managed. |
+
+**`route.steps[]`**
+
+Each step is one provider attempt. `index` values are contiguous starting at 1.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `index` | int | yes | Step ordinal within the route. Cycles are forbidden — `output[].next` must point to a higher index. |
+| `provider_id` | string | yes | Must match the `provider_id` of the referenced connection. |
+| `connection_id` | UUID | yes | Must be `ACTIVE`, in the same account, and support the routing's `payment_method`. |
+| `output[]` | object[] | no | Per-outcome handlers. **Omit for terminal steps with no chaining or per-decline customization** — the route will just run the step and terminate with whatever the provider returned. |
+
+**`output[]` entries**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `status` | enum | yes | What outcome this entry reacts to. See enum below. |
+| `decline_types[]` | string[] | only with `status = DECLINE_GROUP` | Subset of Yuno's normalized decline taxonomy. |
+| `error_rate_threshold` | object | only with `status = ERROR_RATE` | `{ threshold_percent: int, window_seconds: int }`. |
+| `next` | int \| null | yes | Index of the step to jump to, or `null` to terminate. |
+
+**`status` enum**
+
+| Value | Triggers when | Companion field |
+|---|---|---|
+| `APPROVED` | The provider returned success. Implicit by default; list explicitly only for post-approval routing. | — |
+| `DECLINED` | Any decline (catch-all). Place last in the array. | — |
+| `DECLINE_GROUP` | Decline whose normalized code is in `decline_types[]`. | `decline_types[]` |
+| `ERROR_RATE` | The step's rolling error rate exceeds `error_rate_threshold`. | `error_rate_threshold` |
+| `TIMEOUT` | The provider didn't respond within Yuno's per-step timeout. | — |
+| `INTERNAL_ERROR` | The provider returned a 5xx or connection error before reaching the issuer. | — |
+
+**Evaluation rules**
+
+1. The route enters at `index: 1`.
+2. The provider call runs.
+3. Yuno walks `output[]` top-to-bottom; the first entry whose `status` (plus optional `decline_types` / `error_rate_threshold` predicate) matches the outcome wins.
+4. If the matched entry's `next` is an integer, jump to that step. If `null` or no entry matches, the route terminates with the actual provider outcome.

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -1,17 +1,24 @@
 ---
 title: "Update a Routing"
 description: "Replaces the routing's full configuration."
+api: "PATCH /v1/routing/{routing_id}"
 ---
 
 Replaces the routing's full configuration. The body has the same shape as [Create a Routing](/reference/organizations/routing/create-routing) — the new `default_route` and `condition_sets[]` entirely supersede the previous live state. **There is no field-level merge.**
 
 `account_code` and `payment_method` are sticky to the `routing_id` — they're set at creation and cannot be changed by `PATCH`.
 
-### Request
+### Path Parameters
 
 <ParamField path="routing_id" type="string" required>
   The id returned by [Create a Routing](/reference/organizations/routing/create-routing).
 </ParamField>
+
+### Response
+
+<ResponseField name="id" type="string">
+  Unique identifier for the routing.
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL
@@ -36,19 +43,7 @@ curl --request PATCH \
 }
 '
 ```
-</CodeGroup>
 
-#### Body
-
-The body follows the same schema as [Create a Routing](/reference/organizations/routing/create-routing).
-
-### Response
-
-<ResponseField name="id" type="string">
-  Unique identifier for the routing.
-</ResponseField>
-
-<CodeGroup>
 ```json Response Example
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -3,27 +3,68 @@ title: "Update a Routing"
 description: "Replaces the routing's full configuration."
 ---
 
-Replaces the routing's full configuration. The body has the same shape as `POST /v1/routing` — the new `default_route` and `condition_sets[]` entirely supersede the previous live state. **There is no field-level merge.**
+Replaces the routing's full configuration. The body has the same shape as [Create a Routing](/reference/organizations/routing/create-routing) — the new `default_route` and `condition_sets[]` entirely supersede the previous live state. **There is no field-level merge.**
 
 `account_code` and `payment_method` are sticky to the `routing_id` — they're set at creation and cannot be changed by `PATCH`.
 
 ### Request
 
+<ParamField path="routing_id" type="string" required>
+  The id returned by [Create a Routing](/reference/organizations/routing/create-routing).
+</ParamField>
+
+<CodeGroup>
+```bash cURL
+curl --request PATCH \
+     --url https://api.y.uno/v1/routing/{routing_id} \
+     --header 'Content-Type: application/json' \
+     --header 'X-Idempotency-Key: <UUID>' \
+     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
+     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
+     --data '
+{
+  "name": "Updated Card routing",
+  "default_route": {
+    "steps": [
+      {
+        "index": 1,
+        "provider_id": "ADYEN",
+        "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+      }
+    ]
+  }
+}
+'
 ```
-PATCH /v1/routing/{routing_id}
+</CodeGroup>
+
+#### Body
+
+The body follows the same schema as [Create a Routing](/reference/organizations/routing/create-routing).
+
+### Response
+
+<ResponseField name="id" type="string">
+  Unique identifier for the routing.
+</ResponseField>
+
+<CodeGroup>
+```json Response Example
+{
+  "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
+  "account_code": "acc-uuid",
+  "payment_method": "CARD",
+  "name": "Updated Card routing",
+  "default_route": {
+    "steps": [
+      { "index": 1, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f" }
+    ]
+  },
+  "created_at": "2026-05-12T14:30:00Z",
+  "updated_at": "2026-05-12T15:00:00Z"
+}
 ```
-
-**Headers**
-
-`X-Idempotency-Key` is required.
-
-**Body**
-
-Same shape as [Create a Routing](/reference/organizations/routing/create-routing).
-
-### Response — `200 OK`
-
-Full updated routing (same shape as `POST /v1/routing` response). `updated_at` is refreshed.
+</CodeGroup>
 
 ### Errors
 
@@ -33,6 +74,5 @@ Full updated routing (same shape as `POST /v1/routing` response). `updated_at` i
 | `400` | `ROUTING_VALIDATION_FAILED` | Schema or rule violation. |
 | `400` | `ROUTING_PROVIDER_NOT_AVAILABLE` | A step references an inactive/unknown connection. |
 | `400` | `ROUTING_PAYMENT_METHOD_IMMUTABLE` | Body's `payment_method` doesn't match the routing's `payment_method`. |
-| `409` | `ROUTING_VERSION_CONFLICT` | Another concurrent `PATCH` won the publish race. Re-fetch via `GET` and retry. |
-| `409` | `ROUTING_IDEMPOTENCY_REPLAY` | Idempotency key replayed with different body. |
+| `409` | `ROUTING_VERSION_CONFLICT` | Another concurrent `PATCH` won the publish race. |
 | `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:write`. |

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Update a Routing"
 description: "Replaces the routing's full configuration."
-api: "PATCH /v1/routing/{routing_id}"
+openapi: "/openapi/organizations/routing/update-routing.json PATCH /routing/{routing_id}"
 ---
 
 Replaces the routing's full configuration. The body has the same shape as [Create a Routing](/reference/organizations/routing/create-routing) — the new `default_route` and `condition_sets[]` entirely supersede the previous live state. **There is no field-level merge.**

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -1,0 +1,38 @@
+---
+title: "Update a Routing"
+description: "Replaces the routing's full configuration."
+---
+
+Replaces the routing's full configuration. The body has the same shape as `POST /v1/routing` — the new `default_route` and `condition_sets[]` entirely supersede the previous live state. **There is no field-level merge.**
+
+`account_code` and `payment_method` are sticky to the `routing_id` — they're set at creation and cannot be changed by `PATCH`.
+
+### Request
+
+```
+PATCH /v1/routing/{routing_id}
+```
+
+**Headers**
+
+`X-Idempotency-Key` is required.
+
+**Body**
+
+Same shape as [Create a Routing](/reference/organizations/routing/create-routing).
+
+### Response — `200 OK`
+
+Full updated routing (same shape as `POST /v1/routing` response). `updated_at` is refreshed.
+
+### Errors
+
+| HTTP | `code` | When |
+|---|---|---|
+| `404` | `ROUTING_NOT_FOUND` | Unknown `routing_id`, or id belongs to a different account. |
+| `400` | `ROUTING_VALIDATION_FAILED` | Schema or rule violation. |
+| `400` | `ROUTING_PROVIDER_NOT_AVAILABLE` | A step references an inactive/unknown connection. |
+| `400` | `ROUTING_PAYMENT_METHOD_IMMUTABLE` | Body's `payment_method` doesn't match the routing's `payment_method`. |
+| `409` | `ROUTING_VERSION_CONFLICT` | Another concurrent `PATCH` won the publish race. Re-fetch via `GET` and retry. |
+| `409` | `ROUTING_IDEMPOTENCY_REPLAY` | Idempotency key replayed with different body. |
+| `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:write`. |


### PR DESCRIPTION
## Summary

This PR adds the complete API reference documentation for the new **Connections** and **Routing** surfaces under the **Organizations** category.


**Changes:**
- Created two new sub-categories under `Organizations`: **Connections** and **Routing**.
- Added a shared overview page covering the common contract, base URL, and authentication headers.
- Implemented 3 endpoints for Connections (Catalog, Create, Retrieve).
- Implemented 3 endpoints for Routing (Create, Retrieve, Update) with detailed resource shape and conditions reference.
- Updated `docs.json` navigation to include the new sections.

**Pages:**
- `reference/organizations/connections-routing-overview`
- `reference/organizations/connections/get-provider-catalog`
- `reference/organizations/connections/create-connection`
- `reference/organizations/connections/retrieve-connection`
- `reference/organizations/routing/routing-resource-shape`
- `reference/organizations/routing/routing-conditions`
- `reference/organizations/routing/create-routing`
- `reference/organizations/routing/retrieve-routing`
- `reference/organizations/routing/update-routing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes (navigation + new OpenAPI specs and MDX pages) with no production code path impact; main risk is incorrect or inconsistent endpoint/schema descriptions.
> 
> **Overview**
> Adds a new **Organizations** reference section for **Connections** and **Routing**, plus a shared `connections-routing-overview` page documenting base URL, auth headers/idempotency, conventions, and required API-key scopes.
> 
> Introduces new OpenAPI specs and MDX reference pages for Connections (`GET /connections/catalog/{provider_id}`, `POST /connections`, `GET /connections/{connection_id}`) and Routing (`POST /routing`, `GET /routing/{routing_id}`, `PATCH /routing/{routing_id}`), including detailed routing resource shape and condition semantics (step chaining via `output[]`, condition set ordering, and error codes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2635d15a30f0999b27893d3adde4dfcfed12b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->