### PR TITLE
docs(web): backfill missing v1.8.1 entries

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -34,6 +34,30 @@
           "group": "Core SDK",
           "migration_guide": null,
           "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Auto-Select Single Payment Method",
+          "description": "When the checkout renders with exactly one regular (non-express) payment method available, that method is now auto-selected so the customer goes straight to the form. Express buttons (Apple Pay, Google Pay, PayPal) are no longer treated as a backend-preferred method that short-circuits this flow.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Deferred Installments in Click to Pay Golden Flow",
+          "description": "Installment plans in the Click to Pay Golden Flow are now shown on a dedicated screen after the customer picks between Click to Pay and the standard card rail, instead of being fetched automatically while the PAN is typed. The card form stays mounted underneath so secure-field state is preserved between screens.",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Detailed Errors from generateOTT()",
+          "description": "When `apiClientPayment().generateToken` (`generateOTT`) fails, the rejected error now contains the backend response body (with error codes and detail) instead of just the generic axios error. Merchants catching this call receive actionable error information.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
         }
       ]
     },


### PR DESCRIPTION
## Why

v1.8.1 (sdk-web tag `v12.0.1`, published 2026-05-22) shipped several merchant-facing changes that never made it into docs.y.uno because their PRs landed without a `.changeset/*.md` carrying a public-facing entry. The existing v1.8.1 docs page only shows Mongolian Language Support.

This PR adds 3 missing entries reconstructed from the actual PR contents:

- **CORECM-17057** — Auto-Select Single Payment Method (#2114) — ADDED
- **CORECM-16352** — Deferred Installments in Click to Pay Golden Flow (#2080) — CHANGED
- **YSHUB-4648** — Detailed Errors from generateOTT() (#2118) — FIXED

Other v12.0.1 PRs were left out intentionally:
- CORECM-17190 (top error banner) — same feature already documented in v1.6.20.
- CORECM-17218, CI gate hardening — internal-only.
- CORECM-17296, CORECM-15653 — internal dep bumps with no merchant-observable change.

Going forward, the gate landed in https://github.com/yuno-payments/sdk-web/pull/2151 (`changeset-check` in the test script) will block PRs that don't add a `.changeset/{TICKET}.md`, so this kind of backfill should not be needed for future releases.

## Test plan
- [x] `releases[1.8.1].entries.length === 4` (1 existing + 3 backfilled)
- [x] Mongolian entry preserved verbatim
- [x] Entries sorted ADDED → CHANGED → FIXED
- [x] No other release entry modified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSON changelog update with no runtime or API code changes.
> 
> **Overview**
> **Backfills the web SDK v1.8.1 release notes** in `changelog/source/web.json` so docs match what shipped in sdk-web `v12.0.1`. The existing Mongolian locale entry is unchanged; **three merchant-facing items** are added, ordered ADDED → CHANGED → FIXED.
> 
> **Auto-Select Single Payment Method** (ADDED, Core SDK): documents checkout auto-selecting the sole non-express payment method and no longer letting express wallets block that behavior.
> 
> **Deferred Installments in Click to Pay Golden Flow** (CHANGED, Click to Pay): documents installments on a post-rail-choice screen instead of during PAN entry, with the card form kept mounted for secure-field state.
> 
> **Detailed Errors from generateOTT()** (FIXED, Core SDK): documents `generateOTT` / `generateToken` rejections including the backend response body for merchant error handling.
> 
> No other release versions or entries in the file are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e33ee428e6fac19126d466a05652664d0d5e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->