### PR TITLE
Update iOS SDK release notes for version 2.17.0

### DIFF
--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,48 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.17.0",
+      "release_date": "2026-05-15",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.17.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.17.0'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Netcetera Native 3DS SDK Support",
+          "description": "Introduced support for the Netcetera Native 3DS SDK to enhance security and compliance with 3DS protocols.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Slim Form Variant",
+          "description": "Added a slim form variant for card, APM, and enrolled card forms behind the `slimmer_form_enabled` flag, consolidating card information and address sections with unified error chips and exposing external section headers for composites and standalone fields.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Secure Payment Tag Setting",
+          "description": "Included the `show_secure_payment_tag` flag in the settings UI to allow hiding the \"Secure payment with YUNO\" badge.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.16.0",
       "release_date": "2026-05-08",
       "upgrade": [


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.17.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to `changelog/source/ios.json`; no runtime code paths are affected.
> 
> **Overview**
> Adds a new iOS SDK `2.17.0` release entry to `changelog/source/ios.json`, including updated SPM/CocoaPods upgrade snippets.
> 
> Release notes call out **Netcetera Native 3DS support**, a new *slim form variant* behind the `slimmer_form_enabled` flag, and a setting to hide the “Secure payment with YUNO” badge via `show_secure_payment_tag`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6eacb8c7387273dc6af7cb0abb965ccbeda9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->