### PR TITLE
docs(changelog): backfill web SDK v1.6.7

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -328,6 +328,72 @@
       ]
     },
     {
+      "version": "1.6.7",
+      "release_date": "2026-03-31",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.7",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Card Password Field for Korean Cards",
+          "description": "New secure field for the first 2 digits of the cardholder PIN required by Korean issuers. Available across standard card, step-by-step, and Click to Pay (new + enrolled) flows. Enable by passing `cardPinElementSelector` in `startCheckout` config; the field renders when enabled for the merchant.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Passkey Activation with Multiple Card Providers",
+          "description": "When multiple card providers are configured, the SDK now searches all of them for valid 3DS parameters instead of only the first. Passkey now activates correctly when the 3DS-capable provider is not listed first.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Hindi, Bengali, Malayalam, and Urdu Translations",
+          "description": "Available via `language: 'hi' | 'bn' | 'ml' | 'ur'`.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Merchant Installments via `onGetInstallments`",
+          "description": "Merchants can supply their own installment options via the `onGetInstallments(cardBin)` callback; the SDK falls back to Yuno installments when the callback returns empty. A new `onInstallmentSelected` callback fires on both auto-selection and user picks across all card flows. Merchant-supplied installments are omitted from one-time-token creation since the merchant handles them server-side.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "`subStatus` in `yunoPaymentResult`",
+          "description": "The callback now receives `subStatus` as a second argument: `yunoPaymentResult(status, subStatus?)`, giving finer-grained outcome information (notably on cancel flows).",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Bundle Size Reduction (-16%)",
+          "description": "SWC `env.targets` configured to eliminate ES5 polyfills on modern browsers.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "PayPal Locale",
+          "description": "SDK language is now passed as `locale` to the PayPal `loadScript` call so the PayPal UI matches the configured checkout language.",
+          "group": "PayPal",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.7 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.7 (release date 2026-03-31), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 7.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.7 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change adding a new release block to `changelog/source/web.json` with no runtime code impact beyond potential JSON/schema or rendering issues.
> 
> **Overview**
> Adds a new `1.6.7` (2026-03-31) release entry to `changelog/source/web.json` so it appears in the published Web SDK changelog.
> 
> The new block documents 7 items across Card Payments, Click to Pay, Core SDK, and PayPal (Korean card PIN field, passkey fix for multi-provider 3DS, new translations, merchant-provided installments callbacks, `subStatus` on `yunoPaymentResult`, bundle-size reduction note, and PayPal locale fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0399c14ee27a5f1fc1d5e8a5ba4f09b57979c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->