### PR TITLE
docs(api): add connections and routing reference

### DIFF
--- a/openapi/organizations/connections/create-connection.json
+++ b/openapi/organizations/connections/create-connection.json
@@ -53,8 +53,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "connection_id": { "type": "string" },
-                    "status": { "type": "string" }
+                    "connection_id": { "type": "string", "example": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" },
+                    "merchant_connection_id": { "type": "string", "example": "adyen-us-prod-001" },
+                    "provider_id": { "type": "string", "example": "ADYEN" },
+                    "status": { "type": "string", "example": "ACTIVE" },
+                    "flow_type": { "type": "string", "example": "PAYIN" },
+                    "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY", "IDEAL"] },
+                    "params": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "param_id": { "type": "string", "example": "merchantAccount" },
+                          "value": { "type": "string", "example": "ACME_LIVE" }
+                        }
+                      }
+                    },
+                    "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" },
+                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" }
                   }
                 }
               }

--- a/openapi/organizations/connections/get-provider-catalog.json
+++ b/openapi/organizations/connections/get-provider-catalog.json
@@ -26,8 +26,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "payment_method_type": { "type": "array", "items": { "type": "string" } },
-                    "params": { "type": "array", "items": { "type": "object" } }
+                    "payment_method_type": { 
+                      "type": "array", 
+                      "items": { "type": "string" },
+                      "example": ["CARD", "GOOGLE_PAY", "IDEAL", "PIX"]
+                    },
+                    "params": { 
+                      "type": "array", 
+                      "items": { 
+                        "type": "object",
+                        "properties": {
+                          "param_id": { "type": "string", "example": "merchantAccount" },
+                          "field_type": { "type": "string", "enum": ["string", "boolean", "number", "array"], "example": "string" },
+                          "description": { "type": "string", "example": "Account Code" },
+                          "editable_field": { "type": "boolean", "example": true },
+                          "optional": { "type": "boolean", "example": false },
+                          "secret": { "type": "boolean", "example": false },
+                          "params": { "type": "array", "items": { "type": "object" }, "description": "Nested parameters" }
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/openapi/organizations/connections/retrieve-connection.json
+++ b/openapi/organizations/connections/retrieve-connection.json
@@ -26,8 +26,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "connection_id": { "type": "string" },
-                    "status": { "type": "string" }
+                    "connection_id": { "type": "string", "example": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" },
+                    "merchant_connection_id": { "type": "string", "example": "adyen-us-prod-001" },
+                    "provider_id": { "type": "string", "example": "ADYEN" },
+                    "status": { "type": "string", "example": "ACTIVE" },
+                    "flow_type": { "type": "string", "example": "PAYIN" },
+                    "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY", "IDEAL"] },
+                    "params": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "param_id": { "type": "string", "example": "merchantAccount" },
+                          "value": { "type": "string", "example": "ACME_LIVE" }
+                        }
+                      }
+                    },
+                    "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" },
+                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" }
                   }
                 }
               }

--- a/openapi/organizations/routing/create-routing.json
+++ b/openapi/organizations/routing/create-routing.json
@@ -59,13 +59,28 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "account_code": { "type": "string" },
-                    "payment_method": { "type": "string" },
-                    "name": { "type": "string" },
-                    "default_route": { "type": "object" },
-                    "created_at": { "type": "string", "format": "date-time" },
-                    "updated_at": { "type": "string", "format": "date-time" }
+                    "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
+                    "account_code": { "type": "string", "example": "acc-uuid" },
+                    "payment_method": { "type": "string", "example": "CARD" },
+                    "name": { "type": "string", "example": "Card routing" },
+                    "default_route": { 
+                      "type": "object",
+                      "properties": {
+                        "steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "index": { "type": "integer", "example": 1 },
+                              "provider_id": { "type": "string", "example": "STRIPE" },
+                              "connection_id": { "type": "string", "example": "f1a3c4d5-..." }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
+                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
                   }
                 }
               }

--- a/openapi/organizations/routing/retrieve-routing.json
+++ b/openapi/organizations/routing/retrieve-routing.json
@@ -26,13 +26,28 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "account_code": { "type": "string" },
-                    "payment_method": { "type": "string" },
-                    "name": { "type": "string" },
-                    "default_route": { "type": "object" },
-                    "created_at": { "type": "string", "format": "date-time" },
-                    "updated_at": { "type": "string", "format": "date-time" }
+                    "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
+                    "account_code": { "type": "string", "example": "acc-uuid" },
+                    "payment_method": { "type": "string", "example": "CARD" },
+                    "name": { "type": "string", "example": "Card routing" },
+                    "default_route": { 
+                      "type": "object",
+                      "properties": {
+                        "steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "index": { "type": "integer", "example": 1 },
+                              "provider_id": { "type": "string", "example": "STRIPE" },
+                              "connection_id": { "type": "string", "example": "f1a3c4d5-..." }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
+                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
                   }
                 }
               }

--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -42,13 +42,28 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "account_code": { "type": "string" },
-                    "payment_method": { "type": "string" },
-                    "name": { "type": "string" },
-                    "default_route": { "type": "object" },
-                    "created_at": { "type": "string", "format": "date-time" },
-                    "updated_at": { "type": "string", "format": "date-time" }
+                    "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
+                    "account_code": { "type": "string", "example": "acc-uuid" },
+                    "payment_method": { "type": "string", "example": "CARD" },
+                    "name": { "type": "string", "example": "Updated Card routing" },
+                    "default_route": { 
+                      "type": "object",
+                      "properties": {
+                        "steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "index": { "type": "integer", "example": 1 },
+                              "provider_id": { "type": "string", "example": "STRIPE" },
+                              "connection_id": { "type": "string", "example": "f1a3c4d5-..." }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
+                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
                   }
                 }
               }

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -75,9 +75,29 @@ Creates a connection in `ACTIVE` status from credentials and configuration you f
 <ResponseField name="connection_id" type="string">
   Unique identifier for the connection. **Save this value** to reference it from routing rules.
 </ResponseField>
-
+<ResponseField name="merchant_connection_id" type="string">
+  Your internal label for this connection.
+</ResponseField>
+<ResponseField name="provider_id" type="string">
+  The provider this connection belongs to (e.g., `ADYEN`).
+</ResponseField>
 <ResponseField name="status" type="string">
   Current status (always `ACTIVE` on create).
+</ResponseField>
+<ResponseField name="flow_type" type="string">
+  Always `PAYIN`.
+</ResponseField>
+<ResponseField name="payment_methods" type="string[]">
+  List of supported payment methods.
+</ResponseField>
+<ResponseField name="params" type="object[]">
+  Echoed parameters. Sensitive values are masked as `***`.
+</ResponseField>
+<ResponseField name="created_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+<ResponseField name="updated_at" type="string">
+  ISO 8601 timestamp.
 </ResponseField>
 
 <CodeGroup>

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -59,6 +59,27 @@ Creates a routing for one `(account_code, payment_method)` pair. Each routing re
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
+<ResponseField name="account_code" type="string">
+  Unique code for the account.
+</ResponseField>
+<ResponseField name="payment_method" type="enum">
+  The payment method this routing applies to (e.g., `CARD`).
+</ResponseField>
+<ResponseField name="name" type="string">
+  Label for the routing.
+</ResponseField>
+<ResponseField name="default_route" type="object">
+  The default routing logic.
+</ResponseField>
+<ResponseField name="condition_sets" type="object[]">
+  Optional conditional logic.
+</ResponseField>
+<ResponseField name="created_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+<ResponseField name="updated_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -17,6 +17,27 @@ Returns the routing's current live configuration.
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
+<ResponseField name="account_code" type="string">
+  Unique code for the account.
+</ResponseField>
+<ResponseField name="payment_method" type="enum">
+  The payment method this routing applies to (e.g., `CARD`).
+</ResponseField>
+<ResponseField name="name" type="string">
+  Label for the routing.
+</ResponseField>
+<ResponseField name="default_route" type="object">
+  The default routing logic.
+</ResponseField>
+<ResponseField name="condition_sets" type="object[]">
+  Optional conditional logic.
+</ResponseField>
+<ResponseField name="created_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+<ResponseField name="updated_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -19,6 +19,27 @@ Replaces the routing's full configuration. The body has the same shape as [Creat
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
+<ResponseField name="account_code" type="string">
+  Unique code for the account.
+</ResponseField>
+<ResponseField name="payment_method" type="enum">
+  The payment method this routing applies to (e.g., `CARD`).
+</ResponseField>
+<ResponseField name="name" type="string">
+  Label for the routing.
+</ResponseField>
+<ResponseField name="default_route" type="object">
+  The default routing logic.
+</ResponseField>
+<ResponseField name="condition_sets" type="object[]">
+  Optional conditional logic.
+</ResponseField>
+<ResponseField name="created_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+<ResponseField name="updated_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL


### PR DESCRIPTION
## Summary

This PR adds the complete API reference documentation for the new **Connections** and **Routing** surfaces under the **Organizations** category.


**Changes:**
- Created two new sub-categories under `Organizations`: **Connections** and **Routing**.
- Added a shared overview page covering the common contract, base URL, and authentication headers.
- Implemented 3 endpoints for Connections (Catalog, Create, Retrieve).
- Implemented 3 endpoints for Routing (Create, Retrieve, Update) with detailed resource shape and conditions reference.
- **Audited and fixed response schemas**: Updated all OpenAPI `.json` files to include detailed properties and examples (fixing the generic `{}` issue in the playground).
- **Completed MDX response fields**: Ensured all `ResponseField` components match the full API response and the reference guide provided by the product team.
- Updated `docs.json` navigation to include the new sections.

**Pages:**
- `reference/organizations/connections-routing-overview`
- `reference/organizations/connections/get-provider-catalog`
- `reference/organizations/connections/create-connection`
- `reference/organizations/connections/retrieve-connection`
- `reference/organizations/routing/routing-resource-shape`
- `reference/organizations/routing/routing-conditions`
- `reference/organizations/routing/create-routing`
- `reference/organizations/routing/retrieve-routing`
- `reference/organizations/routing/update-routing`