### PR TITLE
chore: backfill missing web SDK changelog entries

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -342,6 +342,50 @@
       ]
     },
     {
+      "version": "1.6.13",
+      "release_date": "2026-04-06",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.13",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Apple Pay Cancel OTT Handling",
+          "description": "Apple Pay cancellation flow now correctly handles the one-time token, preventing stuck states when the user dismisses the payment sheet.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Apple Pay Trial Billing Period",
+          "description": "Apple Pay trial subscriptions now compute the trial end date correctly when the trial spans month boundaries.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.9",
+      "release_date": "2026-04-02",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.9",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Apple Pay Regular Billing Date",
+          "description": "`regularBilling` payments now include the start and end date metadata expected by Apple Pay.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.6.8",
       "release_date": "2026-04-15",
       "upgrade": {
@@ -778,6 +822,24 @@
       ]
     },
     {
+      "version": "1.5.24",
+      "release_date": "2026-05-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.24",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "NuPay Credit Option Rendering",
+          "description": "NuPay credit option no longer shows a literal \"0\" when the interest rate field is missing in the provider response.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.5.20",
       "release_date": "2026-04-07",
       "upgrade": {
@@ -928,6 +990,42 @@
           "title": "Country-Aware Fraud Collection",
           "description": "Fraud signal collection now uses the customer's country across payment methods, lite flow, secure fields, PayPal, Google Pay, Apple Pay, and the headless API client, improving provider routing and accuracy.",
           "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.10",
+      "release_date": "2026-03-02",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.10",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Dependency Security Updates",
+          "description": "Resolved ReDoS and DoS vulnerabilities in `minimatch`, `qs`, `axios`, and `ajv`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.9",
+      "release_date": "2026-02-27",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.9",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Axios Vulnerability Updates",
+          "description": "Upgraded `axios` to address known vulnerabilities tracked in security advisories.",
+          "group": null,
           "migration_guide": null,
           "links": []
         }


### PR DESCRIPTION
## Summary

Backfills missing public changelog entries for 5 web SDK patch releases identified by walking the diff between consecutive internal tags (v9.15.7 → v10.1.12). These versions were released but never got a `changelog/source/web.json` entry, so they don't appear on https://docs.y.uno/changelog/web.

## Versions added

| Version | Type | Title | Group |
|---|---|---|---|
| 1.5.9 | SECURITY | Axios Vulnerability Updates | — |
| 1.5.10 | SECURITY | Dependency Security Updates | — |
| 1.5.24 | FIXED | NuPay Credit Option Rendering | Payment Actions |
| 1.6.9 | ADDED | Apple Pay Regular Billing Date | Apple Pay |
| 1.6.13 | FIXED | Apple Pay Cancel OTT Handling | Apple Pay |
| 1.6.13 | CHANGED | Apple Pay Trial Billing Period | Apple Pay |

## Dedupe pass

These candidates were initially identified but **dropped** because the underlying change is already documented in an adjacent version:

| Dropped | Already covered by |
|---|---|
| 1.5.6 — Financial Cost (Click to Pay & Enrolled Cards) | 1.5.8 `Financial Cost in C2P` + `Financial Cost in Enrolled Cards` |
| 1.5.9 — Checkout Crash on Some Sessions | 1.6.1 `Crash with External-Buttons-Only Sessions` |
| 1.6.12 — Forter Per-Account Token Scoping | 1.5.19 `Forter token isolation` (and 1.6.8 `Forter Token Listener`) |

## How this was generated

1. Mapped each public version → internal git tag in `yuno-payments/sdk-web` via `package.json:version` at each tag
2. Identified 16 versions with no existing docs entry
3. Generated tight per-version diff summaries (commit subjects + filenames)
4. AI-assisted analysis of merchant-facing changes (skipping refactors / telemetry / lockfiles / tests / dependency bumps without CVE relevance)
5. Curated to drop internal observability noise and normalize titles
6. **Cross-checked every proposed entry against ALL existing entries** to drop duplicates

## Files changed

- `changelog/source/web.json` — 5 new release objects in semver-descending order

> `changelog/web.mdx` is intentionally **not** included — that file is regenerated from `web.json` by yuno-docs CI / the docs team on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates changelog JSON content (no runtime code changes), though it documents security-related dependency updates that may draw reviewer attention.
> 
> **Overview**
> Adds missing release entries to the public Web SDK changelog (`changelog/source/web.json`), including Apple Pay metadata/cancellation/trial-period notes for `1.6.9` and `1.6.13`, a NuPay rendering fix in `1.5.24`, and **security** entries for `1.5.9`/`1.5.10` covering `axios` and other dependency vulnerability fixes.
> 
> Also fixes the JSON file formatting by ensuring it ends with a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1bdab79e66f11489dc9bde86e641f8dc46ca35f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->