### PR TITLE
Update Flutter SDK release notes for version 1.0.13

### DIFF
--- a/changelog/source/flutter.json
+++ b/changelog/source/flutter.json
@@ -2,6 +2,32 @@
   "sdk": "flutter",
   "releases": [
     {
+      "version": "1.0.13",
+      "release_date": null,
+      "upgrade": {
+        "snippet": "flutter pub add yuno:1.0.13",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Updated Android SDK",
+          "description": "The native Android SDK has been updated to version 2.15.0.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Updated iOS SDK",
+          "description": "The native iOS SDK has been updated to version 2.16.0.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.0.11",
       "release_date": null,
       "upgrade": {


### PR DESCRIPTION
Automated update of Flutter SDK release notes for version 1.0.13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates a changelog JSON entry and does not affect runtime code paths.
> 
> **Overview**
> Adds a new Flutter SDK release entry for `1.0.13` in `changelog/source/flutter.json`, including an updated install snippet and notes that the native Android SDK is now `2.15.0` and the native iOS SDK is now `2.16.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d751d53f5596cbaedd957aff0eac1abbd77369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->