### PR TITLE
feat: add VTEX and WooCommerce plugin changelog entries

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,8 +5,1063 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
-## v1.5.0
-*February 20, 2026*
+## v4.2.300
+*May 13, 2026*
 
-- <ChangelogBadge type="changed" /> **VTEX Checkout V6 Compatibility**  
-  Improved compatibility with VTEX Checkout V6. Merchants running Checkout V6 should upgrade to this version to ensure correct behavior.
+**Performance & Latency**
+
+- <ChangelogBadge type="added" /> **Optimize authorize hot path**  
+  Reduces authorization latency by parallelizing previously sequential calls, coalescing duplicate in-flight requests, and tightening the data flow around preflight, persistence, and Yuno API calls. Functional behaviour is preserved end-to-end.
+
+## v4.2.299
+*May 11, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Installments-plan endpoint**  
+  Exposes a new endpoint that returns the configured installments plan for an affiliation, used by Apple Pay and Google Pay to render the correct installment options at checkout.
+
+## v4.2.298
+*April 27, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Choose Yuno vs provider transaction ID**  
+  Adds a Transaction Identification From setting so merchants can choose whether the Yuno TID (default) or the underlying provider TID is returned to VTEX.
+
+## v4.2.297
+*April 15, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Transaction Identification From custom field**  
+  Adds a Transaction Identification From option in the VTEX Admin so merchants can pick between the Yuno TID and the underlying provider TID for the transaction reference.
+
+## v4.2.296
+*April 14, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Re-add Payment Mode field to configuration**  
+  Restores the Payment Mode configuration with the same two options as before: Payment App (default) and Redirect (legacy).
+
+## v4.2.295
+*April 12, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="fixed" /> **Remove Payment Mode setting (later restored)**  
+  Temporarily removes the Payment Mode configuration field. The setting is restored in the following release.
+
+## v4.2.294
+*April 10, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Payment Mode setting for legacy redirect**  
+  Adds a Payment Mode configuration so merchants can choose between the default Payment App flow and the legacy redirect flow.
+
+## v4.2.293
+*April 10, 2026*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Upgrade diff and cookie to patch CVE-2026-24001 and CVE-2024-47764**  
+  Patches two reported third-party vulnerabilities: a denial-of-service in the diff library and a cookie attribute injection in cookie.
+
+## v4.2.292
+*April 6, 2026*
+
+- <ChangelogBadge type="fixed" /> **Recognize VTEX IO transient errors**  
+  Treats common transient infrastructure errors (timeouts, dropped connections, refused connections) as recoverable so the authorization stays pending instead of failing immediately.
+
+## v4.2.290
+*March 31, 2026*
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Preflight payments for Apple Pay and Google Pay**  
+  Adds pre-created checkout sessions for Apple Pay and Google Pay so the wallet sheet can be opened immediately when the buyer clicks pay.
+
+## v4.2.288
+*March 26, 2026*
+
+**Multi-Account**
+
+- <ChangelogBadge type="fixed" /> **Route franchise sub-account payments to the correct account**  
+  On franchise sub-accounts the connector now routes the payment using the order's merchant identifier instead of the parent account hostname, so payments reach the correct sub-account.
+
+## v4.2.287
+*March 18, 2026*
+
+**Reliability**
+
+- <ChangelogBadge type="added" /> **Retry-payment-validation endpoint**  
+  Adds an endpoint that resolves "phantom" orders by retrying the payment validation, restoring the simple fire-and-forget callback behaviour.
+
+## v4.2.286
+*March 17, 2026*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Patch qs vulnerability (CVE-2026-2391)**  
+  Patches a reported vulnerability in the qs query-string dependency.
+
+## v4.2.285
+*March 12, 2026*
+
+- <ChangelogBadge type="added" /> **External-button action for Yuno SDK v1.5**  
+  Adds an external-button action option that targets Yuno SDK v1.5, used for payment methods that render their own UI outside the SDK.
+
+## v4.2.284
+*March 10, 2026*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Pin minimatch and koa**  
+  Locks minimatch and koa to patched versions to close reported regular-expression and request-handling vulnerabilities.
+
+## v4.2.283
+*March 4, 2026*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Pin qs to 6.14.2**  
+  Locks qs to the patched version across both root and node workspaces to close a reported vulnerability.
+
+## v4.2.282
+*February 27, 2026*
+
+**Customer & Address**
+
+- <ChangelogBadge type="fixed" /> **Customer payer city for Chile**  
+  Reads the city from the neighborhood field for Chilean orders, where VTEX populates the city there, so payments are no longer declined for missing city data.
+
+## v4.2.281
+*February 25, 2026*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Upgrade vulnerable dependencies**  
+  Bulk upgrade addressing several reported third-party dependency vulnerabilities.
+
+**Pagaleve**
+
+- <ChangelogBadge type="fixed" /> **OTT metadata headers and Pagaleve close-button toggle**  
+  Sends OTT metadata headers to the secure-proxy and adds a toggle for the Pagaleve Transparente checkout to hide the VTEX close button.
+
+## v4.2.280
+*February 23, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Order placed page URL setting**  
+  Adds a configuration option for the VTEX order-placed page URL and forwards it through the pending-authorization flow.
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Patch js-yaml vulnerability**  
+  Forces js-yaml to a patched version to close CVE-2024-4068.
+
+## v4.2.277
+*January 14, 2026*
+
+**Performance & Latency**
+
+- <ChangelogBadge type="added" /> **Per-client caching for VTEX APIs**  
+  Adds in-memory caches across VTEX clients (Account, Affiliations, Catalog, Master Data) to cut redundant API calls and reduce checkout latency.
+
+## v4.2.273
+*January 7, 2026*
+
+**Tax IDs**
+
+- <ChangelogBadge type="fixed" /> **Per-merchant tax ID mapping**  
+  Adds merchant-aware tax ID (CNPJ) mapping so each payment is tagged with the correct ID and merchant metadata for downstream reconciliation.
+
+## v4.2.272
+*January 6, 2026*
+
+**Tax IDs**
+
+- <ChangelogBadge type="added" /> **Add default CNPJ for testing**  
+  Provides a default merchant tax ID (CNPJ) when the configured affiliation has none, so testing flows can run without manual setup.
+
+## v4.2.271
+*January 5, 2026*
+
+**Pagaleve**
+
+- <ChangelogBadge type="added" /> **Update Pagaleve parcelado integration tag**  
+  Updates the configuration tag for Pagaleve installment-Pix so the connector targets the latest provider integration.
+
+## v4.2.267
+*December 24, 2025*
+
+**Payment Metadata**
+
+- <ChangelogBadge type="added" /> **Map VTEX fields to Cybersource MDD metadata**  
+  Maps additional VTEX order fields into Yuno metadata so Cybersource MDD (Merchant Defined Data) rules can use them for fraud screening.
+
+## v4.2.266
+*December 24, 2025*
+
+**Pagaleve**
+
+- <ChangelogBadge type="added" /> **Pagaleve Transparente for Pix parcelado**  
+  Adds Pagaleve Transparente as a supported method for both Pix and installment-Pix flows.
+
+## v4.2.264
+*December 24, 2025*
+
+**Click to Pay**
+
+- <ChangelogBadge type="added" /> **Hide installments for Click to Pay**  
+  Hides the installments option when the buyer is paying with Click to Pay, where instalments are not supported by the upstream networks.
+
+## v4.2.263
+*December 15, 2025*
+
+**Cancellation Flow**
+
+- <ChangelogBadge type="fixed" /> **Validate transactions before cancel**  
+  Validates that VTEX transactions exist on the order before triggering the cancellation flow, preventing spurious failures.
+
+## v4.2.262
+*December 12, 2025*
+
+**PicPay**
+
+- <ChangelogBadge type="fixed" /> **Restore PicPay support**  
+  Restores PicPay as a supported payment method after it was unintentionally removed.
+
+## v4.2.260
+*December 11, 2025*
+
+- <ChangelogBadge type="added" /> **Group-order handling**  
+  Treats VTEX order groups as a single payment, avoiding partial-payment artifacts when several orders are placed together.
+
+**Apple Pay**
+
+- <ChangelogBadge type="added" /> **Apple Pay installment plans**  
+  Adds installment-plan support for Apple Pay so the merchant's configured installment options appear in the Apple Pay sheet.
+
+## v4.2.258
+*December 9, 2025*
+
+**Mercado Pago**
+
+- <ChangelogBadge type="added" /> **Add Mercado Pago Checkout Pro**  
+  Adds Mercado Pago Checkout Pro as a redirect-style payment method. Existing Monnet and PicPay redirect flows are unified onto the same shared flow and forward additional payment metadata, including the merchant domain.
+
+## v4.2.252
+*November 27, 2025*
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Defense-mode fallback for delayed card payments**  
+  Falls back to direct card processing (defense mode) when the standard flow is delayed by fraud screening, completing the payment without losing the order.
+
+## v4.2.251
+*November 20, 2025*
+
+**Mercado Pago**
+
+- <ChangelogBadge type="added" /> **Mercado Pago Checkout Pro**  
+  Adds Mercado Pago Checkout Pro as a supported redirect-style payment method.
+
+## v4.2.250
+*November 19, 2025*
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Show status page when a Gift Card is present**  
+  Renders the standard status page when the order includes a gift-card payment, preventing the connector from short-circuiting the flow.
+
+## v4.2.248
+*November 12, 2025*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Create-customer toggle**  
+  Adds an optional Create Customer setting so the connector can register the buyer in Yuno's customer registry before the first payment.
+
+## v4.2.247
+*November 11, 2025*
+
+**Fulfillment**
+
+- <ChangelogBadge type="fixed" /> **Verify tracking_id and tracking_url in fulfillment events**  
+  Validates tracking_id and tracking_url before forwarding carrier fulfillment events to Yuno so updates with missing values are skipped gracefully.
+
+## v4.2.244
+*October 31, 2025*
+
+**Pix**
+
+- <ChangelogBadge type="added" /> **NSU on Pix responses**  
+  Includes the NSU transaction identifier in the Pix response so it can be reconciled with the bank.
+
+## v4.2.242
+*October 22, 2025*
+
+- <ChangelogBadge type="added" /> **Skip redundant payment-status call**  
+  Skips the payment-status check when the local state is already PENDING, reducing redundant gateway round-trips.
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Card IIN lookup and dynamic card type detection**  
+  Looks up the card BIN (IIN) at checkout so the connector can detect the card brand and whether it is credit or debit dynamically, instead of relying on a static configuration.
+
+- <ChangelogBadge type="added" /> **Soft Descriptor configuration**  
+  Adds a Soft Descriptor configuration field so merchants can control the text that appears on the customer's card statement.
+
+## v4.2.241
+*September 24, 2025*
+
+**Payment Metadata**
+
+- <ChangelogBadge type="added" /> **Send payment reference in metadata**  
+  Sends the merchant payment reference along with the payment metadata so it can be used for downstream reconciliation.
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Patch brace-expansion dependency**  
+  Upgrades the brace-expansion dependency to a patched version to close a reported vulnerability.
+
+- <ChangelogBadge type="security" /> **Pin brace-expansion across transitive paths**  
+  Pins brace-expansion across all transitive paths so only the patched version is resolved.
+
+## v4.2.240
+*September 4, 2025*
+
+- <ChangelogBadge type="added" /> **Update koa dependency**  
+  Upgrades the Koa server framework to a newer release line.
+
+- <ChangelogBadge type="changed" /> **Revert Koa upgrade**  
+  Rolls back the Koa framework upgrade shipped in the previous release while compatibility issues are resolved.
+
+## v4.2.238
+*July 31, 2025*
+
+- <ChangelogBadge type="added" /> **Non-blocking hostname lookup**  
+  Removes blocking I/O from the connector's hostname lookup so a slow DNS response can't stall the request.
+
+**Webhooks**
+
+- <ChangelogBadge type="fixed" /> **Support webhook v2**  
+  Adds support for webhook v2.
+
+## v4.2.235
+*July 7, 2025*
+
+**PSE**
+
+- <ChangelogBadge type="added" /> **PSE for Colombia**  
+  Adds PSE (Pagos Seguros en Línea) as a supported payment method for Colombian merchants, using the bank-redirect flow.
+
+## v4.2.234
+*July 7, 2025*
+
+**PCI & Secure Proxy**
+
+- <ChangelogBadge type="fixed" /> **Proxy authorization header on PCI calls**  
+  Adds the Proxy-Authorization header on outbound calls that traverse the VTEX IO proxy, fixing 407 responses on tokenized requests.
+
+## v4.2.231
+*June 27, 2025*
+
+- <ChangelogBadge type="fixed" /> **Forward proxy and protocol headers**  
+  Forwards the original VTEX request headers (X-Forwarded-Proto and Port) so downstream services see the merchant's protocol correctly.
+
+## v4.2.230
+*June 18, 2025*
+
+- <ChangelogBadge type="added" /> **Uppercase platform identifier**  
+  Normalizes the platform identifier sent to Yuno to upper-case, aligning with the gateway's expected enum value.
+
+## v4.2.229
+*June 11, 2025*
+
+**Reliability**
+
+- <ChangelogBadge type="fixed" /> **Axios request timeout**  
+  Adds an explicit timeout to the Axios HTTP client so hanging connections fail fast instead of stalling the payment.
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Patch tar-fs vulnerability**  
+  Upgrades the tar-fs dependency to a patched version to close a reported security advisory.
+
+## v4.2.227
+*May 14, 2025*
+
+- <ChangelogBadge type="fixed" /> **Update dependencies**  
+  Bumps several third-party dependencies to their latest patched versions, including the Koa server framework.
+
+## v4.2.226
+*May 13, 2025*
+
+**Capture**
+
+- <ChangelogBadge type="fixed" /> **Use the VTEX-supplied amount on capture**  
+  Captures the exact amount that VTEX sends with the capture request, instead of recomputing it from the original order total. This prevents capture mismatches when the order total has changed (partial refunds, gift cards, marketplace splits).
+
+## v4.2.225
+*May 7, 2025*
+
+**Reliability**
+
+- <ChangelogBadge type="fixed" /> **Log retry-limit exhaustion**  
+  Adds a clear log entry when the connector exhausts the retry budget for an outbound request, easing on-call diagnosis.
+
+## v4.2.223
+*April 30, 2025*
+
+**Fulfillment**
+
+- <ChangelogBadge type="added" /> **Additional shipping-type mappings**  
+  Extends the fulfillment mapping with extra shipping types (such as store pickup and marketplace handoff) so more order flows are reported back to the gateway.
+
+## v4.2.222
+*April 29, 2025*
+
+**Payment Metadata**
+
+- <ChangelogBadge type="added" /> **Total cart value as metadata**  
+  Includes the total cart value as metadata on each payment, useful for risk scoring and reporting.
+
+## v4.2.221
+*April 29, 2025*
+
+- <ChangelogBadge type="fixed" /> **Preserve original order dates**  
+  Stops overriding the original order dates when updating a payment, preserving the merchant-facing timestamps.
+
+## v4.2.218
+*April 11, 2025*
+
+**Reliability**
+
+- <ChangelogBadge type="added" /> **4-hour retry window for stuck payments**  
+  Adds a 4-hour retry window before re-attempting a stuck payment, reducing pressure on the gateway.
+
+## v4.2.217
+*April 11, 2025*
+
+**Capture**
+
+- <ChangelogBadge type="added" /> **Capture wallet payments**  
+  Triggers the capture call to Yuno for wallet-based payments so capture timing matches the auto-settle window.
+
+## v4.2.216
+*April 10, 2025*
+
+**Cancellation Flow**
+
+- <ChangelogBadge type="added" /> **4-hour auto-cancel window**  
+  Raises the auto-cancellation window to 4 hours, giving slow alternative payment methods enough time to settle.
+
+## v4.2.215
+*April 9, 2025*
+
+**Fulfillment**
+
+- <ChangelogBadge type="added" /> **Forward carrier status**  
+  Retrieves the carrier status from VTEX and forwards it to Yuno as part of the fulfillment update.
+
+## v4.2.214
+*April 9, 2025*
+
+**Fulfillment**
+
+- <ChangelogBadge type="added" /> **Send fulfillment completed event**  
+  Sends a fulfillment-completed event to Yuno when the VTEX order has been fully delivered.
+
+## v4.2.213
+*March 28, 2025*
+
+**Fulfillment**
+
+- <ChangelogBadge type="added" /> **Include shipped-at timestamp**  
+  Sends the actual shipping timestamp in fulfillment updates so Yuno can compute accurate delivery SLAs.
+
+**Dependency Updates**
+
+- <ChangelogBadge type="changed" /> **Upgrade Axios HTTP client**  
+  Updates the Axios HTTP client to the latest stable version, picking up bug fixes and security patches.
+
+## v4.2.210
+*March 21, 2025*
+
+- <ChangelogBadge type="added" /> **Include product brand on items**  
+  Includes the product brand on each line item sent to Yuno so brand-level reporting is possible.
+
+## v4.2.209
+*March 20, 2025*
+
+**Multi-Account**
+
+- <ChangelogBadge type="fixed" /> **Skip account lookup when main account is configured**  
+  Skips the account-lookup call when a main account is already configured, removing a redundant VTEX API request.
+
+## v4.2.204
+*March 17, 2025*
+
+**Cancellation Flow**
+
+- <ChangelogBadge type="added" /> **Skip cancel when payment is still pending**  
+  Skips the cancellation path when a payment is not yet made and the order is in a transient state, preventing premature aborts.
+
+## v4.2.202
+*March 14, 2025*
+
+**Fulfillment**
+
+- <ChangelogBadge type="fixed" /> **Tracking URL and ID as arrays**  
+  Sends shipping tracking URL and ID as arrays in fulfillment updates, matching Yuno's updated schema.
+
+## v4.2.201
+*March 12, 2025*
+
+- <ChangelogBadge type="added" /> **Reject non-numeric order IDs**  
+  Adds order-id format validation to reject non-numeric or malformed identifiers before the payment is created.
+
+## v4.2.199
+*March 10, 2025*
+
+- <ChangelogBadge type="added" /> **Check for existing Yuno payment before creating**  
+  Before creating a new Yuno session the connector first checks whether the merchant order already has a payment recorded, avoiding duplicates.
+
+## v4.2.198
+*March 10, 2025*
+
+- <ChangelogBadge type="added" /> **Validate and recover order ID**  
+  Validates the order ID before processing and, when invalid, attempts to recover the canonical order ID from VTEX.
+
+## v4.2.197
+*March 6, 2025*
+
+**Customer & Address**
+
+- <ChangelogBadge type="added" /> **Send customer creation date**  
+  Includes the customer creation date in the payment payload so Yuno can apply customer-tenure-based rules.
+
+## v4.2.196
+*March 6, 2025*
+
+**Monnet**
+
+- <ChangelogBadge type="added" /> **Support Monnet in Yuno VTEX SDK**  
+  Adds support for monnet in Yuno VTEX SDK.
+
+## v4.2.195
+*March 5, 2025*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Patch dependency vulnerabilities (cross-spawn, koa)**  
+  Patches reported vulnerabilities across two dependencies (cross-spawn and koa) in one update.
+
+**Fulfillment**
+
+- <ChangelogBadge type="added" /> **Send fulfillment events to Yuno**  
+  Forwards VTEX fulfillment events (shipped, delivered) to Yuno so it reflects the order lifecycle.
+
+## v4.2.186
+*February 24, 2025*
+
+**Multi-Account**
+
+- <ChangelogBadge type="changed" /> **Expose account name to the front-end**  
+  Exposes the connector account name to the front-end so multi-account checkouts can be routed correctly.
+
+## v4.2.184
+*February 7, 2025*
+
+**PicPay**
+
+- <ChangelogBadge type="added" /> **PicPay Wallet**  
+  Adds PicPay digital wallet as a supported payment method through the wallet-redirect flow.
+
+## v4.2.182
+*January 30, 2025*
+
+- <ChangelogBadge type="fixed" /> **Handle socket hang-ups on Yuno calls**  
+  Adds handling for socket-level hang-ups when calling the Yuno API, retrying instead of failing the transaction.
+
+## v4.2.176
+*January 20, 2025*
+
+- <ChangelogBadge type="added" /> **Coupons total as a separate line item**  
+  Sends the coupon-discount total as a separate line item to Yuno so the order totals reconcile correctly.
+
+## v4.2.175
+*January 17, 2025*
+
+**Multi-Account**
+
+- <ChangelogBadge type="added" /> **Sub-store / multi-account routing**  
+  Adds sub-store support so franchises can route payments through a parent account when needed.
+
+## v4.2.168
+*December 18, 2024*
+
+**Reliability**
+
+- <ChangelogBadge type="added" /> **Retry secure-proxy tokenization**  
+  Adds retries on the Yuno Secure Proxy tokenization call so transient PCI gateway failures don't fail the payment.
+
+## v4.2.155
+*December 16, 2024*
+
+**Multi-Account**
+
+- <ChangelogBadge type="added" /> **Sales-channel policy resolution**  
+  Resolves the sales-channel policy so the connector picks the right policy when multiple are configured on the merchant account.
+
+## v4.2.146
+*December 9, 2024*
+
+- <ChangelogBadge type="added" /> **Wait before auto-cancelling**  
+  Adds a wait window before auto-cancelling a payment, giving wallet redirects enough time to complete.
+
+## v4.2.144
+*December 6, 2024*
+
+**Cancellation Flow**
+
+- <ChangelogBadge type="added" /> **Faster auto-cancel for generic Yuno method**  
+  Reduces the auto-cancel delay when the payment method is the generic Yuno option, improving the merchant's view of pending transactions.
+
+## v4.2.141
+*December 4, 2024*
+
+- <ChangelogBadge type="fixed" /> **Upgrade semver-regex**  
+  Upgrades the semver-regex dependency to patch a reported vulnerability.
+
+- <ChangelogBadge type="fixed" /> **Patch reported vulnerabilities (group 1)**  
+  Bulk upgrade of dependencies to patch a batch of reported third-party vulnerabilities.
+
+- <ChangelogBadge type="fixed" /> **Patch reported vulnerabilities (group 2)**  
+  Bulk upgrade of dependencies to patch a further batch of reported third-party vulnerabilities.
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump the npm_and_yarn group across 2 directories with 19 updates**  
+  Patches 19 reported third-party dependency vulnerabilities in one bulk security update.
+
+- <ChangelogBadge type="security" /> **Bump the npm_and_yarn group across 2 directories with 15 updates**  
+  Patches 15 reported third-party dependency vulnerabilities in one bulk security update.
+
+- <ChangelogBadge type="security" /> **Bump the npm_and_yarn group across 2 directories with 8 updates**  
+  Patches 8 reported third-party dependency vulnerabilities in one bulk security update.
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Debit cards (Maestro, Voucher, Elo Débito)**  
+  Adds Maestro, Visa Electron, Elo Débito, Mastercard Debit and Voucher as supported debit-card payment methods.
+
+## v4.2.137
+*November 19, 2024*
+
+**Webhooks**
+
+- <ChangelogBadge type="added" /> **Webhook logging**  
+  Adds structured logging to the webhook handler so incoming Yuno events can be traced.
+
+## v4.2.136
+*November 14, 2024*
+
+**Fulfillment**
+
+- <ChangelogBadge type="changed" /> **Send shipping status to Yuno**  
+  Forwards the order's shipping status as part of the fulfillment update so Yuno has end-to-end order context.
+
+## v4.2.135
+*November 8, 2024*
+
+- <ChangelogBadge type="added" /> **Expanded payment status mapping**  
+  Recognizes additional payment statuses from Yuno so terminal states are mapped correctly back to VTEX.
+
+## v4.2.134
+*November 7, 2024*
+
+**Monnet**
+
+- <ChangelogBadge type="changed" /> **Monnet cash and bank transfer**  
+  Adds Monnet cash and bank transfer as supported payment methods through an iframe flow.
+
+## v4.2.133
+*October 22, 2024*
+
+**Pix**
+
+- <ChangelogBadge type="changed" /> **Pix Parcelado**  
+  Adds Pix Parcelado (installment Pix) as a supported payment method for Brazilian merchants.
+
+## v4.2.132
+*September 19, 2024*
+
+**Cancellation Flow**
+
+- <ChangelogBadge type="changed" /> **Approve cancellation when order is already known**  
+  Returns a cancellation-approved response when the merchant order is already on record, avoiding spurious cancellation failures.
+
+## v4.2.131
+*September 5, 2024*
+
+**Pagaleve**
+
+- <ChangelogBadge type="changed" /> **Pagaleve one-time Pix**  
+  Adds support for Pagaleve's single-payment Pix option (a vista).
+
+## v4.2.130
+*August 29, 2024*
+
+**Pagaleve**
+
+- <ChangelogBadge type="changed" /> **Pagaleve installment Pix**  
+  Adds support for Pagaleve's installment-Pix offering, letting buyers split a Pix payment over multiple instalments.
+
+## v4.2.129
+*August 29, 2024*
+
+**Pagaleve**
+
+- <ChangelogBadge type="changed" /> **Add Pagaleve initial support**  
+  Adds initial support for Pagaleve as a buy-now-pay-later option for Brazilian merchants.
+
+## v4.2.128
+*August 28, 2024*
+
+**Boleto**
+
+- <ChangelogBadge type="changed" /> **Boleto Banco do Brasil**  
+  Adds Boleto Banco do Brasil as a supported payment option.
+
+## v4.2.127
+*August 28, 2024*
+
+**Pix**
+
+- <ChangelogBadge type="changed" /> **Pix redirect flow**  
+  Adds the Pix redirect flow as an alternative to QR code, so merchants can route customers to the bank-side payment page.
+
+## v4.2.126
+*August 19, 2024*
+
+**Customer & Address**
+
+- <ChangelogBadge type="changed" /> **Richer logs and neighborhood extraction**  
+  Enriches connector logs with more context and extracts the neighborhood field from VTEX addresses so it can be sent to the gateway.
+
+## v4.2.117
+*August 15, 2024*
+
+**Customer & Address**
+
+- <ChangelogBadge type="changed" /> **Improve customer address handling**  
+  Forwards all address sub-fields (state, neighborhood, complement) to Yuno so payments include the complete buyer address.
+
+## v4.2.115
+*August 14, 2024*
+
+**Alelo**
+
+- <ChangelogBadge type="changed" /> **Add Alelo brand**  
+  Adds the Alelo card brand to the supported payment-method list in the provider configuration.
+
+## v4.2.114
+*August 12, 2024*
+
+**Refunds**
+
+- <ChangelogBadge type="changed" /> **Fix typo on refund description**  
+  Corrects a typo in the message returned to VTEX after a refund is processed.
+
+## v4.2.113
+*August 8, 2024*
+
+- <ChangelogBadge type="changed" /> **Fetch payment details from VTEX**  
+  Looks up payment details from the VTEX transactions API so the connector has accurate context when handling captures and refunds.
+
+## v4.2.107
+*July 18, 2024*
+
+**Configuration**
+
+- <ChangelogBadge type="changed" /> **Remove custom field**  
+  Removes a custom configuration field that was no longer used by any merchant.
+
+## v4.2.106
+*July 18, 2024*
+
+- <ChangelogBadge type="changed" /> **Restore AES session encryption**  
+  Restores AES-256-CBC encryption for sensitive session data passed between front-end and back-end after a regression removed it.
+
+## v4.2.92
+*July 15, 2024*
+
+**Card Payments**
+
+- <ChangelogBadge type="changed" /> **Two-card split payments**  
+  Adds support for splitting a payment across two cards in the same VTEX checkout.
+
+## v4.2.91
+*July 10, 2024*
+
+**Alelo**
+
+- <ChangelogBadge type="changed" /> **Alelo (initial support)**  
+  Adds Alelo benefit cards as a supported payment method (initial integration).
+
+## v4.2.90
+*July 5, 2024*
+
+**Apple Pay**
+
+- <ChangelogBadge type="changed" /> **Support Apple pay**  
+  Adds Apple Pay support, including the Apple-Pay-sheet flow at the VTEX checkout.
+
+## v4.2.89
+*June 28, 2024*
+
+- <ChangelogBadge type="changed" /> **Alternative payment method status validation**  
+  Adds payment-status validation for alternative payment methods so the connector reports the correct final state back to VTEX.
+
+## v4.2.88
+*June 20, 2024*
+
+**Multi-Account**
+
+- <ChangelogBadge type="changed" /> **Forward merchant account on payments**  
+  Sends the merchant account identifier with each payment so Yuno can resolve the correct affiliation when multiple are configured.
+
+## v4.2.87
+*June 19, 2024*
+
+**Google Pay**
+
+- <ChangelogBadge type="changed" /> **Enable Google Pay**  
+  Activates Google Pay as a supported payment method at the VTEX checkout.
+
+## v4.2.86
+*June 17, 2024*
+
+**Nubank**
+
+- <ChangelogBadge type="changed" /> **Nu Pay support**  
+  Adds Nu Pay (Nubank's credit-line payment) as a supported method for Brazilian merchants.
+
+## v4.2.85
+*June 13, 2024*
+
+**Boleto**
+
+- <ChangelogBadge type="changed" /> **Boleto Bancário integration**  
+  Adds support for Boleto Bancário, returning the barcode and payment URL so merchants can render them at checkout.
+
+## v4.2.84
+*May 31, 2024*
+
+**Card Payments**
+
+- <ChangelogBadge type="changed" /> **Improve card logs**  
+  Adds more context to card-payment logs to speed up incident triage and merchant support investigations.
+
+## v4.2.83
+*May 28, 2024*
+
+**Webhooks**
+
+- <ChangelogBadge type="added" /> **Webhook receiver for payment status**  
+  Adds a webhook receiver so the connector can update VTEX payment status when Yuno publishes terminal events.
+
+## v4.2.81
+*April 30, 2024*
+
+**Nubank**
+
+- <ChangelogBadge type="changed" /> **Add Nubank**  
+  Adds Nubank as a supported payment method for Brazilian merchants.
+
+## v4.2.80
+*April 26, 2024*
+
+**PagoEfectivo & SafetyPay**
+
+- <ChangelogBadge type="added" /> **PagoEfectivo and SafetyPay**  
+  Adds initial support for PagoEfectivo and SafetyPay as redirect-style payment options targeting Peru.
+
+## v4.2.76
+*April 4, 2024*
+
+**Capture**
+
+- <ChangelogBadge type="changed" /> **Declare auto-settle support**  
+  Declares auto-settle support in the provider configuration so VTEX correctly hands off capture timing to the connector.
+
+## v4.2.74
+*March 19, 2024*
+
+**Apple Pay**
+
+- <ChangelogBadge type="changed" /> **Enable Apple Pay**  
+  Activates Apple Pay as a supported payment method at the VTEX checkout for merchants enrolled in the Apple Pay program.
+
+## v4.2.73
+*March 15, 2024*
+
+**Pix**
+
+- <ChangelogBadge type="changed" /> **Support vtex pix**  
+  Adds support for vtex pix.
+
+## v4.2.72
+*March 11, 2024*
+
+- <ChangelogBadge type="changed" /> **NSU transaction identifier**  
+  Includes the NSU (transaction sequence number) in the payment response so merchants can reconcile transactions with the acquirer.
+
+## v4.2.71
+*March 4, 2024*
+
+- <ChangelogBadge type="changed" /> **Send raw payment response**  
+  Includes the raw Yuno payment response in the VTEX callback so merchants and support teams have full provider context when investigating.
+
+## v4.2.70
+*October 4, 2023*
+
+**Observability**
+
+- <ChangelogBadge type="changed" /> **Upgrade event-log library to v1**  
+  Picks up new fields, bug fixes, and improved trace-ID support from the v1 release of the event-log library.
+
+## v4.2.69
+*October 4, 2023*
+
+**Performance & Latency**
+
+- <ChangelogBadge type="changed" /> **Performance improvement**  
+  Reduces latency on the payment authorization path through targeted optimizations in the hottest code paths.
+
+## v4.2.67
+*September 20, 2023*
+
+**Observability**
+
+- <ChangelogBadge type="changed" /> **Yuno event-log library integration**  
+  Wires in the Yuno event-log library so connector errors are tracked centrally with trace IDs that link gateway and merchant logs.
+
+## v4.2.55
+*September 13, 2023*
+
+**Observability**
+
+- <ChangelogBadge type="changed" /> **Structured event logs**  
+  Introduces structured event logging across the connector to make production troubleshooting easier.
+
+## v4.2.35
+*August 17, 2023*
+
+**3-D Secure**
+
+- <ChangelogBadge type="changed" /> **3-D Secure support**  
+  Adds end-to-end 3-D Secure for card payments so merchants can comply with strong-customer-authentication requirements.
+
+## v3.0.0
+*May 26, 2023*
+
+**Observability**
+
+- <ChangelogBadge type="changed" /> **Event log parsed error fixed**  
+  Fixes a parsing error that prevented some failures from being recorded in the event log.
+
+## v1.2.0
+*December 21, 2021*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump urijs from 1.19.6 to 1.19.11 in /node**  
+  Patches several reported vulnerabilities in the urijs URL-parsing dependency.
+
+## v1.1.0
+*December 21, 2021*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump minimatch from 3.0.4 to 3.1.2 in /node**  
+  Patches a regular-expression denial-of-service issue in the minimatch dependency.
+
+## v1.0.6
+*November 18, 2021*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump @babel/traverse from 7.13.0 to 7.23.6 in /node**  
+  Patches an arbitrary-code-execution vulnerability in the @babel/traverse build-time dependency.
+
+- <ChangelogBadge type="security" /> **Bump async from 2.6.3 to 2.6.4 in /node**  
+  Patches a prototype-pollution issue in the async dependency.
+
+## v1.0.5
+*May 20, 2021*
+
+- <ChangelogBadge type="changed" /> **Return undefined when the payment state is pending**  
+  Aligns the connector's response for pending payments with VTEX expectations so pending payments are no longer marked as failed.
+
+## v1.0.4
+*May 17, 2021*
+
+**3-D Secure**
+
+- <ChangelogBadge type="added" /> **Support for the VTEX card form**  
+  Adds full support for the VTEX card-payment form across all major brands, including 3-D Secure authentication.
+
+## v1.0.3
+*April 28, 2021*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump semver from 5.7.1 to 5.7.2 in /node**  
+  Patches a denial-of-service vulnerability reported in the semver dependency.
+
+## v1.0.2
+*March 2, 2021*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump minimatch from 3.0.4 to 3.1.2**  
+  Patches a regular-expression denial-of-service issue in the minimatch dependency.
+
+## v1.0.1
+*March 1, 2021*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump path-parse from 1.0.6 to 1.0.7**  
+  Patches a regular-expression denial-of-service vulnerability in the path-parse transitive dependency.
+
+## v1.0.0
+*February 27, 2021*
+
+- <ChangelogBadge type="changed" /> **Fix discount handling**  
+  Corrects how discount amounts are forwarded to the gateway so coupon and promotion values are reflected accurately on the payment.
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump json5 from 1.0.1 to 1.0.2**  
+  Patches a __proto__ prototype-pollution vulnerability in the json5 dependency.
+
+**Fulfillment**
+
+- <ChangelogBadge type="added" /> **Order events**  
+  Adds order-event tracking so VTEX order state transitions propagate to Yuno.
+
+## v0.0.2
+*February 28, 2020*
+
+**Dependency Updates**
+
+- <ChangelogBadge type="security" /> **Bump minimist from 1.2.5 to 1.2.8**  
+  Patches a reported prototype-pollution vulnerability in the minimist dependency.

--- a/changelog/plugins/woocommerce.mdx
+++ b/changelog/plugins/woocommerce.mdx
@@ -5,8 +5,68 @@ description: "Latest updates and version history for the Yuno WooCommerce Plugin
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
-## v1.0.0
-*January 15, 2026*
+## v1.0.1
+*April 13, 2026*
 
-- <ChangelogBadge type="added" /> **Initial Release**  
-  First public release of the Yuno WooCommerce plugin. Supports the basic payment flow and credit card payments.
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Hide payment selection when Yuno is the only gateway**  
+  Adds a Hide Payment Selection setting so the payment method radio buttons are hidden at checkout when Yuno is the only active gateway, presenting a cleaner one-method checkout experience. Applies to both legacy and block-based checkouts.
+
+## v1.0.0
+*April 7, 2026*
+
+- <ChangelogBadge type="added" /> **Initial WordPress Plugin Directory release**  
+  First public release of the Yuno WooCommerce payment gateway on the WordPress Plugin Directory, integrating Yuno's payment orchestration platform with WooCommerce through the Yuno Web SDK and a PHP REST API layer.
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Card payments, wallets, and local payment methods**  
+  Accepts cards, digital wallets, and local payment methods through Yuno's payment orchestration platform from a single integration, with intelligent payment routing across multiple providers.
+
+- <ChangelogBadge type="added" /> **3D Secure and additional authentication support**  
+  Handles 3D Secure challenges and additional authentication flows during payment, including a return-from-3DS detection that prevents accidental order duplication.
+
+**Block Checkout**
+
+- <ChangelogBadge type="added" /> **WooCommerce block-based checkout support**  
+  Supports both the legacy shortcode checkout and the WooCommerce block-based checkout (default since WooCommerce 8.3). Both flows converge at the order-pay page so the SDK orchestration is shared.
+
+**Webhooks**
+
+- <ChangelogBadge type="added" /> **Webhook receiver for asynchronous payment status**  
+  Receives Yuno payment events (succeeded, pending, failed, chargeback, refund) with three-layer HMAC verification and idempotent processing through transient locks.
+
+**Marketplace**
+
+- <ChangelogBadge type="added" /> **Marketplace split payments**  
+  Splits the order total between a seller recipient and a platform commission, configurable as a percentage or a fixed minor-unit amount.
+
+**Reliability**
+
+- <ChangelogBadge type="added" /> **In-place retry on failed payments**  
+  Lets the customer retry a failed payment in place by remounting the SDK, instead of creating a new duplicate order on each retry attempt.
+
+- <ChangelogBadge type="added" /> **Server-side payment verification**  
+  Verifies every reported payment status against the Yuno API before updating the WooCommerce order, never trusting client-reported status.
+
+**Order Management**
+
+- <ChangelogBadge type="added" /> **Auto-complete for virtual and downloadable orders**  
+  Orders that contain only virtual or downloadable products skip the processing state and go straight to completed after payment.
+
+- <ChangelogBadge type="added" /> **HPOS compatibility**  
+  Declares compatibility with WooCommerce High-Performance Order Storage (custom order tables) and uses HPOS-safe order queries throughout.
+
+**Customer & Address**
+
+- <ChangelogBadge type="added" /> **Per-order Yuno customer strategy**  
+  Creates a fresh Yuno customer per WooCommerce order, with automatic recovery from duplicate-customer and customer-not-found errors so payments are never blocked by stale customer state.
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Multi-environment support**  
+  Auto-detects the Yuno API environment (development, staging, sandbox, production) from the Public API Key prefix.
+
+- <ChangelogBadge type="added" /> **Configurable debug logging with PII redaction**  
+  Optional WooCommerce-integrated logging for troubleshooting payments and webhooks. Phone numbers, email addresses, and full API payloads are never logged.

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,18 +2,2472 @@
   "sdk": "vtex",
   "releases": [
     {
-      "version": "1.5.0",
-      "release_date": "2026-02-20",
+      "version": "4.2.300",
+      "release_date": "2026-05-13",
       "upgrade": {
-        "snippet": "vtex install yuno.checkout@1.5.0",
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.300",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Optimize authorize hot path",
+          "description": "Reduces authorization latency by parallelizing previously sequential calls, coalescing duplicate in-flight requests, and tightening the data flow around preflight, persistence, and Yuno API calls. Functional behaviour is preserved end-to-end.",
+          "group": "Performance & Latency",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.299",
+      "release_date": "2026-05-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.299",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Installments-plan endpoint",
+          "description": "Exposes a new endpoint that returns the configured installments plan for an affiliation, used by Apple Pay and Google Pay to render the correct installment options at checkout.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.298",
+      "release_date": "2026-04-27",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.298",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Choose Yuno vs provider transaction ID",
+          "description": "Adds a Transaction Identification From setting so merchants can choose whether the Yuno TID (default) or the underlying provider TID is returned to VTEX.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.297",
+      "release_date": "2026-04-15",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.297",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Transaction Identification From custom field",
+          "description": "Adds a Transaction Identification From option in the VTEX Admin so merchants can pick between the Yuno TID and the underlying provider TID for the transaction reference.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.296",
+      "release_date": "2026-04-14",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.296",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Re-add Payment Mode field to configuration",
+          "description": "Restores the Payment Mode configuration with the same two options as before: Payment App (default) and Redirect (legacy).",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.295",
+      "release_date": "2026-04-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.295",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Remove Payment Mode setting (later restored)",
+          "description": "Temporarily removes the Payment Mode configuration field. The setting is restored in the following release.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.294",
+      "release_date": "2026-04-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.294",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Payment Mode setting for legacy redirect",
+          "description": "Adds a Payment Mode configuration so merchants can choose between the default Payment App flow and the legacy redirect flow.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.293",
+      "release_date": "2026-04-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.293",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Upgrade diff and cookie to patch CVE-2026-24001 and CVE-2024-47764",
+          "description": "Patches two reported third-party vulnerabilities: a denial-of-service in the diff library and a cookie attribute injection in cookie.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.292",
+      "release_date": "2026-04-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.292",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Recognize VTEX IO transient errors",
+          "description": "Treats common transient infrastructure errors (timeouts, dropped connections, refused connections) as recoverable so the authorization stays pending instead of failing immediately.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.290",
+      "release_date": "2026-03-31",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.290",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Preflight payments for Apple Pay and Google Pay",
+          "description": "Adds pre-created checkout sessions for Apple Pay and Google Pay so the wallet sheet can be opened immediately when the buyer clicks pay.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.288",
+      "release_date": "2026-03-26",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.288",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Route franchise sub-account payments to the correct account",
+          "description": "On franchise sub-accounts the connector now routes the payment using the order's merchant identifier instead of the parent account hostname, so payments reach the correct sub-account.",
+          "group": "Multi-Account",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.287",
+      "release_date": "2026-03-18",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.287",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Retry-payment-validation endpoint",
+          "description": "Adds an endpoint that resolves \"phantom\" orders by retrying the payment validation, restoring the simple fire-and-forget callback behaviour.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.286",
+      "release_date": "2026-03-17",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.286",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Patch qs vulnerability (CVE-2026-2391)",
+          "description": "Patches a reported vulnerability in the qs query-string dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.285",
+      "release_date": "2026-03-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.285",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "External-button action for Yuno SDK v1.5",
+          "description": "Adds an external-button action option that targets Yuno SDK v1.5, used for payment methods that render their own UI outside the SDK.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.284",
+      "release_date": "2026-03-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.284",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Pin minimatch and koa",
+          "description": "Locks minimatch and koa to patched versions to close reported regular-expression and request-handling vulnerabilities.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.283",
+      "release_date": "2026-03-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.283",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Pin qs to 6.14.2",
+          "description": "Locks qs to the patched version across both root and node workspaces to close a reported vulnerability.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.282",
+      "release_date": "2026-02-27",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.282",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Customer payer city for Chile",
+          "description": "Reads the city from the neighborhood field for Chilean orders, where VTEX populates the city there, so payments are no longer declined for missing city data.",
+          "group": "Customer & Address",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.281",
+      "release_date": "2026-02-25",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.281",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Upgrade vulnerable dependencies",
+          "description": "Bulk upgrade addressing several reported third-party dependency vulnerabilities.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "OTT metadata headers and Pagaleve close-button toggle",
+          "description": "Sends OTT metadata headers to the secure-proxy and adds a toggle for the Pagaleve Transparente checkout to hide the VTEX close button.",
+          "group": "Pagaleve",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.280",
+      "release_date": "2026-02-23",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.280",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Order placed page URL setting",
+          "description": "Adds a configuration option for the VTEX order-placed page URL and forwards it through the pending-authorization flow.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Patch js-yaml vulnerability",
+          "description": "Forces js-yaml to a patched version to close CVE-2024-4068.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.277",
+      "release_date": "2026-01-14",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.277",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Per-client caching for VTEX APIs",
+          "description": "Adds in-memory caches across VTEX clients (Account, Affiliations, Catalog, Master Data) to cut redundant API calls and reduce checkout latency.",
+          "group": "Performance & Latency",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.273",
+      "release_date": "2026-01-07",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.273",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Per-merchant tax ID mapping",
+          "description": "Adds merchant-aware tax ID (CNPJ) mapping so each payment is tagged with the correct ID and merchant metadata for downstream reconciliation.",
+          "group": "Tax IDs",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.272",
+      "release_date": "2026-01-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.272",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Add default CNPJ for testing",
+          "description": "Provides a default merchant tax ID (CNPJ) when the configured affiliation has none, so testing flows can run without manual setup.",
+          "group": "Tax IDs",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.271",
+      "release_date": "2026-01-05",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.271",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Update Pagaleve parcelado integration tag",
+          "description": "Updates the configuration tag for Pagaleve installment-Pix so the connector targets the latest provider integration.",
+          "group": "Pagaleve",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.267",
+      "release_date": "2025-12-24",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.267",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Map VTEX fields to Cybersource MDD metadata",
+          "description": "Maps additional VTEX order fields into Yuno metadata so Cybersource MDD (Merchant Defined Data) rules can use them for fraud screening.",
+          "group": "Payment Metadata",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.266",
+      "release_date": "2025-12-24",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.266",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Pagaleve Transparente for Pix parcelado",
+          "description": "Adds Pagaleve Transparente as a supported method for both Pix and installment-Pix flows.",
+          "group": "Pagaleve",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.264",
+      "release_date": "2025-12-24",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.264",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Hide installments for Click to Pay",
+          "description": "Hides the installments option when the buyer is paying with Click to Pay, where instalments are not supported by the upstream networks.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.263",
+      "release_date": "2025-12-15",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.263",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Validate transactions before cancel",
+          "description": "Validates that VTEX transactions exist on the order before triggering the cancellation flow, preventing spurious failures.",
+          "group": "Cancellation Flow",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.262",
+      "release_date": "2025-12-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.262",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Restore PicPay support",
+          "description": "Restores PicPay as a supported payment method after it was unintentionally removed.",
+          "group": "PicPay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.260",
+      "release_date": "2025-12-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.260",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Apple Pay installment plans",
+          "description": "Adds installment-plan support for Apple Pay so the merchant's configured installment options appear in the Apple Pay sheet.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Group-order handling",
+          "description": "Treats VTEX order groups as a single payment, avoiding partial-payment artifacts when several orders are placed together.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.258",
+      "release_date": "2025-12-09",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.258",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Add Mercado Pago Checkout Pro",
+          "description": "Adds Mercado Pago Checkout Pro as a redirect-style payment method. Existing Monnet and PicPay redirect flows are unified onto the same shared flow and forward additional payment metadata, including the merchant domain.",
+          "group": "Mercado Pago",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.252",
+      "release_date": "2025-11-27",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.252",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Defense-mode fallback for delayed card payments",
+          "description": "Falls back to direct card processing (defense mode) when the standard flow is delayed by fraud screening, completing the payment without losing the order.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.251",
+      "release_date": "2025-11-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.251",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Mercado Pago Checkout Pro",
+          "description": "Adds Mercado Pago Checkout Pro as a supported redirect-style payment method.",
+          "group": "Mercado Pago",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.250",
+      "release_date": "2025-11-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.250",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Show status page when a Gift Card is present",
+          "description": "Renders the standard status page when the order includes a gift-card payment, preventing the connector from short-circuiting the flow.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.248",
+      "release_date": "2025-11-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.248",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Create-customer toggle",
+          "description": "Adds an optional Create Customer setting so the connector can register the buyer in Yuno's customer registry before the first payment.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.247",
+      "release_date": "2025-11-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.247",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Verify tracking_id and tracking_url in fulfillment events",
+          "description": "Validates tracking_id and tracking_url before forwarding carrier fulfillment events to Yuno so updates with missing values are skipped gracefully.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.244",
+      "release_date": "2025-10-31",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.244",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "NSU on Pix responses",
+          "description": "Includes the NSU transaction identifier in the Pix response so it can be reconciled with the bank.",
+          "group": "Pix",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.242",
+      "release_date": "2025-10-22",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.242",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Skip redundant payment-status call",
+          "description": "Skips the payment-status check when the local state is already PENDING, reducing redundant gateway round-trips.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Card IIN lookup and dynamic card type detection",
+          "description": "Looks up the card BIN (IIN) at checkout so the connector can detect the card brand and whether it is credit or debit dynamically, instead of relying on a static configuration.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Soft Descriptor configuration",
+          "description": "Adds a Soft Descriptor configuration field so merchants can control the text that appears on the customer's card statement.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.241",
+      "release_date": "2025-09-24",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.241",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Send payment reference in metadata",
+          "description": "Sends the merchant payment reference along with the payment metadata so it can be used for downstream reconciliation.",
+          "group": "Payment Metadata",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Patch brace-expansion dependency",
+          "description": "Upgrades the brace-expansion dependency to a patched version to close a reported vulnerability.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Pin brace-expansion across transitive paths",
+          "description": "Pins brace-expansion across all transitive paths so only the patched version is resolved.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.240",
+      "release_date": "2025-09-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.240",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Update koa dependency",
+          "description": "Upgrades the Koa server framework to a newer release line.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Revert Koa upgrade",
+          "description": "Rolls back the Koa framework upgrade shipped in the previous release while compatibility issues are resolved.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.238",
+      "release_date": "2025-07-31",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.238",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Support webhook v2",
+          "description": "Adds support for webhook v2.",
+          "group": "Webhooks",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Non-blocking hostname lookup",
+          "description": "Removes blocking I/O from the connector's hostname lookup so a slow DNS response can't stall the request.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.235",
+      "release_date": "2025-07-07",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.235",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "PSE for Colombia",
+          "description": "Adds PSE (Pagos Seguros en Línea) as a supported payment method for Colombian merchants, using the bank-redirect flow.",
+          "group": "PSE",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.234",
+      "release_date": "2025-07-07",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.234",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Proxy authorization header on PCI calls",
+          "description": "Adds the Proxy-Authorization header on outbound calls that traverse the VTEX IO proxy, fixing 407 responses on tokenized requests.",
+          "group": "PCI & Secure Proxy",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.231",
+      "release_date": "2025-06-27",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.231",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Forward proxy and protocol headers",
+          "description": "Forwards the original VTEX request headers (X-Forwarded-Proto and Port) so downstream services see the merchant's protocol correctly.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.230",
+      "release_date": "2025-06-18",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.230",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Uppercase platform identifier",
+          "description": "Normalizes the platform identifier sent to Yuno to upper-case, aligning with the gateway's expected enum value.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.229",
+      "release_date": "2025-06-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.229",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Axios request timeout",
+          "description": "Adds an explicit timeout to the Axios HTTP client so hanging connections fail fast instead of stalling the payment.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Patch tar-fs vulnerability",
+          "description": "Upgrades the tar-fs dependency to a patched version to close a reported security advisory.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.227",
+      "release_date": "2025-05-14",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.227",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Update dependencies",
+          "description": "Bumps several third-party dependencies to their latest patched versions, including the Koa server framework.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.226",
+      "release_date": "2025-05-13",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.226",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Use the VTEX-supplied amount on capture",
+          "description": "Captures the exact amount that VTEX sends with the capture request, instead of recomputing it from the original order total. This prevents capture mismatches when the order total has changed (partial refunds, gift cards, marketplace splits).",
+          "group": "Capture",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.225",
+      "release_date": "2025-05-07",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.225",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Log retry-limit exhaustion",
+          "description": "Adds a clear log entry when the connector exhausts the retry budget for an outbound request, easing on-call diagnosis.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.223",
+      "release_date": "2025-04-30",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.223",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Additional shipping-type mappings",
+          "description": "Extends the fulfillment mapping with extra shipping types (such as store pickup and marketplace handoff) so more order flows are reported back to the gateway.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.222",
+      "release_date": "2025-04-29",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.222",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Total cart value as metadata",
+          "description": "Includes the total cart value as metadata on each payment, useful for risk scoring and reporting.",
+          "group": "Payment Metadata",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.221",
+      "release_date": "2025-04-29",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.221",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Preserve original order dates",
+          "description": "Stops overriding the original order dates when updating a payment, preserving the merchant-facing timestamps.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.218",
+      "release_date": "2025-04-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.218",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "4-hour retry window for stuck payments",
+          "description": "Adds a 4-hour retry window before re-attempting a stuck payment, reducing pressure on the gateway.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.217",
+      "release_date": "2025-04-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.217",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Capture wallet payments",
+          "description": "Triggers the capture call to Yuno for wallet-based payments so capture timing matches the auto-settle window.",
+          "group": "Capture",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.216",
+      "release_date": "2025-04-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.216",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "4-hour auto-cancel window",
+          "description": "Raises the auto-cancellation window to 4 hours, giving slow alternative payment methods enough time to settle.",
+          "group": "Cancellation Flow",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.215",
+      "release_date": "2025-04-09",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.215",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Forward carrier status",
+          "description": "Retrieves the carrier status from VTEX and forwards it to Yuno as part of the fulfillment update.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.214",
+      "release_date": "2025-04-09",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.214",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Send fulfillment completed event",
+          "description": "Sends a fulfillment-completed event to Yuno when the VTEX order has been fully delivered.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.213",
+      "release_date": "2025-03-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.213",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Include shipped-at timestamp",
+          "description": "Sends the actual shipping timestamp in fulfillment updates so Yuno can compute accurate delivery SLAs.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Upgrade Axios HTTP client",
+          "description": "Updates the Axios HTTP client to the latest stable version, picking up bug fixes and security patches.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.210",
+      "release_date": "2025-03-21",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.210",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Include product brand on items",
+          "description": "Includes the product brand on each line item sent to Yuno so brand-level reporting is possible.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.209",
+      "release_date": "2025-03-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.209",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Skip account lookup when main account is configured",
+          "description": "Skips the account-lookup call when a main account is already configured, removing a redundant VTEX API request.",
+          "group": "Multi-Account",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.204",
+      "release_date": "2025-03-17",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.204",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Skip cancel when payment is still pending",
+          "description": "Skips the cancellation path when a payment is not yet made and the order is in a transient state, preventing premature aborts.",
+          "group": "Cancellation Flow",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.202",
+      "release_date": "2025-03-14",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.202",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Tracking URL and ID as arrays",
+          "description": "Sends shipping tracking URL and ID as arrays in fulfillment updates, matching Yuno's updated schema.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.201",
+      "release_date": "2025-03-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.201",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Reject non-numeric order IDs",
+          "description": "Adds order-id format validation to reject non-numeric or malformed identifiers before the payment is created.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.199",
+      "release_date": "2025-03-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.199",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Check for existing Yuno payment before creating",
+          "description": "Before creating a new Yuno session the connector first checks whether the merchant order already has a payment recorded, avoiding duplicates.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.198",
+      "release_date": "2025-03-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.198",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Validate and recover order ID",
+          "description": "Validates the order ID before processing and, when invalid, attempts to recover the canonical order ID from VTEX.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.197",
+      "release_date": "2025-03-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.197",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Send customer creation date",
+          "description": "Includes the customer creation date in the payment payload so Yuno can apply customer-tenure-based rules.",
+          "group": "Customer & Address",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.196",
+      "release_date": "2025-03-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.196",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Support Monnet in Yuno VTEX SDK",
+          "description": "Adds support for monnet in Yuno VTEX SDK.",
+          "group": "Monnet",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.195",
+      "release_date": "2025-03-05",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.195",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Patch dependency vulnerabilities (cross-spawn, koa)",
+          "description": "Patches reported vulnerabilities across two dependencies (cross-spawn and koa) in one update.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Send fulfillment events to Yuno",
+          "description": "Forwards VTEX fulfillment events (shipped, delivered) to Yuno so it reflects the order lifecycle.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.186",
+      "release_date": "2025-02-24",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.186",
         "language": "bash"
       },
       "entries": [
         {
           "type": "CHANGED",
-          "title": "VTEX Checkout V6 Compatibility",
-          "description": "Improved compatibility with VTEX Checkout V6. Merchants running Checkout V6 should upgrade to this version to ensure correct behavior.",
+          "title": "Expose account name to the front-end",
+          "description": "Exposes the connector account name to the front-end so multi-account checkouts can be routed correctly.",
+          "group": "Multi-Account",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.184",
+      "release_date": "2025-02-07",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.184",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "PicPay Wallet",
+          "description": "Adds PicPay digital wallet as a supported payment method through the wallet-redirect flow.",
+          "group": "PicPay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.182",
+      "release_date": "2025-01-30",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.182",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Handle socket hang-ups on Yuno calls",
+          "description": "Adds handling for socket-level hang-ups when calling the Yuno API, retrying instead of failing the transaction.",
           "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.176",
+      "release_date": "2025-01-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.176",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Coupons total as a separate line item",
+          "description": "Sends the coupon-discount total as a separate line item to Yuno so the order totals reconcile correctly.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.175",
+      "release_date": "2025-01-17",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.175",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Sub-store / multi-account routing",
+          "description": "Adds sub-store support so franchises can route payments through a parent account when needed.",
+          "group": "Multi-Account",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.168",
+      "release_date": "2024-12-18",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.168",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Retry secure-proxy tokenization",
+          "description": "Adds retries on the Yuno Secure Proxy tokenization call so transient PCI gateway failures don't fail the payment.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.155",
+      "release_date": "2024-12-16",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.155",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Sales-channel policy resolution",
+          "description": "Resolves the sales-channel policy so the connector picks the right policy when multiple are configured on the merchant account.",
+          "group": "Multi-Account",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.146",
+      "release_date": "2024-12-09",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.146",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Wait before auto-cancelling",
+          "description": "Adds a wait window before auto-cancelling a payment, giving wallet redirects enough time to complete.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.144",
+      "release_date": "2024-12-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.144",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Faster auto-cancel for generic Yuno method",
+          "description": "Reduces the auto-cancel delay when the payment method is the generic Yuno option, improving the merchant's view of pending transactions.",
+          "group": "Cancellation Flow",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.141",
+      "release_date": "2024-12-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.141",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump the npm_and_yarn group across 2 directories with 19 updates",
+          "description": "Patches 19 reported third-party dependency vulnerabilities in one bulk security update.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Bump the npm_and_yarn group across 2 directories with 15 updates",
+          "description": "Patches 15 reported third-party dependency vulnerabilities in one bulk security update.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Bump the npm_and_yarn group across 2 directories with 8 updates",
+          "description": "Patches 8 reported third-party dependency vulnerabilities in one bulk security update.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Debit cards (Maestro, Voucher, Elo Débito)",
+          "description": "Adds Maestro, Visa Electron, Elo Débito, Mastercard Debit and Voucher as supported debit-card payment methods.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Upgrade semver-regex",
+          "description": "Upgrades the semver-regex dependency to patch a reported vulnerability.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Patch reported vulnerabilities (group 1)",
+          "description": "Bulk upgrade of dependencies to patch a batch of reported third-party vulnerabilities.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Patch reported vulnerabilities (group 2)",
+          "description": "Bulk upgrade of dependencies to patch a further batch of reported third-party vulnerabilities.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.137",
+      "release_date": "2024-11-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.137",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Webhook logging",
+          "description": "Adds structured logging to the webhook handler so incoming Yuno events can be traced.",
+          "group": "Webhooks",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.136",
+      "release_date": "2024-11-14",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.136",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Send shipping status to Yuno",
+          "description": "Forwards the order's shipping status as part of the fulfillment update so Yuno has end-to-end order context.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.135",
+      "release_date": "2024-11-08",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.135",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Expanded payment status mapping",
+          "description": "Recognizes additional payment statuses from Yuno so terminal states are mapped correctly back to VTEX.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.134",
+      "release_date": "2024-11-07",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.134",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Monnet cash and bank transfer",
+          "description": "Adds Monnet cash and bank transfer as supported payment methods through an iframe flow.",
+          "group": "Monnet",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.133",
+      "release_date": "2024-10-22",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.133",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Pix Parcelado",
+          "description": "Adds Pix Parcelado (installment Pix) as a supported payment method for Brazilian merchants.",
+          "group": "Pix",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.132",
+      "release_date": "2024-09-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.132",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Approve cancellation when order is already known",
+          "description": "Returns a cancellation-approved response when the merchant order is already on record, avoiding spurious cancellation failures.",
+          "group": "Cancellation Flow",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.131",
+      "release_date": "2024-09-05",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.131",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Pagaleve one-time Pix",
+          "description": "Adds support for Pagaleve's single-payment Pix option (a vista).",
+          "group": "Pagaleve",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.130",
+      "release_date": "2024-08-29",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.130",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Pagaleve installment Pix",
+          "description": "Adds support for Pagaleve's installment-Pix offering, letting buyers split a Pix payment over multiple instalments.",
+          "group": "Pagaleve",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.129",
+      "release_date": "2024-08-29",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.129",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Add Pagaleve initial support",
+          "description": "Adds initial support for Pagaleve as a buy-now-pay-later option for Brazilian merchants.",
+          "group": "Pagaleve",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.128",
+      "release_date": "2024-08-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.128",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Boleto Banco do Brasil",
+          "description": "Adds Boleto Banco do Brasil as a supported payment option.",
+          "group": "Boleto",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.127",
+      "release_date": "2024-08-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.127",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Pix redirect flow",
+          "description": "Adds the Pix redirect flow as an alternative to QR code, so merchants can route customers to the bank-side payment page.",
+          "group": "Pix",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.126",
+      "release_date": "2024-08-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.126",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Richer logs and neighborhood extraction",
+          "description": "Enriches connector logs with more context and extracts the neighborhood field from VTEX addresses so it can be sent to the gateway.",
+          "group": "Customer & Address",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.117",
+      "release_date": "2024-08-15",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.117",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Improve customer address handling",
+          "description": "Forwards all address sub-fields (state, neighborhood, complement) to Yuno so payments include the complete buyer address.",
+          "group": "Customer & Address",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.115",
+      "release_date": "2024-08-14",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.115",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Add Alelo brand",
+          "description": "Adds the Alelo card brand to the supported payment-method list in the provider configuration.",
+          "group": "Alelo",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.114",
+      "release_date": "2024-08-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.114",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Fix typo on refund description",
+          "description": "Corrects a typo in the message returned to VTEX after a refund is processed.",
+          "group": "Refunds",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.113",
+      "release_date": "2024-08-08",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.113",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Fetch payment details from VTEX",
+          "description": "Looks up payment details from the VTEX transactions API so the connector has accurate context when handling captures and refunds.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.107",
+      "release_date": "2024-07-18",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.107",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Remove custom field",
+          "description": "Removes a custom configuration field that was no longer used by any merchant.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.106",
+      "release_date": "2024-07-18",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.106",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Restore AES session encryption",
+          "description": "Restores AES-256-CBC encryption for sensitive session data passed between front-end and back-end after a regression removed it.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.92",
+      "release_date": "2024-07-15",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.92",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Two-card split payments",
+          "description": "Adds support for splitting a payment across two cards in the same VTEX checkout.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.91",
+      "release_date": "2024-07-10",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.91",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Alelo (initial support)",
+          "description": "Adds Alelo benefit cards as a supported payment method (initial integration).",
+          "group": "Alelo",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.90",
+      "release_date": "2024-07-05",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.90",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Support Apple pay",
+          "description": "Adds Apple Pay support, including the Apple-Pay-sheet flow at the VTEX checkout.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.89",
+      "release_date": "2024-06-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.89",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Alternative payment method status validation",
+          "description": "Adds payment-status validation for alternative payment methods so the connector reports the correct final state back to VTEX.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.88",
+      "release_date": "2024-06-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.88",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Forward merchant account on payments",
+          "description": "Sends the merchant account identifier with each payment so Yuno can resolve the correct affiliation when multiple are configured.",
+          "group": "Multi-Account",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.87",
+      "release_date": "2024-06-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.87",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Enable Google Pay",
+          "description": "Activates Google Pay as a supported payment method at the VTEX checkout.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.86",
+      "release_date": "2024-06-17",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.86",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Nu Pay support",
+          "description": "Adds Nu Pay (Nubank's credit-line payment) as a supported method for Brazilian merchants.",
+          "group": "Nubank",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.85",
+      "release_date": "2024-06-13",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.85",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Boleto Bancário integration",
+          "description": "Adds support for Boleto Bancário, returning the barcode and payment URL so merchants can render them at checkout.",
+          "group": "Boleto",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.84",
+      "release_date": "2024-05-31",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.84",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Improve card logs",
+          "description": "Adds more context to card-payment logs to speed up incident triage and merchant support investigations.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.83",
+      "release_date": "2024-05-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.83",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Webhook receiver for payment status",
+          "description": "Adds a webhook receiver so the connector can update VTEX payment status when Yuno publishes terminal events.",
+          "group": "Webhooks",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.81",
+      "release_date": "2024-04-30",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.81",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Add Nubank",
+          "description": "Adds Nubank as a supported payment method for Brazilian merchants.",
+          "group": "Nubank",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.80",
+      "release_date": "2024-04-26",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.80",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "PagoEfectivo and SafetyPay",
+          "description": "Adds initial support for PagoEfectivo and SafetyPay as redirect-style payment options targeting Peru.",
+          "group": "PagoEfectivo & SafetyPay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.76",
+      "release_date": "2024-04-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.76",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Declare auto-settle support",
+          "description": "Declares auto-settle support in the provider configuration so VTEX correctly hands off capture timing to the connector.",
+          "group": "Capture",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.74",
+      "release_date": "2024-03-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.74",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Enable Apple Pay",
+          "description": "Activates Apple Pay as a supported payment method at the VTEX checkout for merchants enrolled in the Apple Pay program.",
+          "group": "Apple Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.73",
+      "release_date": "2024-03-15",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.73",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Support vtex pix",
+          "description": "Adds support for vtex pix.",
+          "group": "Pix",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.72",
+      "release_date": "2024-03-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.72",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "NSU transaction identifier",
+          "description": "Includes the NSU (transaction sequence number) in the payment response so merchants can reconcile transactions with the acquirer.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.71",
+      "release_date": "2024-03-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.71",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Send raw payment response",
+          "description": "Includes the raw Yuno payment response in the VTEX callback so merchants and support teams have full provider context when investigating.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.70",
+      "release_date": "2023-10-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.70",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Upgrade event-log library to v1",
+          "description": "Picks up new fields, bug fixes, and improved trace-ID support from the v1 release of the event-log library.",
+          "group": "Observability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.69",
+      "release_date": "2023-10-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.69",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Performance improvement",
+          "description": "Reduces latency on the payment authorization path through targeted optimizations in the hottest code paths.",
+          "group": "Performance & Latency",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.67",
+      "release_date": "2023-09-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.67",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Yuno event-log library integration",
+          "description": "Wires in the Yuno event-log library so connector errors are tracked centrally with trace IDs that link gateway and merchant logs.",
+          "group": "Observability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.55",
+      "release_date": "2023-09-13",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.55",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Structured event logs",
+          "description": "Introduces structured event logging across the connector to make production troubleshooting easier.",
+          "group": "Observability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.35",
+      "release_date": "2023-08-17",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.35",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "3-D Secure support",
+          "description": "Adds end-to-end 3-D Secure for card payments so merchants can comply with strong-customer-authentication requirements.",
+          "group": "3-D Secure",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "3.0.0",
+      "release_date": "2023-05-26",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@3.0.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Event log parsed error fixed",
+          "description": "Fixes a parsing error that prevented some failures from being recorded in the event log.",
+          "group": "Observability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "release_date": "2021-12-21",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.2.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump urijs from 1.19.6 to 1.19.11 in /node",
+          "description": "Patches several reported vulnerabilities in the urijs URL-parsing dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "release_date": "2021-12-21",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.1.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump minimatch from 3.0.4 to 3.1.2 in /node",
+          "description": "Patches a regular-expression denial-of-service issue in the minimatch dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.6",
+      "release_date": "2021-11-18",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.6",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump @babel/traverse from 7.13.0 to 7.23.6 in /node",
+          "description": "Patches an arbitrary-code-execution vulnerability in the @babel/traverse build-time dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "SECURITY",
+          "title": "Bump async from 2.6.3 to 2.6.4 in /node",
+          "description": "Patches a prototype-pollution issue in the async dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.5",
+      "release_date": "2021-05-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Return undefined when the payment state is pending",
+          "description": "Aligns the connector's response for pending payments with VTEX expectations so pending payments are no longer marked as failed.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.4",
+      "release_date": "2021-05-17",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Support for the VTEX card form",
+          "description": "Adds full support for the VTEX card-payment form across all major brands, including 3-D Secure authentication.",
+          "group": "3-D Secure",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.3",
+      "release_date": "2021-04-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.3",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump semver from 5.7.1 to 5.7.2 in /node",
+          "description": "Patches a denial-of-service vulnerability reported in the semver dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.2",
+      "release_date": "2021-03-02",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump minimatch from 3.0.4 to 3.1.2",
+          "description": "Patches a regular-expression denial-of-service issue in the minimatch dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.1",
+      "release_date": "2021-03-01",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump path-parse from 1.0.6 to 1.0.7",
+          "description": "Patches a regular-expression denial-of-service vulnerability in the path-parse transitive dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "release_date": "2021-02-27",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@1.0.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump json5 from 1.0.1 to 1.0.2",
+          "description": "Patches a __proto__ prototype-pollution vulnerability in the json5 dependency.",
+          "group": "Dependency Updates",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Order events",
+          "description": "Adds order-event tracking so VTEX order state transitions propagate to Yuno.",
+          "group": "Fulfillment",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Fix discount handling",
+          "description": "Corrects how discount amounts are forwarded to the gateway so coupon and promotion values are reflected accurately on the payment.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "0.0.2",
+      "release_date": "2020-02-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@0.0.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Bump minimist from 1.2.5 to 1.2.8",
+          "description": "Patches a reported prototype-pollution vulnerability in the minimist dependency.",
+          "group": "Dependency Updates",
           "migration_guide": null,
           "links": []
         }

--- a/changelog/source/woocommerce.json
+++ b/changelog/source/woocommerce.json
@@ -2,18 +2,132 @@
   "sdk": "woocommerce",
   "releases": [
     {
-      "version": "1.0.0",
-      "release_date": "2026-01-15",
+      "version": "1.0.1",
+      "release_date": "2026-04-13",
       "upgrade": {
-        "snippet": "wp plugin install yuno-payments --activate",
+        "snippet": "wp plugin install yuno-payment-gateway --version=1.0.1 --activate",
         "language": "bash"
       },
       "entries": [
         {
           "type": "ADDED",
-          "title": "Initial Release",
-          "description": "First public release of the Yuno WooCommerce plugin. Supports the basic payment flow and credit card payments.",
+          "title": "Hide payment selection when Yuno is the only gateway",
+          "description": "Adds a Hide Payment Selection setting so the payment method radio buttons are hidden at checkout when Yuno is the only active gateway, presenting a cleaner one-method checkout experience. Applies to both legacy and block-based checkouts.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "release_date": "2026-04-07",
+      "upgrade": {
+        "snippet": "wp plugin install yuno-payment-gateway --version=1.0.0 --activate",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Initial WordPress Plugin Directory release",
+          "description": "First public release of the Yuno WooCommerce payment gateway on the WordPress Plugin Directory, integrating Yuno's payment orchestration platform with WooCommerce through the Yuno Web SDK and a PHP REST API layer.",
           "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Card payments, wallets, and local payment methods",
+          "description": "Accepts cards, digital wallets, and local payment methods through Yuno's payment orchestration platform from a single integration, with intelligent payment routing across multiple providers.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "WooCommerce block-based checkout support",
+          "description": "Supports both the legacy shortcode checkout and the WooCommerce block-based checkout (default since WooCommerce 8.3). Both flows converge at the order-pay page so the SDK orchestration is shared.",
+          "group": "Block Checkout",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Webhook receiver for asynchronous payment status",
+          "description": "Receives Yuno payment events (succeeded, pending, failed, chargeback, refund) with three-layer HMAC verification and idempotent processing through transient locks.",
+          "group": "Webhooks",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Marketplace split payments",
+          "description": "Splits the order total between a seller recipient and a platform commission, configurable as a percentage or a fixed minor-unit amount.",
+          "group": "Marketplace",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "In-place retry on failed payments",
+          "description": "Lets the customer retry a failed payment in place by remounting the SDK, instead of creating a new duplicate order on each retry attempt.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Auto-complete for virtual and downloadable orders",
+          "description": "Orders that contain only virtual or downloadable products skip the processing state and go straight to completed after payment.",
+          "group": "Order Management",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "3D Secure and additional authentication support",
+          "description": "Handles 3D Secure challenges and additional authentication flows during payment, including a return-from-3DS detection that prevents accidental order duplication.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "HPOS compatibility",
+          "description": "Declares compatibility with WooCommerce High-Performance Order Storage (custom order tables) and uses HPOS-safe order queries throughout.",
+          "group": "Order Management",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Per-order Yuno customer strategy",
+          "description": "Creates a fresh Yuno customer per WooCommerce order, with automatic recovery from duplicate-customer and customer-not-found errors so payments are never blocked by stale customer state.",
+          "group": "Customer & Address",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Server-side payment verification",
+          "description": "Verifies every reported payment status against the Yuno API before updating the WooCommerce order, never trusting client-reported status.",
+          "group": "Reliability",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Multi-environment support",
+          "description": "Auto-detects the Yuno API environment (development, staging, sandbox, production) from the Public API Key prefix.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Configurable debug logging with PII redaction",
+          "description": "Optional WooCommerce-integrated logging for troubleshooting payments and webhooks. Phone numbers, email addresses, and full API payloads are never logged.",
+          "group": "Configuration",
           "migration_guide": null,
           "links": []
         }


### PR DESCRIPTION
## Summary
- Add new changelog entries for VTEX plugin in both source JSON and rendered MDX
- Add new changelog entries for WooCommerce plugin in both source JSON and rendered MDX

## Test plan
- [ ] Verify VTEX changelog renders correctly on the docs site
- [ ] Verify WooCommerce changelog renders correctly on the docs site
- [ ] Confirm source JSON files stay in sync with their MDX counterparts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (MDX/JSON changelog data) with no runtime code changes; main risk is content drift or rendering issues due to the large VTEX changelog expansion.
> 
> **Overview**
> Updates the docs changelogs to add **new VTEX plugin releases** (now listing versions `v4.2.300` back through historical entries) and publishes the corresponding structured release data in `changelog/source/vtex.json`, including updated install snippets.
> 
> Adds **WooCommerce changelog entries** for `v1.0.1` and refreshes `v1.0.0` details (release date, install command, and expanded feature list) in both `changelog/plugins/woocommerce.mdx` and `changelog/source/woocommerce.json` so rendered pages stay in sync with source JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53eba49353663254cc99a99c4848dca89c14675f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->