### PR TITLE
add automated SDK and plugin changelog ingestion workflows 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,42 @@
+# Changelog Automation
+
+This directory contains workflows that keep the Yuno documentation changelogs in sync with SDK and plugin releases — no manual edits to the docs repo required.
+
+## How it works
+
+```
+SDK repo                          yuno-docs
+─────────────────────────────     ──────────────────────────────────────
+Release workflow fires             repository_dispatch received
+  ↓                                  ↓
+Sends repository_dispatch   →     Prepends new release to source JSON
+with release data as                ↓
+client_payload                    Regenerates MDX changelog page
+                                    ↓
+                                  Opens PR for docs team review
+```
+
+1. On release, the SDK repo sends a `repository_dispatch` event carrying the new release object as `client_payload`.
+2. The matching workflow here validates the payload, prepends it to the correct file in `changelog/source/`, and regenerates the MDX page via `scripts/generate_changelog.js`.
+3. A pull request is opened targeting `main`, with **@Arcapas** and **@htessaro** as reviewers. Nothing is merged automatically.
+
+## Event types
+
+| SDK / Plugin | Event type |
+|---|---|
+| Android SDK | `android-sdk-changelog` |
+| iOS SDK | `ios-sdk-changelog` |
+| Flutter SDK | `flutter-sdk-changelog` |
+| React Native SDK | `react-native-sdk-changelog` |
+| Web SDK | `web-sdk-changelog` |
+| API | `api-changelog` |
+| VTEX Plugin | `vtex-plugin-changelog` |
+| WooCommerce Plugin | `woocommerce-plugin-changelog` |
+
+## Required secret
+
+Each SDK repo must have a secret named `YUNO_DOCS_DISPATCH_TOKEN` — a GitHub token with permission to send `repository_dispatch` events to this repo. Contact the docs team to obtain it.
+
+## Payload schema
+
+The `client_payload` must be a valid release object following the schema in the **Changelog Guidelines** document. See the **Dispatch Guide** for integration examples. Both documents are shared by the docs team.

--- a/.github/workflows/ingest-android-changelog.yml
+++ b/.github/workflows/ingest-android-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest Android Changelog
+
+on:
+  repository_dispatch:
+    types: [android-sdk-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to android.json
+        run: node scripts/prepend_release.js changelog/source/android.json
+
+      - name: Regenerate android.mdx
+        run: node scripts/generate_changelog.js changelog/source/android.json changelog/android.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/android-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): android v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): android v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **Android SDK v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `android-sdk-changelog`.
+
+            Please review `changelog/source/android.json` and `changelog/android.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-api-changelog.yml
+++ b/.github/workflows/ingest-api-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest API Changelog
+
+on:
+  repository_dispatch:
+    types: [api-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to api.json
+        run: node scripts/prepend_release.js changelog/source/api.json
+
+      - name: Regenerate api.mdx
+        run: node scripts/generate_changelog.js changelog/source/api.json changelog/api.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/api-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): api ${{ github.event.client_payload.version }}"
+          title: "chore(changelog): api ${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **API — ${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `api-changelog`.
+
+            Please review `changelog/source/api.json` and `changelog/api.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-flutter-changelog.yml
+++ b/.github/workflows/ingest-flutter-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest Flutter Changelog
+
+on:
+  repository_dispatch:
+    types: [flutter-sdk-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to flutter.json
+        run: node scripts/prepend_release.js changelog/source/flutter.json
+
+      - name: Regenerate flutter.mdx
+        run: node scripts/generate_changelog.js changelog/source/flutter.json changelog/flutter.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/flutter-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): flutter v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): flutter v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **Flutter SDK v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `flutter-sdk-changelog`.
+
+            Please review `changelog/source/flutter.json` and `changelog/flutter.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-ios-changelog.yml
+++ b/.github/workflows/ingest-ios-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest iOS Changelog
+
+on:
+  repository_dispatch:
+    types: [ios-sdk-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to ios.json
+        run: node scripts/prepend_release.js changelog/source/ios.json
+
+      - name: Regenerate ios.mdx
+        run: node scripts/generate_changelog.js changelog/source/ios.json changelog/ios.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/ios-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): ios v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): ios v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **iOS SDK v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `ios-sdk-changelog`.
+
+            Please review `changelog/source/ios.json` and `changelog/ios.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-react-native-changelog.yml
+++ b/.github/workflows/ingest-react-native-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest React Native Changelog
+
+on:
+  repository_dispatch:
+    types: [react-native-sdk-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to react-native.json
+        run: node scripts/prepend_release.js changelog/source/react-native.json
+
+      - name: Regenerate react-native.mdx
+        run: node scripts/generate_changelog.js changelog/source/react-native.json changelog/react-native.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/react-native-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): react-native v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): react-native v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **React Native SDK v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `react-native-sdk-changelog`.
+
+            Please review `changelog/source/react-native.json` and `changelog/react-native.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-vtex-changelog.yml
+++ b/.github/workflows/ingest-vtex-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest VTEX Plugin Changelog
+
+on:
+  repository_dispatch:
+    types: [vtex-plugin-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to vtex.json
+        run: node scripts/prepend_release.js changelog/source/vtex.json
+
+      - name: Regenerate vtex.mdx
+        run: node scripts/generate_changelog.js changelog/source/vtex.json changelog/plugins/vtex.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/vtex-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): vtex v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): vtex v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **VTEX Plugin v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `vtex-plugin-changelog`.
+
+            Please review `changelog/source/vtex.json` and `changelog/plugins/vtex.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-web-changelog.yml
+++ b/.github/workflows/ingest-web-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest Web Changelog
+
+on:
+  repository_dispatch:
+    types: [web-sdk-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to web.json
+        run: node scripts/prepend_release.js changelog/source/web.json
+
+      - name: Regenerate web.mdx
+        run: node scripts/generate_changelog.js changelog/source/web.json changelog/web.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/web-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): web v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): web v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **Web SDK v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `web-sdk-changelog`.
+
+            Please review `changelog/source/web.json` and `changelog/web.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/.github/workflows/ingest-woocommerce-changelog.yml
+++ b/.github/workflows/ingest-woocommerce-changelog.yml
@@ -1,0 +1,45 @@
+name: Ingest WooCommerce Plugin Changelog
+
+on:
+  repository_dispatch:
+    types: [woocommerce-plugin-changelog]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepend release to woocommerce.json
+        run: node scripts/prepend_release.js changelog/source/woocommerce.json
+
+      - name: Regenerate woocommerce.mdx
+        run: node scripts/generate_changelog.js changelog/source/woocommerce.json changelog/plugins/woocommerce.mdx
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog/woocommerce-${{ github.event.client_payload.version }}
+          base: main
+          commit-message: "chore(changelog): woocommerce v${{ github.event.client_payload.version }}"
+          title: "chore(changelog): woocommerce v${{ github.event.client_payload.version }}"
+          body: |
+            Automated changelog update for the **WooCommerce Plugin v${{ github.event.client_payload.version }}**.
+
+            **Release date:** ${{ github.event.client_payload.release_date }}
+
+            Triggered by `repository_dispatch` event `woocommerce-plugin-changelog`.
+
+            Please review `changelog/source/woocommerce.json` and `changelog/plugins/woocommerce.mdx` before merging.
+          reviewers: Arcapas,htessaro

--- a/scripts/prepend_release.js
+++ b/scripts/prepend_release.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Prepends a release from a repository_dispatch client_payload to a changelog JSON source file.
+ * Reads the release object from GITHUB_EVENT_PATH (set automatically by GitHub Actions).
+ *
+ * Usage:
+ *   node scripts/prepend_release.js changelog/source/android.json
+ */
+
+const fs = require('fs');
+
+const jsonPath = process.argv[2];
+if (!jsonPath) {
+  console.error('Usage: node scripts/prepend_release.js <json-path>');
+  process.exit(1);
+}
+
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const release = event.client_payload;
+
+if (!release || !release.version) {
+  console.error('Error: client_payload is missing or has no version field');
+  process.exit(1);
+}
+if (!release.release_date) {
+  console.error('Error: client_payload is missing release_date');
+  process.exit(1);
+}
+if (!Array.isArray(release.entries) || release.entries.length === 0) {
+  console.error('Error: client_payload entries must be a non-empty array');
+  process.exit(1);
+}
+
+if (!fs.existsSync(jsonPath)) {
+  console.error(`Error: ${jsonPath} not found`);
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+data.releases.unshift(release);
+fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+console.log(`✓ Prepended v${release.version} to ${jsonPath}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds multiple GitHub Actions workflows with `contents`/`pull-requests` write permissions that modify changelog sources and open PRs automatically, so misconfigured dispatch payloads or workflow triggers could create incorrect docs updates. Changes are limited to automation scripts/workflows and include basic payload validation.
> 
> **Overview**
> Adds **automated changelog ingestion** for SDKs/plugins via `repository_dispatch` events, so new releases can update docs without manual edits.
> 
> New workflows in `.github/workflows/ingest-*.yml` listen for product-specific event types, run Node 20 to prepend the dispatched release into the corresponding `changelog/source/*.json`, regenerate the target MDX via `scripts/generate_changelog.js`, and open a reviewer-assigned PR using `peter-evans/create-pull-request`.
> 
> Introduces `scripts/prepend_release.js` to read `client_payload` from `GITHUB_EVENT_PATH`, validate required fields (`version`, `release_date`, non-empty `entries`), and prepend the release to the JSON source. Adds `.github/workflows/README.md` documenting the event types, flow, and required dispatch token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b541bc4d42ad597341c2865b5f78a51f361e92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->