### PR TITLE
Added REQUEST_IN_PROCESS error to POST /payments responses

### DIFF
--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -28182,6 +28182,39 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "409",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Request in process": {
+                    "value": {
+                      "code": "REQUEST_IN_PROCESS",
+                      "messages": [
+                        "Request with the same idempotency is already in process. Try again in a few seconds."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "REQUEST_IN_PROCESS"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Request with the same idempotency is already in process. Try again in a few seconds."
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "deprecated": false


### PR DESCRIPTION
## PR Description

Adds the `REQUEST_IN_PROCESS` 409 error response to the POST /payments endpoint documentation, as requested by Andrea. Merchants sending a request with an idempotency key that is already being processed will now see this error documented alongside the existing 400, 401, and 403 responses.

## Changes

- Added `409` response entry to `openapi/payments/create-payment.json` with the `REQUEST_IN_PROCESS` error code and message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change to the OpenAPI spec; no runtime behavior or data handling is modified.
> 
> **Overview**
> Documents an additional `409` error response for `POST /payments` in `openapi/payments/create-payment.json`.
> 
> The new response describes the `REQUEST_IN_PROCESS` error returned when the same idempotency key is already being processed, including example payload and schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b692c2d41f4f93d886f00734db7202f9b3f6a831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->