### PR TITLE
docs(api): add connections and routing reference

### DIFF
--- a/openapi/organizations/connections/create-connection.json
+++ b/openapi/organizations/connections/create-connection.json
@@ -54,23 +54,46 @@
                   "type": "object",
                   "properties": {
                     "connection_id": { "type": "string", "example": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" },
-                    "merchant_connection_id": { "type": "string", "example": "adyen-us-prod-001" },
-                    "provider_id": { "type": "string", "example": "ADYEN" },
+                    "merchant_connection_id": { "type": "string", "example": "stripe-us-prod-001" },
+                    "provider_id": { "type": "string", "example": "STRIPE" },
                     "status": { "type": "string", "example": "ACTIVE" },
                     "flow_type": { "type": "string", "example": "PAYIN" },
-                    "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY", "IDEAL"] },
-                    "params": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "param_id": { "type": "string", "example": "merchantAccount" },
-                          "value": { "type": "string", "example": "ACME_LIVE" }
-                        }
-                      }
-                    },
+                    "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY", "APPLE_PAY"] },
+                    "params": { "type": "array", "items": { "type": "object" } },
+                    "costs": { "type": "array", "items": { "type": "object" } },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "validation_error" },
+                    "code": { "type": "string", "example": "MISSING_REQUIRED_PARAM" },
+                    "message": { "type": "string", "example": "Required param 'API_KEY' is missing" },
+                    "details": { "type": "object" }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "conflict" },
+                    "code": { "type": "string", "example": "CONNECTION_MERCHANT_ID_CONFLICT" },
+                    "message": { "type": "string", "example": "A connection with this merchant_connection_id already exists" }
                   }
                 }
               }

--- a/openapi/organizations/connections/get-provider-catalog.json
+++ b/openapi/organizations/connections/get-provider-catalog.json
@@ -29,23 +29,52 @@
                     "payment_method_type": { 
                       "type": "array", 
                       "items": { "type": "string" },
-                      "example": ["CARD", "GOOGLE_PAY", "IDEAL", "PIX"]
+                      "example": ["CARD", "GOOGLE_PAY", "APPLE_PAY", "ACH", "KLARNA_PAY_NOW", "KLARNA_PAY_LATER", "IDEAL", "GIROPAY", "BANCONTACT", "SEPA_DEBIT"]
                     },
                     "params": { 
                       "type": "array", 
                       "items": { 
                         "type": "object",
                         "properties": {
-                          "param_id": { "type": "string", "example": "merchantAccount" },
-                          "field_type": { "type": "string", "enum": ["string", "boolean", "number", "array"], "example": "string" },
-                          "description": { "type": "string", "example": "Account Code" },
+                          "param_id": { "type": "string", "example": "API_KEY" },
+                          "field_type": { "type": "string", "example": "string" },
+                          "description": { "type": "string", "example": "Stripe Secret API Key" },
                           "editable_field": { "type": "boolean", "example": true },
                           "optional": { "type": "boolean", "example": false },
-                          "secret": { "type": "boolean", "example": false },
-                          "params": { "type": "array", "items": { "type": "object" }, "description": "Nested parameters" }
+                          "secret": { "type": "boolean", "example": true }
                         }
                       }
                     }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "not_found" },
+                    "code": { "type": "string", "example": "PROVIDER_NOT_FOUND" },
+                    "message": { "type": "string", "example": "Provider 'NOT_A_PROVIDER' is not in the Yuno provider catalog" }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "auth_error" },
+                    "code": { "type": "string", "example": "INSUFFICIENT_SCOPE" },
+                    "message": { "type": "string", "example": "API key is missing required scope 'connections:read'" }
                   }
                 }
               }

--- a/openapi/organizations/connections/retrieve-connection.json
+++ b/openapi/organizations/connections/retrieve-connection.json
@@ -27,11 +27,11 @@
                   "type": "object",
                   "properties": {
                     "connection_id": { "type": "string", "example": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e" },
-                    "merchant_connection_id": { "type": "string", "example": "adyen-us-prod-001" },
-                    "provider_id": { "type": "string", "example": "ADYEN" },
+                    "merchant_connection_id": { "type": "string", "example": "stripe-us-prod-001" },
+                    "provider_id": { "type": "string", "example": "STRIPE" },
                     "status": { "type": "string", "example": "ACTIVE" },
                     "flow_type": { "type": "string", "example": "PAYIN" },
-                    "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY", "IDEAL"] },
+                    "payment_methods": { "type": "array", "items": { "type": "string" }, "example": ["CARD", "GOOGLE_PAY", "APPLE_PAY"] },
                     "params": {
                       "type": "array",
                       "items": {
@@ -55,6 +55,36 @@
                     },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "not_found" },
+                    "code": { "type": "string", "example": "CONNECTION_NOT_FOUND" },
+                    "message": { "type": "string", "example": "Connection '...' was not found" }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "auth_error" },
+                    "code": { "type": "string", "example": "INSUFFICIENT_SCOPE" },
+                    "message": { "type": "string", "example": "API key is missing required scope 'connections:read'" }
                   }
                 }
               }

--- a/openapi/organizations/connections/retrieve-connection.json
+++ b/openapi/organizations/connections/retrieve-connection.json
@@ -42,6 +42,17 @@
                         }
                       }
                     },
+                    "costs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sort_number": { "type": "integer", "example": 1 },
+                          "cost_name": { "type": "string", "example": "Transaction Fee" },
+                          "currency": { "type": "string", "example": "USD" }
+                        }
+                      }
+                    },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T10:24:00Z" }
                   }

--- a/openapi/organizations/routing/create-routing.json
+++ b/openapi/organizations/routing/create-routing.json
@@ -79,8 +79,51 @@
                         }
                       }
                     },
+                    "condition_sets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sort_number": { "type": "integer", "example": 1 },
+                          "name": { "type": "string", "example": "High Value US" },
+                          "conditions": { "type": "array", "items": { "type": "object" } },
+                          "route": { "type": "object" }
+                        }
+                      }
+                    },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
-                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
+                    "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
+                    "warnings": { "type": "array", "items": { "type": "string" }, "example": ["MONITOR_REDISTRIBUTION_DEFERRED"] }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "validation_error" },
+                    "code": { "type": "string", "example": "ROUTING_VALIDATION_FAILED" },
+                    "message": { "type": "string", "example": "Steps must be contiguous" }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "conflict" },
+                    "code": { "type": "string", "example": "ROUTING_ALREADY_EXISTS" },
+                    "message": { "type": "string", "example": "A routing already exists for this payment method" }
                   }
                 }
               }

--- a/openapi/organizations/routing/retrieve-routing.json
+++ b/openapi/organizations/routing/retrieve-routing.json
@@ -29,7 +29,7 @@
                     "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
                     "account_code": { "type": "string", "example": "acc-uuid" },
                     "payment_method": { "type": "string", "example": "CARD" },
-                    "name": { "type": "string", "example": "Card routing" },
+                    "name": { "type": "string", "example": "Card routing — Stripe primary, Adyen fallback" },
                     "default_route": { 
                       "type": "object",
                       "properties": {
@@ -60,6 +60,21 @@
                     },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "not_found" },
+                    "code": { "type": "string", "example": "ROUTING_NOT_FOUND" },
+                    "message": { "type": "string", "example": "Routing '...' was not found" }
                   }
                 }
               }

--- a/openapi/organizations/routing/retrieve-routing.json
+++ b/openapi/organizations/routing/retrieve-routing.json
@@ -46,6 +46,18 @@
                         }
                       }
                     },
+                    "condition_sets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sort_number": { "type": "integer", "example": 1 },
+                          "name": { "type": "string", "example": "High Value US" },
+                          "conditions": { "type": "array", "items": { "type": "object" } },
+                          "route": { "type": "object" }
+                        }
+                      }
+                    },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
                   }

--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -45,7 +45,7 @@
                     "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
                     "account_code": { "type": "string", "example": "acc-uuid" },
                     "payment_method": { "type": "string", "example": "CARD" },
-                    "name": { "type": "string", "example": "Updated Card routing" },
+                    "name": { "type": "string", "example": "Updated Card routing v2" },
                     "default_route": { 
                       "type": "object",
                       "properties": {
@@ -76,6 +76,51 @@
                     },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "validation_error" },
+                    "code": { "type": "string", "example": "ROUTING_VALIDATION_FAILED" },
+                    "message": { "type": "string", "example": "Validation failed for update" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "not_found" },
+                    "code": { "type": "string", "example": "ROUTING_NOT_FOUND" },
+                    "message": { "type": "string", "example": "Routing '...' was not found" }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "conflict" },
+                    "code": { "type": "string", "example": "ROUTING_VERSION_CONFLICT" },
+                    "message": { "type": "string", "example": "Another concurrent PATCH won the publish race" }
                   }
                 }
               }

--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -62,6 +62,18 @@
                         }
                       }
                     },
+                    "condition_sets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sort_number": { "type": "integer", "example": 1 },
+                          "name": { "type": "string", "example": "Updated Card routing" },
+                          "conditions": { "type": "array", "items": { "type": "object" } },
+                          "route": { "type": "object" }
+                        }
+                      }
+                    },
                     "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
                     "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
                   }

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -93,6 +93,9 @@ Creates a connection in `ACTIVE` status from credentials and configuration you f
 <ResponseField name="params" type="object[]">
   Echoed parameters. Sensitive values are masked as `***`.
 </ResponseField>
+<ResponseField name="costs" type="object[]">
+  Cost configuration for the connection.
+</ResponseField>
 <ResponseField name="created_at" type="string">
   ISO 8601 timestamp.
 </ResponseField>
@@ -102,21 +105,51 @@ Creates a connection in `ACTIVE` status from credentials and configuration you f
 
 <CodeGroup>
 ```bash cURL
-curl --request POST \
-     --url https://api.y.uno/v1/connections \
-     --header 'Content-Type: application/json' \
-     --header 'X-Idempotency-Key: <UUID>' \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
-     --data '
+curl -X POST 'https://api.y.uno/v1/connections' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Idempotency-Key: <UUID>' \
+  -d '{
+    "merchant_connection_id": "stripe-us-prod-001",
+    "provider_id": "STRIPE",
+    "flow_type": "PAYIN",
+    "payment_methods": ["CARD", "GOOGLE_PAY", "APPLE_PAY"],
+    "params": [
+      { "param_id": "API_KEY",           "value": "sk_live_..." },
+      { "param_id": "PUBLISHABLE_KEY",   "value": "pk_live_..." },
+      { "param_id": "INTEGRATION_TYPE",  "value": "PAYMENT_INTENTS" },
+      { "param_id": "3DS_ENABLED",       "value": true },
+      { "param_id": "ORIGIN_URL",        "value": "https://checkout.acme.com" }
+    ],
+    "costs": [
+      {
+        "sort_number": 1,
+        "cost_name": "Transaction Fee",
+        "currency": "USD",
+        "cost_values": {
+          "successful":   { "fixed_fee": 0.30, "percentage": 2.9 },
+          "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
+        }
+      }
+    ]
+  }'
+```
+
+```json 201 Created — Stripe
 {
-  "merchant_connection_id": "adyen-us-prod-001",
-  "provider_id": "ADYEN",
+  "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+  "merchant_connection_id": "stripe-us-prod-001",
+  "provider_id": "STRIPE",
+  "status": "ACTIVE",
   "flow_type": "PAYIN",
-  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
+  "payment_methods": ["CARD", "GOOGLE_PAY", "APPLE_PAY"],
   "params": [
-    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
-    { "param_id": "x-api-key",              "value": "AQEx…W4w==" }
+    { "param_id": "API_KEY",             "value": "***" },
+    { "param_id": "PUBLISHABLE_KEY",     "value": "pk_live_..." },
+    { "param_id": "INTEGRATION_TYPE",    "value": "PAYMENT_INTENTS" },
+    { "param_id": "3DS_ENABLED",         "value": true },
+    { "param_id": "ORIGIN_URL",          "value": "https://checkout.acme.com" }
   ],
   "costs": [
     {
@@ -124,29 +157,67 @@ curl --request POST \
       "cost_name": "Transaction Fee",
       "currency": "USD",
       "cost_values": {
-        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
+        "successful":   { "fixed_fee": 0.30, "percentage": 2.9 },
         "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
       }
     }
-  ]
+  ],
+  "created_at": "2026-05-12T10:24:00Z",
+  "updated_at": "2026-05-12T10:24:00Z"
 }
-'
 ```
 
-```json Response
+```json 201 Created — Adyen
 {
-  "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
-  "merchant_connection_id": "adyen-us-prod-001",
+  "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f",
+  "merchant_connection_id": "adyen-eu-prod-001",
   "provider_id": "ADYEN",
   "status": "ACTIVE",
   "flow_type": "PAYIN",
   "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
   "params": [
     { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
-    { "param_id": "x-api-key",              "value": "***" }
+    { "param_id": "x-api-key",              "value": "***" },
+    { "param_id": "HMAC_KEY",               "value": "***" },
+    { "param_id": "url-prefix",             "value": "acme-live" },
+    { "param_id": "transaction-identifier", "value": "MERCHANT_REFERENCE" },
+    { "param_id": "MERCHANT_NAME",          "value": "ACME Inc." },
+    { "param_id": "CAPTURE_DELAY_HOURS",    "value": "24" },
+    { "param_id": "recurring-model",        "value": "CardOnFile" },
+    { "param_id": "3DS_ENABLED",            "value": true },
+    { "param_id": "ORIGIN_URL",             "value": "https://checkout.acme.com" }
   ],
-  "created_at": "2026-05-12T10:24:00Z",
-  "updated_at": "2026-05-12T10:24:00Z"
+  "costs": [
+    {
+      "sort_number": 1,
+      "cost_name": "Transaction Fee",
+      "currency": "EUR",
+      "cost_values": {
+        "successful":   { "fixed_fee": 0.12, "percentage": 1.2 },
+        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
+      }
+    }
+  ],
+  "created_at": "2026-05-12T10:31:42Z",
+  "updated_at": "2026-05-12T10:31:42Z"
+}
+```
+
+```json 400 — Missing Param
+{
+  "type": "validation_error",
+  "code": "MISSING_REQUIRED_PARAM",
+  "message": "Required param 'API_KEY' is missing for provider 'STRIPE'",
+  "details": { "provider_id": "STRIPE", "param_id": "API_KEY" }
+}
+```
+
+```json 409 — Conflict
+{
+  "type": "conflict",
+  "code": "CONNECTION_MERCHANT_ID_CONFLICT",
+  "message": "A connection with merchant_connection_id 'stripe-us-prod-001' already exists in this account",
+  "details": { "merchant_connection_id": "stripe-us-prod-001" }
 }
 ```
 </CodeGroup>

--- a/reference/organizations/connections/get-provider-catalog.mdx
+++ b/reference/organizations/connections/get-provider-catalog.mdx
@@ -71,30 +71,52 @@ This endpoint is provider-scoped, not connection-scoped. It returns a schema, no
 
 <CodeGroup>
 ```bash cURL
-curl --request GET \
-     --url https://api.y.uno/v1/connections/catalog/{provider_id} \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
+curl -X GET 'https://api.y.uno/v1/connections/catalog/STRIPE' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>'
 ```
 
-```json Response Example
+```json 200 OK — Stripe
 {
-  "payment_method_type": ["CARD", "GOOGLE_PAY", "IDEAL", "PIX", "..."],
+  "payment_method_type": [
+    "CARD",
+    "GOOGLE_PAY",
+    "APPLE_PAY",
+    "ACH",
+    "KLARNA_PAY_NOW",
+    "KLARNA_PAY_LATER",
+    "IDEAL",
+    "GIROPAY",
+    "BANCONTACT",
+    "SEPA_DEBIT"
+  ],
   "params": [
     {
-      "param_id": "merchantAccount",
+      "param_id": "API_KEY",
       "field_type": "string",
-      "description": "Account Code",
+      "secret": true,
+      "description": "Stripe Secret API Key",
       "editable_field": true,
       "optional": false
     },
     {
-      "param_id": "x-api-key",
+      "param_id": "PUBLISHABLE_KEY",
       "field_type": "string",
-      "secret": true,
-      "description": "x-api-key",
+      "description": "Stripe Publishable Key",
       "editable_field": true,
       "optional": false
+    },
+    {
+      "param_id": "INTEGRATION_TYPE",
+      "field_type": "string",
+      "description": "Stripe integration variant",
+      "editable_field": true,
+      "optional": false,
+      "options": [
+        "PAYMENT_INTENTS",
+        "CHARGES",
+        "CONNECT_DESTINATION"
+      ]
     },
     {
       "param_id": "3DS_ENABLED",
@@ -106,13 +128,31 @@ curl --request GET \
         {
           "param_id": "ORIGIN_URL",
           "field_type": "string",
-          "description": "Your origin url",
+          "description": "Your checkout origin URL",
           "editable_field": true,
           "optional": true
         }
       ]
     }
   ]
+}
+```
+
+```json 404 Not Found
+{
+  "type": "not_found",
+  "code": "PROVIDER_NOT_FOUND",
+  "message": "Provider 'NOT_A_PROVIDER' is not in the Yuno provider catalog",
+  "details": { "provider_id": "NOT_A_PROVIDER" }
+}
+```
+
+```json 403 Forbidden
+{
+  "type": "auth_error",
+  "code": "INSUFFICIENT_SCOPE",
+  "message": "API key is missing required scope 'connections:read'",
+  "details": { "required_scope": "connections:read" }
 }
 ```
 </CodeGroup>

--- a/reference/organizations/connections/retrieve-connection.mdx
+++ b/reference/organizations/connections/retrieve-connection.mdx
@@ -17,29 +17,75 @@ Returns a connection you previously created. Secrets are masked.
 <ResponseField name="connection_id" type="string">
   Unique identifier for the connection.
 </ResponseField>
+<ResponseField name="merchant_connection_id" type="string">
+  Your internal label for this connection.
+</ResponseField>
+<ResponseField name="provider_id" type="string">
+  The provider this connection belongs to.
+</ResponseField>
+<ResponseField name="status" type="string">
+  Current status.
+</ResponseField>
+<ResponseField name="flow_type" type="string">
+  Always `PAYIN`.
+</ResponseField>
+<ResponseField name="payment_methods" type="string[]">
+  List of supported payment methods.
+</ResponseField>
+<ResponseField name="params" type="object[]">
+  Echoed parameters. Sensitive values are masked as `***`.
+</ResponseField>
+<ResponseField name="costs" type="object[]">
+  Cost configuration for the connection.
+</ResponseField>
+<ResponseField name="created_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+<ResponseField name="updated_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL
-curl --request GET \
-     --url https://api.y.uno/v1/connections/{connection_id} \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
+curl -X GET 'https://api.y.uno/v1/connections/f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>'
 ```
 
-```json Response Example
+```json 200 OK — Stripe
 {
   "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
-  "merchant_connection_id": "adyen-us-prod-001",
-  "provider_id": "ADYEN",
+  "merchant_connection_id": "stripe-us-prod-001",
+  "provider_id": "STRIPE",
   "status": "ACTIVE",
   "flow_type": "PAYIN",
-  "payment_methods": ["CARD", "GOOGLE_PAY", "IDEAL"],
+  "payment_methods": ["CARD", "GOOGLE_PAY", "APPLE_PAY"],
   "params": [
-    { "param_id": "merchantAccount",        "value": "ACME_LIVE" },
-    { "param_id": "x-api-key",              "value": "***" }
+    { "param_id": "API_KEY",             "value": "***" },
+    { "param_id": "PUBLISHABLE_KEY",     "value": "pk_live_..." }
+  ],
+  "costs": [
+    {
+      "sort_number": 1,
+      "cost_name": "Transaction Fee",
+      "currency": "USD",
+      "cost_values": {
+        "successful":   { "fixed_fee": 0.30, "percentage": 2.9 },
+        "unsuccessful": { "fixed_fee": 0.0,  "percentage": 0.0 }
+      }
+    }
   ],
   "created_at": "2026-05-12T10:24:00Z",
   "updated_at": "2026-05-12T10:24:00Z"
+}
+```
+
+```json 404 Not Found
+{
+  "type": "not_found",
+  "code": "CONNECTION_NOT_FOUND",
+  "message": "Connection '...' was not found",
+  "details": { "connection_id": "..." }
 }
 ```
 </CodeGroup>

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -83,42 +83,106 @@ Creates a routing for one `(account_code, payment_method)` pair. Each routing re
 
 <CodeGroup>
 ```bash cURL
-curl --request POST \
-     --url https://api.y.uno/v1/routing \
-     --header 'Content-Type: application/json' \
-     --header 'X-Idempotency-Key: <UUID>' \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
-     --data '
+curl -X POST 'https://api.y.uno/v1/routing' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Idempotency-Key: <UUID>' \
+  -d '{
+    "payment_method": "CARD",
+    "name": "Card routing — Stripe primary, Adyen fallback",
+    "default_route": {
+      "steps": [
+        {
+          "index": 1,
+          "provider_id": "STRIPE",
+          "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+          "output": [
+            {
+              "status": "DECLINE_GROUP",
+              "decline_types": ["DECLINED_BY_BANK", "DO_NOT_HONOR"],
+              "next": 2
+            },
+            { "status": "TIMEOUT",        "next": 2 },
+            { "status": "INTERNAL_ERROR", "next": 2 }
+          ]
+        },
+        {
+          "index": 2,
+          "provider_id": "ADYEN",
+          "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+        }
+      ]
+    },
+    "condition_sets": [
+      {
+        "sort_number": 1,
+        "name": "Brazil — 3 to 6 installments via Adyen",
+        "description": "BR card transactions with 3–6 installments go to Adyen directly",
+        "conditions": [
+          { "condition_type": "COUNTRY",      "conditional": "EQUAL",   "values": ["BR"] },
+          { "condition_type": "INSTALLMENTS", "conditional": "BETWEEN", "values": ["3", "6"] }
+        ],
+        "route": {
+          "steps": [
+            { "index": 1, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-..." }
+          ]
+        }
+      }
+    ]
+  }'
+```
+
+```json 201 Created
 {
+  "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
+  "account_code": "acc-uuid",
   "payment_method": "CARD",
-  "name": "Card routing",
+  "name": "Card routing — Stripe primary, Adyen fallback",
   "default_route": {
     "steps": [
       {
         "index": 1,
         "provider_id": "STRIPE",
-        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e"
-      }
-    ]
-  }
-}
-'
-```
-
-```json Response Example
-{
-  "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
-  "account_code": "acc-uuid",
-  "payment_method": "CARD",
-  "name": "Card routing",
-  "default_route": {
-    "steps": [
-      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-..." }
+        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+        "output": [
+          { "status": "DECLINE_GROUP", "next": 2 },
+          { "status": "TIMEOUT",        "next": 2 }
+        ]
+      },
+      { "index": 2, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-..." }
     ]
   },
+  "condition_sets": [
+    {
+      "sort_number": 1,
+      "name": "Brazil — 3 to 6 installments via Adyen",
+      "conditions": [
+        { "condition_type": "COUNTRY", "conditional": "EQUAL", "values": ["BR"] }
+      ],
+      "route": { "steps": ["..."] }
+    }
+  ],
   "created_at": "2026-05-12T14:30:00Z",
   "updated_at": "2026-05-12T14:30:00Z"
+}
+```
+
+```json 400 — Non-contiguous Index
+{
+  "type": "validation_error",
+  "code": "ROUTING_VALIDATION_FAILED",
+  "message": "default_route.steps[].index must be contiguous starting at 1",
+  "details": { "path": "default_route.steps[1].index", "expected": 2, "received": 3 }
+}
+```
+
+```json 409 — Already Exists
+{
+  "type": "conflict",
+  "code": "ROUTING_ALREADY_EXISTS",
+  "message": "A routing already exists for account 'acc-uuid' and payment_method 'CARD'",
+  "details": { "payment_method": "CARD", "existing_routing_id": "r_..." }
 }
 ```
 </CodeGroup>

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -38,28 +38,48 @@ Returns the routing's current live configuration.
 <ResponseField name="updated_at" type="string">
   ISO 8601 timestamp.
 </ResponseField>
+<ResponseField name="warnings" type="string[]">
+  Optional list of non-blocking orchestration warnings (e.g., `MONITOR_REDISTRIBUTION_DEFERRED`).
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL
-curl --request GET \
-     --url https://api.y.uno/v1/routing/{routing_id} \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>'
+curl -X GET 'https://api.y.uno/v1/routing/r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>'
 ```
 
-```json Response Example
+```json 200 OK
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
   "account_code": "acc-uuid",
   "payment_method": "CARD",
-  "name": "Card routing",
+  "name": "Card routing — Stripe primary, Adyen fallback",
   "default_route": {
     "steps": [
-      { "index": 1, "provider_id": "STRIPE", "connection_id": "f1a3c4d5-..." }
+      {
+        "index": 1,
+        "provider_id": "STRIPE",
+        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+        "output": [
+          { "status": "DECLINE_GROUP", "next": 2 },
+          { "status": "TIMEOUT",        "next": 2 }
+        ]
+      },
+      { "index": 2, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-..." }
     ]
   },
   "created_at": "2026-05-12T14:30:00Z",
   "updated_at": "2026-05-12T14:30:00Z"
+}
+```
+
+```json 404 Not Found
+{
+  "type": "not_found",
+  "code": "ROUTING_NOT_FOUND",
+  "message": "Routing '...' was not found",
+  "details": { "routing_id": "..." }
 }
 ```
 </CodeGroup>

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -43,41 +43,92 @@ Replaces the routing's full configuration. The body has the same shape as [Creat
 
 <CodeGroup>
 ```bash cURL
-curl --request PATCH \
-     --url https://api.y.uno/v1/routing/{routing_id} \
-     --header 'Content-Type: application/json' \
-     --header 'X-Idempotency-Key: <UUID>' \
-     --header 'private-secret-key: <YOUR_SECRET_KEY>' \
-     --header 'public-api-key: <YOUR_PUBLIC_KEY>' \
-     --data '
-{
-  "name": "Updated Card routing",
-  "default_route": {
-    "steps": [
+curl -X PATCH 'https://api.y.uno/v1/routing/r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Idempotency-Key: <UUID>' \
+  -d '{
+    "payment_method": "CARD",
+    "name": "Card routing v2 — adds BR installments rule",
+    "default_route": {
+      "steps": [
+        {
+          "index": 1,
+          "provider_id": "STRIPE",
+          "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+          "output": [
+            { "status": "DECLINED", "next": 2 }
+          ]
+        },
+        {
+          "index": 2,
+          "provider_id": "ADYEN",
+          "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+        }
+      ]
+    },
+    "condition_sets": [
       {
-        "index": 1,
-        "provider_id": "ADYEN",
-        "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+        "sort_number": 1,
+        "name": "Brazil — 3 to 6 installments via Adyen",
+        "description": "BR card transactions with 3–6 installments go to Adyen directly",
+        "conditions": [
+          { "condition_type": "COUNTRY",      "conditional": "EQUAL",   "values": ["BR"] },
+          { "condition_type": "INSTALLMENTS", "conditional": "BETWEEN", "values": ["3", "6"] }
+        ],
+        "route": {
+          "steps": [
+            { "index": 1, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-..." }
+          ]
+        }
       }
     ]
-  }
-}
-'
+  }'
 ```
 
-```json Response Example
+```json 200 OK — Updated
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
   "account_code": "acc-uuid",
   "payment_method": "CARD",
-  "name": "Updated Card routing",
+  "name": "Card routing v2 — adds BR installments rule",
   "default_route": {
     "steps": [
-      { "index": 1, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-1a2b-3c4d-5e6f-7a8b9c0d1e2f" }
+      {
+        "index": 1,
+        "provider_id": "STRIPE",
+        "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+        "output": [ { "status": "DECLINED", "next": 2 } ]
+      },
+      { "index": 2, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-..." }
     ]
   },
+  "condition_sets": [
+    {
+      "sort_number": 1,
+      "name": "Brazil — 3 to 6 installments via Adyen",
+      "conditions": [
+        { "condition_type": "COUNTRY", "conditional": "EQUAL", "values": ["BR"] }
+      ],
+      "route": { "steps": ["..."] }
+    }
+  ],
   "created_at": "2026-05-12T14:30:00Z",
-  "updated_at": "2026-05-12T15:00:00Z"
+  "updated_at": "2026-05-13T09:18:42Z"
+}
+```
+
+```json 400 — Immutable Payment Method
+{
+  "type": "validation_error",
+  "code": "ROUTING_PAYMENT_METHOD_IMMUTABLE",
+  "message": "payment_method cannot be changed on an existing routing",
+  "details": {
+    "routing_id": "r_...",
+    "current_payment_method": "CARD",
+    "received_payment_method": "PIX"
+  }
 }
 ```
 </CodeGroup>


### PR DESCRIPTION
This PR adds the complete API reference documentation for the new **Connections** and **Routing** surfaces under the **Organizations** category.


**Changes:**
- Created two new sub-categories under `Organizations`: **Connections** and **Routing**.
- Added a shared overview page covering the common contract, base URL, and authentication headers.
- Implemented 3 endpoints for Connections (Catalog, Create, Retrieve).
- Implemented 3 endpoints for Routing (Create, Retrieve, Update) with detailed resource shape and conditions reference.
- **Exhaustive Example Integration**: Integrated the complete request/response examples guide provided by product. Added Stripe and Adyen success scenarios and a full suite of error responses (400, 403, 404, 409) to all endpoint pages.
- **Audited and fixed response schemas**: Updated all OpenAPI `.json` files to include detailed properties and examples (fixing the generic `{}` issue in the playground).
- **Completed MDX response fields**: Ensured all `ResponseField` components match the full API response and the reference guide provided by the product team.
- Updated `docs.json` navigation to include the new sections.

**Pages:**
- `reference/organizations/connections-routing-overview`
- `reference/organizations/connections/get-provider-catalog`
- `reference/organizations/connections/create-connection`
- `reference/organizations/connections/retrieve-connection`
- `reference/organizations/routing/routing-resource-shape`
- `reference/organizations/routing/routing-conditions`
- `reference/organizations/routing/create-routing`
- `reference/organizations/routing/retrieve-routing`
- `reference/organizations/routing/update-routing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes updating OpenAPI schema examples and MDX reference content; no runtime code paths are affected.
> 
> **Overview**
> Updates the **Organizations → Connections** and **Routing** API reference to better match the real API contract by expanding OpenAPI response schemas (e.g., `costs`, `condition_sets`, `warnings`) and enriching provider/payment method examples (notably STRIPE vs ADYEN).
> 
> Adds documented error responses across these endpoints (e.g., `400`, `403`, `404`, `409`) and refreshes the MDX pages with fuller cURL + success/error payload examples and clearer parameter/secret-masking guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c573efc432d68863402f488a46021a44f0190238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->