### PR TITLE
docs(changelog): backfill web SDK v1.6.4

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -388,6 +388,24 @@
       ]
     },
     {
+      "version": "1.6.4",
+      "release_date": "2026-03-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Riskified Integration",
+          "description": "The Riskified script now loads with the correct shop and session identifiers, restoring reliable fraud signal collection when the shop domain is configured on the fraud provider.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.0",
       "release_date": "2026-01-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.4 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.4 (release date 2026-03-19), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.4 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update that adds a missing changelog entry and does not affect runtime code.
> 
> **Overview**
> Adds a backfilled `@yuno-payments/sdk-web` **v1.6.4** release entry (2026-03-19) to `changelog/source/web.json`, documenting a single fix for **Riskified integration** (correct shop/session identifiers for script loading).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9778242912dd2e51a18e608e4eb2ea2098f103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->