### PR TITLE
docs(changelog): backfill web SDK v1.6.3

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,40 @@
       ]
     },
     {
+      "version": "1.6.3",
+      "release_date": "2026-03-18",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.3",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Unified User-Cancel Flow",
+          "description": "Wallet, APM, Click to Pay, 3DS modal and lite checkout cancellations now emit `yunoPaymentResult` with `PENDING` status and `CANCELLED_BY_USER` substatus, replacing the previous `ERROR CANCELED_BY_USER` event. Integrations that branched on the legacy error should switch to the substatus.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Additional Load-Time Optimizations",
+          "description": "Google Pay and Apple Pay scripts are now preloaded, and `startCheckout`/`startSeamlessCheckout` prefetch payment methods earlier.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Document Type Options",
+          "description": "Removed a redundant country filter that could hide valid document types in some locales.",
+          "group": "Customer Fields",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.3 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.3 (release date 2026-03-18), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 3.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.3 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only change updating the public changelog JSON with a new release block; no runtime code paths are affected.
> 
> **Overview**
> Adds a new `1.6.3` release block to `changelog/source/web.json` (dated 2026-03-18) so it appears in the Web SDK public changelog.
> 
> The entry documents three items: a *unified user-cancel event contract* (now `yunoPaymentResult` with `PENDING` + `CANCELLED_BY_USER` substatus instead of a legacy error), *wallet load-time optimizations* (preloading Apple Pay/Google Pay scripts and earlier prefetch), and a fix for *document type options* (removing an overly restrictive country filter).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814a0a3d98e8370e3b6200701f6532ca8a04e715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->