### PR TITLE
docs(changelog): backfill web SDK v1.6.16

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -244,6 +244,32 @@
       ]
     },
     {
+      "version": "1.6.16",
+      "release_date": "2026-04-16",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.16",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Cancel 3DS Challenge on Browser Back",
+          "description": "Pressing the browser back button during a 3DS challenge now cancels the challenge cleanly. Merchants receive the cancellation via `yunoPaymentResult` with status `PENDING` / `CANCELLED_BY_USER`; no `yunoError` is emitted and the modal unmounts without leaving stale state.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Action Button Order on Mobile",
+          "description": "On mobile and tablet viewports, the Click to Pay action buttons in the card form have been reordered so the primary action sits below the secondary, improving the UX hierarchy. Desktop layout is unchanged.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.8",
       "release_date": "2026-04-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.16 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.16 (release date 2026-04-16), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 2.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.16 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only JSON changelog update with no runtime code changes; main risk is incorrect/duplicate release metadata affecting published docs.
> 
> **Overview**
> Backfills the Web SDK `v1.6.16` (2026-04-16) release block into `changelog/source/web.json` so it appears in the published changelog.
> 
> Adds two entries: **(1)** clean cancellation behavior when users hit browser back during a 3DS challenge (reported via `yunoPaymentResult` with `PENDING` / `CANCELLED_BY_USER`), and **(2)** a mobile/tablet-only Click to Pay card-form action button order change (desktop unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb563282152d2644059325f82a6f806376a638c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->