### PR TITLE
Remove legacy callout banners from Seamless SDK pages

### DIFF
--- a/docs/sdks/seamless-sdk/android-payments.mdx
+++ b/docs/sdks/seamless-sdk/android-payments.mdx
@@ -5,10 +5,6 @@ description: >-
   Step-by-step guide on integrating Yuno's Seamless Android SDK into your
   mobile application for a flexible payment experience.
 ---
-import LegacyOrientation from '/snippets/LegacyOrientation.mdx'
-
-<LegacyOrientation />
-
 This page provides a guide to the Yuno Seamless SDK for Android payments.
 
 <Tip>

--- a/docs/sdks/seamless-sdk/index.mdx
+++ b/docs/sdks/seamless-sdk/index.mdx
@@ -5,9 +5,6 @@ description: >-
   Yuno's Seamless SDK provides a simple and efficient integration while giving
   you full control over the payment experience.
 ---
-import LegacyOrientation from '/snippets/LegacyOrientation.mdx'
-
-<LegacyOrientation />
 Yuno's **Seamless SDK** provides a simple and efficient integration while giving you full control over the payment experience. Like the [Lite SDK](/docs/sdks/overview/quickstart), it allows you to retrieve available payment methods and decide which to display during checkout. Once the selection is made, a single API and SDK call completes the payment process, creating an experience identical to the Lite SDK.
 
 When using the Seamless SDK, you can:

--- a/docs/sdks/seamless-sdk/ios-payments.mdx
+++ b/docs/sdks/seamless-sdk/ios-payments.mdx
@@ -5,9 +5,6 @@ description: >-
   Step-by-step guide on integrating Yuno's Seamless iOS SDK into your mobile
   application for a flexible payment experience.
 ---
-import LegacyOrientation from '/snippets/LegacyOrientation.mdx'
-
-<LegacyOrientation />
 On this page, you will find all the steps to add, configure, and use the Seamless iOS SDK to make payments in your iOS project.
 
 <Tip>

--- a/docs/sdks/seamless-sdk/web-payments.mdx
+++ b/docs/sdks/seamless-sdk/web-payments.mdx
@@ -5,9 +5,6 @@ description: >-
   Step-by-step guide on integrating Yuno's Seamless Web SDK for a flexible
   payment experience with pre-built UI components.
 ---
-import LegacyOrientation from '/snippets/LegacyOrientation.mdx'
-
-<LegacyOrientation />
 Follow this step-by-step guide to implement and enable Yuno's Seamless Web SDK payment functionality in your application.
 
 <Tip>

--- a/snippets/LegacyOrientation.mdx
+++ b/snippets/LegacyOrientation.mdx
@@ -1,6 +1,0 @@
-<Warning>
-
-**Orientation: Choosing Your Integration Flow**
-- This SDK is now **Legacy**. We recommend using [Full Checkout](/docs/sdks/full-checkout/web-payments) for a more modern and supported integration.
-- Before you begin, please review the [Official Integration Flow](/docs/sdks/overview/understanding-flows).
-</Warning>


### PR DESCRIPTION
## PR Description

Removes the legacy callout banners from all Seamless SDK pages, as requested by Damián following Caio's feedback. The removed callout was a `<Warning>` banner titled "Orientation: Choosing Your Integration Flow" that marked the Seamless SDK as Legacy and recommended Full Checkout instead.

## Changes

- Removed `<LegacyOrientation />` import and usage from `docs/sdks/seamless-sdk/index.mdx`
- Removed `<LegacyOrientation />` import and usage from `docs/sdks/seamless-sdk/web-payments.mdx`
- Removed `<LegacyOrientation />` import and usage from `docs/sdks/seamless-sdk/ios-payments.mdx`
- Removed `<LegacyOrientation />` import and usage from `docs/sdks/seamless-sdk/android-payments.mdx`
- Deleted orphaned snippet `snippets/LegacyOrientation.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change removing a legacy warning callout and its shared snippet; no runtime or API behavior changes.
> 
> **Overview**
> Removes the `LegacyOrientation` warning banner from all Seamless SDK docs pages (index + Web/iOS/Android payment guides), so the pages no longer label Seamless as *Legacy* or redirect readers to Full Checkout.
> 
> Deletes the now-unused `snippets/LegacyOrientation.mdx` include.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b0f33d806a3dce9b4c9972aba35b9810dc1adc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->