### PR TITLE
docs(changelog): backfill web SDK v1.5.17

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -328,6 +328,32 @@
       ]
     },
     {
+      "version": "1.5.17",
+      "release_date": "2026-04-01",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.17",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "`sdkType` initialization option",
+          "description": "New option on `Yuno.initialize()` for identifying integrations (plugins, embedded contexts) via the `x-sdk-type` request header for downstream attribution.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Forter Token Capture",
+          "description": "Token capture now uses a listener-based approach for reliable session capture across page lifecycles.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.17 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.17 (release date 2026-04-01), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 2.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.17 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only JSON changelog update with no runtime or API behavior changes. Main risk is incorrect or duplicated release metadata affecting rendered docs.
> 
> **Overview**
> Adds a new `1.5.17` release section to `changelog/source/web.json` (dated `2026-04-01`) so it appears in the Web SDK public changelog.
> 
> The entry documents an added `sdkType` option on `Yuno.initialize()` (sent via `x-sdk-type` header) and a fix to Forter token capture using a listener-based approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54084718020bae13b49356acd03d27131c7d5f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->