### PR TITLE
Correct field names in Create Payment Link response

### DIFF
--- a/openapi/payment-links/create-payment-link.json
+++ b/openapi/payment-links/create-payment-link.json
@@ -733,7 +733,7 @@
                 "examples": {
                   "CREATE PAYMENT LINK": {
                     "value": {
-                      "code": "e1512b4d-9057-4c73-8e49-921c51eb5ba2",
+                      "id": "555933df-4eed-4af4-ae83-a32072ef34af",
                       "country": "US",
                       "availability": {
                         "start_at": "2023-01-15T14:00:12Z",
@@ -763,7 +763,7 @@
                         "order": null,
                         "seller_details": null
                       },
-                      "account_code": "493e9374-510a-4201-9e09-de669d75f256",
+                      "account_id": "493e9374-510a-4201-9e09-de669d75f256",
                       "checkout_url": "https://checkout.sandbox.y.uno/payment?session=2f6d9754-43d0-4dca-b023-6aba4b107179",
                       "payments_number": 0,
                       "merchant_image": ""
@@ -773,9 +773,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "code": {
+                    "id": {
                       "type": "string",
-                      "example": "e1512b4d-9057-4c73-8e49-921c51eb5ba2"
+                      "example": "555933df-4eed-4af4-ae83-a32072ef34af"
                     },
                     "country": {
                       "type": "string",
@@ -859,7 +859,7 @@
                         "seller_details": {}
                       }
                     },
-                    "account_code": {
+                    "account_id": {
                       "type": "string",
                       "example": "493e9374-510a-4201-9e09-de669d75f256"
                     },

--- a/openapi/yuno_sandbox_tested.json
+++ b/openapi/yuno_sandbox_tested.json
@@ -2809,7 +2809,7 @@
       "PaymentLink": {
         "type": "object",
         "properties": {
-          "code": {
+          "id": {
             "type": "string"
           },
           "checkout_url": {


### PR DESCRIPTION
## PR Description

The live API returns `id` and `account_id` as identifiers in the Create Payment Link response, but the docs incorrectly documented them as `code` and `account_code`. Reported by Pedro Scarapicchia after a merchant noticed the mismatch. The response example payload, schema, and shared PaymentLink component have been corrected to reflect the actual API behavior, verified against a sandbox test.

## Changes made

- `openapi/payment-links/create-payment-link.json`: renamed `code` to `id` in the 200 response example payload and response schema, with the UUID updated to the sandbox-verified value (`555933df-4eed-4af4-ae83-a32072ef34af`).
- `openapi/payment-links/create-payment-link.json`: renamed `account_code` to `account_id` in the 200 response example payload and response schema.
- `openapi/yuno_sandbox_tested.json`: renamed `code` to `id` in the shared `PaymentLink` schema component (affects Create, Get, and Cancel Payment Link pages).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only OpenAPI changes, but could impact downstream codegen/clients that rely on the previously documented `code`/`account_code` fields.
> 
> **Overview**
> Updates the OpenAPI specs for **Create Payment Link** to align with actual API responses by renaming identifier fields from `code` to `id` and from `account_code` to `account_id`.
> 
> The change is applied in both the endpoint-specific spec (`create-payment-link.json`) and the consolidated schema (`yuno_sandbox_tested.json`), including the 200-response example payload and response schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3905b6fb6df44c92a84f9d8f97a9631490a7690a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->