### PR TITLE
docs(changelog): backfill web SDK v1.5.11

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,48 @@
       ]
     },
     {
+      "version": "1.5.11",
+      "release_date": "2026-03-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.11",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Billing Contact Collection",
+          "description": "Apple Pay can now collect the cardholder's billing name and postal address from the Apple Pay sheet when enabled via merchant configuration. The cardholder name is forwarded in the payment payload. No SDK code change required by merchants.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "EBANX Device Session Collection",
+          "description": "New EBANX fraud collector with automatic script mounting, retry, and unmount handling.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Cielo CyberSource Fraud Provider",
+          "description": "Added Cielo CyberSource as a supported fraud provider.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Country-Aware Fraud Collection",
+          "description": "Fraud signal collection now uses the customer's country across payment methods, lite flow, secure fields, PayPal, Google Pay, Apple Pay, and the headless API client, improving provider routing and accuracy.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.11 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.11 (release date 2026-03-09), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 4.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.11 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new changelog entry; main risk is incorrect/duplicate release metadata in JSON affecting docs rendering.
> 
> **Overview**
> Adds a missing Web SDK `1.5.11` release section (dated `2026-03-09`) to `changelog/source/web.json`, including upgrade snippet and four entries covering Apple Pay billing contact collection plus several Fraud & Risk updates (EBANX device session collection, Cielo CyberSource provider support, and country-aware fraud signal collection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0b4616fb076d5b6cdc153a8d750c2f46b8161c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->