### PR TITLE
docs(changelog): backfill web SDK v1.5.14

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,32 @@
       ]
     },
     {
+      "version": "1.5.14",
+      "release_date": "2026-03-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.14",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "APM Enrollment Button Text",
+          "description": "The enrollment confirmation button for APMs now reads \"Continue\" instead of \"Save\".",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Riskified Beacon Parameters",
+          "description": "Missing query parameters added to the default beacon URL, restoring fraud signal collection.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.14 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.14 (release date 2026-03-19), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 2.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.14 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a JSON changelog entry; main risk is schema/formatting issues affecting docs rendering.
> 
> **Overview**
> Adds a new Web SDK `v1.5.14` (2026-03-19) release block to `changelog/source/web.json` so it appears in the published changelog.
> 
> The backfilled entries document a *Core SDK* UX text change (APM enrollment button now says `Continue`) and a *Fraud & Risk* fix restoring Riskified beacon query parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b172cdd28d1bf675c230dcbbeeb01cc6ea8826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->