### PR TITLE
docs(changelog): backfill web SDK v1.6.17

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -244,6 +244,24 @@
       ]
     },
     {
+      "version": "1.6.17",
+      "release_date": "2026-05-06",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.17",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "More Accurate Cancellation Reasons",
+          "description": "Apple Pay cancellations are now reported with a precise reason, distinguishing user dismissal (`CANCELLED_BY_USER`) from merchant-validation or provider failures (`CANCELLED_BY_PROVIDER`). Improves the accuracy of drop-off analytics and provider health signals; no integration changes required.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.8",
       "release_date": "2026-04-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.17 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.17 (release date 2026-05-06), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.17 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that inserts a new changelog block; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a missing Web SDK `v1.6.17` release block (dated `2026-05-06`) to `changelog/source/web.json`.
> 
> The new entry documents an Apple Pay change that reports more precise cancellation reasons (`CANCELLED_BY_USER` vs `CANCELLED_BY_PROVIDER`), with no integration changes required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dbc93845d8538004d5e8678b37c08a3ea382d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->