### PR TITLE
docs(changelog): backfill web SDK v1.5.19

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -328,6 +328,32 @@
       ]
     },
     {
+      "version": "1.5.19",
+      "release_date": "2026-04-02",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.19",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Forter token isolation",
+          "description": "Tokens are now scoped per Forter `siteId` so concurrent or sequential checkout sessions no longer read a stale token from a previous provider/session.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Forter beacon script",
+          "description": "Consolidated to a single URL (`https://prod.y.uno/sdk-static-bundles-ms/v1/static/js/forter/forter.js`) with an updated SRI hash for both sandbox and production. Merchants with a strict CSP `script-src` allowlist should ensure `prod.y.uno` is permitted.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.19 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.19 (release date 2026-04-02), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 2.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.19 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates `changelog/source/web.json` with a new release entry; no runtime code paths are affected.
> 
> **Overview**
> Adds a missing Web SDK `1.5.19` release block (2026-04-02) to `changelog/source/web.json` so it appears in the published changelog.
> 
> The new entries document a **Forter token scoping fix** (tokens isolated per `siteId`) and a **Forter beacon script URL/SRI update**, including a note for merchants with strict CSP allowlists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070fb9ea99a23722130764be17bace0ba37e636b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->