### PR TITLE
docs(changelog): backfill web SDK v1.5.x

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -116,24 +116,6 @@
       ]
     },
     {
-      "version": "1.6.20",
-      "release_date": "2026-05-13",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.6.20",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "ADDED",
-          "title": "Card Form Top Error Banner",
-          "description": "On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.",
-          "group": "Card Payments",
-          "migration_guide": null,
-          "links": []
-        }
-      ]
-    },
-    {
       "version": "1.7.3",
       "release_date": "2026-05-11",
       "upgrade": {
@@ -256,6 +238,24 @@
           "title": "Transaction Amount Support for Passkey Flows",
           "description": "Click to Pay initialization now includes transaction amount metadata for supported passkey flows.",
           "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.20",
+      "release_date": "2026-05-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.20",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Card Form Top Error Banner",
+          "description": "On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.",
+          "group": "Card Payments",
           "migration_guide": null,
           "links": []
         }
@@ -592,66 +592,6 @@
       ]
     },
     {
-      "version": "1.6.0",
-      "release_date": "2026-03-20",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.6.0",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "ADDED",
-          "title": "Subresource Integrity Support",
-          "description": "The SDK script tag now supports the `integrity` attribute for SRI-compliant loading, preventing unauthorized code injection. The `@yuno-payments/sdk-web` npm package exposes a `loadScript` method for SRI-compliant dynamic loading.",
-          "group": null,
-          "migration_guide": null,
-          "links": [],
-          "example": {
-            "title": "Script tag with SRI",
-            "language": "html",
-            "snippet": "<script\n  src=\"https://sdk-web.y.uno/v1.6/main.js\"\n  integrity=\"sha384-...\"\n  crossorigin=\"anonymous\"\n></script>"
-          }
-        },
-        {
-          "type": "ADDED",
-          "title": "Arabic Language and RTL Layout",
-          "description": "Added Arabic (`ar`) language support. The checkout UI automatically switches to a Right-to-Left layout when Arabic is selected — no extra configuration required.",
-          "group": null,
-          "migration_guide": null,
-          "links": [],
-          "example": {
-            "title": "Initialize with Arabic",
-            "language": "js",
-            "snippet": "const yuno = await window.Yuno.initialize(publicApiKey);\n\nawait yuno.startCheckout({\n  checkoutSession,\n  elementSelector: '#root',\n  countryCode: 'AE',\n  language: 'ar',\n});"
-          }
-        },
-        {
-          "type": "CHANGED",
-          "title": "Faster Initialization",
-          "description": "Improved initialization performance for both Lite and Full SDKs, reducing time-to-interactive on first load.",
-          "group": null,
-          "migration_guide": null,
-          "links": []
-        },
-        {
-          "type": "ADDED",
-          "title": "Detailed Error Codes",
-          "description": "Configuration errors now surface more descriptive error codes, making it easier to diagnose integration issues during development.",
-          "group": null,
-          "migration_guide": null,
-          "links": []
-        },
-        {
-          "type": "FIXED",
-          "title": "3DS Modal Centering",
-          "description": "Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.",
-          "group": null,
-          "migration_guide": null,
-          "links": []
-        }
-      ]
-    },
-    {
       "version": "1.6.4",
       "release_date": "2026-03-19",
       "upgrade": {
@@ -771,6 +711,300 @@
           "type": "FIXED",
           "title": "Sanitize Functions from Log Payloads",
           "description": "Functions in the merchant-provided initial state are stripped before debug log serialization, preventing serialization issues across checkout, seamless checkout, headless payment/enrollment, and status flows.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.0",
+      "release_date": "2026-03-20",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Subresource Integrity Support",
+          "description": "The SDK script tag now supports the `integrity` attribute for SRI-compliant loading, preventing unauthorized code injection. The `@yuno-payments/sdk-web` npm package exposes a `loadScript` method for SRI-compliant dynamic loading.",
+          "group": null,
+          "migration_guide": null,
+          "links": [],
+          "example": {
+            "title": "Script tag with SRI",
+            "language": "html",
+            "snippet": "<script\n  src=\"https://sdk-web.y.uno/v1.6/main.js\"\n  integrity=\"sha384-...\"\n  crossorigin=\"anonymous\"\n></script>"
+          }
+        },
+        {
+          "type": "ADDED",
+          "title": "Arabic Language and RTL Layout",
+          "description": "Added Arabic (`ar`) language support. The checkout UI automatically switches to a Right-to-Left layout when Arabic is selected — no extra configuration required.",
+          "group": null,
+          "migration_guide": null,
+          "links": [],
+          "example": {
+            "title": "Initialize with Arabic",
+            "language": "js",
+            "snippet": "const yuno = await window.Yuno.initialize(publicApiKey);\n\nawait yuno.startCheckout({\n  checkoutSession,\n  elementSelector: '#root',\n  countryCode: 'AE',\n  language: 'ar',\n});"
+          }
+        },
+        {
+          "type": "CHANGED",
+          "title": "Faster Initialization",
+          "description": "Improved initialization performance for both Lite and Full SDKs, reducing time-to-interactive on first load.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Detailed Error Codes",
+          "description": "Configuration errors now surface more descriptive error codes, making it easier to diagnose integration issues during development.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "3DS Modal Centering",
+          "description": "Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.20",
+      "release_date": "2026-04-07",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.20",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Cancel Flow",
+          "description": "When the customer aborts an Apple Pay session, the cancel error now carries a `metadata` object with `paymentCreated` and `ottCreated` booleans so merchants can tell how far the flow had progressed. If a payment is created after the user has cancelled, the SDK automatically abandons the checkout session to prevent payments getting stuck in `PENDING`. (Backport of the v1.6.8 fix to the 1.5.x line.)",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.19",
+      "release_date": "2026-04-02",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.19",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Forter token isolation",
+          "description": "Tokens are now scoped per Forter `siteId` so concurrent or sequential checkout sessions no longer read a stale token from a previous provider/session.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Forter beacon script",
+          "description": "Consolidated to a single URL (`https://prod.y.uno/sdk-static-bundles-ms/v1/static/js/forter/forter.js`) with an updated SRI hash for both sandbox and production. Merchants with a strict CSP `script-src` allowlist should ensure `prod.y.uno` is permitted.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.17",
+      "release_date": "2026-04-01",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.17",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "`sdkType` initialization option",
+          "description": "New option on `Yuno.initialize()` for identifying integrations (plugins, embedded contexts) via the `x-sdk-type` request header for downstream attribution.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Forter Token Capture",
+          "description": "Token capture now uses a listener-based approach for reliable session capture across page lifecycles.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.15",
+      "release_date": "2026-03-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.15",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Backend-Driven Warning Banner",
+          "description": "Flexible payment-action screens (e.g. Punto Pago) can now render a server-driven banner (title + description) after the instruction steps. Configured server-side; no merchant code change required.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.14",
+      "release_date": "2026-03-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.14",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "APM Enrollment Button Text",
+          "description": "The enrollment confirmation button for APMs now reads \"Continue\" instead of \"Save\".",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Riskified Beacon Parameters",
+          "description": "Missing query parameters added to the default beacon URL, restoring fraud signal collection.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.11",
+      "release_date": "2026-03-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.11",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Billing Contact Collection",
+          "description": "Apple Pay can now collect the cardholder's billing name and postal address from the Apple Pay sheet when enabled via merchant configuration. The cardholder name is forwarded in the payment payload. No SDK code change required by merchants.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "EBANX Device Session Collection",
+          "description": "New EBANX fraud collector with automatic script mounting, retry, and unmount handling.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Cielo CyberSource Fraud Provider",
+          "description": "Added Cielo CyberSource as a supported fraud provider.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Country-Aware Fraud Collection",
+          "description": "Fraud signal collection now uses the customer's country across payment methods, lite flow, secure fields, PayPal, Google Pay, Apple Pay, and the headless API client, improving provider routing and accuracy.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.8",
+      "release_date": "2026-02-24",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.8",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Wallet Domain URL",
+          "description": "Apple Pay transactions now include the wallet domain URL.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Financial Cost in Enrolled Cards",
+          "description": "Financial cost detail is shown for enrolled card payments.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Financial Cost in C2P",
+          "description": "Financial cost detail is shown for Click to Pay flows.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Third-Party Gateway Support",
+          "description": "Google Pay can now route through third-party gateways (Adyen, Stripe, etc.) with the gateway and merchant ID supplied via a new SDK provider configuration.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.5",
+      "release_date": "2026-02-16",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Reload on Already-Open Sheet",
+          "description": "Reloads if the Google Pay sheet is already open, preventing a stuck state.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.4",
+      "release_date": "2026-02-16",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Document Types by Country",
+          "description": "New general-settings configuration for document types per country (server-side merchant config; no merchant code change).",
           "group": "Core SDK",
           "migration_guide": null,
           "links": []

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -57,14 +57,6 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="fixed" /> **EBANX Device Session Reliability**  
   Improved reliability of device ID propagation in payment requests, fixing Payment Link flows where it was occasionally dropped before reaching EBANX.
 
-## v1.6.20
-*May 13, 2026*
-
-**Card Payments**
-
-- <ChangelogBadge type="added" /> **Card Form Top Error Banner**  
-  On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.
-
 ## v1.7.3
 *May 11, 2026*
 
@@ -125,6 +117,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="added" /> **Transaction Amount Support for Passkey Flows**  
   Click to Pay initialization now includes transaction amount metadata for supported passkey flows.
+
+## v1.6.20
+*May 13, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Card Form Top Error Banner**  
+  On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.
 
 ## v1.6.19
 *May 8, 2026*
@@ -299,51 +299,6 @@ yuno.startSeamlessCheckout({
 - <ChangelogBadge type="added" /> **Backend-Driven Warning Banner**  
   Flexible payment instructions can now render an optional warning banner returned by the backend, enabling provider-specific notices such as the Punto Pago disclaimer.
 
-## v1.6.0
-*March 20, 2026*
-
-- <ChangelogBadge type="added" /> **Subresource Integrity Support**  
-  The SDK script tag now supports the `integrity` attribute for SRI-compliant loading, preventing unauthorized code injection. The `@yuno-payments/sdk-web` npm package exposes a `loadScript` method for SRI-compliant dynamic loading.
-
-<Accordion title="Script tag with SRI">
-
-```html
-<script
-  src="https://sdk-web.y.uno/v1.6/main.js"
-  integrity="sha384-..."
-  crossorigin="anonymous"
-></script>
-```
-
-</Accordion>
-
-- <ChangelogBadge type="added" /> **Arabic Language and RTL Layout**  
-  Added Arabic (`ar`) language support. The checkout UI automatically switches to a Right-to-Left layout when Arabic is selected — no extra configuration required.
-
-<Accordion title="Initialize with Arabic">
-
-```js
-const yuno = await window.Yuno.initialize(publicApiKey);
-
-await yuno.startCheckout({
-  checkoutSession,
-  elementSelector: '#root',
-  countryCode: 'AE',
-  language: 'ar',
-});
-```
-
-</Accordion>
-
-- <ChangelogBadge type="changed" /> **Faster Initialization**  
-  Improved initialization performance for both Lite and Full SDKs, reducing time-to-interactive on first load.
-
-- <ChangelogBadge type="added" /> **Detailed Error Codes**  
-  Configuration errors now surface more descriptive error codes, making it easier to diagnose integration issues during development.
-
-- <ChangelogBadge type="fixed" /> **3DS Modal Centering**  
-  Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.
-
 ## v1.6.4
 *March 19, 2026*
 
@@ -402,6 +357,162 @@ await yuno.startCheckout({
 
 - <ChangelogBadge type="fixed" /> **Sanitize Functions from Log Payloads**  
   Functions in the merchant-provided initial state are stripped before debug log serialization, preventing serialization issues across checkout, seamless checkout, headless payment/enrollment, and status flows.
+
+## v1.6.0
+*March 20, 2026*
+
+- <ChangelogBadge type="added" /> **Subresource Integrity Support**  
+  The SDK script tag now supports the `integrity` attribute for SRI-compliant loading, preventing unauthorized code injection. The `@yuno-payments/sdk-web` npm package exposes a `loadScript` method for SRI-compliant dynamic loading.
+
+<Accordion title="Script tag with SRI">
+
+```html
+<script
+  src="https://sdk-web.y.uno/v1.6/main.js"
+  integrity="sha384-..."
+  crossorigin="anonymous"
+></script>
+```
+
+</Accordion>
+
+- <ChangelogBadge type="added" /> **Arabic Language and RTL Layout**  
+  Added Arabic (`ar`) language support. The checkout UI automatically switches to a Right-to-Left layout when Arabic is selected — no extra configuration required.
+
+<Accordion title="Initialize with Arabic">
+
+```js
+const yuno = await window.Yuno.initialize(publicApiKey);
+
+await yuno.startCheckout({
+  checkoutSession,
+  elementSelector: '#root',
+  countryCode: 'AE',
+  language: 'ar',
+});
+```
+
+</Accordion>
+
+- <ChangelogBadge type="changed" /> **Faster Initialization**  
+  Improved initialization performance for both Lite and Full SDKs, reducing time-to-interactive on first load.
+
+- <ChangelogBadge type="added" /> **Detailed Error Codes**  
+  Configuration errors now surface more descriptive error codes, making it easier to diagnose integration issues during development.
+
+- <ChangelogBadge type="fixed" /> **3DS Modal Centering**  
+  Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.
+
+## v1.5.20
+*April 7, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="fixed" /> **Cancel Flow**  
+  When the customer aborts an Apple Pay session, the cancel error now carries a `metadata` object with `paymentCreated` and `ottCreated` booleans so merchants can tell how far the flow had progressed. If a payment is created after the user has cancelled, the SDK automatically abandons the checkout session to prevent payments getting stuck in `PENDING`. (Backport of the v1.6.8 fix to the 1.5.x line.)
+
+## v1.5.19
+*April 2, 2026*
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="fixed" /> **Forter token isolation**  
+  Tokens are now scoped per Forter `siteId` so concurrent or sequential checkout sessions no longer read a stale token from a previous provider/session.
+
+- <ChangelogBadge type="changed" /> **Forter beacon script**  
+  Consolidated to a single URL (`https://prod.y.uno/sdk-static-bundles-ms/v1/static/js/forter/forter.js`) with an updated SRI hash for both sandbox and production. Merchants with a strict CSP `script-src` allowlist should ensure `prod.y.uno` is permitted.
+
+## v1.5.17
+*April 1, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="added" /> **`sdkType` initialization option**  
+  New option on `Yuno.initialize()` for identifying integrations (plugins, embedded contexts) via the `x-sdk-type` request header for downstream attribution.
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="fixed" /> **Forter Token Capture**  
+  Token capture now uses a listener-based approach for reliable session capture across page lifecycles.
+
+## v1.5.15
+*March 19, 2026*
+
+**Payment Actions**
+
+- <ChangelogBadge type="added" /> **Backend-Driven Warning Banner**  
+  Flexible payment-action screens (e.g. Punto Pago) can now render a server-driven banner (title + description) after the instruction steps. Configured server-side; no merchant code change required.
+
+## v1.5.14
+*March 19, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **APM Enrollment Button Text**  
+  The enrollment confirmation button for APMs now reads "Continue" instead of "Save".
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="fixed" /> **Riskified Beacon Parameters**  
+  Missing query parameters added to the default beacon URL, restoring fraud signal collection.
+
+## v1.5.11
+*March 9, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Billing Contact Collection**  
+  Apple Pay can now collect the cardholder's billing name and postal address from the Apple Pay sheet when enabled via merchant configuration. The cardholder name is forwarded in the payment payload. No SDK code change required by merchants.
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="added" /> **EBANX Device Session Collection**  
+  New EBANX fraud collector with automatic script mounting, retry, and unmount handling.
+
+- <ChangelogBadge type="added" /> **Cielo CyberSource Fraud Provider**  
+  Added Cielo CyberSource as a supported fraud provider.
+
+- <ChangelogBadge type="changed" /> **Country-Aware Fraud Collection**  
+  Fraud signal collection now uses the customer's country across payment methods, lite flow, secure fields, PayPal, Google Pay, Apple Pay, and the headless API client, improving provider routing and accuracy.
+
+## v1.5.8
+*February 24, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Wallet Domain URL**  
+  Apple Pay transactions now include the wallet domain URL.
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Financial Cost in Enrolled Cards**  
+  Financial cost detail is shown for enrolled card payments.
+
+**Click to Pay**
+
+- <ChangelogBadge type="added" /> **Financial Cost in C2P**  
+  Financial cost detail is shown for Click to Pay flows.
+
+**Google Pay**
+
+- <ChangelogBadge type="added" /> **Third-Party Gateway Support**  
+  Google Pay can now route through third-party gateways (Adyen, Stripe, etc.) with the gateway and merchant ID supplied via a new SDK provider configuration.
+
+## v1.5.5
+*February 16, 2026*
+
+**Google Pay**
+
+- <ChangelogBadge type="fixed" /> **Reload on Already-Open Sheet**  
+  Reloads if the Google Pay sheet is already open, preventing a stuck state.
+
+## v1.5.4
+*February 16, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="added" /> **Document Types by Country**  
+  New general-settings configuration for document types per country (server-side merchant config; no merchant code change).
 
 ## v1.5.0
 *January 15, 2026*


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.5.x patch releases into `changelog/source/web.json` so they appear in the public changelog at docs.y.uno.

Each release block is sourced from the matching GitHub release on `yuno-payments/sdk-web`, with per-PR verification to filter out internal-only changes and correct naming inconsistencies.

### Versions included (9 releases, 18 entries)

- v1.5.20 (2026-04-07) — 1 entries
- v1.5.19 (2026-04-02) — 2 entries
- v1.5.17 (2026-04-01) — 2 entries
- v1.5.15 (2026-03-19) — 1 entries
- v1.5.14 (2026-03-19) — 2 entries
- v1.5.11 (2026-03-09) — 4 entries
- v1.5.8 (2026-02-24) — 4 entries
- v1.5.5 (2026-02-16) — 1 entries
- v1.5.4 (2026-02-16) — 1 entries

This is part of the gap-fill between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] JSON validates against the schema
- [ ] Mintlify preview renders each new release block correctly
- [ ] No duplicate of any of the above versions already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that reorder/add changelog entries without affecting runtime code. Main risk is publishing inaccurate or duplicated release notes due to the volume of backfilled entries.
> 
> **Overview**
> Backfills the Web SDK **v1.5.x** patch release notes into both `changelog/source/web.json` and the rendered `changelog/web.mdx`, filling the gap between `v1.5.0` and `v1.7.0`.
> 
> Also reorders the `v1.6.20` block (and adds `v1.6.4`, `v1.6.3`, `v1.6.1` sections in `web.mdx`) so entries appear in the intended version chronology in the published docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41eef4e39fbfa483c429b75898ba5a3f3084850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->