### PR TITLE
chore: web sdk changelog 1.9.0

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.0",
+      "release_date": "2026-05-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "BREAKING",
+          "title": "White Label",
+          "description": "- **Whitelabel-Neutral Public API**: Public-facing CSS class names, DOM ids, and event/callback names have been renamed to neutral, whitelabel-friendly identifiers. Existing `window.Yuno`, the `yuno-sdk-ready` event, and `yuno*` callback aliases continue to work, so existing merchant integrations need no changes.  `Yuno` class names prefix changed to `sdk-payments`.  `window.Yuno` deprecated in favor of `window.SdkPayments` - **Custom API and Asset URLs**: Added `options.apiUrl` and `options.assetUrl` initialization overrides so the SDK can point at partner-hosted backends, 3DS endpoints, secure-field iframes, and card-form assets instead of the default Yuno URLs. The override is also forwarded to the monitoring layer, mediator, and card-form iframes. - **Hide Secure Payment Badge on Custom Hosting**: When `apiUrl` or `assetUrl` overrides are set, the `Secure Payment with Yuno` badge is automatically hidden in both the standard checkout and the Click to Pay flow. ### Patch Changes - More Resilient Asset Resolution: Guard the webpack public path when running under Vite, skip duplicate `/v<x.y>` suffixes when the asset URL already includes one, and use the configured `apiUrl` directly as the API client base URL to avoid region-prefix corruption.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.8.1",
       "release_date": "2026-05-22",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.0
+*May 26, 2026*
+
+- <ChangelogBadge type="breaking" /> **White Label**  
+  - **Whitelabel-Neutral Public API**: Public-facing CSS class names, DOM ids, and event/callback names have been renamed to neutral, whitelabel-friendly identifiers. Existing `window.Yuno`, the `yuno-sdk-ready` event, and `yuno*` callback aliases continue to work, so existing merchant integrations need no changes.  `Yuno` class names prefix changed to `sdk-payments`.  `window.Yuno` deprecated in favor of `window.SdkPayments` - **Custom API and Asset URLs**: Added `options.apiUrl` and `options.assetUrl` initialization overrides so the SDK can point at partner-hosted backends, 3DS endpoints, secure-field iframes, and card-form assets instead of the default Yuno URLs. The override is also forwarded to the monitoring layer, mediator, and card-form iframes. - **Hide Secure Payment Badge on Custom Hosting**: When `apiUrl` or `assetUrl` overrides are set, the `Secure Payment with Yuno` badge is automatically hidden in both the standard checkout and the Click to Pay flow. ### Patch Changes - More Resilient Asset Resolution: Guard the webpack public path when running under Vite, skip duplicate `/v<x.y>` suffixes when the asset URL already includes one, and use the configured `apiUrl` directly as the API client base URL to avoid region-prefix corruption.
+
 ## v1.8.1
 *May 22, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.0`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.0

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to changelog JSON and MDX; no runtime or integration code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.0** (May 26, 2026) by prepending a new release block to `changelog/source/web.json` and a matching **v1.9.0** section at the top of `changelog/web.mdx`.
> 
> The entry is labeled **breaking** under **White Label** and summarizes SDK **v13.0.0** release notes: neutral public CSS/DOM/event names (`sdk-payments` prefix, `window.SdkPayments` with legacy `window.Yuno` / `yuno*` kept), new `options.apiUrl` and `options.assetUrl`, auto-hiding the secure payment badge when those overrides are set, and patch-level asset/API resolution fixes. Install snippet: `npm install @yuno-payments/sdk-web@1.9.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832a848d0129218d7217cdcf23a4a755aaacea1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->