### PR TITLE
docs(changelog): backfill web SDK v1.6.x

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -116,6 +116,24 @@
       ]
     },
     {
+      "version": "1.6.20",
+      "release_date": "2026-05-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.20",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Card Form Top Error Banner",
+          "description": "On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.7.3",
       "release_date": "2026-05-11",
       "upgrade": {
@@ -244,6 +262,86 @@
       ]
     },
     {
+      "version": "1.6.19",
+      "release_date": "2026-05-08",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.19",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Card form button alignment on desktop",
+          "description": "Restored correct LTR alignment for the action button and the \"Secure Payment by Yuno\" badge in the Click to Pay card form (regression on v1.6.x; v1.5 and v1.7 were unaffected). RTL layout is preserved.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.18",
+      "release_date": "2026-05-07",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.18",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Card Number Length Validation",
+          "description": "Card tokenization now waits for the BIN/IIN lookup to complete before submitting, so card numbers are validated against the correct scheme-specific minimum length. Previously, a short Luhn-valid PAN submitted before the BIN lookup settled could be sent to the provider and rejected; users now see an inline length error instead.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.17",
+      "release_date": "2026-05-06",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.17",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "More Accurate Cancellation Reasons",
+          "description": "Apple Pay cancellations are now reported with a precise reason, distinguishing user dismissal (`CANCELLED_BY_USER`) from merchant-validation or provider failures (`CANCELLED_BY_PROVIDER`). Improves the accuracy of drop-off analytics and provider health signals; no integration changes required.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.16",
+      "release_date": "2026-04-16",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.16",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Cancel 3DS Challenge on Browser Back",
+          "description": "Pressing the browser back button during a 3DS challenge now cancels the challenge cleanly. Merchants receive the cancellation via `yunoPaymentResult` with status `PENDING` / `CANCELLED_BY_USER`; no `yunoError` is emitted and the modal unmounts without leaving stale state.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Action Button Order on Mobile",
+          "description": "On mobile and tablet viewports, the Click to Pay action buttons in the card form have been reordered so the primary action sits below the secondary, improving the UX hierarchy. Desktop layout is unchanged.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.8",
       "release_date": "2026-04-15",
       "upgrade": {
@@ -328,6 +426,172 @@
       ]
     },
     {
+      "version": "1.6.7",
+      "release_date": "2026-03-31",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.7",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Card Password Field for Korean Cards",
+          "description": "New secure field for the first 2 digits of the cardholder PIN required by Korean issuers. Available across standard card, step-by-step, and Click to Pay (new + enrolled) flows. Enable by passing `cardPinElementSelector` in `startCheckout` config; the field renders when enabled for the merchant.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Passkey Activation with Multiple Card Providers",
+          "description": "When multiple card providers are configured, the SDK now searches all of them for valid 3DS parameters instead of only the first. Passkey now activates correctly when the 3DS-capable provider is not listed first.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Hindi, Bengali, Malayalam, and Urdu Translations",
+          "description": "Available via `language: 'hi' | 'bn' | 'ml' | 'ur'`.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Merchant Installments via `onGetInstallments`",
+          "description": "Merchants can supply their own installment options via the `onGetInstallments(cardBin)` callback; the SDK falls back to Yuno installments when the callback returns empty. A new `onInstallmentSelected` callback fires on both auto-selection and user picks across all card flows. Merchant-supplied installments are omitted from one-time-token creation since the merchant handles them server-side.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "`subStatus` in `yunoPaymentResult`",
+          "description": "The callback now receives `subStatus` as a second argument: `yunoPaymentResult(status, subStatus?)`, giving finer-grained outcome information (notably on cancel flows).",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Bundle Size Reduction (-16%)",
+          "description": "SWC `env.targets` configured to eliminate ES5 polyfills on modern browsers.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "PayPal Locale",
+          "description": "SDK language is now passed as `locale` to the PayPal `loadScript` call so the PayPal UI matches the configured checkout language.",
+          "group": "PayPal",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.6",
+      "release_date": "2026-03-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.6",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "`externalButtons` Customization",
+          "description": "New configuration on `externalButtons` for per-wallet button customization (Apple Pay, Google Pay, PayPal).",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "WebSocket Race Condition in Redirect Flows",
+          "description": "Resolved a race that could lose status updates.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "WebSocket Error Handling",
+          "description": "Added error handling for WebSocket initialization to prevent unhandled failures in status polling.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.5",
+      "release_date": "2026-03-20",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Unified Apple Pay Button",
+          "description": "Legacy Apple Pay implementation was removed; the SDK now uses a single Apple Pay button consistently across standard checkout and `mountExternalButtons` integrations, driven by the SDK payment flow.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Faster Apple Pay Button Render",
+          "description": "Apple Pay SDK loading, amount lookup, and config fetch now run in parallel, with a styled placeholder shown until the real button is ready.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Earlier Fraud Signal Collection",
+          "description": "Fraud signals are collected during Apple Pay button initialization for broader coverage on wallet flows.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Google Pay Button Placeholder",
+          "description": "A styled placeholder is shown while the Google Pay SDK loads, replacing the previous skeleton.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "APM Enrollment Button Text",
+          "description": "The enrollment confirmation button for APMs now reads \"Continue\" across Full, Lite, Seamless, and Render Mode flows.",
+          "group": "Enrollment",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Inline Payment Method Selection Error (Desktop)",
+          "description": "Clicking \"Pay\" without selecting a payment method now shows an inline error message below the payment method list on desktop. Mobile continues to use the existing toast.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Backend-Driven Warning Banner",
+          "description": "Flexible payment instructions can now render an optional warning banner returned by the backend, enabling provider-specific notices such as the Punto Pago disclaimer.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.0",
       "release_date": "2026-03-20",
       "upgrade": {
@@ -382,6 +646,132 @@
           "title": "3DS Modal Centering",
           "description": "Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.",
           "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.4",
+      "release_date": "2026-03-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Riskified Integration",
+          "description": "The Riskified script now loads with the correct shop and session identifiers, restoring reliable fraud signal collection when the shop domain is configured on the fraud provider.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.3",
+      "release_date": "2026-03-18",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.3",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Unified User-Cancel Flow",
+          "description": "Wallet, APM, Click to Pay, 3DS modal and lite checkout cancellations now emit `yunoPaymentResult` with `PENDING` status and `CANCELLED_BY_USER` substatus, replacing the previous `ERROR CANCELED_BY_USER` event. Integrations that branched on the legacy error should switch to the substatus.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Additional Load-Time Optimizations",
+          "description": "Google Pay and Apple Pay scripts are now preloaded, and `startCheckout`/`startSeamlessCheckout` prefetch payment methods earlier.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Document Type Options",
+          "description": "Removed a redundant country filter that could hide valid document types in some locales.",
+          "group": "Customer Fields",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.1",
+      "release_date": "2026-03-12",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Billing Contact Collection",
+          "description": "Apple Pay can now capture the cardholder's billing name and postal address from the Apple Pay sheet when enabled via merchant configuration. The cardholder name is forwarded in the payment payload on completion.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Free Trial Support for Recurring Payments",
+          "description": "Apple Pay now supports recurring billing with trial periods, configurable via merchant config (Apple Pay JS v14).",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Network Selector",
+          "description": "Dropdown across step-by-step payment, card unfolded, card modal, enrollment, and Click to Pay. Driven by server-side merchant configuration.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Cielo CyberSource Fraud Provider",
+          "description": "Cielo CyberSource added as a fraud provider, routed through the existing CyberSource integration.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "EBANX Device Fingerprint Provider",
+          "description": "New device-fingerprinting provider with country-based initialization. Customer country is now propagated through the fraud pipeline.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Crash with External-Buttons-Only Sessions",
+          "description": "Fixed a crash that occurred when only external buttons (e.g. Apple Pay) were configured without SDK-rendered payment methods.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Enrolled Card Form Crash",
+          "description": "Prevents a runtime crash when card metadata is missing while detecting Amex on enrolled cards.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Sanitize Functions from Log Payloads",
+          "description": "Functions in the merchant-provided initial state are stripped before debug log serialization, preventing serialization issues across checkout, seamless checkout, headless payment/enrollment, and status flows.",
+          "group": "Core SDK",
           "migration_guide": null,
           "links": []
         }

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -57,6 +57,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="fixed" /> **EBANX Device Session Reliability**  
   Improved reliability of device ID propagation in payment requests, fixing Payment Link flows where it was occasionally dropped before reaching EBANX.
 
+## v1.6.20
+*May 13, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Card Form Top Error Banner**  
+  On payment retry, a banner appears at the top of the card form describing why the previous attempt failed. The banner scrolls into view and is highlighted if the customer tries to submit again without correcting the issue. Invalid-card-data errors and unknown response codes are now surfaced through this banner instead of per-field errors.
+
 ## v1.7.3
 *May 11, 2026*
 
@@ -118,6 +126,43 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="added" /> **Transaction Amount Support for Passkey Flows**  
   Click to Pay initialization now includes transaction amount metadata for supported passkey flows.
 
+## v1.6.19
+*May 8, 2026*
+
+**Click to Pay**
+
+- <ChangelogBadge type="fixed" /> **Card form button alignment on desktop**  
+  Restored correct LTR alignment for the action button and the "Secure Payment by Yuno" badge in the Click to Pay card form (regression on v1.6.x; v1.5 and v1.7 were unaffected). RTL layout is preserved.
+
+## v1.6.18
+*May 7, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Card Number Length Validation**  
+  Card tokenization now waits for the BIN/IIN lookup to complete before submitting, so card numbers are validated against the correct scheme-specific minimum length. Previously, a short Luhn-valid PAN submitted before the BIN lookup settled could be sent to the provider and rejected; users now see an inline length error instead.
+
+## v1.6.17
+*May 6, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="changed" /> **More Accurate Cancellation Reasons**  
+  Apple Pay cancellations are now reported with a precise reason, distinguishing user dismissal (`CANCELLED_BY_USER`) from merchant-validation or provider failures (`CANCELLED_BY_PROVIDER`). Improves the accuracy of drop-off analytics and provider health signals; no integration changes required.
+
+## v1.6.16
+*April 16, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="added" /> **Cancel 3DS Challenge on Browser Back**  
+  Pressing the browser back button during a 3DS challenge now cancels the challenge cleanly. Merchants receive the cancellation via `yunoPaymentResult` with status `PENDING` / `CANCELLED_BY_USER`; no `yunoError` is emitted and the modal unmounts without leaving stale state.
+
+**Click to Pay**
+
+- <ChangelogBadge type="changed" /> **Action Button Order on Mobile**  
+  On mobile and tablet viewports, the Click to Pay action buttons in the card form have been reordered so the primary action sits below the secondary, improving the UX hierarchy. Desktop layout is unchanged.
+
 ## v1.6.8
 *April 15, 2026*
 
@@ -172,6 +217,88 @@ yuno.startSeamlessCheckout({
 - <ChangelogBadge type="added" /> **PayPal Button Modal**  
   New `PaypalButtonModal` component that renders the PayPal button inside a modal overlay, useful for merchants using a custom checkout UI.
 
+## v1.6.7
+*March 31, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Card Password Field for Korean Cards**  
+  New secure field for the first 2 digits of the cardholder PIN required by Korean issuers. Available across standard card, step-by-step, and Click to Pay (new + enrolled) flows. Enable by passing `cardPinElementSelector` in `startCheckout` config; the field renders when enabled for the merchant.
+
+**Click to Pay**
+
+- <ChangelogBadge type="fixed" /> **Passkey Activation with Multiple Card Providers**  
+  When multiple card providers are configured, the SDK now searches all of them for valid 3DS parameters instead of only the first. Passkey now activates correctly when the 3DS-capable provider is not listed first.
+
+**Core SDK**
+
+- <ChangelogBadge type="added" /> **Hindi, Bengali, Malayalam, and Urdu Translations**  
+  Available via `language: 'hi' | 'bn' | 'ml' | 'ur'`.
+
+- <ChangelogBadge type="added" /> **Merchant Installments via `onGetInstallments`**  
+  Merchants can supply their own installment options via the `onGetInstallments(cardBin)` callback; the SDK falls back to Yuno installments when the callback returns empty. A new `onInstallmentSelected` callback fires on both auto-selection and user picks across all card flows. Merchant-supplied installments are omitted from one-time-token creation since the merchant handles them server-side.
+
+- <ChangelogBadge type="added" /> **`subStatus` in `yunoPaymentResult`**  
+  The callback now receives `subStatus` as a second argument: `yunoPaymentResult(status, subStatus?)`, giving finer-grained outcome information (notably on cancel flows).
+
+- <ChangelogBadge type="changed" /> **Bundle Size Reduction (-16%)**  
+  SWC `env.targets` configured to eliminate ES5 polyfills on modern browsers.
+
+**PayPal**
+
+- <ChangelogBadge type="fixed" /> **PayPal Locale**  
+  SDK language is now passed as `locale` to the PayPal `loadScript` call so the PayPal UI matches the configured checkout language.
+
+## v1.6.6
+*March 26, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **`externalButtons` Customization**  
+  New configuration on `externalButtons` for per-wallet button customization (Apple Pay, Google Pay, PayPal).
+
+**Core SDK**
+
+- <ChangelogBadge type="fixed" /> **WebSocket Race Condition in Redirect Flows**  
+  Resolved a race that could lose status updates.
+
+- <ChangelogBadge type="fixed" /> **WebSocket Error Handling**  
+  Added error handling for WebSocket initialization to prevent unhandled failures in status polling.
+
+## v1.6.5
+*March 20, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="changed" /> **Unified Apple Pay Button**  
+  Legacy Apple Pay implementation was removed; the SDK now uses a single Apple Pay button consistently across standard checkout and `mountExternalButtons` integrations, driven by the SDK payment flow.
+
+- <ChangelogBadge type="changed" /> **Faster Apple Pay Button Render**  
+  Apple Pay SDK loading, amount lookup, and config fetch now run in parallel, with a styled placeholder shown until the real button is ready.
+
+- <ChangelogBadge type="changed" /> **Earlier Fraud Signal Collection**  
+  Fraud signals are collected during Apple Pay button initialization for broader coverage on wallet flows.
+
+**Google Pay**
+
+- <ChangelogBadge type="changed" /> **Google Pay Button Placeholder**  
+  A styled placeholder is shown while the Google Pay SDK loads, replacing the previous skeleton.
+
+**Enrollment**
+
+- <ChangelogBadge type="changed" /> **APM Enrollment Button Text**  
+  The enrollment confirmation button for APMs now reads "Continue" across Full, Lite, Seamless, and Render Mode flows.
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Inline Payment Method Selection Error (Desktop)**  
+  Clicking "Pay" without selecting a payment method now shows an inline error message below the payment method list on desktop. Mobile continues to use the existing toast.
+
+**Payment Actions**
+
+- <ChangelogBadge type="added" /> **Backend-Driven Warning Banner**  
+  Flexible payment instructions can now render an optional warning banner returned by the backend, enabling provider-specific notices such as the Punto Pago disclaimer.
+
 ## v1.6.0
 *March 20, 2026*
 
@@ -216,6 +343,65 @@ await yuno.startCheckout({
 
 - <ChangelogBadge type="fixed" /> **3DS Modal Centering**  
   Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.
+
+## v1.6.4
+*March 19, 2026*
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="fixed" /> **Riskified Integration**  
+  The Riskified script now loads with the correct shop and session identifiers, restoring reliable fraud signal collection when the shop domain is configured on the fraud provider.
+
+## v1.6.3
+*March 18, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Unified User-Cancel Flow**  
+  Wallet, APM, Click to Pay, 3DS modal and lite checkout cancellations now emit `yunoPaymentResult` with `PENDING` status and `CANCELLED_BY_USER` substatus, replacing the previous `ERROR CANCELED_BY_USER` event. Integrations that branched on the legacy error should switch to the substatus.
+
+- <ChangelogBadge type="changed" /> **Additional Load-Time Optimizations**  
+  Google Pay and Apple Pay scripts are now preloaded, and `startCheckout`/`startSeamlessCheckout` prefetch payment methods earlier.
+
+**Customer Fields**
+
+- <ChangelogBadge type="fixed" /> **Document Type Options**  
+  Removed a redundant country filter that could hide valid document types in some locales.
+
+## v1.6.1
+*March 12, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Billing Contact Collection**  
+  Apple Pay can now capture the cardholder's billing name and postal address from the Apple Pay sheet when enabled via merchant configuration. The cardholder name is forwarded in the payment payload on completion.
+
+- <ChangelogBadge type="added" /> **Free Trial Support for Recurring Payments**  
+  Apple Pay now supports recurring billing with trial periods, configurable via merchant config (Apple Pay JS v14).
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Network Selector**  
+  Dropdown across step-by-step payment, card unfolded, card modal, enrollment, and Click to Pay. Driven by server-side merchant configuration.
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="added" /> **Cielo CyberSource Fraud Provider**  
+  Cielo CyberSource added as a fraud provider, routed through the existing CyberSource integration.
+
+- <ChangelogBadge type="added" /> **EBANX Device Fingerprint Provider**  
+  New device-fingerprinting provider with country-based initialization. Customer country is now propagated through the fraud pipeline.
+
+**Core SDK**
+
+- <ChangelogBadge type="fixed" /> **Crash with External-Buttons-Only Sessions**  
+  Fixed a crash that occurred when only external buttons (e.g. Apple Pay) were configured without SDK-rendered payment methods.
+
+- <ChangelogBadge type="fixed" /> **Enrolled Card Form Crash**  
+  Prevents a runtime crash when card metadata is missing while detecting Amex on enrolled cards.
+
+- <ChangelogBadge type="fixed" /> **Sanitize Functions from Log Payloads**  
+  Functions in the merchant-provided initial state are stripped before debug log serialization, preventing serialization issues across checkout, seamless checkout, headless payment/enrollment, and status flows.
 
 ## v1.5.0
 *January 15, 2026*


### PR DESCRIPTION
## Summary

Backfills the Web SDK v1.6.x patch releases into `changelog/source/web.json` so they appear in the public changelog at docs.y.uno.

Each release block is sourced from the matching GitHub release on `yuno-payments/sdk-web`, with per-PR verification to filter out internal-only changes and correct naming inconsistencies.

### Versions included (11 releases, 35 entries)

- v1.6.20 (2026-05-13) — 1 entries
- v1.6.19 (2026-05-08) — 1 entries
- v1.6.18 (2026-05-07) — 1 entries
- v1.6.17 (2026-05-06) — 1 entries
- v1.6.16 (2026-04-16) — 2 entries
- v1.6.7 (2026-03-31) — 7 entries
- v1.6.6 (2026-03-26) — 3 entries
- v1.6.5 (2026-03-20) — 7 entries
- v1.6.4 (2026-03-19) — 1 entries
- v1.6.3 (2026-03-18) — 3 entries
- v1.6.1 (2026-03-12) — 8 entries

This is part of the gap-fill between v1.5.0 and v1.7.0 in the published changelog.

## Test plan
- [ ] JSON validates against the schema
- [ ] Mintlify preview renders each new release block correctly
- [ ] No duplicate of any of the above versions already exists in `web.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates adding missing Web SDK v1.6.x release notes, with no runtime or API behavior changes in this repo.
> 
> **Overview**
> Backfills the public Web SDK changelog by adding missing `v1.6.x` patch releases (from `1.6.1` through `1.6.20`) into `changelog/source/web.json` and mirroring them in `changelog/web.mdx`.
> 
> These additions fill the gap between `v1.5.0` and `v1.7.0`, ensuring the docs site renders the historical release notes with correct dates, upgrade snippets, and grouped entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1a3813aa107d3f1717d704ac9de5b72729ed05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->