### PR TITLE
Added API documentation and OpenApi specifications for Checkout Builder Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ openapi.zip
 postman-collection.json
 postman-environment.json
 openapi/merged.json
-resources
+.local-resources

--- a/docs.json
+++ b/docs.json
@@ -342,6 +342,29 @@
             ]
           },
           {
+            "dropdown": "Checkout Builder",
+            "icon": "sliders",
+            "pages": [
+              "reference/checkout-builder/overview",
+              {
+                "group": "Payment Method Configuration",
+                "pages": [
+                  "reference/checkout-builder/fetch-checkout-configuration",
+                  "reference/checkout-builder/publish-checkout-configuration",
+                  "reference/checkout-builder/get-required-fields",
+                  "reference/checkout-builder/get-country-data"
+                ]
+              },
+              {
+                "group": "Styling & SDK Settings",
+                "pages": [
+                  "reference/checkout-builder/fetch-styling-settings",
+                  "reference/checkout-builder/update-styling-settings"
+                ]
+              }
+            ]
+          },
+          {
             "dropdown": "Payment Methods (Direct Workflow)",
             "icon": "code-branch",
             "pages": [

--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -299,11 +299,5 @@
         "deprecated": false
       }
     }
-  },
-  "x-readme": {
-    "headers": [{ "value": "utf-8", "key": "charset" }],
-    "explorer-enabled": true,
-    "proxy-enabled": true
-  },
-  "x-readme-fauxas": true
+  }
 }

--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -1,0 +1,309 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://prod.y.uno/dashboard-bff/api"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "JWT issued by Yuno's auth provider. Tokens are short-lived — refresh before expiry."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-account-code",
+        "x-default": "<Your account UUID>"
+      },
+      "environment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-environment",
+        "x-default": "live"
+      },
+      "orgCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-organization-code",
+        "x-default": ""
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "accountCode": [],
+      "environment": [],
+      "orgCode": []
+    }
+  ],
+  "paths": {
+    "/checkouts/{checkoutCode}": {
+      "get": {
+        "summary": "Fetch Checkout Configuration",
+        "description": "Returns the full checkout configuration for the given checkout code, including all payment methods, their active state, display order, conditions, and required-field overrides.",
+        "operationId": "get-checkout-configuration",
+        "parameters": [
+          {
+            "name": "checkoutCode",
+            "in": "path",
+            "description": "The unique identifier of the checkout to retrieve (UUID, 36 chars).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Success": {
+                    "value": {
+                      "account_code": "b91b3970-dbf7-4d6a-b34d-96adbf3a0988",
+                      "code": "8005ca91-dcfb-4428-b9f6-49c6e3446474",
+                      "name": "Default Checkout",
+                      "description": "",
+                      "is_active": true,
+                      "is_archive": false,
+                      "organization_code": "org-uuid",
+                      "root": true,
+                      "created_at": "2026-01-01T00:00:00Z",
+                      "updated_at": "2026-05-18T13:06:08Z",
+                      "payment_methods": [
+                        {
+                          "is_active": true,
+                          "payment_method_type": "CARD",
+                          "order_to_show": 1,
+                          "type": "PAYMENT_METHOD",
+                          "active_enrollment_type": "BOTH",
+                          "conditions_to_override": [],
+                          "required_fields_to_override": null
+                        }
+                      ],
+                      "general_settings": {
+                        "country_documents": [
+                          { "country_code": "AR", "documents": ["DNI", "CUIT"] }
+                        ]
+                      },
+                      "feature_flags": {
+                        "custom_required_fields": true,
+                        "custom_logo_icon": false
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "account_code": {
+                      "type": "string",
+                      "description": "Account UUID.",
+                      "example": "b91b3970-dbf7-4d6a-b34d-96adbf3a0988"
+                    },
+                    "code": {
+                      "type": "string",
+                      "description": "Checkout UUID.",
+                      "example": "8005ca91-dcfb-4428-b9f6-49c6e3446474"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Checkout name.",
+                      "example": "Default Checkout"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Checkout description.",
+                      "example": ""
+                    },
+                    "is_active": {
+                      "type": "boolean",
+                      "description": "Whether the checkout is active.",
+                      "example": true
+                    },
+                    "is_archive": {
+                      "type": "boolean",
+                      "description": "Whether the checkout is archived.",
+                      "example": false
+                    },
+                    "organization_code": {
+                      "type": "string",
+                      "description": "Organization UUID.",
+                      "example": "org-uuid"
+                    },
+                    "root": {
+                      "type": "boolean",
+                      "description": "Whether this is the root (default) checkout for the account.",
+                      "example": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "Creation timestamp (ISO 8601).",
+                      "example": "2026-01-01T00:00:00Z"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "Last updated timestamp (ISO 8601).",
+                      "example": "2026-05-18T13:06:08Z"
+                    },
+                    "payment_methods": {
+                      "type": "array",
+                      "description": "List of payment methods configured for this checkout.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "is_active": {
+                            "type": "boolean",
+                            "description": "Whether the method is offered in the checkout.",
+                            "example": true
+                          },
+                          "payment_method_type": {
+                            "type": "string",
+                            "description": "Payment method type (e.g. CARD, GOOGLE_PAY, APPLE_PAY, PAYPAL).",
+                            "example": "CARD"
+                          },
+                          "order_to_show": {
+                            "type": "integer",
+                            "description": "Display order. Lower = shown first. This field drives order, not the array position.",
+                            "example": 1
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "PAYMENT_METHOD (standard) or ENROLLMENT (tokenization/saved-credentials flow).",
+                            "enum": ["PAYMENT_METHOD", "ENROLLMENT"],
+                            "example": "PAYMENT_METHOD"
+                          },
+                          "active_enrollment_type": {
+                            "type": "string",
+                            "description": "For methods that support both flows (e.g. CARD): BOTH, NONE, ENROLLMENT, or NO_ENROLLMENT. Only applicable when type is PAYMENT_METHOD.",
+                            "enum": ["BOTH", "NONE", "ENROLLMENT", "NO_ENROLLMENT"],
+                            "example": "BOTH",
+                            "nullable": true
+                          },
+                          "conditions_to_override": {
+                            "type": "array",
+                            "description": "Condition sets that gate when the method appears. The method is shown if any set matches (sets are OR'd; conditions within a set are AND'd).",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "required_fields_to_override": {
+                            "type": "object",
+                            "description": "Per-field configuration for enrolled and non-enrolled flows.",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    },
+                    "general_settings": {
+                      "type": "object",
+                      "description": "General checkout settings.",
+                      "properties": {
+                        "country_documents": {
+                          "type": "array",
+                          "description": "Accepted document types per country.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "country_code": {
+                                "type": "string",
+                                "description": "ISO 3166-1 alpha-2 country code.",
+                                "example": "AR"
+                              },
+                              "documents": {
+                                "type": "array",
+                                "description": "List of accepted document types for this country.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "example": ["DNI", "CUIT"]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "feature_flags": {
+                      "type": "object",
+                      "description": "Feature flags enabled for this checkout.",
+                      "properties": {
+                        "custom_required_fields": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "custom_logo_icon": {
+                          "type": "boolean",
+                          "example": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": ["Invalid credentials"]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_CREDENTIALS" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "code": "AUTHORIZATION_REQUIRED",
+                      "messages": ["The merchant has no authorization to use this API."]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "AUTHORIZATION_REQUIRED" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/checkout-builder/fetch-styling-settings.json
+++ b/openapi/checkout-builder/fetch-styling-settings.json
@@ -350,11 +350,5 @@
         "deprecated": false
       }
     }
-  },
-  "x-readme": {
-    "headers": [{ "value": "utf-8", "key": "charset" }],
-    "explorer-enabled": true,
-    "proxy-enabled": true
-  },
-  "x-readme-fauxas": true
+  }
 }

--- a/openapi/checkout-builder/fetch-styling-settings.json
+++ b/openapi/checkout-builder/fetch-styling-settings.json
@@ -1,0 +1,360 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://prod.y.uno/dashboard-bff/api"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "JWT issued by Yuno's auth provider. Tokens are short-lived — refresh before expiry."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-account-code",
+        "x-default": "<Your account UUID>"
+      },
+      "environment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-environment",
+        "x-default": "live"
+      },
+      "orgCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-organization-code",
+        "x-default": ""
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "accountCode": [],
+      "environment": [],
+      "orgCode": []
+    }
+  ],
+  "paths": {
+    "/v1/checkouts/builder/settings": {
+      "get": {
+        "summary": "Fetch Styling & SDK Settings",
+        "description": "Returns the full styling and SDK configuration — colors, fonts, button shapes, SDK render mode, payment-method-list layout, dark mode, Payment Link branding, and the available font catalog.",
+        "operationId": "get-builder-settings",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Success": {
+                    "value": {
+                      "styles": {
+                        "global": {
+                          "accent_color": "#282A30",
+                          "primary_background_color": "#FFFFFF",
+                          "primary_text_color": "#282A30",
+                          "primary_button_text_color": "#FFFFFF",
+                          "secondary_background_color": "#ECEFF2",
+                          "secondary_text_color": "#84807F",
+                          "secondary_button_background_color": "#FFFFFF",
+                          "secondary_button_text_color": "#282A30",
+                          "font_family": "Inter"
+                        },
+                        "header": {
+                          "logo_border_size": 0,
+                          "logo_border_color": "#282A30",
+                          "logo_corner_radius": 8,
+                          "font_size": 18,
+                          "font_weight": 700
+                        },
+                        "button": {
+                          "corner_radius": 8,
+                          "border_size": 0,
+                          "primary_border_color": "#282A30",
+                          "secondary_border_color": "#282A30",
+                          "font_size": 18,
+                          "font_weight": 400
+                        }
+                      },
+                      "settings": {
+                        "card": {
+                          "credit_card_only_processing": false,
+                          "default_network": "DOM",
+                          "enable_ocr": false,
+                          "enable_payment_retry": null,
+                          "save_on_success": false,
+                          "visualization_mode": "ONE_STEP"
+                        },
+                        "sdk_type": { "web": "SEAMLESS", "mobile": "SEAMLESS" },
+                        "web_sdk": { "render_mode": "MODAL", "hide_pay_button": true },
+                        "payment_method_list": {
+                          "unfolded_display": true,
+                          "condensed_checkout_view": false,
+                          "preselected_payment_method": false,
+                          "edit_payment_method_list": false,
+                          "blik_unfolded_display": null,
+                          "moon_active_experience": null
+                        },
+                        "payment_link": { "show_result_screen": false },
+                        "ui": { "dark_mode": false, "show_secure_payment_tag": true }
+                      },
+                      "payment_link_styles": {
+                        "panel": { "left": { "logo": null, "background": { "color": "#ECEFF2" } } },
+                        "checkbox": { "color": "#282A30" },
+                        "border": { "color": "#282A30" },
+                        "radio_button": { "color": "#282A30" },
+                        "button": { "background": { "color": "#282A30" }, "text": { "color": "#FFFFFF" } }
+                      },
+                      "flags": { "force_default_styles": false },
+                      "external_fonts": [
+                        {
+                          "family_name": "Inter",
+                          "files": [
+                            { "url": "https://prod.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-Regular.ttf", "weight": 400 },
+                            { "url": "https://prod.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-Medium.ttf", "weight": 500 },
+                            { "url": "https://prod.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-SemiBold.ttf", "weight": 600 },
+                            { "url": "https://prod.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-Bold.ttf", "weight": 700 }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "styles": {
+                      "type": "object",
+                      "description": "Visual styles for the checkout SDK.",
+                      "properties": {
+                        "global": {
+                          "type": "object",
+                          "description": "Global color and font settings applied to every screen.",
+                          "properties": {
+                            "accent_color": { "type": "string", "description": "Highlights, focus rings, active states, links.", "example": "#282A30" },
+                            "primary_background_color": { "type": "string", "description": "Main checkout surface background.", "example": "#FFFFFF" },
+                            "primary_text_color": { "type": "string", "description": "Body text, headings, input labels.", "example": "#282A30" },
+                            "primary_button_text_color": { "type": "string", "description": "Text inside the Pay button and primary actions.", "example": "#FFFFFF" },
+                            "secondary_background_color": { "type": "string", "description": "Cards, info panels, sub-sections.", "example": "#ECEFF2" },
+                            "secondary_text_color": { "type": "string", "description": "Captions, helper text, secondary labels.", "example": "#84807F" },
+                            "secondary_button_background_color": { "type": "string", "description": "Background of secondary buttons.", "example": "#FFFFFF" },
+                            "secondary_button_text_color": { "type": "string", "description": "Text inside secondary buttons.", "example": "#282A30" },
+                            "font_family": { "type": "string", "description": "Font name. Must match a family_name in external_fonts.", "example": "Inter" }
+                          }
+                        },
+                        "header": {
+                          "type": "object",
+                          "description": "Header band styles (where the merchant logo sits).",
+                          "properties": {
+                            "logo_border_size": { "type": "number", "description": "Width (px) of the border around the logo.", "example": 0 },
+                            "logo_border_color": { "type": "string", "description": "Color of the logo border.", "example": "#282A30" },
+                            "logo_corner_radius": { "type": "number", "description": "Corner-radius (px) of the logo container.", "example": 8 },
+                            "font_size": { "type": "number", "description": "Header title text size (px).", "example": 18 },
+                            "font_weight": { "type": "number", "description": "Header title weight. Use multiples of 100 (100–900).", "example": 700 }
+                          }
+                        },
+                        "button": {
+                          "type": "object",
+                          "description": "Styles applied to all SDK buttons.",
+                          "properties": {
+                            "corner_radius": { "type": "number", "description": "Border-radius (px) for all buttons.", "example": 8 },
+                            "border_size": { "type": "number", "description": "Border width (px) on all buttons.", "example": 0 },
+                            "primary_border_color": { "type": "string", "description": "Border color for primary buttons.", "example": "#282A30" },
+                            "secondary_border_color": { "type": "string", "description": "Border color for secondary buttons.", "example": "#282A30" },
+                            "font_size": { "type": "number", "description": "Button text size (px).", "example": 18 },
+                            "font_weight": { "type": "number", "description": "Button text weight.", "example": 400 }
+                          }
+                        }
+                      }
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "SDK behavior and UI options.",
+                      "properties": {
+                        "card": {
+                          "type": "object",
+                          "description": "Card-payment-specific behavior.",
+                          "properties": {
+                            "credit_card_only_processing": { "type": "boolean", "description": "Block debit cards — only credit-card transactions accepted.", "example": false },
+                            "default_network": { "type": "string", "description": "Preferred routing network for dual-network cards.", "example": "DOM" },
+                            "enable_ocr": { "type": "boolean", "description": "Enable card-number OCR scan on mobile. Ignored on web.", "example": false },
+                            "enable_payment_retry": { "type": "boolean", "nullable": true, "description": "Auto-retry for failed transactions. null inherits BFF default.", "example": null },
+                            "save_on_success": { "type": "boolean", "description": "Offer/perform save-card after a successful payment.", "example": false },
+                            "visualization_mode": { "type": "string", "description": "ONE_STEP (single screen) or STEP_BY_STEP (wizard).", "enum": ["ONE_STEP", "STEP_BY_STEP"], "example": "ONE_STEP" }
+                          }
+                        },
+                        "sdk_type": {
+                          "type": "object",
+                          "description": "Top-level SDK rendering type — independent for web and mobile.",
+                          "properties": {
+                            "web": { "type": "string", "description": "SEAMLESS (embedded in your page) or FULL (Yuno-hosted full-page checkout).", "enum": ["SEAMLESS", "FULL"], "example": "SEAMLESS" },
+                            "mobile": { "type": "string", "description": "SEAMLESS (embedded in your app) or FULL (Yuno-presented native checkout).", "enum": ["SEAMLESS", "FULL"], "example": "SEAMLESS" }
+                          }
+                        },
+                        "web_sdk": {
+                          "type": "object",
+                          "description": "Web-SDK-only options. Ignored on mobile.",
+                          "properties": {
+                            "render_mode": { "type": "string", "description": "MODAL (overlay) or RENDER (inline into a DOM container).", "enum": ["MODAL", "RENDER"], "example": "MODAL" },
+                            "hide_pay_button": { "type": "boolean", "description": "If true, the SDK's Pay button is hidden — your page must call .pay() directly.", "example": true }
+                          }
+                        },
+                        "payment_method_list": {
+                          "type": "object",
+                          "description": "Controls the payment-method picker.",
+                          "properties": {
+                            "unfolded_display": { "type": "boolean", "description": "Render the first method expanded (form visible) instead of collapsed.", "example": true },
+                            "condensed_checkout_view": { "type": "boolean", "description": "Compact list layout — smaller logos, tighter spacing.", "example": false },
+                            "preselected_payment_method": { "type": "boolean", "description": "Auto-select the first available method on load.", "example": false },
+                            "edit_payment_method_list": { "type": "boolean", "description": "Allow customers to add/remove saved methods from the picker.", "example": false },
+                            "blik_unfolded_display": { "type": "boolean", "nullable": true, "description": "BLIK-specific override of unfolded_display. null to inherit.", "example": null },
+                            "moon_active_experience": { "type": "boolean", "nullable": true, "description": "Moon-Active-specific UI variant. Leave null unless explicitly enabled.", "example": null }
+                          }
+                        },
+                        "payment_link": {
+                          "type": "object",
+                          "description": "Behavior of the hosted Payment Link page.",
+                          "properties": {
+                            "show_result_screen": { "type": "boolean", "description": "Show a Yuno-hosted result screen after payment before any merchant redirect.", "example": false }
+                          }
+                        },
+                        "ui": {
+                          "type": "object",
+                          "description": "Top-level UI toggles.",
+                          "properties": {
+                            "dark_mode": { "type": "boolean", "description": "Use the SDK's dark theme. When enabled, custom styles are suppressed.", "example": false },
+                            "show_secure_payment_tag": { "type": "boolean", "description": "Show the Secured by Yuno footer tag.", "example": true }
+                          }
+                        }
+                      }
+                    },
+                    "payment_link_styles": {
+                      "type": "object",
+                      "description": "Visual styles for the hosted Payment Link page. Independent from styles — does not inherit from it.",
+                      "properties": {
+                        "panel": {
+                          "type": "object",
+                          "properties": {
+                            "left": {
+                              "type": "object",
+                              "properties": {
+                                "logo": { "type": "string", "nullable": true, "description": "Merchant logo for the left panel. HTTPS URL or base64 data: URI. null = no logo." },
+                                "background": {
+                                  "type": "object",
+                                  "properties": {
+                                    "color": { "type": "string", "description": "Left panel background color.", "example": "#ECEFF2" }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "checkbox": { "type": "object", "properties": { "color": { "type": "string", "description": "Checkbox active color.", "example": "#282A30" } } },
+                        "border": { "type": "object", "properties": { "color": { "type": "string", "description": "Input and divider border color.", "example": "#282A30" } } },
+                        "radio_button": { "type": "object", "properties": { "color": { "type": "string", "description": "Radio button active color.", "example": "#282A30" } } },
+                        "button": {
+                          "type": "object",
+                          "properties": {
+                            "background": { "type": "object", "properties": { "color": { "type": "string", "description": "Primary action button background.", "example": "#282A30" } } },
+                            "text": { "type": "object", "properties": { "color": { "type": "string", "description": "Primary action button text color.", "example": "#FFFFFF" } } }
+                          }
+                        }
+                      }
+                    },
+                    "flags": {
+                      "type": "object",
+                      "description": "Feature flags.",
+                      "properties": {
+                        "force_default_styles": {
+                          "type": "boolean",
+                          "description": "If true, custom styles are bypassed and the SDK renders with built-in defaults. Stored styles are preserved — set back to false to restore them.",
+                          "example": false
+                        }
+                      }
+                    },
+                    "external_fonts": {
+                      "type": "array",
+                      "description": "Font families available to the SDK. The default catalog includes 18 Yuno-hosted families.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "family_name": { "type": "string", "description": "Font family name. Must match exactly when used in styles.global.font_family.", "example": "Inter" },
+                          "files": {
+                            "type": "array",
+                            "description": "One entry per font weight.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "url": { "type": "string", "description": "HTTPS URL to the .ttf font file.", "example": "https://prod.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-Regular.ttf" },
+                                "weight": { "type": "integer", "description": "CSS font-weight (100–900).", "example": 400 }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": { "code": "INVALID_CREDENTIALS", "messages": ["Invalid credentials"] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_CREDENTIALS" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": { "code": "AUTHORIZATION_REQUIRED", "messages": ["The merchant has no authorization to use this API."] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "AUTHORIZATION_REQUIRED" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/checkout-builder/get-country-data.json
+++ b/openapi/checkout-builder/get-country-data.json
@@ -131,11 +131,5 @@
         "deprecated": false
       }
     }
-  },
-  "x-readme": {
-    "headers": [{ "value": "utf-8", "key": "charset" }],
-    "explorer-enabled": true,
-    "proxy-enabled": true
-  },
-  "x-readme-fauxas": true
+  }
 }

--- a/openapi/checkout-builder/get-country-data.json
+++ b/openapi/checkout-builder/get-country-data.json
@@ -1,0 +1,141 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://prod.y.uno/dashboard-bff/api"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "JWT issued by Yuno's auth provider. Tokens are short-lived — refresh before expiry."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-account-code",
+        "x-default": "<Your account UUID>"
+      },
+      "environment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-environment",
+        "x-default": "live"
+      },
+      "orgCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-organization-code",
+        "x-default": ""
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "accountCode": [],
+      "environment": [],
+      "orgCode": []
+    }
+  ],
+  "paths": {
+    "/checkouts/country-data": {
+      "get": {
+        "summary": "Get Country Data",
+        "description": "Returns supported countries and their accepted document types. Use this to build the general_settings.country_documents array when publishing a checkout configuration.",
+        "operationId": "get-country-data",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Success": {
+                    "value": [
+                      { "country_code": "AR", "documents": ["DNI", "CUIT", "CUIL", "CDI", "LE", "LC", "CI", "PASSPORT", "OTHER"] },
+                      { "country_code": "BR", "documents": ["CPF", "CNPJ"] },
+                      { "country_code": "CO", "documents": ["CC", "NIT", "CE", "PASSPORT", "OTHER"] },
+                      { "country_code": "MX", "documents": ["RFC", "CURP", "IFE", "PASSPORT", "OTHER"] },
+                      { "country_code": "PE", "documents": ["DNI", "RUC", "CE", "PASSPORT", "OTHER"] }
+                    ]
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "description": "List of supported countries with their accepted document types.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "country_code": {
+                        "type": "string",
+                        "description": "ISO 3166-1 alpha-2 country code.",
+                        "example": "AR"
+                      },
+                      "documents": {
+                        "type": "array",
+                        "description": "List of accepted document type identifiers for this country.",
+                        "items": { "type": "string" },
+                        "example": ["DNI", "CUIT"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": { "code": "INVALID_CREDENTIALS", "messages": ["Invalid credentials"] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_CREDENTIALS" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": { "code": "AUTHORIZATION_REQUIRED", "messages": ["The merchant has no authorization to use this API."] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "AUTHORIZATION_REQUIRED" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/checkout-builder/get-required-fields.json
+++ b/openapi/checkout-builder/get-required-fields.json
@@ -162,11 +162,5 @@
         "deprecated": false
       }
     }
-  },
-  "x-readme": {
-    "headers": [{ "value": "utf-8", "key": "charset" }],
-    "explorer-enabled": true,
-    "proxy-enabled": true
-  },
-  "x-readme-fauxas": true
+  }
 }

--- a/openapi/checkout-builder/get-required-fields.json
+++ b/openapi/checkout-builder/get-required-fields.json
@@ -1,0 +1,172 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://prod.y.uno/dashboard-bff/api"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "JWT issued by Yuno's auth provider. Tokens are short-lived — refresh before expiry."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-account-code",
+        "x-default": "<Your account UUID>"
+      },
+      "environment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-environment",
+        "x-default": "live"
+      },
+      "orgCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-organization-code",
+        "x-default": ""
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "accountCode": [],
+      "environment": [],
+      "orgCode": []
+    }
+  ],
+  "paths": {
+    "/checkouts/payment-methods/{paymentMethodType}/required-fields": {
+      "get": {
+        "summary": "Get Required Fields",
+        "description": "Returns the set of configurable required fields for a given payment method and flow type. Use this before building a required_fields_to_override payload to ensure you reference valid field names.",
+        "operationId": "get-required-fields",
+        "parameters": [
+          {
+            "name": "paymentMethodType",
+            "in": "path",
+            "description": "The payment method type (e.g. CARD, GOOGLE_PAY, APPLE_PAY).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The flow to query: ENROLLMENT for the saved-card flow, or PAYMENT_METHOD for the first-time entry flow.",
+            "schema": {
+              "type": "string",
+              "enum": ["ENROLLMENT", "PAYMENT_METHOD"]
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "CARD enrollment fields": {
+                    "value": [
+                      { "field_name": "security_code", "is_active": true, "current_value": null },
+                      { "field_name": "installment",   "is_active": true, "current_value": null },
+                      { "field_name": "first_name",    "is_active": true, "current_value": null },
+                      { "field_name": "last_name",     "is_active": true, "current_value": null },
+                      { "field_name": "document",      "is_active": true, "current_value": null },
+                      { "field_name": "email",         "is_active": true, "current_value": null },
+                      { "field_name": "phone",         "is_active": true, "current_value": null },
+                      { "field_name": "billing_address",  "is_active": true, "current_value": null },
+                      { "field_name": "shipping_address", "is_active": true, "current_value": null },
+                      { "field_name": "zip_code",      "is_active": false, "current_value": null }
+                    ]
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "description": "List of configurable required fields for this payment method and flow.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "field_name": {
+                        "type": "string",
+                        "description": "Field identifier used in required_fields_to_override. Common values for CARD: security_code, installment, first_name, last_name, document, email, phone, billing_address, shipping_address, zip_code.",
+                        "example": "security_code"
+                      },
+                      "is_active": {
+                        "type": "boolean",
+                        "description": "Default active state for this field.",
+                        "example": true
+                      },
+                      "current_value": {
+                        "type": "string",
+                        "description": "Default value override. For security_code, FIRST_TIME means CVV is only required on first use.",
+                        "nullable": true,
+                        "example": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": { "code": "INVALID_CREDENTIALS", "messages": ["Invalid credentials"] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_CREDENTIALS" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": { "code": "AUTHORIZATION_REQUIRED", "messages": ["The merchant has no authorization to use this API."] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "AUTHORIZATION_REQUIRED" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/checkout-builder/publish-checkout-configuration.json
+++ b/openapi/checkout-builder/publish-checkout-configuration.json
@@ -413,11 +413,5 @@
         "deprecated": false
       }
     }
-  },
-  "x-readme": {
-    "headers": [{ "value": "utf-8", "key": "charset" }],
-    "explorer-enabled": true,
-    "proxy-enabled": true
-  },
-  "x-readme-fauxas": true
+  }
 }

--- a/openapi/checkout-builder/publish-checkout-configuration.json
+++ b/openapi/checkout-builder/publish-checkout-configuration.json
@@ -1,0 +1,423 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://prod.y.uno/dashboard-bff/api"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "JWT issued by Yuno's auth provider. Tokens are short-lived — refresh before expiry."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-account-code",
+        "x-default": "<Your account UUID>"
+      },
+      "environment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-environment",
+        "x-default": "live"
+      },
+      "orgCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-organization-code",
+        "x-default": ""
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "accountCode": [],
+      "environment": [],
+      "orgCode": []
+    }
+  ],
+  "paths": {
+    "/checkouts/publish": {
+      "patch": {
+        "summary": "Publish Checkout Configuration",
+        "description": "Replaces the checkout's full payment method configuration. This is a full replace — always send every method you want present. Changes take effect immediately on the live checkout.",
+        "operationId": "patch-checkout-publish",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["checkoutCode", "paymentMethods"],
+                "properties": {
+                  "checkoutCode": {
+                    "type": "string",
+                    "description": "The UUID of the checkout to update.",
+                    "example": "8005ca91-dcfb-4428-b9f6-49c6e3446474"
+                  },
+                  "paymentMethods": {
+                    "type": "array",
+                    "description": "Full list of payment methods for this checkout. This is a full replace — omitting a method may remove it.",
+                    "items": {
+                      "type": "object",
+                      "required": ["is_active", "payment_method_type", "order_to_show", "type"],
+                      "properties": {
+                        "is_active": {
+                          "type": "boolean",
+                          "description": "Whether the method is offered in the checkout.",
+                          "example": true
+                        },
+                        "payment_method_type": {
+                          "type": "string",
+                          "description": "Payment method type. Common values: CARD, GOOGLE_PAY, APPLE_PAY, PAYPAL, PAYPAL_ENROLLMENT, NU_PAY, NU_PAY_ENROLLMENT, WALLET, MODO, DLOCAL_CHECKOUT, PUNTO_PAGO.",
+                          "example": "CARD"
+                        },
+                        "order_to_show": {
+                          "type": "integer",
+                          "description": "Display order in the checkout. Lower = shown first. This field drives order, not array position.",
+                          "example": 1
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "PAYMENT_METHOD (standard) or ENROLLMENT (tokenization/saved-credentials flow).",
+                          "enum": ["PAYMENT_METHOD", "ENROLLMENT"],
+                          "example": "PAYMENT_METHOD"
+                        },
+                        "active_enrollment_type": {
+                          "type": "string",
+                          "description": "For PAYMENT_METHOD entries that support enrollment (e.g. CARD): BOTH, NONE, ENROLLMENT, or NO_ENROLLMENT. Omit for ENROLLMENT-type entries.",
+                          "enum": ["BOTH", "NONE", "ENROLLMENT", "NO_ENROLLMENT"],
+                          "example": "BOTH"
+                        },
+                        "conditions_to_override": {
+                          "type": "array",
+                          "description": "Condition sets that gate when the method appears. The method is shown if any set matches (sets are OR'd; conditions within a set are AND'd).",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Display name for the condition set.",
+                                "example": "Argentina small amounts"
+                              },
+                              "order": {
+                                "type": "integer",
+                                "description": "Sort order among sets.",
+                                "example": 0
+                              },
+                              "is_active": {
+                                "type": "boolean",
+                                "description": "Whether this set is enforced. Inactive sets are saved but not evaluated.",
+                                "example": true
+                              },
+                              "payment_method_data": {
+                                "type": "object",
+                                "description": "Optional display overrides for this condition. Set all fields to null if unused.",
+                                "properties": {
+                                  "logo": { "type": "string", "nullable": true },
+                                  "name": { "type": "string", "nullable": true },
+                                  "description": { "type": "string", "nullable": true }
+                                }
+                              },
+                              "conditions": {
+                                "type": "array",
+                                "description": "Array of individual conditions (all must match for the set to apply).",
+                                "items": {
+                                  "type": "object",
+                                  "required": ["condition_type", "conditional", "values"],
+                                  "properties": {
+                                    "condition_type": {
+                                      "type": "string",
+                                      "description": "Type of condition to evaluate.",
+                                      "enum": ["CURRENCY", "CURRENCY_AND_AMOUNT", "COUNTRY", "METADATA", "ADDITIONAL_FIELD", "CARD_BIN", "CARD_ISSUER", "TIME_PERIOD"],
+                                      "example": "COUNTRY"
+                                    },
+                                    "conditional": {
+                                      "type": "string",
+                                      "description": "Comparison operator.",
+                                      "enum": ["ONE_OF", "NOT_ONE_OF", "EQUAL", "NOT_EQUAL", "BETWEEN", "GREATER_THAN", "LESS_THAN"],
+                                      "example": "ONE_OF"
+                                    },
+                                    "values": {
+                                      "type": "array",
+                                      "description": "Array of string values to compare against. For BETWEEN, exactly [min, max].",
+                                      "items": { "type": "string" },
+                                      "example": ["AR", "BR"]
+                                    },
+                                    "metadata_key": {
+                                      "type": "string",
+                                      "description": "Required when condition_type is METADATA. The key in the payment metadata to compare.",
+                                      "example": "hideCVVfield"
+                                    },
+                                    "additional_field_name": {
+                                      "type": "string",
+                                      "description": "Required when condition_type is METADATA. Data type of the metadata field.",
+                                      "example": "TEXT"
+                                    },
+                                    "complex_name": {
+                                      "type": "string",
+                                      "description": "Required when condition_type is CURRENCY_AND_AMOUNT. CURRENCY or AMOUNT.",
+                                      "enum": ["CURRENCY", "AMOUNT"],
+                                      "example": "CURRENCY"
+                                    },
+                                    "complex_index": {
+                                      "type": "integer",
+                                      "description": "Required when condition_type is CURRENCY_AND_AMOUNT. Both rows of the same currency+amount tuple share the same index.",
+                                      "example": 0
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "required_fields_to_override": {
+                          "type": "object",
+                          "description": "Per-field configuration for the enrolled and non-enrolled flows. Use GET /checkouts/payment-methods/{type}/required-fields to discover valid field names.",
+                          "properties": {
+                            "is_active": {
+                              "type": "boolean",
+                              "description": "Whether required-field overrides are active for the non-enrolled flow.",
+                              "example": true
+                            },
+                            "is_enrollment_active": {
+                              "type": "boolean",
+                              "description": "Whether required-field overrides are active for the enrolled flow.",
+                              "example": true
+                            },
+                            "fields": {
+                              "type": "array",
+                              "description": "Field configs for the non-enrolled (first-time payer) flow. Pass an empty array to leave this flow unchanged.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "field_name": {
+                                    "type": "string",
+                                    "description": "The field to configure. Common values: security_code, installment, first_name, last_name, document, email, phone, billing_address, shipping_address, zip_code.",
+                                    "example": "security_code"
+                                  },
+                                  "is_active": {
+                                    "type": "boolean",
+                                    "description": "Whether this field is shown.",
+                                    "example": true
+                                  },
+                                  "current_value": {
+                                    "type": "string",
+                                    "description": "Special value override. For security_code, use FIRST_TIME to only require CVV on first use.",
+                                    "nullable": true,
+                                    "example": "FIRST_TIME"
+                                  },
+                                  "conditions_to_override": {
+                                    "type": "array",
+                                    "description": "Per-field condition sets. Note: conditions here use condition_value (not values) on each condition object.",
+                                    "items": { "type": "object" }
+                                  }
+                                }
+                              }
+                            },
+                            "enrollment_fields": {
+                              "type": "array",
+                              "description": "Field configs for the enrolled (returning payer / saved-card) flow. Pass an empty array to leave this flow unchanged.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "field_name": {
+                                    "type": "string",
+                                    "description": "The field to configure.",
+                                    "example": "installment"
+                                  },
+                                  "is_active": {
+                                    "type": "boolean",
+                                    "description": "Whether this field is shown.",
+                                    "example": true
+                                  },
+                                  "current_value": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "example": null
+                                  },
+                                  "conditions_to_override": {
+                                    "type": "array",
+                                    "description": "Per-field condition sets. Each condition uses condition_value (not values).",
+                                    "items": { "type": "object" }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "general_settings": {
+                    "type": "object",
+                    "description": "General checkout settings.",
+                    "properties": {
+                      "country_documents": {
+                        "type": "array",
+                        "description": "Accepted document types per country. Use GET /checkouts/country-data to fetch valid values.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "country_code": {
+                              "type": "string",
+                              "description": "ISO 3166-1 alpha-2 country code.",
+                              "example": "AR"
+                            },
+                            "documents": {
+                              "type": "array",
+                              "items": { "type": "string" },
+                              "example": ["DNI", "CUIT"]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "Disable CARD": {
+                  "summary": "Disable a payment method",
+                  "value": {
+                    "checkoutCode": "8005ca91-dcfb-4428-b9f6-49c6e3446474",
+                    "paymentMethods": [
+                      { "is_active": false, "payment_method_type": "NU_PAY_ENROLLMENT", "order_to_show": 1, "type": "ENROLLMENT" },
+                      { "is_active": true,  "payment_method_type": "PAYPAL_ENROLLMENT",  "order_to_show": 2, "type": "ENROLLMENT" },
+                      { "is_active": false, "payment_method_type": "CARD",               "order_to_show": 3, "type": "PAYMENT_METHOD", "active_enrollment_type": "NONE" },
+                      { "is_active": true,  "payment_method_type": "GOOGLE_PAY",         "order_to_show": 4, "type": "PAYMENT_METHOD" },
+                      { "is_active": true,  "payment_method_type": "APPLE_PAY",          "order_to_show": 5, "type": "PAYMENT_METHOD" }
+                    ]
+                  }
+                },
+                "Enable CARD with conditions": {
+                  "summary": "Enable CARD with condition sets",
+                  "value": {
+                    "checkoutCode": "8005ca91-dcfb-4428-b9f6-49c6e3446474",
+                    "paymentMethods": [
+                      {
+                        "is_active": true,
+                        "payment_method_type": "CARD",
+                        "order_to_show": 1,
+                        "type": "PAYMENT_METHOD",
+                        "active_enrollment_type": "BOTH",
+                        "conditions_to_override": [
+                          {
+                            "name": "AR small amounts",
+                            "order": 0,
+                            "is_active": true,
+                            "payment_method_data": { "logo": null, "name": null, "description": null },
+                            "conditions": [
+                              { "condition_type": "CURRENCY_AND_AMOUNT", "conditional": "ONE_OF",  "values": ["ARS"], "complex_name": "CURRENCY", "complex_index": 0 },
+                              { "condition_type": "CURRENCY_AND_AMOUNT", "conditional": "BETWEEN", "values": ["4.00","6.00"], "complex_name": "AMOUNT", "complex_index": 0 },
+                              { "condition_type": "COUNTRY", "conditional": "ONE_OF", "values": ["AR"] }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Success": {
+                    "value": {
+                      "code": "8005ca91-dcfb-4428-b9f6-49c6e3446474",
+                      "updated_at": "2026-05-18T14:00:00Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "description": "Checkout UUID.", "example": "8005ca91-dcfb-4428-b9f6-49c6e3446474" },
+                    "updated_at": { "type": "string", "description": "Timestamp of the update.", "example": "2026-05-18T14:00:00Z" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Bad Request": {
+                    "value": { "code": "INVALID_REQUEST", "messages": ["Invalid request"] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_REQUEST" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": { "code": "INVALID_CREDENTIALS", "messages": ["Invalid credentials"] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_CREDENTIALS" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": { "code": "AUTHORIZATION_REQUIRED", "messages": ["The merchant has no authorization to use this API."] }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "AUTHORIZATION_REQUIRED" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/checkout-builder/update-styling-settings.json
+++ b/openapi/checkout-builder/update-styling-settings.json
@@ -1,0 +1,378 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://prod.y.uno/dashboard-bff/api"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "JWT issued by Yuno's auth provider. Tokens are short-lived — refresh before expiry."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-account-code",
+        "x-default": "<Your account UUID>"
+      },
+      "environment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-environment",
+        "x-default": "live"
+      },
+      "orgCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-organization-code",
+        "x-default": ""
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "accountCode": [],
+      "environment": [],
+      "orgCode": []
+    }
+  ],
+  "paths": {
+    "/v1/checkouts/builder/settings": {
+      "patch": {
+        "summary": "Update Styling & SDK Settings",
+        "description": "Updates styling and SDK configuration. The BFF deep-merges what you send with the existing config — only include the sections you want to change. Changes take effect immediately; there is no separate publish step.",
+        "operationId": "patch-builder-settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "styles": {
+                    "type": "object",
+                    "description": "Visual styles for the checkout SDK. Send {} to leave unchanged.",
+                    "properties": {
+                      "global": {
+                        "type": "object",
+                        "description": "Global color and font settings applied to every screen.",
+                        "properties": {
+                          "accent_color": { "type": "string", "description": "Highlights, focus rings, active states, links. 6-char hex.", "example": "#282A30" },
+                          "primary_background_color": { "type": "string", "description": "Main checkout surface background.", "example": "#FFFFFF" },
+                          "primary_text_color": { "type": "string", "description": "Body text, headings, input labels.", "example": "#282A30" },
+                          "primary_button_text_color": { "type": "string", "description": "Text inside the Pay button and primary actions.", "example": "#FFFFFF" },
+                          "secondary_background_color": { "type": "string", "description": "Cards, info panels, sub-sections.", "example": "#ECEFF2" },
+                          "secondary_text_color": { "type": "string", "description": "Captions, helper text, secondary labels.", "example": "#84807F" },
+                          "secondary_button_background_color": { "type": "string", "description": "Background of secondary buttons.", "example": "#FFFFFF" },
+                          "secondary_button_text_color": { "type": "string", "description": "Text inside secondary buttons.", "example": "#282A30" },
+                          "font_family": { "type": "string", "description": "Font name. Must match a family_name in external_fonts.", "example": "Inter" }
+                        }
+                      },
+                      "header": {
+                        "type": "object",
+                        "description": "Header band styles (where the merchant logo sits).",
+                        "properties": {
+                          "logo_border_size": { "type": "number", "description": "Width (px) of the border around the logo.", "example": 0 },
+                          "logo_border_color": { "type": "string", "description": "Color of the logo border.", "example": "#282A30" },
+                          "logo_corner_radius": { "type": "number", "description": "Corner-radius (px) of the logo container.", "example": 8 },
+                          "font_size": { "type": "number", "description": "Header title text size (px).", "example": 18 },
+                          "font_weight": { "type": "number", "description": "Header title weight. Use multiples of 100 (100–900).", "example": 700 }
+                        }
+                      },
+                      "button": {
+                        "type": "object",
+                        "description": "Styles applied to all SDK buttons.",
+                        "properties": {
+                          "corner_radius": { "type": "number", "description": "Border-radius (px) for all buttons.", "example": 8 },
+                          "border_size": { "type": "number", "description": "Border width (px) on all buttons.", "example": 0 },
+                          "primary_border_color": { "type": "string", "description": "Border color for primary buttons.", "example": "#282A30" },
+                          "secondary_border_color": { "type": "string", "description": "Border color for secondary buttons.", "example": "#282A30" },
+                          "font_size": { "type": "number", "description": "Button text size (px).", "example": 18 },
+                          "font_weight": { "type": "number", "description": "Button text weight.", "example": 400 }
+                        }
+                      }
+                    }
+                  },
+                  "settings": {
+                    "type": "object",
+                    "description": "SDK behavior and UI options. Send {} to leave unchanged.",
+                    "properties": {
+                      "card": {
+                        "type": "object",
+                        "description": "Card-payment-specific behavior.",
+                        "properties": {
+                          "credit_card_only_processing": { "type": "boolean", "description": "Block debit cards — only credit-card transactions accepted.", "example": false },
+                          "default_network": { "type": "string", "description": "Preferred routing network for dual-network cards.", "example": "DOM" },
+                          "enable_ocr": { "type": "boolean", "description": "Enable card-number OCR scan on mobile. Ignored on web.", "example": false },
+                          "enable_payment_retry": { "type": "boolean", "nullable": true, "description": "Auto-retry for failed transactions. null inherits BFF default.", "example": null },
+                          "save_on_success": { "type": "boolean", "description": "Offer/perform save-card after a successful payment.", "example": false },
+                          "visualization_mode": { "type": "string", "description": "ONE_STEP (single screen) or STEP_BY_STEP (wizard).", "enum": ["ONE_STEP", "STEP_BY_STEP"], "example": "ONE_STEP" }
+                        }
+                      },
+                      "sdk_type": {
+                        "type": "object",
+                        "description": "Top-level SDK rendering type — independent for web and mobile.",
+                        "properties": {
+                          "web": { "type": "string", "description": "SEAMLESS (embedded in your page) or FULL (Yuno-hosted full-page checkout).", "enum": ["SEAMLESS", "FULL"], "example": "SEAMLESS" },
+                          "mobile": { "type": "string", "description": "SEAMLESS (embedded in your app) or FULL (Yuno-presented native checkout).", "enum": ["SEAMLESS", "FULL"], "example": "SEAMLESS" }
+                        }
+                      },
+                      "web_sdk": {
+                        "type": "object",
+                        "description": "Web-SDK-only options. Ignored on mobile.",
+                        "properties": {
+                          "render_mode": { "type": "string", "description": "MODAL (overlay) or RENDER (inline into a DOM container).", "enum": ["MODAL", "RENDER"], "example": "MODAL" },
+                          "hide_pay_button": { "type": "boolean", "description": "If true, the SDK's Pay button is hidden — your page must call .pay() directly.", "example": true }
+                        }
+                      },
+                      "payment_method_list": {
+                        "type": "object",
+                        "description": "Controls the payment-method picker.",
+                        "properties": {
+                          "unfolded_display": { "type": "boolean", "description": "Render the first method expanded (form visible) instead of collapsed.", "example": true },
+                          "condensed_checkout_view": { "type": "boolean", "description": "Compact list layout — smaller logos, tighter spacing.", "example": false },
+                          "preselected_payment_method": { "type": "boolean", "description": "Auto-select the first available method on load.", "example": false },
+                          "edit_payment_method_list": { "type": "boolean", "description": "Allow customers to add/remove saved methods from the picker.", "example": false },
+                          "blik_unfolded_display": { "type": "boolean", "nullable": true, "description": "BLIK-specific override of unfolded_display. null to inherit.", "example": null },
+                          "moon_active_experience": { "type": "boolean", "nullable": true, "description": "Moon-Active-specific UI variant. Leave null unless explicitly enabled.", "example": null }
+                        }
+                      },
+                      "payment_link": {
+                        "type": "object",
+                        "description": "Behavior of the hosted Payment Link page.",
+                        "properties": {
+                          "show_result_screen": { "type": "boolean", "description": "Show a Yuno-hosted result screen after payment before any merchant redirect.", "example": false }
+                        }
+                      },
+                      "ui": {
+                        "type": "object",
+                        "description": "Top-level UI toggles.",
+                        "properties": {
+                          "dark_mode": { "type": "boolean", "description": "Use the SDK's dark theme. When enabled, custom styles are suppressed.", "example": false },
+                          "show_secure_payment_tag": { "type": "boolean", "description": "Show the Secured by Yuno footer tag.", "example": true }
+                        }
+                      },
+                      "click_to_pay": { "type": "object", "nullable": true, "description": "Click-to-Pay (EMVCo) integration options. Confirm shape with Yuno BFF team." },
+                      "form": { "type": "object", "nullable": true, "description": "Form-field collection / validation overrides. Confirm shape with Yuno BFF team." },
+                      "google_pay": { "type": "object", "nullable": true, "description": "Google Pay-specific config. Confirm shape with Yuno BFF team." },
+                      "urls": { "type": "object", "nullable": true, "description": "Custom redirect URLs (success / failure / cancel). Confirm shape with Yuno BFF team." }
+                    }
+                  },
+                  "payment_link_styles": {
+                    "type": "object",
+                    "description": "Visual styles for the hosted Payment Link page. Independent from styles — does not inherit from it.",
+                    "properties": {
+                      "panel": {
+                        "type": "object",
+                        "properties": {
+                          "left": {
+                            "type": "object",
+                            "properties": {
+                              "logo": { "type": "string", "nullable": true, "description": "Merchant logo for the left panel. HTTPS URL or base64 data: URI. null = no logo." },
+                              "background": {
+                                "type": "object",
+                                "properties": {
+                                  "color": { "type": "string", "description": "Left panel background color.", "example": "#ECEFF2" }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "checkbox": {
+                        "type": "object",
+                        "properties": { "color": { "type": "string", "description": "Checkbox active color.", "example": "#282A30" } }
+                      },
+                      "border": {
+                        "type": "object",
+                        "properties": { "color": { "type": "string", "description": "Input and divider border color.", "example": "#282A30" } }
+                      },
+                      "radio_button": {
+                        "type": "object",
+                        "properties": { "color": { "type": "string", "description": "Radio button active color.", "example": "#282A30" } }
+                      },
+                      "button": {
+                        "type": "object",
+                        "properties": {
+                          "background": {
+                            "type": "object",
+                            "properties": { "color": { "type": "string", "description": "Primary action button background.", "example": "#282A30" } }
+                          },
+                          "text": {
+                            "type": "object",
+                            "properties": { "color": { "type": "string", "description": "Primary action button text color.", "example": "#FFFFFF" } }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "flags": {
+                    "type": "object",
+                    "description": "Feature flags.",
+                    "properties": {
+                      "force_default_styles": {
+                        "type": "boolean",
+                        "description": "If true, custom styles are bypassed and the SDK renders with built-in defaults. Stored styles are preserved — set back to false to restore them.",
+                        "example": false
+                      }
+                    }
+                  },
+                  "external_fonts": {
+                    "type": "array",
+                    "description": "Font families available to the SDK. Each family_name must match exactly when used in styles.global.font_family. Custom font URLs must be CORS-enabled.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "family_name": { "type": "string", "description": "Font family name.", "example": "Inter" },
+                        "files": {
+                          "type": "array",
+                          "description": "One entry per font weight.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "url": { "type": "string", "description": "HTTPS URL to the .ttf font file.", "example": "https://prod.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-Regular.ttf" },
+                              "weight": { "type": "integer", "description": "CSS font-weight (100–900).", "example": 400 }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "Change accent color": {
+                  "summary": "Change only the accent color",
+                  "value": {
+                    "styles": { "global": { "accent_color": "#1A73E8" } }
+                  }
+                },
+                "Enable dark mode": {
+                  "summary": "Turn dark mode on",
+                  "value": {
+                    "settings": { "ui": { "dark_mode": true } }
+                  }
+                },
+                "Reset to defaults": {
+                  "summary": "Reset styling and SDK settings to defaults",
+                  "value": {
+                    "styles": {
+                      "global": {
+                        "accent_color": "#282A30",
+                        "primary_background_color": "#FFFFFF",
+                        "primary_text_color": "#282A30",
+                        "primary_button_text_color": "#FFFFFF",
+                        "secondary_background_color": "#ECEFF2",
+                        "secondary_text_color": "#84807F",
+                        "secondary_button_background_color": "#FFFFFF",
+                        "secondary_button_text_color": "#282A30",
+                        "font_family": "Inter"
+                      },
+                      "header": { "logo_border_size": 0, "logo_border_color": "#282A30", "logo_corner_radius": 8, "font_size": 18, "font_weight": 700 },
+                      "button": { "corner_radius": 8, "border_size": 0, "primary_border_color": "#282A30", "secondary_border_color": "#282A30", "font_size": 18, "font_weight": 400 }
+                    },
+                    "settings": {
+                      "card": { "credit_card_only_processing": false, "default_network": "DOM", "enable_ocr": false, "enable_payment_retry": null, "save_on_success": false, "visualization_mode": "ONE_STEP" },
+                      "sdk_type": { "web": "SEAMLESS", "mobile": "SEAMLESS" },
+                      "web_sdk": { "render_mode": "MODAL", "hide_pay_button": true },
+                      "payment_method_list": { "unfolded_display": true, "condensed_checkout_view": false, "preselected_payment_method": false, "edit_payment_method_list": false, "blik_unfolded_display": null, "moon_active_experience": null },
+                      "payment_link": { "show_result_screen": false },
+                      "ui": { "dark_mode": false, "show_secure_payment_tag": true },
+                      "click_to_pay": null, "form": null, "google_pay": null, "urls": null
+                    },
+                    "flags": { "force_default_styles": false }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Success": {
+                    "value": { "updated_at": "2026-05-18T14:00:00Z" }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "updated_at": { "type": "string", "description": "Timestamp of the update.", "example": "2026-05-18T14:00:00Z" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Bad Request": { "value": { "code": "INVALID_REQUEST", "messages": ["Invalid request"] } }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_REQUEST" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": { "value": { "code": "INVALID_CREDENTIALS", "messages": ["Invalid credentials"] } }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_CREDENTIALS" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": { "value": { "code": "AUTHORIZATION_REQUIRED", "messages": ["The merchant has no authorization to use this API."] } }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "AUTHORIZATION_REQUIRED" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/checkout-builder/update-styling-settings.json
+++ b/openapi/checkout-builder/update-styling-settings.json
@@ -368,11 +368,5 @@
         "deprecated": false
       }
     }
-  },
-  "x-readme": {
-    "headers": [{ "value": "utf-8", "key": "charset" }],
-    "explorer-enabled": true,
-    "proxy-enabled": true
-  },
-  "x-readme-fauxas": true
+  }
 }

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Fetch Checkout Configuration"
 openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /checkouts/{checkoutCode}"
+hidden: true
 ---

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -1,0 +1,4 @@
+---
+title: "Fetch Checkout Configuration"
+openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /checkouts/{checkoutCode}"
+---

--- a/reference/checkout-builder/fetch-styling-settings.mdx
+++ b/reference/checkout-builder/fetch-styling-settings.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Fetch Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/fetch-styling-settings.json GET /v1/checkouts/builder/settings"
+hidden: true
 ---

--- a/reference/checkout-builder/fetch-styling-settings.mdx
+++ b/reference/checkout-builder/fetch-styling-settings.mdx
@@ -1,0 +1,4 @@
+---
+title: "Fetch Styling & SDK Settings"
+openapi: "/openapi/checkout-builder/fetch-styling-settings.json GET /v1/checkouts/builder/settings"
+---

--- a/reference/checkout-builder/get-country-data.mdx
+++ b/reference/checkout-builder/get-country-data.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Get Country Data"
 openapi: "/openapi/checkout-builder/get-country-data.json GET /checkouts/country-data"
+hidden: true
 ---

--- a/reference/checkout-builder/get-country-data.mdx
+++ b/reference/checkout-builder/get-country-data.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Country Data"
+openapi: "/openapi/checkout-builder/get-country-data.json GET /checkouts/country-data"
+---

--- a/reference/checkout-builder/get-required-fields.mdx
+++ b/reference/checkout-builder/get-required-fields.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Required Fields"
+openapi: "/openapi/checkout-builder/get-required-fields.json GET /checkouts/payment-methods/{paymentMethodType}/required-fields"
+---

--- a/reference/checkout-builder/get-required-fields.mdx
+++ b/reference/checkout-builder/get-required-fields.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Get Required Fields"
 openapi: "/openapi/checkout-builder/get-required-fields.json GET /checkouts/payment-methods/{paymentMethodType}/required-fields"
+hidden: true
 ---

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -26,11 +26,11 @@ Every request requires a short-lived JWT from Yuno's auth provider and the follo
 
 | Header | Required | Description |
 | --- | --- | --- |
-| `Authorization` | Yes | `Bearer <JWT>` — issued by Yuno's auth provider (WorkOS-backed). |
+| `Authorization` | Yes | `Bearer <JWT>` — issued by Yuno's auth provider. |
 | `x-account-code` | Yes | Account UUID — the merchant account scope for the request. |
 | `x-environment` | Yes | `live` or `sandbox`. Determines which environment is being configured. |
 | `x-organization-code` | Optional | Organization UUID. May be sent empty for single-org accounts. |
-| `Content-Type` | Yes (PATCH/POST) | `application/json` |
+| `Content-Type` | Yes (PATCH only) | `application/json` |
 | `Accept` | Recommended | `application/json` |
 
 <Warning>
@@ -40,7 +40,7 @@ Tokens are short-lived. Your client must refresh them before expiry; the API wil
 ## Key behaviors
 
 <Note>
-**`PATCH /checkouts/publish` is a full replace.** Always send the complete `paymentMethods` list. Omitting a method may remove it from the checkout configuration.
+**`PATCH /checkouts/publish` is a full replace.** Always send the complete `payment_methods` list. Omitting a method may remove it from the checkout configuration.
 </Note>
 
 - **Order is driven by `order_to_show`**, not by array position. Change the integer values to re-order; the API sorts ascending when rendering.

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -1,0 +1,48 @@
+---
+title: "Checkout Builder"
+description: "Programmatically configure your Yuno checkout — payment methods, conditions, required fields, and styling — via the same API the Checkout Builder UI uses."
+---
+
+The Checkout Builder Management API lets you read and update a merchant's checkout configuration programmatically. It is the same API the Checkout Builder UI in the Yuno dashboard uses internally — if a configuration is possible in the dashboard, it is possible via this API.
+
+## What you can configure
+
+- **Payment methods** — which methods are shown and in what display order
+- **Conditions** — per-method rules (currency, country, amount, metadata) that gate when a method appears
+- **Required fields** — per-method form field configuration (CVV, installments, billing address, etc.) for both the enrolled (saved-card) and non-enrolled (first-time) flows
+- **General settings** — accepted document types per country
+- **Styling & SDK settings** — colors, fonts, button shapes, dark mode, render mode, payment-method list layout, and Payment Link branding
+
+## Base URL
+
+| Environment | Base URL |
+| --- | --- |
+| Production | `https://prod.y.uno/dashboard-bff/api` |
+| Staging | `https://staging.y.uno/dashboard-bff/api` |
+
+## Authentication
+
+Every request requires a short-lived JWT from Yuno's auth provider and the following headers:
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `Authorization` | Yes | `Bearer <JWT>` — issued by Yuno's auth provider (WorkOS-backed). |
+| `x-account-code` | Yes | Account UUID — the merchant account scope for the request. |
+| `x-environment` | Yes | `live` or `sandbox`. Determines which environment is being configured. |
+| `x-organization-code` | Optional | Organization UUID. May be sent empty for single-org accounts. |
+| `Content-Type` | Yes (PATCH/POST) | `application/json` |
+| `Accept` | Recommended | `application/json` |
+
+<Warning>
+Tokens are short-lived. Your client must refresh them before expiry; the API will reject expired tokens with `401`.
+</Warning>
+
+## Key behaviors
+
+<Note>
+**`PATCH /checkouts/publish` is a full replace.** Always send the complete `paymentMethods` list. Omitting a method may remove it from the checkout configuration.
+</Note>
+
+- **Order is driven by `order_to_show`**, not by array position. Change the integer values to re-order; the API sorts ascending when rendering.
+- **`x-environment` controls live vs sandbox.** There is no separate URL per environment — be deliberate about which value you send.
+- **Changes take effect immediately.** Validate your payload with `x-environment: sandbox` before applying to live.

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Checkout Builder"
 description: "Programmatically configure your Yuno checkout — payment methods, conditions, required fields, and styling — via the same API the Checkout Builder UI uses."
+hidden: true
 ---
 
 The Checkout Builder Management API lets you read and update a merchant's checkout configuration programmatically. It is the same API the Checkout Builder UI in the Yuno dashboard uses internally — if a configuration is possible in the dashboard, it is possible via this API.
@@ -40,7 +41,7 @@ Tokens are short-lived. Your client must refresh them before expiry; the API wil
 ## Key behaviors
 
 <Note>
-**`PATCH /checkouts/publish` is a full replace.** Always send the complete `payment_methods` list. Omitting a method may remove it from the checkout configuration.
+**`PATCH /checkouts/publish` is a full replace.** Always send the complete `paymentMethods` list. Omitting a method may remove it from the checkout configuration.
 </Note>
 
 - **Order is driven by `order_to_show`**, not by array position. Change the integer values to re-order; the API sorts ascending when rendering.

--- a/reference/checkout-builder/publish-checkout-configuration.mdx
+++ b/reference/checkout-builder/publish-checkout-configuration.mdx
@@ -1,0 +1,4 @@
+---
+title: "Publish Checkout Configuration"
+openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /checkouts/publish"
+---

--- a/reference/checkout-builder/publish-checkout-configuration.mdx
+++ b/reference/checkout-builder/publish-checkout-configuration.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Publish Checkout Configuration"
 openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /checkouts/publish"
+hidden: true
 ---

--- a/reference/checkout-builder/update-styling-settings.mdx
+++ b/reference/checkout-builder/update-styling-settings.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update Styling & SDK Settings"
+openapi: "/openapi/checkout-builder/update-styling-settings.json PATCH /v1/checkouts/builder/settings"
+---

--- a/reference/checkout-builder/update-styling-settings.mdx
+++ b/reference/checkout-builder/update-styling-settings.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Update Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/update-styling-settings.json PATCH /v1/checkouts/builder/settings"
+hidden: true
 ---


### PR DESCRIPTION
## Description:

  Summary

  - Adds a new Checkout Builder dropdown to the API Reference, covering the Dashboard BFF endpoints that power the Checkout Builder UI in the Yuno dashboard    
  - Creates an overview page explaining what the API configures, base URLs, authentication headers, and key behaviors
  - Adds 6 individual endpoint pages backed by OpenAPI specs, organized into two groups: Payment Method Configuration and Styling & SDK Settings

##  Changes

### docs.json
  - Added Checkout Builder dropdown under the API Reference navigation with two groups: Payment Method Configuration and Styling & SDK Settings

###  reference/checkout-builder/ (new)
  - overview.mdx — intro page: capabilities, base URL, auth headers, key behaviors
  - fetch-checkout-configuration.mdx — GET /checkouts/{checkoutCode}
  - publish-checkout-configuration.mdx — PATCH /checkouts/publish
  - get-required-fields.mdx — GET /checkouts/payment-methods/{type}/required-fields
  - get-country-data.mdx — GET /checkouts/country-data
  - fetch-styling-settings.mdx — GET /v1/checkouts/builder/settings
  - update-styling-settings.mdx — PATCH /v1/checkouts/builder/settings

###  openapi/checkout-builder/ (new)
  - One OpenAPI 3.1 spec per endpoint with full request/response schemas, enum values, and request examples
  - publish-checkout-configuration.json covers the full PaymentMethod, ConditionSet, and RequiredFieldsOverride models including condition operators and the condition_value vs values field distinction
  - update-styling-settings.json covers all styling and SDK behavior fields (styles.global, styles.header, styles.button, settings.card, settings.sdk_type, settings.web_sdk, settings.payment_method_list, settings.ui, payment_link_styles, flags, external_fonts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only visibility and wording changes with no runtime or API behavior impact.
> 
> **Overview**
> **Hides the Checkout Builder API reference** from the docs site by setting `hidden: true` in the frontmatter on the overview and all six endpoint MDX pages (fetch/publish configuration, required fields, country data, styling settings).
> 
> **Updates the overview note** for `PATCH /checkouts/publish` so the full-replace guidance refers to the **`paymentMethods`** list instead of **`payment_methods`**, aligning the doc with the API payload naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c862fa3300a4f146230b4359e3661205062a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->