### PR TITLE
docs(changelog): add Web SDK v1.8.0 and create sync workflow

### DIFF
--- a/.github/workflows/sync-changelogs.yml
+++ b/.github/workflows/sync-changelogs.yml
@@ -1,0 +1,57 @@
+name: Sync Changelogs
+
+on:
+  pull_request:
+    paths:
+      - 'changelog/source/*.json'
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Regenerate MDX from changed source files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          declare -A MAP=(
+            ["changelog/source/web.json"]="changelog/web.mdx"
+            ["changelog/source/android.json"]="changelog/android.mdx"
+            ["changelog/source/ios.json"]="changelog/ios.mdx"
+            ["changelog/source/flutter.json"]="changelog/flutter.mdx"
+            ["changelog/source/react-native.json"]="changelog/react-native.mdx"
+            ["changelog/source/api.json"]="changelog/api.mdx"
+            ["changelog/source/vtex.json"]="changelog/plugins/vtex.mdx"
+            ["changelog/source/woocommerce.json"]="changelog/plugins/woocommerce.mdx"
+          )
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- 'changelog/source/*.json')
+          for src in $changed; do
+            mdx="${MAP[$src]}"
+            if [[ -n "$mdx" ]]; then
+              echo "Regenerating $mdx from $src"
+              node scripts/generate_changelog.js "$src" "$mdx"
+            else
+              echo "No MDX mapping found for $src — skipping"
+            fi
+          done
+      - name: Commit regenerated MDX files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add changelog/*.mdx changelog/plugins/*.mdx
+          if git diff --cached --quiet; then
+            echo "MDX files already up to date — nothing to commit"
+          else
+            git commit -m "chore(changelog): regenerate MDX from source JSON"
+            git push
+          fi

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,120 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.0",
+      "release_date": "2026-05-14",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Apple Pay Address Collection",
+          "description": "Apple Pay payment sheet can now collect billing and shipping addresses when configured via `required_fields`. Default behavior is unchanged when not configured.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Apple Pay BIN Available Pre-Payment",
+          "description": "DPAN BIN is now available in the OTT before payment, enabling BIN-based promotions and discounts. Existing card BIN flow is unaffected.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Improved Apple Pay Availability Detection",
+          "description": "Apple Pay button now appears more accurately on supported devices, reducing cases where the button shows for users who cannot complete an Apple Pay payment.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Google Pay Address Collection",
+          "description": "Google Pay payment sheet can now collect billing address, shipping address, and cardholder name when configured via `required_fields`. Address detail level adjusts automatically based on what is requested.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Google Pay Contact Field Collection",
+          "description": "Google Pay payment sheet can now collect customer email and phone number when configured via `contactFields`. Works in both standard and seamless external-button integrations.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Separate Billing and Shipping Sections",
+          "description": "Card form now renders billing and shipping as distinct sections with their own headers and an optional `Address line 2` field. When both addresses are required, a `Billing address is the same as shipping` checkbox appears, enabled by default.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Compact Card Form Layout",
+          "description": "New slimmer card form layout with tighter spacing, grouped card details, and inline field-level error messages. Available across all SDK form variants. Behind a feature flag for A/B testing.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Card Form Auto-Advance",
+          "description": "Card form auto-advances focus once fields reach their expected length (PAN by detected scheme, expiry, CVV), reducing the number of taps to complete the form. Manual selection always takes precedence. Behind a feature flag, default off, for A/B testing.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Real-Time Card Field Validation",
+          "description": "Card form fields now validate on blur once the user has interacted with them, instead of only on Pay click. Errors clear immediately when the user corrects an invalid field.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dynamic Enrollment Actions",
+          "description": "Enrollment flow now supports server-driven dynamic UI components: image, OTP, PIN, and info screens, rendered based on the fields returned by the server.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Smarter Currency Display",
+          "description": "Currency now shows a symbol only for the 21 currencies with globally unique symbols (€, £, ₹, R$, ₩, ₺, ₪, etc.). All others display the 3-letter ISO code (for example `COP 9.200.000`, `MXN 1.500,00`). USD is the only currency that owns the `$` symbol.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Hide Yuno Secure Payment Badge",
+          "description": "The `Secure Payment with Yuno` badge can now be hidden via Checkout Builder. When disabled, the badge is fully removed from the DOM in both the standard checkout and the Click to Pay flow.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "EBANX Device Session Reliability",
+          "description": "Improved reliability of device ID propagation in payment requests, fixing Payment Link flows where it was occasionally dropped before reaching EBANX.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.7.3",
       "release_date": "2026-05-11",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,8 +5,60 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.8.0
+*May 14, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Apple Pay Address Collection**  
+  Apple Pay payment sheet can now collect billing and shipping addresses when configured via `required_fields`. Default behavior is unchanged when not configured.
+
+- <ChangelogBadge type="added" /> **Apple Pay BIN Available Pre-Payment**  
+  DPAN BIN is now available in the OTT before payment, enabling BIN-based promotions and discounts. Existing card BIN flow is unaffected.
+
+- <ChangelogBadge type="changed" /> **Improved Apple Pay Availability Detection**  
+  Apple Pay button now appears more accurately on supported devices, reducing cases where the button shows for users who cannot complete an Apple Pay payment.
+
+**Google Pay**
+
+- <ChangelogBadge type="added" /> **Google Pay Address Collection**  
+  Google Pay payment sheet can now collect billing address, shipping address, and cardholder name when configured via `required_fields`. Address detail level adjusts automatically based on what is requested.
+
+- <ChangelogBadge type="added" /> **Google Pay Contact Field Collection**  
+  Google Pay payment sheet can now collect customer email and phone number when configured via `contactFields`. Works in both standard and seamless external-button integrations.
+
+**Card Payments**
+
+- <ChangelogBadge type="changed" /> **Separate Billing and Shipping Sections**  
+  Card form now renders billing and shipping as distinct sections with their own headers and an optional `Address line 2` field. When both addresses are required, a `Billing address is the same as shipping` checkbox appears, enabled by default.
+
+- <ChangelogBadge type="added" /> **Compact Card Form Layout**  
+  New slimmer card form layout with tighter spacing, grouped card details, and inline field-level error messages. Available across all SDK form variants. Behind a feature flag for A/B testing.
+
+- <ChangelogBadge type="added" /> **Card Form Auto-Advance**  
+  Card form auto-advances focus once fields reach their expected length (PAN by detected scheme, expiry, CVV), reducing the number of taps to complete the form. Manual selection always takes precedence. Behind a feature flag, default off, for A/B testing.
+
+- <ChangelogBadge type="changed" /> **Real-Time Card Field Validation**  
+  Card form fields now validate on blur once the user has interacted with them, instead of only on Pay click. Errors clear immediately when the user corrects an invalid field.
+
+**Core SDK**
+
+- <ChangelogBadge type="added" /> **Dynamic Enrollment Actions**  
+  Enrollment flow now supports server-driven dynamic UI components: image, OTP, PIN, and info screens, rendered based on the fields returned by the server.
+
+- <ChangelogBadge type="changed" /> **Smarter Currency Display**  
+  Currency now shows a symbol only for the 21 currencies with globally unique symbols (€, £, ₹, R$, ₩, ₺, ₪, etc.). All others display the 3-letter ISO code (for example `COP 9.200.000`, `MXN 1.500,00`). USD is the only currency that owns the `$` symbol.
+
+- <ChangelogBadge type="added" /> **Hide Yuno Secure Payment Badge**  
+  The `Secure Payment with Yuno` badge can now be hidden via Checkout Builder. When disabled, the badge is fully removed from the DOM in both the standard checkout and the Click to Pay flow.
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="fixed" /> **EBANX Device Session Reliability**  
+  Improved reliability of device ID propagation in payment requests, fixing Payment Link flows where it was occasionally dropped before reaching EBANX.
+
 ## v1.7.3
-*May 11, 2026* 
+*May 11, 2026*
 
 **Fraud & Risk**
 


### PR DESCRIPTION
## Summary

This PR introduces the Sync Changelogs GitHub Actions workflow to automate the regeneration of MDX changelog pages from changed source JSON files, and adds the release notes for Web SDK v1.8.0.

**Changes:**
- Created `.github/workflows/sync-changelogs.yml` to trigger MDX regeneration whenever `changelog/source/*.json` is modified in a Pull Request.
- **Security Fix:** Addressed a medium severity script injection vulnerability by passing the `github.base_ref` branch context through an environment variable (`BASE_REF`) inside the step, preventing any shell injection via branch names.
- Updated `changelog/source/web.json` with the new Web SDK v1.8.0 release containing 13 improvements, features, and fixes.
- Regenerated `changelog/web.mdx` using `scripts/generate_changelog.js` with correct formatting and grouping.

**Files:**
- `.github/workflows/sync-changelogs.yml`
- `changelog/source/web.json`
- `changelog/web.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a PR-triggered GitHub Actions workflow that regenerates and pushes commits back to the PR branch, which can affect contributor branches and CI behavior if misconfigured. Changelog content updates are low risk but the automation touches repo write permissions.
> 
> **Overview**
> **Automates changelog regeneration.** Introduces a new PR-triggered GitHub Actions workflow (`sync-changelogs.yml`) that detects changed `changelog/source/*.json` files, runs `scripts/generate_changelog.js` to regenerate the mapped MDX files, and commits/pushes the results back to the PR branch.
> 
> **Updates Web SDK release notes.** Adds the `v1.8.0` release to `changelog/source/web.json` and regenerates `changelog/web.mdx` to include the new entries (Apple Pay/Google Pay collection options, card form UX changes, core UI/format tweaks, and an EBANX device-session fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9826bc84e37d5aa2f823c948102d066adee2c530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->