### PR TITLE
Added Headless SDK dynamic diagram to Understanding flow page

### DIFF
--- a/docs/sdks/overview/understanding-flows.mdx
+++ b/docs/sdks/overview/understanding-flows.mdx
@@ -84,6 +84,10 @@ If a customer has an enrolled payment method, they can use a **vaulted token** t
 
 The **Headless SDK** provides maximum flexibility by allowing you to manage the entire user interface while Yuno handles the complex payment logic and security (like 3DS).
 
+<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/headless-sdk-flow.html" style={{ width: "100%", aspectRatio: "1600 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
+
+<div style={{ display: "flex", gap: "20px", flexWrap: "wrap", fontSize: "13px", color: "#64748b", marginTop: "8px", marginBottom: "4px" }}><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#3e4fe0" }}></span>Request</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#f97316" }}></span>Response</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#15803d" }}></span>Success</span></div>
+
 ### Headless flow steps
 
 1. **Merchant Server**: `Create Customer` → **Yuno Server**: `Creates Customer`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is reliance on an external iframe URL rendering correctly.
> 
> **Overview**
> Adds a dynamic `iframe` diagram and matching request/response/success legend to the **Headless SDK flow** section in `docs/sdks/overview/understanding-flows.mdx` to visually illustrate the flow alongside the existing step list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25cd8b6a542ded7775127d4019ed74f7c345b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->