### PR TITLE
docs(changelog): backfill web SDK v1.5.8

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,48 @@
       ]
     },
     {
+      "version": "1.5.8",
+      "release_date": "2026-02-24",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.8",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Wallet Domain URL",
+          "description": "Apple Pay transactions now include the wallet domain URL.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Financial Cost in Enrolled Cards",
+          "description": "Financial cost detail is shown for enrolled card payments.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Financial Cost in C2P",
+          "description": "Financial cost detail is shown for Click to Pay flows.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Third-Party Gateway Support",
+          "description": "Google Pay can now route through third-party gateways (Adyen, Stripe, etc.) with the gateway and merchant ID supplied via a new SDK provider configuration.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.8 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.8 (release date 2026-02-24), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 4.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.8 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a JSON changelog entry; main risk is accidental schema/formatting issues impacting docs rendering.
> 
> **Overview**
> Backfills a new Web SDK `v1.5.8` release section into `changelog/source/web.json` (dated `2026-02-24`) so it appears in the published changelog.
> 
> The added entries document four *ADDED* items: Apple Pay wallet domain URL inclusion, financial cost details shown for enrolled cards and Click to Pay, and Google Pay third-party gateway routing via new provider configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b849118180c80388e4d614c5986c6a6d66a65547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->