### PR TITLE
feat: add iOS v2.16.0 changelog entry for flexible actions in enrollment

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.16.0
+*May 8, 2026*
+
+- <ChangelogBadge type="added" /> **Flexible Actions in Enrollment**  
+  Enrollment now supports the same dynamic action screens used in payments, including PIN, image, payment code, OTP, and info screens.
+
 ## v2.15.0
 *April 10, 2026*
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change adding a new changelog entry with no runtime or API impact.
> 
> **Overview**
> Adds a new `v2.16.0` entry to the iOS SDK changelog documenting **Flexible Actions in Enrollment**, noting enrollment now supports the same dynamic action screens as payments (PIN, image, payment code, OTP, info).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69e43e900764943d048b962e23e1839ba176116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->