### PR TITLE
docs(changelog): backfill web SDK v1.5.5

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,24 @@
       ]
     },
     {
+      "version": "1.5.5",
+      "release_date": "2026-02-16",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Reload on Already-Open Sheet",
+          "description": "Reloads if the Google Pay sheet is already open, preventing a stuck state.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.5 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.5 (release date 2026-02-16), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.5 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds a single changelog release block with no runtime code impact; main risk is incorrect/duplicate release metadata.
> 
> **Overview**
> Adds a new Web SDK `1.5.5` release block (dated `2026-02-16`) to `changelog/source/web.json`, including the upgrade snippet and one **FIXED** entry for Google Pay: reloading when the payment sheet is already open to avoid a stuck state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8715dddee61b13951c209568bc2a1c2ae8b4b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->