### PR TITLE
Adding documentation for Netcetera 3DS native modules for Android and iOS

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -796,6 +796,13 @@
                 ]
               }
             ]
+          },
+          {
+            "group": "External Native Modules",
+            "pages": [
+              "docs/sdks/external-native-modules/netcetera-3ds-ios",
+              "docs/sdks/external-native-modules/netcetera-3ds-android"
+            ]
           }
         ]
       },

--- a/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
@@ -1,0 +1,131 @@
+---
+title: "3DS Native SDKs (Android)"
+sidebarTitle: "Netcetera 3DS (Android)"
+description: "Run 3-D Secure challenges natively in your Android app with Netcetera's 3DS SDK."
+robots: index
+---
+
+The Yuno Android SDK supports running 3-D Secure (3DS) challenges natively inside your app using **Netcetera's 3DS SDK**. Native 3DS gives a smoother UX than the WebView-based fallback (no in-app browser jump) and is required by some acquirers for frictionless authentication.
+
+<Warning>
+  **Payment flows only** — Native 3DS via Netcetera is currently supported for **payment** flows only. It does not apply to enrollment flows.
+</Warning>
+
+<Note>
+  Native 3DS is **opt-in**: you only need to install the provider module if your integration runs 3DS challenges in-app. If you are not enabling 3DS, you can skip this guide.
+</Note>
+
+## Requirements
+
+- Android **API level 21** (Lollipop) or higher.
+- **Yuno Payments SDK 2.16.0 or higher** already installed in your app (`com.yuno.payments:android-sdk`).
+- The Netcetera 3DS provider module (`com.yuno.payments:yuno-sdk-3ds-netcetera`), installed via Gradle (see below).
+
+<Warning>
+  The Netcetera provider bundles a full 3DS challenge UI and the vendor's root certificates, which adds to your final app binary. This is why it ships as a separate module — merchants who don't use 3DS don't pay this cost.
+</Warning>
+
+## Compatibility
+
+Each release of this module is built and tested against a minimum version of the Yuno Payments SDK. The module's POM does not pin a specific core version, leaving you in full control of which `com.yuno.payments:android-sdk` version your app runs against — but versions below the minimum may not expose the APIs this module relies on and can fail at runtime with `NoSuchMethodError` / `NoSuchFieldError`.
+
+| Yuno 3DS Netcetera | Requires Yuno Payments SDK |
+|---|---|
+| `1.0.1` | `≥ 2.16.0` |
+
+When upgrading either dependency, bump both sides together so the combination stays within a supported pair.
+
+## Step 1: Declare the Netcetera Maven repository
+
+The Netcetera 3DS SDK is hosted on Netcetera's public Maven server. Because Gradle does not propagate transitive repositories through POM metadata, your app must declare the repo explicitly so it can resolve the Netcetera SDK dependency.
+
+Add the entry to your project's settings file inside `dependencyResolutionManagement.repositories`:
+
+<Tabs>
+  <Tab title="Groovy DSL">
+    In `settings.gradle`:
+
+    ```groovy
+    dependencyResolutionManagement {
+        repositories {
+            google()
+            mavenCentral()
+            maven { url "https://yunopayments.jfrog.io/artifactory/snapshots-libs-release" }
+            // Required by Yuno 3DS Netcetera module
+            maven { url "https://nexus.extranet.netcetera.biz/nexus/repository/public-repository-maven/" }
+        }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Kotlin DSL">
+    In `settings.gradle.kts`:
+
+    ```kotlin
+    dependencyResolutionManagement {
+        repositories {
+            google()
+            mavenCentral()
+            maven { url = uri("https://yunopayments.jfrog.io/artifactory/snapshots-libs-release") }
+            // Required by Yuno 3DS Netcetera module
+            maven { url = uri("https://nexus.extranet.netcetera.biz/nexus/repository/public-repository-maven/") }
+        }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Info>
+  If you are using the legacy `allprojects { repositories { … } }` block in your root `build.gradle`, add the same Netcetera `maven { url "…" }` line there instead.
+</Info>
+
+## Step 2: Add the dependency
+
+Add the Yuno 3DS Netcetera dependency to your app module's build file:
+
+<Tabs>
+  <Tab title="Groovy DSL">
+    In `build.gradle`:
+
+    ```groovy
+    dependencies {
+        implementation "com.yuno.payments:android-sdk:{last_version}"
+        implementation "com.yuno.payments:yuno-sdk-3ds-netcetera:{last_version}"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Kotlin DSL">
+    In `build.gradle.kts`:
+
+    ```kotlin
+    dependencies {
+        implementation("com.yuno.payments:android-sdk:{last_version}")
+        implementation("com.yuno.payments:yuno-sdk-3ds-netcetera:{last_version}")
+    }
+    ```
+  </Tab>
+</Tabs>
+
+The Netcetera 3DS SDK and its required `androidx.startup` dependency are pulled in transitively — you don't need to declare them yourself.
+
+## Activating the 3DS provider
+
+The module **auto-registers** with the Yuno Payments SDK when your app process starts (via [Jetpack App Startup](https://developer.android.com/topic/libraries/app-startup)). **No extra code is required** — just initialize the Yuno SDK as usual:
+
+```kotlin
+import com.yuno.payments.Yuno
+
+Yuno.initialize(
+    application = this,
+    apiKey = "YOUR_API_KEY",
+)
+```
+
+<Tip>
+  Once registered, the Yuno Payments SDK automatically routes any 3DS challenge during checkout through the Netcetera provider. **You don't need to change any of your payment code.**
+</Tip>
+
+### Permissions
+
+`android.permission.INTERNET` is declared by the module's manifest and merged into your app automatically — no action required.

--- a/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
@@ -42,7 +42,7 @@ The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside yo
     Add to your `Podfile`:
 
     ```ruby
-    platform :ios, '14.0'
+    platform :ios, '15.0'
 
     target 'YourApp' do
       use_frameworks!

--- a/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
@@ -1,0 +1,132 @@
+---
+title: "3DS Native SDKs (iOS)"
+sidebarTitle: "Netcetera 3DS (iOS)"
+description: "Run 3-D Secure challenges natively in your iOS app with Netcetera's 3DS SDK."
+robots: index
+---
+
+The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside your app using **Netcetera's 3DS SDK**. Native 3DS gives a smoother UX than web-based challenges (no Safari View Controller jump) and is required by some acquirers for frictionless authentication.
+
+<Warning>
+  **Payment flows only** — Native 3DS via Netcetera is currently supported for **payment** flows only. It does not apply to enrollment flows.
+</Warning>
+
+<Note>
+  Native 3DS is **opt-in**: you only need to install the provider package if your integration runs 3DS challenges in-app. If you are not enabling 3DS, you can skip this guide.
+</Note>
+
+## Requirements
+
+- iOS **15.0** or higher.
+- **YunoSDK 2.17.0 or higher** already installed in your app.
+- The Netcetera 3DS provider package ([`Yuno3DSNetcetera`](https://github.com/yuno-payments/yuno-3DS-netcetera-iOS)), installed via Swift Package Manager or CocoaPods (see below).
+
+<Warning>
+  The Netcetera provider adds approximately **5 MB** to your final app binary (it bundles a full 3DS challenge UI and the vendor's root certificates). This is why it lives in a separate package — merchants who don't use 3DS don't pay this cost.
+</Warning>
+
+## Installation
+
+<Tabs>
+  <Tab title="Swift Package Manager">
+    In Xcode go to **File → Add Package Dependencies…** and add:
+
+    ```
+    https://github.com/yuno-payments/yuno-3DS-netcetera-iOS
+    ```
+
+    Select the `Yuno3DSNetcetera` library and add it to your app target. Make sure both `YunoSDK` and `Yuno3DSNetcetera` resolve to versions `>= 2.17.0`.
+  </Tab>
+
+  <Tab title="CocoaPods">
+    Add to your `Podfile`:
+
+    ```ruby
+    platform :ios, '14.0'
+
+    target 'YourApp' do
+      use_frameworks!
+
+      pod 'YunoSDK',          '~> 2.17'
+      pod 'Yuno3DSNetcetera', '~> 2.17'
+    end
+    ```
+
+    Then run:
+
+    ```bash
+    pod install
+    ```
+  </Tab>
+</Tabs>
+
+## Activating the 3DS provider
+
+<Tabs>
+  <Tab title="Swift Package Manager">
+    The provider **auto-registers** when the framework loads. No extra code is required — just `import Yuno3DSNetcetera` somewhere in your app:
+
+    ```swift
+    import YunoSDK
+    import Yuno3DSNetcetera
+
+    Yuno.initialize(apiKey: "YOUR_API_KEY", config: YunoConfig())
+    ```
+  </Tab>
+
+  <Tab title="CocoaPods">
+    The CocoaPods variant ships as a **static** framework, so the auto-register bootstrap is not included. Call `Yuno3DSNetcetera.register()` **once**, before `Yuno.initialize(...)`:
+
+    ```swift
+    import YunoSDK
+    import Yuno3DSNetcetera
+
+    Yuno3DSNetcetera.register()
+    Yuno.initialize(apiKey: "YOUR_API_KEY", config: YunoConfig())
+    ```
+  </Tab>
+</Tabs>
+
+<Tip>
+  Once registered, YunoSDK automatically routes any 3DS challenge during checkout through the Netcetera provider. **You don't need to change any of your payment code.**
+</Tip>
+
+## Sandbox certificate
+
+When testing against the Yuno sandbox environment, the Netcetera SDK requires a Visa test root certificate (`acq-root-certeq-prev-environment.crt`) to be present in your app's main bundle.
+
+<Info>
+  **Contact your Yuno TAM (Technical Account Manager) to obtain the certificate.** It is not distributed publicly.
+</Info>
+
+Once you have the file:
+
+<Steps>
+  <Step title="Add to Xcode">
+    Drag it into Xcode's Project Navigator inside your app target's group.
+  </Step>
+  <Step title="Select target">
+    Check **Add to targets** and tick your app target.
+  </Step>
+  <Step title="Verify bundle resources">
+    Verify it appears under **Target → Build Phases → Copy Bundle Resources**.
+  </Step>
+</Steps>
+
+<Note>
+  In production environments this certificate is not used and can be omitted from Release builds.
+</Note>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Linker error mentioning YunoThreeDSRegistry">
+    Your `YunoSDK` is older than 2.17.0. Bump it to `>= 2.17.0`.
+  </Accordion>
+  <Accordion title="3DS challenge UI never appears (CocoaPods)">
+    You forgot to call `Yuno3DSNetcetera.register()` before `Yuno.initialize(...)`.
+  </Accordion>
+  <Accordion title="Console: acq-root-certeq-prev-environment.crt not found">
+    Only relevant in sandbox. Add the certificate to your app bundle (see [Sandbox certificate](#sandbox-certificate)). Safe to ignore in production.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## PR Description

Adding documentation for Netcetera 3DS native modules for Android and iOS.

### Summary

  Adds a new **External Native Modules** section to the SDK docs, with
  integration guides for Netcetera's 3DS SDK on iOS and Android.

  - **iOS** (`netcetera-3ds-ios.mdx`) — covers requirements, SPM/CocoaPods
    installation, provider activation, sandbox certificate setup, and
    troubleshooting. Source: Vivi.
  - **Android** (`netcetera-3ds-android.mdx`) — covers requirements,
    Gradle setup (Maven repo + dependency), compatibility matrix, and
    provider activation via Jetpack App Startup. Source: Sebas.
  - **`docs.json`** — new "External Native Modules" sidebar group added
    after "Additional Platforms", with both pages registered.

## Changes

  | File | What changed |
  |---|---|
  | `docs/sdks/external-native-modules/netcetera-3ds-ios.mdx` | New page |
  | `docs/sdks/external-native-modules/netcetera-3ds-android.mdx` | New page |
  | `docs.json` | New sidebar group "External Native Modules" with iOS and Android entries |

## Editorial decisions

  - **Payments-only restriction** (`<Warning>`) added to both pages immediately after the opening paragraph, per Vivi's follow-up correction: native 3DS via Netcetera is currently supported for payment flows only, not enrollment.
  - **`<Tip>` corrected** on both pages: removed "or enrollment" to stay consistent with the restriction above.
  - **`sidebarTitle`** added to both pages (`"Netcetera 3DS (iOS/Android)"`) so the sidebar label is concise while the page `<h1>` stays descriptive (`"3DS Native SDKs (iOS/Android)"`).
  - **`sidebarTitle` from Vivi's draft dropped** from frontmatter convention audit — no other SDK page uses it; only re-introduced here for the shorter sidebar label.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or SDK code modified; incorrect integration steps could mislead merchants but do not affect production systems directly.
> 
> **Overview**
> Adds an **External Native Modules** section to the SDK docs (via `docs.json`) with two new integration guides for opt-in **Netcetera native 3-D Secure** on mobile.
> 
> Both pages stress that native 3DS applies to **payment flows only** (not enrollment) and that checkout routing stays automatic once the provider is registered—merchants should not change payment code. The **Android** guide covers Netcetera Maven repo setup, `yuno-sdk-3ds-netcetera` Gradle dependency, a compatibility matrix with Yuno Payments SDK ≥ 2.16.0, and Jetpack App Startup auto-registration. The **iOS** guide covers SPM/CocoaPods install for `Yuno3DSNetcetera`, explicit `Yuno3DSNetcetera.register()` for CocoaPods static builds, sandbox Visa root certificate bundle steps, and troubleshooting accordions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd4b9b0fd028c465a80fccf0dda6ff437735548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->