### PR TITLE
docs(changelog): backfill web SDK v1.6.5

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -328,6 +328,72 @@
       ]
     },
     {
+      "version": "1.6.5",
+      "release_date": "2026-03-20",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Unified Apple Pay Button",
+          "description": "Legacy Apple Pay implementation was removed; the SDK now uses a single Apple Pay button consistently across standard checkout and `mountExternalButtons` integrations, driven by the SDK payment flow.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Faster Apple Pay Button Render",
+          "description": "Apple Pay SDK loading, amount lookup, and config fetch now run in parallel, with a styled placeholder shown until the real button is ready.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Earlier Fraud Signal Collection",
+          "description": "Fraud signals are collected during Apple Pay button initialization for broader coverage on wallet flows.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Google Pay Button Placeholder",
+          "description": "A styled placeholder is shown while the Google Pay SDK loads, replacing the previous skeleton.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "APM Enrollment Button Text",
+          "description": "The enrollment confirmation button for APMs now reads \"Continue\" across Full, Lite, Seamless, and Render Mode flows.",
+          "group": "Enrollment",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Inline Payment Method Selection Error (Desktop)",
+          "description": "Clicking \"Pay\" without selecting a payment method now shows an inline error message below the payment method list on desktop. Mobile continues to use the existing toast.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Backend-Driven Warning Banner",
+          "description": "Flexible payment instructions can now render an optional warning banner returned by the backend, enabling provider-specific notices such as the Punto Pago disclaimer.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.5 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.5 (release date 2026-03-20), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 7.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.5 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a new changelog entry (`web.json`) with no runtime code or behavior changes.
> 
> **Overview**
> Adds a new **Web SDK `v1.6.5`** release section to `changelog/source/web.json`, documenting Apple Pay button unification/performance and earlier fraud-signal collection, updated Google Pay placeholder and APM enrollment button text, plus new desktop inline “select payment method” error messaging and a backend-driven warning banner for payment instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7cad09c5bd2160fab6e3c58e8a376191994c079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->