### PR TITLE
docs(changelog): backfill web SDK v1.6.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,80 @@
       ]
     },
     {
+      "version": "1.6.1",
+      "release_date": "2026-03-12",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Billing Contact Collection",
+          "description": "Apple Pay can now capture the cardholder's billing name and postal address from the Apple Pay sheet when enabled via merchant configuration. The cardholder name is forwarded in the payment payload on completion.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Free Trial Support for Recurring Payments",
+          "description": "Apple Pay now supports recurring billing with trial periods, configurable via merchant config (Apple Pay JS v14).",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Network Selector",
+          "description": "Dropdown across step-by-step payment, card unfolded, card modal, enrollment, and Click to Pay. Driven by server-side merchant configuration.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Cielo CyberSource Fraud Provider",
+          "description": "Cielo CyberSource added as a fraud provider, routed through the existing CyberSource integration.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "EBANX Device Fingerprint Provider",
+          "description": "New device-fingerprinting provider with country-based initialization. Customer country is now propagated through the fraud pipeline.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Crash with External-Buttons-Only Sessions",
+          "description": "Fixed a crash that occurred when only external buttons (e.g. Apple Pay) were configured without SDK-rendered payment methods.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Enrolled Card Form Crash",
+          "description": "Prevents a runtime crash when card metadata is missing while detecting Amex on enrolled cards.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Sanitize Functions from Log Payloads",
+          "description": "Functions in the merchant-provided initial state are stripped before debug log serialization, preventing serialization issues across checkout, seamless checkout, headless payment/enrollment, and status flows.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.1 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.1 (release date 2026-03-12), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 8.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.1 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new release entry to `web.json` without affecting runtime code.
> 
> **Overview**
> Adds a new `1.6.1` release section to `changelog/source/web.json` (dated 2026-03-12) so it appears in the published Web SDK changelog.
> 
> The new block includes 8 entries covering Apple Pay additions (billing contact capture, recurring trials), card payment network selector, new fraud providers (Cielo CyberSource, EBANX device fingerprinting), and several Core SDK crash/log-serialization fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c4fc61d1e2a53dd494fb98dc24b61414686ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->