### PR TITLE
chore: web sdk changelog 1.8.2

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.2",
+      "release_date": "2026-05-22",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Mongolian Language Support",
+          "description": "Adds Mongolian (mn) as a supported locale for the web SDK checkout experience.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.8.0",
       "release_date": "2026-05-14",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.8.2`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v12.0.2

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a new changelog entry without modifying SDK code or runtime behavior.
> 
> **Overview**
> Adds a new Web SDK changelog release `1.8.2` with upgrade instructions and a single entry noting **Mongolian (`mn`) locale support** for the checkout experience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c224dbb291cc1f2a2aa5a5eb3ddc645de854dcb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->