### PR TITLE
Replace generic CARD enum with normalized payment method values

### DIFF
--- a/openapi/dry-run/register-dry-run-provider-event.json
+++ b/openapi/dry-run/register-dry-run-provider-event.json
@@ -201,10 +201,15 @@
           "payment_method_type": {
             "type": "string",
             "description": "Payment method exercised by this dry-run. Same vocabulary as payment_method.type in POST /v1/payments.",
-            "example": "CARD",
+            "example": "CREDIT_CARD",
             "enum": [
               "",
-              "CARD",
+              "CREDIT_CARD",
+              "CREDIT_CARD_REFERENCE_TRANSACTION",
+              "DEBIT_CARD",
+              "EPX_TOKEN",
+              "TEST_CREDIT_CARD",
+              "UPC_TOKEN_TRANSACTION",
               "APPLE_PAY",
               "GOOGLE_PAY",
               "PIX",
@@ -227,6 +232,7 @@
               "TOSS_PAY",
               "UPI",
               "VENMO",
+              "ACH",
               "BANK_TRANSFER",
               "CRYPTO",
               "CASH"
@@ -374,10 +380,15 @@
           },
           "payment_method_type": {
             "type": "string",
-            "example": "CARD",
+            "example": "CREDIT_CARD",
             "enum": [
               "",
-              "CARD",
+              "CREDIT_CARD",
+              "CREDIT_CARD_REFERENCE_TRANSACTION",
+              "DEBIT_CARD",
+              "EPX_TOKEN",
+              "TEST_CREDIT_CARD",
+              "UPC_TOKEN_TRANSACTION",
               "APPLE_PAY",
               "GOOGLE_PAY",
               "PIX",
@@ -400,6 +411,7 @@
               "TOSS_PAY",
               "UPI",
               "VENMO",
+              "ACH",
               "BANK_TRANSFER",
               "CRYPTO",
               "CASH"

--- a/reference/dry-run/register-dry-run-provider-event.mdx
+++ b/reference/dry-run/register-dry-run-provider-event.mdx
@@ -47,4 +47,4 @@ Use `X-Idempotency-Key` for safe retries. Same key + same payload returns the or
 
 - `merchant_reference` is always required and uniquely identifies the order on your side. Yuno uses it to resolve the event to a payment asynchronously when `payment_id` is not supplied.
 - `payment_id`, if supplied, is resolved immediately. If the id is unknown for your account the request returns `404 PAYMENT_NOT_FOUND`.
-- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (e.g. `stripe` + `CARD`). if omitted, Yuno uses the information from the associated payment.
+- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (e.g. `stripe` + `CREDIT_CARD`). if omitted, Yuno uses the information from the associated payment.


### PR DESCRIPTION
## PR Description

Expands the `payment_method_type` enum in the dry-run endpoint to replace the generic `CARD` value with its normalized variants from the Zuora-to-Yuno payment method mapping. Also adds `ACH` as a normalized bank transfer value alongside the existing `BANK_TRANSFER`.

  ## Changes made

  ### `openapi/dry-run/register-dry-run-provider-event.json`

  - **`DryRunRequest.payment_method_type`**: replaced generic `CARD` with 6 normalized values: `CREDIT_CARD`, `CREDIT_CARD_REFERENCE_TRANSACTION`, `DEBIT_CARD`,
   `EPX_TOKEN`, `TEST_CREDIT_CARD`, `UPC_TOKEN_TRANSACTION`
  - **`DryRunRequest.payment_method_type`**: added `ACH` alongside the existing `BANK_TRANSFER` normalized value
  - **`DryRunRequest.payment_method_type`**: updated `example` from `"CARD"` to `"CREDIT_CARD"`
  - **`DryRunResponse.payment_method_type`**: same changes applied (mirrors request schema)
  
  ### `reference/dry-run/register-dry-run-provider-event.mdx`

  - Updated inline prose example from `CARD` to `CREDIT_CARD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spec-only change but potentially breaking for integrators relying on the removed `CARD` enum value; clients must send one of the new normalized card variants instead.
> 
> **Overview**
> Updates the dry-run `POST /dry-run/provider-events` OpenAPI schema to **remove** the generic `payment_method_type` value `CARD` and replace it with normalized variants (`CREDIT_CARD`, `DEBIT_CARD`, etc.), and **adds** `ACH` alongside `BANK_TRANSFER` (including updated examples).
> 
> Refreshes the reference docs prose example to use `CREDIT_CARD` instead of `CARD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebc907f12512ec3911ed385a43c0f4d919dfb97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->