### PR TITLE
chore: web sdk changelog 1.8.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.1",
+      "release_date": "2026-05-22",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Mongolian Language Support",
+          "description": "Adds Mongolian (mn) as a supported locale for the web SDK checkout experience.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.8.0",
       "release_date": "2026-05-14",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.8.1`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v12.0.3

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no runtime or integration code changes.
> 
> **Overview**
> Documents **web SDK `1.8.1`** in `changelog/source/web.json` by inserting a new release block at the top of the `releases` array (dated 2026-05-22, with `npm install @yuno-payments/sdk-web@1.8.1`).
> 
> The only listed change is **Mongolian (`mn`) locale** support for checkout UI (ADDED / Core SDK). The PR also fixes the file ending so the root JSON closes with a newline after the final `}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17869603d3cfe4116d4b6aab145e10d1d8317812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->