### PR TITLE
docs(changelog): backfill web SDK v1.6.19

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -244,6 +244,24 @@
       ]
     },
     {
+      "version": "1.6.19",
+      "release_date": "2026-05-08",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.19",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Card form button alignment on desktop",
+          "description": "Restored correct LTR alignment for the action button and the \"Secure Payment by Yuno\" badge in the Click to Pay card form (regression on v1.6.x; v1.5 and v1.7 were unaffected). RTL layout is preserved.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.8",
       "release_date": "2026-04-15",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.19 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.19 (release date 2026-05-08), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.19 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the public changelog JSON; no runtime code or SDK behavior is modified.
> 
> **Overview**
> Backfills Web SDK `v1.6.19` into `changelog/source/web.json`, including the upgrade snippet and a single *FIXED* entry for Click to Pay desktop card-form LTR action-button/badge alignment (RTL unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad2f8a19409b6d820a08a9a1a55695014a8b875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->