### PR TITLE
chore: web sdk changelog 1.8.2

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.2",
+      "release_date": "2026-05-15",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "test 2",
+          "description": "description 2",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.7.3",
       "release_date": "2026-05-11",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.8.2`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v12.0.2

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new entry to the web SDK changelog and does not affect runtime code paths.
> 
> **Overview**
> Adds a new `1.8.2` release section to `changelog/source/web.json`, including the npm upgrade snippet and a single `ADDED` changelog entry (`test 2` / `description 2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e7ba1ae552843a5c7632c10903b4af258c4402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->