### PR TITLE
Update iOS SDK release notes for version 2.17.0

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,18 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.17.0
+*May 25, 2026*
+
+- <ChangelogBadge type="added" /> **Netcetera Native 3DS SDK Support**  
+  Introduced support for the Netcetera Native 3DS SDK, enabling enhanced security for transactions.
+
+- <ChangelogBadge type="added" /> **Slim Form Variant**  
+  A new form layout is available that consolidates card information and address sections into a more compact format. This is available as an opt-in setting.
+
+- <ChangelogBadge type="changed" /> **Secure Payment Badge Visibility**  
+  Added an opt-in setting to hide the "Secure payment with YUNO" badge, providing greater flexibility in UI customization.
+
 ## v2.16.0
 *May 8, 2026*
 

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,48 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.17.0",
+      "release_date": "2026-05-25",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.17.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.17.0'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Netcetera Native 3DS SDK Support",
+          "description": "Introduced support for the Netcetera Native 3DS SDK, enabling enhanced security for transactions.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Slim Form Variant",
+          "description": "A new form layout is available that consolidates card information and address sections into a more compact format. This is available as an opt-in setting.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Secure Payment Badge Visibility",
+          "description": "Added an opt-in setting to hide the \"Secure payment with YUNO\" badge, providing greater flexibility in UI customization.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.16.0",
       "release_date": "2026-05-08",
       "upgrade": [


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.17.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or API code changes.
> 
> **Overview**
> Documents **iOS SDK v2.17.0** (May 25, 2026) by prepending a new release block to `changelog/source/ios.json` and adding a matching **v2.17.0** section at the top of `changelog/ios.mdx`.
> 
> The new notes cover **Netcetera Native 3DS SDK** support, an opt-in **Slim Form** layout, and an opt-in setting to **hide the Secure payment with YUNO badge**. SPM and CocoaPods upgrade snippets are set to `2.17.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe16133d442e49438e37baf0d951d8057d5d1de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->