### PR TITLE
docs(changelog): backfill web SDK v1.6.18

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -244,6 +244,24 @@
       ]
     },
     {
+      "version": "1.6.18",
+      "release_date": "2026-05-07",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.18",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Card Number Length Validation",
+          "description": "Card tokenization now waits for the BIN/IIN lookup to complete before submitting, so card numbers are validated against the correct scheme-specific minimum length. Previously, a short Luhn-valid PAN submitted before the BIN lookup settled could be sent to the provider and rejected; users now see an inline length error instead.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.8",
       "release_date": "2026-04-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.18 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.18 (release date 2026-05-07), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.18 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds a single changelog release block with no runtime or behavioral code changes.
> 
> **Overview**
> Adds a new Web SDK `1.6.18` release block (2026-05-07) to `changelog/source/web.json`, including an upgrade snippet and a single *FIXED* entry describing corrected card PAN minimum-length validation by waiting for BIN/IIN lookup before tokenization submission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112ecce12eef433b8b7f5f9bd6eee98b96345088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->