### PR TITLE
docs(changelog): backfill web SDK v1.6.20

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -116,6 +116,24 @@
       ]
     },
     {
+      "version": "1.6.20",
+      "release_date": "2026-05-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.20",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Card Form Top Error Banner",
+          "description": "On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.7.3",
       "release_date": "2026-05-11",
       "upgrade": {


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.20 release block into `changelog/source/web.json` so it appears in the public changelog at docs.y.uno.

Sourced from the GitHub release notes for sdk-web v1.6.20 (release date 2026-05-13), with per-PR verification to filter out internal-only changes and correct any naming inconsistencies. Entries: 1.

This is part of a backfill series filling the gap between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] Confirm release block JSON validates against the schema
- [ ] Confirm Mintlify preview renders the new entry under Web SDK
- [ ] Confirm no duplicate of v1.6.20 already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a missing Web SDK release entry; main risk is incorrect version/date or entry text causing changelog ordering/rendering issues.
> 
> **Overview**
> Backfills Web SDK `v1.6.20` into `changelog/source/web.json` (release date `2026-05-13`) with the npm upgrade snippet.
> 
> Adds a single changelog entry under *Card Payments* describing the new **card form top error banner** behavior on payment retries, including surfacing invalid-card-data/unknown response codes via the banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e9051bdd412b62981ac4395e230e84e3076724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->