### PR TITLE
docs(changelog): backfill web SDK v1.5.4

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,24 @@
       ]
     },
     {
+      "version": "1.5.4",
+      "release_date": "2026-02-16",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Document Types by Country",
+          "description": "New general-settings configuration for document types per country (server-side merchant config; no merchant code change).",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.4 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.4 (release date 2026-02-16), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.4 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a documentation-only change that adds a single changelog release block and does not affect runtime code paths.
> 
> **Overview**
> Adds a missing Web SDK `1.5.4` release block (dated `2026-02-16`) to the public changelog, including the upgrade snippet.
> 
> The release contains one new **Core SDK** entry documenting *Document Types by Country* configuration (server-side merchant setting; no merchant code changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff97704a79d88169604c0487659867d892ebce1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->