### PR TITLE
Android SDK versions 2.15.0 and 2.15.1

### DIFF
--- a/changelog/android.mdx
+++ b/changelog/android.mdx
@@ -5,6 +5,21 @@ description: "Latest updates and version history for the Yuno Android SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.15.1
+*May 19, 2026*
+
+- <ChangelogBadge type="fixed" /> **Flutter Plugin Lifecycle Crash**  
+  Fixed a crash caused by Flutter plugin lifecycle incompatibility with the Android SDK on process death.
+
+## v2.15.0
+*May 8, 2026*
+
+- <ChangelogBadge type="added" /> **Flexible Actions in Enrollment**  
+  Enrollment now supports the same dynamic action screens used in payments, including PIN, image, payment code, OTP, and info screens.
+
+- <ChangelogBadge type="added" /> **Installment Details on Tokenization**  
+  When a card is tokenized with installments selected, the installment information — plan, rate, amount, and selected option — is now returned alongside the one-time token. 
+
 ## v2.13.4
 *April 20, 2026*
 

--- a/changelog/source/android.json
+++ b/changelog/source/android.json
@@ -2,6 +2,24 @@
   "sdk": "android",
   "releases": [
     {
+      "version": "2.15.1",
+      "release_date": "2026-05-19",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.15.1'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Flutter Plugin Lifecycle Crash",
+          "description": "Fixed a crash caused by Flutter plugin lifecycle incompatibility with the Android SDK on process death.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.15.0",
       "release_date": "2026-05-08",
       "upgrade": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update to the Android SDK changelog and its JSON source; no runtime code changes, so impact is limited to release-note accuracy.
> 
> **Overview**
> Adds release notes for **Android SDK `v2.15.0` and `v2.15.1`** to both the rendered `changelog/android.mdx` and the structured `changelog/source/android.json`.
> 
> `v2.15.0` documents *new* enrollment flexible action screens and returning installment details during tokenization, and `v2.15.1` documents a *fix* for a Flutter plugin lifecycle crash on process death.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9c7f444350d1473915ee63f27da958ee2a8c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->