### PR TITLE
added REQUEST_IN_PROCESS error to payments and authentication reference

### DIFF
--- a/reference/getting-started/authentication.mdx
+++ b/reference/getting-started/authentication.mdx
@@ -36,7 +36,7 @@ Some requests include a unique identifier sent as the `X-Idempotency-Key` header
 
 Yuno stores the `X-Idempotency-Key` and the transaction status for 24 hours, regardless of the outcome (captured, authorized, or failed). Any subsequent request with the same key within that window returns the original response instead of creating a new transaction.
 
-If two requests are sent simultaneously, the API may receive the second before responding to the first. In that case, the second request returns a `409 Conflict`, indicating there is already an open call for that `X-Idempotency-Key`.
+If two requests are sent simultaneously, the API may receive the second before responding to the first. In that case, the second request returns a `409 Conflict` with error code `REQUEST_IN_PROCESS`, indicating the first request has not yet completed. Retry the request after a few seconds.
 
 <Note>
   If two requests are sent with the same key but different body contents, the API processes only the first one.


### PR DESCRIPTION
## PR description

  - Updated the Idempotency section in the Authentication reference page to name the `REQUEST_IN_PROCESS` error code and include retry guidance (try again after
   a few seconds), matching the error detail already documented in the payments endpoint.

## Pages changed

  - `reference/getting-started/authentication` — updated the simultaneous-requests paragraph to reference `REQUEST_IN_PROCESS`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies the error code returned for simultaneous idempotent requests and adds retry guidance.
> 
> **Overview**
> Updates the Authentication reference idempotency guidance to specify that concurrent requests with the same `X-Idempotency-Key` return `409 Conflict` with error code `REQUEST_IN_PROCESS`.
> 
> Adds brief guidance to retry the request after a few seconds when this condition occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4801768abe5da0f9163892768dbb5718c1c9534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->