### PR TITLE
docs(changelog): backfill web SDK v1.5.20

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -328,6 +328,24 @@
       ]
     },
     {
+      "version": "1.5.20",
+      "release_date": "2026-04-07",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.20",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Cancel Flow",
+          "description": "When the customer aborts an Apple Pay session, the cancel error now carries a `metadata` object with `paymentCreated` and `ottCreated` booleans so merchants can tell how far the flow had progressed. If a payment is created after the user has cancelled, the SDK automatically abandons the checkout session to prevent payments getting stuck in `PENDING`. (Backport of the v1.6.8 fix to the 1.5.x line.)",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.20 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.5.20 (release date 2026-04-07), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.5.20 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only updates documentation JSON and does not affect runtime code. Risk is limited to potential schema/formatting issues that could break changelog rendering.
> 
> **Overview**
> Adds a new Web SDK `1.5.20` release block to `changelog/source/web.json` (dated `2026-04-07`).
> 
> The entry documents an Apple Pay *cancel-flow* fix: cancel errors now include `metadata.paymentCreated`/`metadata.ottCreated`, and the SDK abandons the checkout session if a payment is created after user cancellation to avoid `PENDING` payments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ba75fce25ee995d54900ea9ae71d00eb288c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->