### PR TITLE
docs(changelog): backfill Android 2.6.4+ and React Native SDK release notes

### DIFF
--- a/changelog/android.mdx
+++ b/changelog/android.mdx
@@ -20,6 +20,60 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="added" /> **Installment Details on Tokenization**  
   When a card is tokenized with installments selected, the installment information — plan, rate, amount, and selected option — is now returned alongside the one-time token. 
 
+## v2.14.0
+*April 30, 2026*
+
+- <ChangelogBadge type="added" /> **Separate Billing and Shipping Address Forms**  
+  Added separate billing and shipping address sections with a same-as-shipping checkbox, including a `BILLING_ONLY` section type and refined field ordering and focus behavior.
+
+- <ChangelogBadge type="added" /> **Auto-Advance Between Card Fields**  
+  Card form now auto-advances focus to the next field on valid input, including correct handling when the CVV field is hidden, when the save-card checkbox is present, and inside the unfolded card form.
+
+- <ChangelogBadge type="added" /> **Dynamic CVV Limit for Enrolled Cards**  
+  The CVV input now applies the correct length limit for enrolled cards based on the card's `securityCodeLength` instead of the default 3-digit limit.
+
+- <ChangelogBadge type="added" /> **Seamless Flow Automation Mode**  
+  Added a seamless checkout flow tailored for automation mode to support end-to-end testing scenarios.
+
+- <ChangelogBadge type="added" /> **3DS WebView Loading Indicator**  
+  Added a loading progress indicator to the 3DS `WebView` to communicate state during authentication.
+
+- <ChangelogBadge type="changed" /> **MVVM and Architecture Cleanup**  
+  Refactored to MVVM using use cases and `StateFlow`, migrated `BehaviorSubject` usages to `StateFlow`, decomposed `ContinueCheckoutFragment`, removed the service locator, and purified the domain layer by removing `Parcelable` and Android framework dependencies. No public API changes required.
+
+- <ChangelogBadge type="changed" /> **Customer Session for Enrollment Card Info**  
+  The card-info API now receives `customer_session` in enrollment flows for improved fraud and risk signals. No integration changes required.
+
+- <ChangelogBadge type="changed" /> **Enrolled Card Flow Address Sections**  
+  Migrated the enrolled card flow to use the new billing and shipping address sections, prefilling shipping with billing when empty.
+
+- <ChangelogBadge type="fixed" /> **Shipping and Billing Validation Focus**  
+  Submit now scrolls to and focuses the first invalid shipping or billing field, and the keyboard `Next` button correctly advances through address fields.
+
+- <ChangelogBadge type="fixed" /> **Installments Dropdown Amount**  
+  The installments dropdown now shows the amount for items that don't have `financial_costs`, ensuring consistent display.
+
+- <ChangelogBadge type="fixed" /> **CheckoutModel Singleton Update**  
+  Fixed `updateCheckoutSession` replacing the `CheckoutModel` singleton with a copy, which broke captured references across the SDK.
+
+- <ChangelogBadge type="fixed" /> **Edge-to-Edge in SeamlessCheckoutActivity**  
+  Applied the edge-to-edge fix to `SeamlessCheckoutActivity` and fixed double system-bars padding after the WebView and 3DS flows on Samsung devices.
+
+- <ChangelogBadge type="fixed" /> **Custom Font Family Coverage**  
+  Merchant-defined `YunoConfig.styles.fontFamily` is now applied across all SDK components.
+
+- <ChangelogBadge type="fixed" /> **Mercado Pago Fingerprint Obfuscation**  
+  Serialized Mercado Pago SDK fingerprint fields and added consumer ProGuard rules so fingerprinting survives R8 obfuscation in merchant release builds.
+
+- <ChangelogBadge type="fixed" /> **WebSocket Reconnection in 3DS Flow**  
+  Fixed WebSocket reconnection after the app returns from the background during a 3DS flow.
+
+- <ChangelogBadge type="fixed" /> **Billing and Shipping Checkbox Autofill**  
+  Fixed the same-as-shipping checkbox autofill behavior based on prefilled customer data.
+
+- <ChangelogBadge type="fixed" /> **Locale Translations**  
+  Added missing translations for Hindi (`hi`), Bengali (`bn`), Malayalam (`ml`), and Urdu (`ur`) locales.
+
 ## v2.13.4
 *April 20, 2026*
 
@@ -49,6 +103,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="added" /> **Keeploader Support**  
   Added integration support for Keeploader. Contact your Yuno technical account manager to enable this feature for your account.
+
+## v2.12.1
+*April 29, 2026*
+
+- <ChangelogBadge type="fixed" /> **WebSocket Alignment with iOS**  
+  Backported the WebSocket alignment hotfix from the 2.6 line: the socket connection now forwards `code`, `public-api-key`, `x-version`, and `x-platform`, and propagates the payment code on reconnect.
 
 ## v2.12.0
 *January 10, 2026*
@@ -93,6 +153,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="fixed" /> **Empty Form on All-False Fields**  
   Fixed a bug where the card form rendered as empty when all `FieldsRequired` flags were set to false. No API changes required.
 
+## v2.11.3
+*March 31, 2026*
+
+- <ChangelogBadge type="fixed" /> **Mercado Pago Fingerprint R8 Obfuscation**  
+  Added `@SerializedName` annotations to Mercado Pago fingerprint classes to prevent R8 from obfuscating field names, which was causing declined transactions in merchant release builds.
+
 ## v2.11.2
 *December 18, 2025*
 
@@ -114,6 +180,66 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **CheckoutBuilder Migration**  
   Removed `cardFlow` from `YunoConfig`. Card flow configuration is now handled exclusively through the Dashboard Checkout Builder. Update your integration before upgrading.  
   [Migration guide →](/changelog/migration-guides/android/v2-10-to-v2-11)
+
+## v2.10.2
+*February 26, 2026*
+
+- <ChangelogBadge type="fixed" /> **Seamless Flow Crash**  
+  Fixed a crash in the seamless checkout flow.
+
+- <ChangelogBadge type="fixed" /> **URL Download Null Handling**  
+  Fixed crashes when a URL download fails or returns null, improving robustness of asset and resource fetching.
+
+- <ChangelogBadge type="fixed" /> **Android 16 Edge-to-Edge Overlap**  
+  Backported the Android 16 edge-to-edge fix from 2.9.4: corrected UI overlap caused by edge-to-edge layout changes.
+
+- <ChangelogBadge type="fixed" /> **Payment Method List Enabled State**  
+  Backported the enabled-state fix from 2.9.4 so payment methods in `PaymentMethodListViewModel` are correctly enabled or disabled based on availability.
+
+## v2.10.1
+*February 10, 2026*
+
+- <ChangelogBadge type="changed" /> **Mercado Libre SDK Dependency Removed**  
+  Backported the Mercado Libre SDK dependency removal from the 2.9.3 hotfix: `PaypalMagnesFraud` now uses a remote dependency instead of the embedded library.
+
+## v2.10.0
+*January 27, 2026*
+
+- <ChangelogBadge type="added" /> **Payment Selected Callback**  
+  Added a payment-selected callback to the payment method list composable so merchants can react when the user chooses a payment method.
+
+- <ChangelogBadge type="added" /> **Size Callback for Payment Method List**  
+  Added a size callback to the payment method list composable, letting merchants adapt their layout to the rendered list dimensions.
+
+- <ChangelogBadge type="added" /> **Arabic Language Support**  
+  Added Arabic translations across the SDK, including enrollment status screens, with proper plural handling.
+
+## v2.9.4
+*February 12, 2026*
+
+- <ChangelogBadge type="fixed" /> **Android 16 Edge-to-Edge Overlap**  
+  Fixed UI overlap on Android 16 caused by edge-to-edge changes in `BaseActivity`, `ContinueCheckoutActivity`, and `ScaffoldComponent`.
+
+- <ChangelogBadge type="fixed" /> **Payment Method List Enabled State**  
+  Fixed enabled-state conditions in `PaymentMethodListViewModel` so payment methods are correctly enabled or disabled based on availability.
+
+## v2.9.3
+*February 3, 2026*
+
+- <ChangelogBadge type="changed" /> **Mercado Libre SDK Dependency Removed**  
+  Removed the bundled Mercado Libre SDK dependency and updated `PaypalMagnesFraud` to use the remote dependency instead of the embedded library, reducing SDK size and easing dependency management.
+
+## v2.9.2
+*January 22, 2026*
+
+- <ChangelogBadge type="changed" /> **Enrollment Status Polling**  
+  Improved `GetStatusEnrollmentViewModel` and `EnrollmentHeadlessViewModel` status handling for more reliable enrollment result delivery in headless flows. No API changes required.
+
+## v2.9.1
+*January 19, 2026*
+
+- <ChangelogBadge type="removed" /> **Bundled PayPal Magnes and Mercado Pago JARs**  
+  Removed the embedded `magnes-paypal.jar` and `sdk-3.1.0.jar` binaries together with the local `PaypalMagnesFraud` and `MercadoPagoFraud` providers and their initialization paths. Fingerprinting is now provided through remote dependencies, reducing SDK size.
 
 ## v2.9.0
 *September 15, 2025*
@@ -144,6 +270,36 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="fixed" /> **EdgeToEdge WebView Layout**  
   Fixed an EdgeToEdge rendering issue in `WebViewActivity` that caused layout overlap on devices with edge-to-edge display mode enabled. No API changes required.
+
+## v2.6.7
+*May 12, 2026*
+
+- <ChangelogBadge type="fixed" /> **WebSocket Alignment with iOS**  
+  Aligned the Android `SocketManager` behavior with iOS by forwarding `code`, `public-api-key`, `x-version`, and `x-platform` on socket connect and propagating the payment code on reconnect. Improves stability for payment-code driven flows.
+
+## v2.6.6
+*November 3, 2025*
+
+- <ChangelogBadge type="added" /> **Click to Pay Passkey Support**  
+  Added passkey support for the Click to Pay flow, including `FLAG_ACTIVITY_CLEAR_TASK` handling for the in-app browser session.
+
+- <ChangelogBadge type="fixed" /> **WebView Edge-to-Edge Rendering**  
+  Fixed an edge-to-edge rendering issue affecting `WebView` content on devices using the newer Android display model.
+
+## v2.6.5
+*October 27, 2025*
+
+- <ChangelogBadge type="changed" /> **Internal Release Pipeline Updates**  
+  Maintenance release with internal build and versioning updates. No merchant-facing API changes.
+
+## v2.6.4
+*November 13, 2025*
+
+- <ChangelogBadge type="added" /> **Google Pay PIX Direct Flow**  
+  Added support for the Google Pay PIX direct flow, enabling merchants to offer PIX payments through the Google Pay integration.
+
+- <ChangelogBadge type="fixed" /> **Google Pay PIX merchantName**  
+  Fixed the `merchantName` parameter being passed incorrectly in the Google Pay PIX flow.
 
 ## v2.6.0
 *June 10, 2025*

--- a/changelog/react-native.mdx
+++ b/changelog/react-native.mdx
@@ -8,3 +8,156 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 <Info>
   Release notes for the React Native SDK are published here as new versions are released. Check back after each SDK update for a detailed summary of changes, new features, and migration guidance.
 </Info>
+## v1.2.0
+*May 19, 2026*
+
+- <ChangelogBadge type="added" /> **Payment Render Flow**  
+  Added the new Payment Render flow with the `<YunoPaymentForm>` component and bridge methods (`startRenderFlow`, `showForm`, `submitForm`, `continueRender`) so merchants can embed the payment form inline with full lifecycle control.
+
+- <ChangelogBadge type="added" /> **Enrollment Render Flow**  
+  Added the Enrollment Render flow with the `<YunoEnrollmentForm>` component for embedded card enrollment, mirroring the Payment Render API.
+
+- <ChangelogBadge type="changed" /> **Native SDK Bumps**  
+  Bumped the underlying native SDKs to Android `2.15.1` and iOS `2.16.0`, bringing the latest payment, enrollment, and security improvements to the React Native wrapper.
+
+- <ChangelogBadge type="fixed" /> **Android 15 Edge-to-Edge Overlap**  
+  Configured edge-to-edge on Android 15 to prevent the payment UI from overlapping system bars, and now runs `enableEdgeToEdge` on the UI thread.
+
+- <ChangelogBadge type="fixed" /> **Samsung One UI Compatibility**  
+  Uses `setDecorFitsSystemWindows` for Samsung One UI compatibility, preventing layout glitches on affected devices.
+
+- <ChangelogBadge type="fixed" /> **Seamless Payment Startup Crashes**  
+  Made native module access fully lazy, ensured payment status events are dispatched on the main thread, safely unwrap the iOS view controller, and resolved a `TurboModuleRegistry` error in seamless flows.
+
+- <ChangelogBadge type="fixed" /> **Android Status Alignment**  
+  Aligned Android status values with the TypeScript `YunoStatus` enum and kept render flow status mappings separate from shared mappings.
+
+- <ChangelogBadge type="security" /> **fast-xml-parser DoS Vulnerability**  
+  Upgraded `fast-xml-parser` to address denial-of-service advisories (VULS-1511 and CVE-2026-25128).
+
+## v1.1.0
+*March 10, 2026*
+
+- <ChangelogBadge type="breaking" /> **CardFlow Configuration Removed**  
+  The `CardFlow` enum and the `cardFlow` property in `YunoConfig` have been removed. Card form type is now configured from the Yuno Dashboard instead of the client SDK. Remove any `CardFlow` import and `cardFlow` references from your initialization code before upgrading.  
+  [Migration guide →](https://github.com/yuno-payments/yuno-sdk-react-native#breaking-changes-v110)
+
+- <ChangelogBadge type="changed" /> **Native SDK Bumps**  
+  Bumped the underlying native SDKs to Android `2.11.0` and iOS `2.12.9-RC`.
+
+- <ChangelogBadge type="fixed" /> **iOS Seamless Payment Flow**  
+  Switched iOS seamless payments to `startPaymentSeamlessLite`, now resolves promises with the final payment status instead of `PROCESSING`, runs the call on `MainActor`, and uses the `currentLanguage` from `initialize` in `SeamlessParams`.
+
+- <ChangelogBadge type="fixed" /> **Android removeListeners Crash**  
+  Fixed an Android crash caused by a type mismatch on `removeListeners`. The parameter type now matches what React Native passes from JS.
+
+- <ChangelogBadge type="fixed" /> **Android onPaymentSelected Signature**  
+  Updated the `onPaymentSelected` callback signature to match Android SDK 2.11.0.
+
+- <ChangelogBadge type="security" /> **minimatch ReDoS Vulnerability**  
+  Updated `minimatch` to resolve a regular-expression denial-of-service (ReDoS) advisory in the dependency tree.
+
+## v1.0.30
+*January 13, 2026*
+
+- <ChangelogBadge type="added" /> **TurboModule Support**  
+  Added TurboModule support for React Native 0.82+ via a new `NativeYunoSdk` codegen spec, while remaining backward compatible with the Old Architecture through a `NativeModules` fallback.
+
+## v1.0.29
+*January 13, 2026*
+
+- <ChangelogBadge type="changed" /> **New Architecture Preparation**  
+  Internal updates preparing the package for React Native 0.82+ and the New Architecture (TurboModules). No public API changes; full TurboModule support arrived in 1.0.30.
+
+## v1.0.28
+*January 13, 2026*
+
+- <ChangelogBadge type="changed" /> **Internal Release Pipeline Updates**  
+  Maintenance republish with no functional changes. No API changes required.
+
+## v1.0.27
+*January 13, 2026*
+
+- <ChangelogBadge type="changed" /> **Internal Release Pipeline Updates**  
+  Maintenance republish with no functional changes. No API changes required.
+
+## v1.0.26
+*December 23, 2025*
+
+- <ChangelogBadge type="fixed" /> **iOS saveCardEnabled Parsing**  
+  Fixed a typo in the iOS config key parser that prevented `saveCardEnabled` from being applied. The toggle now correctly reaches the native SDK.
+
+## v1.0.25
+*December 22, 2025*
+
+- <ChangelogBadge type="changed" /> **iOS Podspec Pin**  
+  Pinned the iOS `YunoSDK` dependency to `2.9.0-r`. No API changes required.
+
+## v1.0.24
+*December 17, 2025*
+
+- <ChangelogBadge type="fixed" /> **iOS Language in Payment Full Flow**  
+  Fixed iOS Payment Full flow to respect the `language` parameter passed at initialization.
+
+## v1.0.23
+*December 17, 2025*
+
+- <ChangelogBadge type="fixed" /> **iOS CardFlow Initialization**  
+  Fixed iOS initialization to honor the `cardFlow` configuration parameter that was previously ignored on iOS.
+
+## v1.0.22
+*December 15, 2025*
+
+- <ChangelogBadge type="changed" /> **Documentation Updates**  
+  Expanded README documentation. No API changes required.
+
+## v1.0.21
+*December 10, 2025*
+
+- <ChangelogBadge type="changed" /> **Simplified Language API**  
+  The `language` parameter now accepts a plain string instead of requiring the `YunoLanguage` enum, simplifying initialization. No migration required for existing integrations using the enum.
+
+## v1.0.20
+*December 10, 2025*
+
+- <ChangelogBadge type="fixed" /> **iOS Language Initialization**  
+  Fixed iOS initialization to honor the `language` configuration parameter (matching the Android key), while keeping backward compatibility with the legacy `lang` parameter.
+
+## v1.0.19
+*December 3, 2025*
+
+- <ChangelogBadge type="changed" /> **Android SDK 2.8.1 Callback Compatibility**  
+  Updated Android callback signatures to be compatible with Android SDK 2.8.1. No API changes required.
+
+## v1.0.18
+*December 3, 2025*
+
+- <ChangelogBadge type="changed" /> **Internal Release Pipeline Updates**  
+  Internal version alignment between the React Native wrapper and the underlying native SDK references. No API changes required.
+
+## v1.0.17
+*December 3, 2025*
+
+- <ChangelogBadge type="added" /> **Headless Payment Flow**  
+  Added a Headless Payment Flow for Android and iOS so merchants can drive payment progression from their own UI while delegating native execution to the SDK.
+
+- <ChangelogBadge type="added" /> **Headless Enrollment Flow**  
+  Added a Headless Enrollment Flow for Android and iOS for card enrollment via custom merchant UI.
+
+- <ChangelogBadge type="added" /> **iOS Payment Full Flow**  
+  Added Payment Full flow support on iOS with the native `YunoPaymentMethods` component for parity with Android.
+
+- <ChangelogBadge type="changed" /> **iOS Native Module for YunoSDK 2.x**  
+  Updated the iOS native module to YunoSDK 2.x, including correct delegate passing for `startPayment` and `continuePayment` and using the `.succeeded` enum case.
+
+- <ChangelogBadge type="fixed" /> **iOS Module Registration**  
+  Fixed the iOS native module registration by adding `moduleName()` and `constantsToExport()` and switching `NativeEventEmitter` to lazy loading, resolving linking issues at startup.
+
+- <ChangelogBadge type="fixed" /> **OTT and Payment Status Events**  
+  OTT and payment status events are now emitted from the Full Payment Flow delegate on iOS, and the Android Payment Full flow no longer reports a stale `CANCELLED` status across sessions.
+
+## v1.0.16
+*December 2, 2025*
+
+- <ChangelogBadge type="fixed" /> **CardFlow Default Alignment**  
+  Aligned the default `CardFlow` value with the native SDK by switching from `MULTI_STEP` to `STEP_BY_STEP` to prevent mismatched card form rendering.

--- a/changelog/source/android.json
+++ b/changelog/source/android.json
@@ -46,6 +46,152 @@
       ]
     },
     {
+      "version": "2.14.0",
+      "release_date": "2026-04-30",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.14.0'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Separate Billing and Shipping Address Forms",
+          "description": "Added separate billing and shipping address sections with a same-as-shipping checkbox, including a `BILLING_ONLY` section type and refined field ordering and focus behavior.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Auto-Advance Between Card Fields",
+          "description": "Card form now auto-advances focus to the next field on valid input, including correct handling when the CVV field is hidden, when the save-card checkbox is present, and inside the unfolded card form.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Dynamic CVV Limit for Enrolled Cards",
+          "description": "The CVV input now applies the correct length limit for enrolled cards based on the card's `securityCodeLength` instead of the default 3-digit limit.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Seamless Flow Automation Mode",
+          "description": "Added a seamless checkout flow tailored for automation mode to support end-to-end testing scenarios.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "3DS WebView Loading Indicator",
+          "description": "Added a loading progress indicator to the 3DS `WebView` to communicate state during authentication.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "MVVM and Architecture Cleanup",
+          "description": "Refactored to MVVM using use cases and `StateFlow`, migrated `BehaviorSubject` usages to `StateFlow`, decomposed `ContinueCheckoutFragment`, removed the service locator, and purified the domain layer by removing `Parcelable` and Android framework dependencies. No public API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Customer Session for Enrollment Card Info",
+          "description": "The card-info API now receives `customer_session` in enrollment flows for improved fraud and risk signals. No integration changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Enrolled Card Flow Address Sections",
+          "description": "Migrated the enrolled card flow to use the new billing and shipping address sections, prefilling shipping with billing when empty.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Shipping and Billing Validation Focus",
+          "description": "Submit now scrolls to and focuses the first invalid shipping or billing field, and the keyboard `Next` button correctly advances through address fields.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Installments Dropdown Amount",
+          "description": "The installments dropdown now shows the amount for items that don't have `financial_costs`, ensuring consistent display.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "CheckoutModel Singleton Update",
+          "description": "Fixed `updateCheckoutSession` replacing the `CheckoutModel` singleton with a copy, which broke captured references across the SDK.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Edge-to-Edge in SeamlessCheckoutActivity",
+          "description": "Applied the edge-to-edge fix to `SeamlessCheckoutActivity` and fixed double system-bars padding after the WebView and 3DS flows on Samsung devices.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Custom Font Family Coverage",
+          "description": "Merchant-defined `YunoConfig.styles.fontFamily` is now applied across all SDK components.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Mercado Pago Fingerprint Obfuscation",
+          "description": "Serialized Mercado Pago SDK fingerprint fields and added consumer ProGuard rules so fingerprinting survives R8 obfuscation in merchant release builds.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "WebSocket Reconnection in 3DS Flow",
+          "description": "Fixed WebSocket reconnection after the app returns from the background during a 3DS flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Billing and Shipping Checkbox Autofill",
+          "description": "Fixed the same-as-shipping checkbox autofill behavior based on prefilled customer data.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Locale Translations",
+          "description": "Added missing translations for Hindi (`hi`), Bengali (`bn`), Malayalam (`ml`), and Urdu (`ur`) locales.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.13.4",
       "release_date": "2026-04-20",
       "upgrade": {
@@ -129,6 +275,24 @@
           "type": "ADDED",
           "title": "Keeploader Support",
           "description": "Added integration support for Keeploader. Contact your Yuno technical account manager to enable this feature for your account.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.12.1",
+      "release_date": "2026-04-29",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.12.1'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "WebSocket Alignment with iOS",
+          "description": "Backported the WebSocket alignment hotfix from the 2.6 line: the socket connection now forwards `code`, `public-api-key`, `x-version`, and `x-platform`, and propagates the payment code on reconnect.",
           "group": null,
           "migration_guide": null,
           "links": []
@@ -242,6 +406,24 @@
       ]
     },
     {
+      "version": "2.11.3",
+      "release_date": "2026-03-31",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.11.3'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Mercado Pago Fingerprint R8 Obfuscation",
+          "description": "Added `@SerializedName` annotations to Mercado Pago fingerprint classes to prevent R8 from obfuscating field names, which was causing declined transactions in merchant release builds.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.11.2",
       "release_date": "2025-12-18",
       "upgrade": {
@@ -306,6 +488,180 @@
             "after_language": null,
             "dashboard_path": "Dashboard > Checkout > Builder > Card Flow"
           },
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.10.2",
+      "release_date": "2026-02-26",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.10.2'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Seamless Flow Crash",
+          "description": "Fixed a crash in the seamless checkout flow.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "URL Download Null Handling",
+          "description": "Fixed crashes when a URL download fails or returns null, improving robustness of asset and resource fetching.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Android 16 Edge-to-Edge Overlap",
+          "description": "Backported the Android 16 edge-to-edge fix from 2.9.4: corrected UI overlap caused by edge-to-edge layout changes.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Payment Method List Enabled State",
+          "description": "Backported the enabled-state fix from 2.9.4 so payment methods in `PaymentMethodListViewModel` are correctly enabled or disabled based on availability.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.10.1",
+      "release_date": "2026-02-10",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.10.1'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Mercado Libre SDK Dependency Removed",
+          "description": "Backported the Mercado Libre SDK dependency removal from the 2.9.3 hotfix: `PaypalMagnesFraud` now uses a remote dependency instead of the embedded library.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.10.0",
+      "release_date": "2026-01-27",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.10.0'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Payment Selected Callback",
+          "description": "Added a payment-selected callback to the payment method list composable so merchants can react when the user chooses a payment method.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Size Callback for Payment Method List",
+          "description": "Added a size callback to the payment method list composable, letting merchants adapt their layout to the rendered list dimensions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Arabic Language Support",
+          "description": "Added Arabic translations across the SDK, including enrollment status screens, with proper plural handling.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.9.4",
+      "release_date": "2026-02-12",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.9.4'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Android 16 Edge-to-Edge Overlap",
+          "description": "Fixed UI overlap on Android 16 caused by edge-to-edge changes in `BaseActivity`, `ContinueCheckoutActivity`, and `ScaffoldComponent`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Payment Method List Enabled State",
+          "description": "Fixed enabled-state conditions in `PaymentMethodListViewModel` so payment methods are correctly enabled or disabled based on availability.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.9.3",
+      "release_date": "2026-02-03",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.9.3'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Mercado Libre SDK Dependency Removed",
+          "description": "Removed the bundled Mercado Libre SDK dependency and updated `PaypalMagnesFraud` to use the remote dependency instead of the embedded library, reducing SDK size and easing dependency management.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.9.2",
+      "release_date": "2026-01-22",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.9.2'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Enrollment Status Polling",
+          "description": "Improved `GetStatusEnrollmentViewModel` and `EnrollmentHeadlessViewModel` status handling for more reliable enrollment result delivery in headless flows. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.9.1",
+      "release_date": "2026-01-19",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.9.1'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "REMOVED",
+          "title": "Bundled PayPal Magnes and Mercado Pago JARs",
+          "description": "Removed the embedded `magnes-paypal.jar` and `sdk-3.1.0.jar` binaries together with the local `PaypalMagnesFraud` and `MercadoPagoFraud` providers and their initialization paths. Fingerprinting is now provided through remote dependencies, reducing SDK size.",
+          "group": null,
+          "migration_guide": null,
           "links": []
         }
       ]
@@ -392,6 +748,94 @@
           "type": "FIXED",
           "title": "EdgeToEdge WebView Layout",
           "description": "Fixed an EdgeToEdge rendering issue in `WebViewActivity` that caused layout overlap on devices with edge-to-edge display mode enabled. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.6.7",
+      "release_date": "2026-05-12",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.6.7'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "WebSocket Alignment with iOS",
+          "description": "Aligned the Android `SocketManager` behavior with iOS by forwarding `code`, `public-api-key`, `x-version`, and `x-platform` on socket connect and propagating the payment code on reconnect. Improves stability for payment-code driven flows.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.6.6",
+      "release_date": "2025-11-03",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.6.6'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Click to Pay Passkey Support",
+          "description": "Added passkey support for the Click to Pay flow, including `FLAG_ACTIVITY_CLEAR_TASK` handling for the in-app browser session.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "WebView Edge-to-Edge Rendering",
+          "description": "Fixed an edge-to-edge rendering issue affecting `WebView` content on devices using the newer Android display model.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.6.5",
+      "release_date": "2025-10-27",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.6.5'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Internal Release Pipeline Updates",
+          "description": "Maintenance release with internal build and versioning updates. No merchant-facing API changes.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "2.6.4",
+      "release_date": "2025-11-13",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.6.4'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Google Pay PIX Direct Flow",
+          "description": "Added support for the Google Pay PIX direct flow, enabling merchants to offer PIX payments through the Google Pay integration.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Google Pay PIX merchantName",
+          "description": "Fixed the `merchantName` parameter being passed incorrectly in the Google Pay PIX flow.",
           "group": null,
           "migration_guide": null,
           "links": []

--- a/changelog/source/react-native.json
+++ b/changelog/source/react-native.json
@@ -1,4 +1,454 @@
 {
   "sdk": "react-native",
-  "releases": []
+  "releases": [
+    {
+      "version": "1.2.0",
+      "release_date": "2026-05-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.2.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Payment Render Flow",
+          "description": "Added the new Payment Render flow with the `<YunoPaymentForm>` component and bridge methods (`startRenderFlow`, `showForm`, `submitForm`, `continueRender`) so merchants can embed the payment form inline with full lifecycle control.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Enrollment Render Flow",
+          "description": "Added the Enrollment Render flow with the `<YunoEnrollmentForm>` component for embedded card enrollment, mirroring the Payment Render API.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Native SDK Bumps",
+          "description": "Bumped the underlying native SDKs to Android `2.15.1` and iOS `2.16.0`, bringing the latest payment, enrollment, and security improvements to the React Native wrapper.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Android 15 Edge-to-Edge Overlap",
+          "description": "Configured edge-to-edge on Android 15 to prevent the payment UI from overlapping system bars, and now runs `enableEdgeToEdge` on the UI thread.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Samsung One UI Compatibility",
+          "description": "Uses `setDecorFitsSystemWindows` for Samsung One UI compatibility, preventing layout glitches on affected devices.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Seamless Payment Startup Crashes",
+          "description": "Made native module access fully lazy, ensured payment status events are dispatched on the main thread, safely unwrap the iOS view controller, and resolved a `TurboModuleRegistry` error in seamless flows.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Android Status Alignment",
+          "description": "Aligned Android status values with the TypeScript `YunoStatus` enum and kept render flow status mappings separate from shared mappings.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "fast-xml-parser DoS Vulnerability",
+          "description": "Upgraded `fast-xml-parser` to address denial-of-service advisories (VULS-1511 and CVE-2026-25128).",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "release_date": "2026-03-10",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.1.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "BREAKING",
+          "title": "CardFlow Configuration Removed",
+          "description": "The `CardFlow` enum and the `cardFlow` property in `YunoConfig` have been removed. Card form type is now configured from the Yuno Dashboard instead of the client SDK. Remove any `CardFlow` import and `cardFlow` references from your initialization code before upgrading.",
+          "group": null,
+          "migration_guide": "https://github.com/yuno-payments/yuno-sdk-react-native#breaking-changes-v110",
+          "migration_notes": {
+            "before": "import { YunoSdk, CardFlow } from '@yuno-payments/yuno-sdk-react-native';\n\nawait YunoSdk.initialize({\n  apiKey,\n  countryCode: 'CO',\n  yunoConfig: {\n    language: 'es',\n    cardFlow: CardFlow.ONE_STEP,\n    saveCardEnabled: true,\n  },\n});",
+            "before_language": "typescript",
+            "after": "import { YunoSdk } from '@yuno-payments/yuno-sdk-react-native';\n\nawait YunoSdk.initialize({\n  apiKey,\n  countryCode: 'CO',\n  yunoConfig: {\n    language: 'es',\n    saveCardEnabled: true,\n  },\n});",
+            "after_language": "typescript",
+            "dashboard_path": "Dashboard > Checkout > Builder > Card Form"
+          },
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Native SDK Bumps",
+          "description": "Bumped the underlying native SDKs to Android `2.11.0` and iOS `2.12.9-RC`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "iOS Seamless Payment Flow",
+          "description": "Switched iOS seamless payments to `startPaymentSeamlessLite`, now resolves promises with the final payment status instead of `PROCESSING`, runs the call on `MainActor`, and uses the `currentLanguage` from `initialize` in `SeamlessParams`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Android removeListeners Crash",
+          "description": "Fixed an Android crash caused by a type mismatch on `removeListeners`. The parameter type now matches what React Native passes from JS.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Android onPaymentSelected Signature",
+          "description": "Updated the `onPaymentSelected` callback signature to match Android SDK 2.11.0.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "minimatch ReDoS Vulnerability",
+          "description": "Updated `minimatch` to resolve a regular-expression denial-of-service (ReDoS) advisory in the dependency tree.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.30",
+      "release_date": "2026-01-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.30",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "TurboModule Support",
+          "description": "Added TurboModule support for React Native 0.82+ via a new `NativeYunoSdk` codegen spec, while remaining backward compatible with the Old Architecture through a `NativeModules` fallback.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.29",
+      "release_date": "2026-01-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.29",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "New Architecture Preparation",
+          "description": "Internal updates preparing the package for React Native 0.82+ and the New Architecture (TurboModules). No public API changes; full TurboModule support arrived in 1.0.30.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.28",
+      "release_date": "2026-01-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.28",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Internal Release Pipeline Updates",
+          "description": "Maintenance republish with no functional changes. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.27",
+      "release_date": "2026-01-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.27",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Internal Release Pipeline Updates",
+          "description": "Maintenance republish with no functional changes. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.26",
+      "release_date": "2025-12-23",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.26",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "iOS saveCardEnabled Parsing",
+          "description": "Fixed a typo in the iOS config key parser that prevented `saveCardEnabled` from being applied. The toggle now correctly reaches the native SDK.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.25",
+      "release_date": "2025-12-22",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.25",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "iOS Podspec Pin",
+          "description": "Pinned the iOS `YunoSDK` dependency to `2.9.0-r`. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.24",
+      "release_date": "2025-12-17",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.24",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "iOS Language in Payment Full Flow",
+          "description": "Fixed iOS Payment Full flow to respect the `language` parameter passed at initialization.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.23",
+      "release_date": "2025-12-17",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.23",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "iOS CardFlow Initialization",
+          "description": "Fixed iOS initialization to honor the `cardFlow` configuration parameter that was previously ignored on iOS.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.22",
+      "release_date": "2025-12-15",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.22",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Documentation Updates",
+          "description": "Expanded README documentation. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.21",
+      "release_date": "2025-12-10",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.21",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Simplified Language API",
+          "description": "The `language` parameter now accepts a plain string instead of requiring the `YunoLanguage` enum, simplifying initialization. No migration required for existing integrations using the enum.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.20",
+      "release_date": "2025-12-10",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.20",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "iOS Language Initialization",
+          "description": "Fixed iOS initialization to honor the `language` configuration parameter (matching the Android key), while keeping backward compatibility with the legacy `lang` parameter.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.19",
+      "release_date": "2025-12-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.19",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Android SDK 2.8.1 Callback Compatibility",
+          "description": "Updated Android callback signatures to be compatible with Android SDK 2.8.1. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.18",
+      "release_date": "2025-12-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.18",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Internal Release Pipeline Updates",
+          "description": "Internal version alignment between the React Native wrapper and the underlying native SDK references. No API changes required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.17",
+      "release_date": "2025-12-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.17",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Headless Payment Flow",
+          "description": "Added a Headless Payment Flow for Android and iOS so merchants can drive payment progression from their own UI while delegating native execution to the SDK.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Headless Enrollment Flow",
+          "description": "Added a Headless Enrollment Flow for Android and iOS for card enrollment via custom merchant UI.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "iOS Payment Full Flow",
+          "description": "Added Payment Full flow support on iOS with the native `YunoPaymentMethods` component for parity with Android.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "iOS Native Module for YunoSDK 2.x",
+          "description": "Updated the iOS native module to YunoSDK 2.x, including correct delegate passing for `startPayment` and `continuePayment` and using the `.succeeded` enum case.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "iOS Module Registration",
+          "description": "Fixed the iOS native module registration by adding `moduleName()` and `constantsToExport()` and switching `NativeEventEmitter` to lazy loading, resolving linking issues at startup.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "OTT and Payment Status Events",
+          "description": "OTT and payment status events are now emitted from the Full Payment Flow delegate on iOS, and the Android Payment Full flow no longer reports a stale `CANCELLED` status across sessions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.16",
+      "release_date": "2025-12-02",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.0.16",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "CardFlow Default Alignment",
+          "description": "Aligned the default `CardFlow` value with the native SDK by switching from `MULTI_STEP` to `STEP_BY_STEP` to prevent mismatched card form rendering.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Backfill the public changelog for the **Android SDK (from 2.6.4 onwards)** and the **React Native wrapper (all final releases up to 1.2.0)** so the new changelog framework launches with full historical coverage. Mirrors the structure used by the iOS backfill (#374 / commit `ee82f867`).

- **Android (14 new versions)** inserted into `changelog/source/android.json` in semver-descending order:
  - `2.6.4`, `2.6.5`, `2.6.6`, `2.6.7` (late hotfix backport)
  - `2.9.1`, `2.9.2`, `2.9.3`, `2.9.4`
  - `2.10.0`, `2.10.1`, `2.10.2`
  - `2.11.3`, `2.12.1`
  - `2.14.0`
- **React Native (17 versions)** in `changelog/source/react-native.json` (previously empty):
  - `1.0.16` through `1.0.30`
  - `1.1.0` — includes the `BREAKING` `CardFlow` removal
  - `1.2.0` — Render Flow + Android 2.15.1 / iOS 2.16.0 bumps

MDX pages were regenerated with `scripts/generate_changelog.js`.

Refs: [CORECM-17255](https://yunopayments.atlassian.net/browse/CORECM-17255)

## Notes for reviewers

1. **RN 1.1.0 hosts the `BREAKING` `CardFlow` removal**, not 1.2.0. Verified by inspecting the commit `f3526cb feat!: remove CardFlow config and bump native SDKs` (Feb 27 2026) and the published npm tarballs for 1.1.0 and 1.2.0 — both no longer ship `CardFlow.ts`.
2. **Migration guide URL for the RN 1.1.0 BREAKING** points at the SDK README anchor (`#breaking-changes-v110`) since no `/changelog/migration-guides/react-native/v1-0-to-v1-1` page exists yet. The entry includes `migration_notes` with before/after TypeScript and the Dashboard path so a Tech Writer can author the formal guide.
3. **Existing Android `2.6.0` entry preserved** — the ticket scope is `2.6.4+`, no pre-existing entries were modified or removed.
4. **Android entry detail** matches the iOS backfill density (1–3 sentences per entry, no forced grouping unless ≥4 entries in a category). Larger releases (`2.14.0` with 17 entries) reflect actual breadth of changes inspected from `git log origin/release/2.13.x..origin/release/2.14.0`.

## Test plan

- [ ] Review `changelog/source/android.json` for the 14 new release blocks
- [ ] Review `changelog/source/react-native.json` (entire file is new content)
- [ ] Sanity-check the regenerated `changelog/android.mdx` and `changelog/react-native.mdx` render correctly (badges, dates, migration guide link)
- [ ] Confirm RN 1.1.0 BREAKING `migration_guide` URL with docs team — replace with internal `/changelog/migration-guides/react-native/...` path if/when published
- [ ] Confirm with @Arcapas / @htessaro before merge per existing reviewer convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-17255]: https://yunopayments.atlassian.net/browse/CORECM-17255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that add historical release entries to changelog sources and regenerate the MDX pages; risk is limited to potential inaccuracies or formatting/rendering issues.
> 
> **Overview**
> Backfills the public changelog data for the Android SDK by adding missing release blocks (e.g., `2.6.4` through `2.14.0`) to `changelog/source/android.json` and regenerating `changelog/android.mdx` accordingly.
> 
> Introduces a full React Native changelog: populates `changelog/source/react-native.json` (previously empty) with releases up to `1.2.0`—including the `1.1.0` *breaking* `CardFlow` removal and the `1.2.0` render-flow additions—and generates `changelog/react-native.mdx` from that source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e2ce61fe9fcf8e3a0548b17985c473ce5856d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->