### PR TITLE
docs(changelog): backfill web SDK v1.6.6

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -328,6 +328,40 @@
       ]
     },
     {
+      "version": "1.6.6",
+      "release_date": "2026-03-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.6",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "`externalButtons` Customization",
+          "description": "New configuration on `externalButtons` for per-wallet button customization (Apple Pay, Google Pay, PayPal).",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "WebSocket Race Condition in Redirect Flows",
+          "description": "Resolved a race that could lose status updates.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "WebSocket Error Handling",
+          "description": "Added error handling for WebSocket initialization to prevent unhandled failures in status polling.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.6 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.6 (release date 2026-03-26), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 3.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.6 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a single release block to the Web SDK changelog; no runtime code paths are affected.
> 
> **Overview**
> Adds a new Web SDK `v1.6.6` entry (2026-03-26) to `changelog/source/web.json`, documenting `externalButtons` per-wallet customization plus two Core SDK fixes for WebSocket redirect-flow status races and initialization error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5d06c3c20395cecf7708b58e4f5e2a5f02f2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->