### PR TITLE
docs: add account_id and document output[] in Create Routing

### DIFF
--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -8,6 +8,10 @@ Creates a routing for one `(account_code, payment_method)` pair. Each routing re
 
 ### Body
 
+<ParamField body="account_id" type="string (UUID)" required>
+  The merchant account ID this routing rule applies to.
+</ParamField>
+
 <ParamField body="payment_method" type="enum" required>
   E.g., `CARD`, `PIX`, `WALLET`. Immutable per routing — to route a different method, create a new routing.
 </ParamField>
@@ -30,6 +34,20 @@ Creates a routing for one `(account_code, payment_method)` pair. Each routing re
         </ParamField>
         <ParamField body="connection_id" type="UUID" required>
             Must be `ACTIVE` and support the `payment_method`.
+        </ParamField>
+        <ParamField body="output" type="object[]">
+          Defines how to handle each possible outcome of this step.
+          <Expandable title="item">
+            <ParamField body="status" type="string" required>
+              The outcome status that triggers this rule (e.g., `APPROVED`, `DECLINED`, `DECLINE_GROUP`, `TIMEOUT`, `INTERNAL_ERROR`).
+            </ParamField>
+            <ParamField body="decline_types" type="string[]">
+              Required when `status` is `DECLINE_GROUP`. Specifies which decline subtypes trigger this rule (e.g., `INSUFFICIENT_FUNDS`, `DECLINED_BY_BANK`).
+            </ParamField>
+            <ParamField body="next" type="integer">
+              The `index` of the next step to execute. Omit if no fallback is needed.
+            </ParamField>
+          </Expandable>
         </ParamField>
       </Expandable>
     </ParamField>
@@ -89,6 +107,7 @@ curl -X POST 'https://api.y.uno/v1/routing' \
   -H 'Content-Type: application/json' \
   -H 'X-Idempotency-Key: <UUID>' \
   -d '{
+    "account_id": "7825fc5e-e50a-4248-9ae8-5d3786afb0be",
     "payment_method": "CARD",
     "name": "Card routing — Stripe primary, Adyen fallback",
     "default_route": {


### PR DESCRIPTION
## PR Description:

Added account_id and document output[] in Create Routing

##  Changes

  - Added account_id (string UUID, required) to the request body schema of the Create Routing endpoint — this field was missing from the docs but required by the API.
  - Added account_id to the cURL request example using the reference value provided.
  - Documented default_route.steps[].output[] and its children (status, decline_types, next) as <ParamField> entries — these fields were already present in the cURL example but had no schema documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the Create Routing reference page; no runtime or API behavior changes.
> 
> **Overview**
> Aligns **Create Routing** request documentation with the API by adding the required **`account_id`** (merchant account UUID) to the body schema and the cURL example.
> 
> Documents **`default_route.steps[].output[]`**, which was already shown in the sample payload but not in the param reference: each rule maps an outcome **`status`** (and optional **`decline_types`** for `DECLINE_GROUP`) to a fallback step via **`next`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e62deed62ce16b99228669148218876a4d94b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->