### PR TITLE
Added explicit -X POST to NuPay APM installments curl examples

### DIFF
--- a/docs/wallets/nupay.mdx
+++ b/docs/wallets/nupay.mdx
@@ -200,7 +200,7 @@ NuPay supports installments for both enrolled payment methods and one-time payme
     <Tabs>
       <Tab title="Enrollment Flow">
         ```bash
-        curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+        curl -X POST --location 'https://api-sandbox.y.uno/v1/apm-installments' \
         --header 'public-api-key: {{your_public_api_key}}' \
         --header 'private-secret-key: {{your_secret_api_key}}' \
         --header 'X-account-code: {{your_account_code}}' \
@@ -221,7 +221,7 @@ NuPay supports installments for both enrolled payment methods and one-time payme
       </Tab>
       <Tab title="2FA Mode">
         ```bash
-        curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+        curl -X POST --location 'https://api-sandbox.y.uno/v1/apm-installments' \
         --header 'public-api-key: {{your_public_api_key}}' \
         --header 'private-secret-key: {{your_secret_api_key}}' \
         --header 'X-account-code: {{your_account_code}}' \
@@ -295,7 +295,7 @@ NuPay supports installments for both enrolled payment methods and one-time payme
     <Tabs>
       <Tab title="Enrollment Flow">
         ```bash
-        curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+        curl -X POST --location 'https://api-sandbox.y.uno/v1/apm-installments' \
         --header 'public-api-key: {{your_public_api_key}}' \
         --header 'private-secret-key: {{your_secret_api_key}}' \
         --header 'X-account-code: {{your_account_code}}' \
@@ -316,7 +316,7 @@ NuPay supports installments for both enrolled payment methods and one-time payme
       </Tab>
       <Tab title="2FA Mode">
         ```bash
-        curl --location 'https://api-sandbox.y.uno/v1/apm-installments' \
+        curl -X POST --location 'https://api-sandbox.y.uno/v1/apm-installments' \
         --header 'public-api-key: {{your_public_api_key}}' \
         --header 'private-secret-key: {{your_secret_api_key}}' \
         --header 'X-account-code: {{your_account_code}}' \


### PR DESCRIPTION
  PR Description

  ## Summary

  Merchants were misreading the HTTP method for the `POST /v1/apm-installments` endpoint on the NuPay guide. The curl examples were already sending a POST implicitly (via `--data`), but the absence of an explicit `-X POST` flag — combined with the section heading "Step 1: Get payment conditions" (where "Get" is plain English, not an HTTP method) — caused confusion.

  This was flagged by OLX and confirmed against the OpenAPI spec by Pedro Scarapicchia Junior on 2026-05-26.

  ## Changes

  - `docs/wallets/nupay.mdx`: Added `-X POST` explicitly to all 4 curl examples targeting `POST /v1/apm-installments` in the "Get payment conditions" step:
    - Yuno SDK tab → Enrollment Flow
    - Yuno SDK tab → 2FA Mode
    - Direct API tab → Enrollment Flow
    - Direct API tab → 2FA Mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only curl example updates; no runtime or API behavior changes.
> 
> **Overview**
> Updates the NuPay wallet guide so **`POST /v1/apm-installments`** is obvious in every installment “Get payment conditions” curl sample.
> 
> Each of the four examples (Yuno SDK and Direct API, Enrollment and 2FA) now uses **`curl -X POST`** instead of relying on `--data` alone, addressing merchant confusion with the “Get payment conditions” heading versus the actual HTTP method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3531acbbcf7a77d51e8f3686a8597741fb741403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->