### PR TITLE
Hide early-resolution paragraph from Chargeback Management page

### DIFF
--- a/docs/payouts-and-disputes/chargeback-management.mdx
+++ b/docs/payouts-and-disputes/chargeback-management.mdx
@@ -60,7 +60,7 @@ The states of chargebacks in Yuno represent the various stages of the process:
 
 ## Predisputes (deflections)
 
-Some networks and providers offer early-resolution programs that can deflect disputes before a formal chargeback is opened. Examples include Visa Rapid Dispute Resolution (RDR), Mastercard's Ethoca ecosystem, and American Express Accelerated Dispute Resolution (ADR).
+{/* Some networks and providers offer early-resolution programs that can deflect disputes before a formal chargeback is opened. Examples include Visa Rapid Dispute Resolution (RDR), Mastercard's Ethoca ecosystem, and American Express Accelerated Dispute Resolution (ADR). */}
 
 When a provider/network explicitly reports a predispute deflection, Yuno:
 


### PR DESCRIPTION
 ## PR Description

  Temporarily hides a paragraph from the **Predisputes (deflections)** section of the Chargeback Management page by commenting it out with MDX syntax. The content is fully preserved in the source and can be restored by removing the comment.

  **Hidden content:** the sentence describing Visa RDR, Mastercard's Ethoca ecosystem, and American Express ADR as early-resolution program examples.

  ## Changes

  - `docs/payouts-and-disputes/chargeback-management.mdx` — commented out one paragraph in the Predisputes (deflections) section using `{/* ... */}`; no other content modified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just hides a single paragraph via MDX comment syntax; no behavior or API changes.
> 
> **Overview**
> **Temporarily hides** the “early-resolution programs” explanatory paragraph in `docs/payouts-and-disputes/chargeback-management.mdx` by converting it to an MDX comment (`{/* ... */}`), preserving the content in-source for easy restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52827efc45467526dac8c11df820b49ceb16adc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->