### PR TITLE
chore: web sdk changelog 1.8.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.1",
+      "release_date": "2026-05-22",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Mongolian Language Support",
+          "description": "Adds Mongolian (mn) as a supported locale for the web SDK checkout experience.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.8.0",
       "release_date": "2026-05-14",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.8.1`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v12.0.1

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `web.json` changelog data and fixes a missing trailing newline, with no runtime code changes.
> 
> **Overview**
> Adds a new **Web SDK `1.8.1`** changelog release entry documenting *Mongolian (`mn`) locale support*, including the npm upgrade snippet.
> 
> Also normalizes the end-of-file newline in `changelog/source/web.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d9f0f2bc0a922da6b5dec7a922821b4a10d375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->