### PR TITLE
docs(changelog): backfill web SDK v1.5.15

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,24 @@
       ]
     },
     {
+      "version": "1.5.15",
+      "release_date": "2026-03-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.15",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Backend-Driven Warning Banner",
+          "description": "Flexible payment-action screens (e.g. Punto Pago) can now render a server-driven banner (title + description) after the instruction steps. Configured server-side; no merchant code change required.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.15 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.15 (release date 2026-03-19), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.15 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating `changelog/source/web.json` with a new release section; no runtime code paths are affected.
> 
> **Overview**
> Backfills Web SDK `v1.5.15` into `changelog/source/web.json` (release date `2026-03-19`), including the npm upgrade snippet.
> 
> The new changelog entry documents an *added* capability: a backend-configured warning banner on flexible payment-action instruction screens (grouped under **Payment Actions**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca1e2e1e6c9440edd954ca69d3cf793f21e41a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->