### PR TITLE
chore: web sdk changelog 1.8.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.1",
+      "release_date": "2026-05-22",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Mongolian Language Support",
+          "description": "Adds Mongolian (mn) as a supported locale for the web SDK checkout experience.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.8.0",
       "release_date": "2026-05-14",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.8.1`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v12.0.3

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `web` SDK changelog JSON and does not modify runtime code paths.
> 
> **Overview**
> Adds a new `web` SDK changelog release entry for `1.8.1` with upgrade instructions and a single **ADDED** item documenting Mongolian (`mn`) locale support. Also normalizes the JSON file ending by ensuring a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2425c291671858af069cdf90c720b5a3cbe80008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->