### PR TITLE
docs(web): backfill 6 missing LTS release entries (1.0.3, 1.5.25/26, 1.6.21/22, 1.7.4)

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -5,3 +5,6 @@
 # Draft content
 drafts/
 *.draft.mdx
+
+# Old reference pages 
+./docs/sdks/resources/release-notes

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -152,6 +152,24 @@
       ]
     },
     {
+      "version": "1.7.4",
+      "release_date": "2026-05-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.7.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Reliable Document Number Validation",
+          "description": "When the backend specifies a `validationFunction` for a document type that the SDK doesn't recognize, the field now falls back to regex validation instead of marking every value invalid. Prevents broken document inputs when a new validation function rolls out backend-first.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.7.3",
       "release_date": "2026-05-11",
       "upgrade": {
@@ -274,6 +292,42 @@
           "title": "Transaction Amount Support for Passkey Flows",
           "description": "Click to Pay initialization now includes transaction amount metadata for supported passkey flows.",
           "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.22",
+      "release_date": "2026-05-27",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.22",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Cybersource Fraud Session ID from Provider",
+          "description": "The Cybersource fraud device-fingerprinting session now uses the provider-supplied `session_id` when present, falling back to `checkoutSession` if the provider doesn't supply one. Aligns the fingerprint session ID with what the fraud provider expects, improving fingerprint match rates.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.6.21",
+      "release_date": "2026-05-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.6.21",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Reliable Document Number Validation",
+          "description": "When the backend specifies a `validationFunction` for a document type that the SDK doesn't recognize, the field now falls back to regex validation instead of marking every value invalid. Prevents broken document inputs when a new validation function rolls out backend-first.",
+          "group": "Core SDK",
           "migration_guide": null,
           "links": []
         }
@@ -808,6 +862,42 @@
           "title": "3DS Modal Centering",
           "description": "Fixed an issue where the 3DS challenge modal was not centered on mobile devices. The modal now correctly fills and centers within the viewport.",
           "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.26",
+      "release_date": "2026-05-27",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.26",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Compact Form Variant (1.5 backport)",
+          "description": "Backports the slimmer card, customer, and billing-address form layout from 1.6.x onto the 1.5.x line. Opt-in via the `slimmerFormEnabled` feature flag — disabled by default, no behavior change for merchants who don't toggle it.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.5.25",
+      "release_date": "2026-05-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.5.25",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Reliable Document Number Validation",
+          "description": "When the backend specifies a `validationFunction` for a document type that the SDK doesn't recognize, the field now falls back to regex validation instead of marking every value invalid. Prevents broken document inputs when a new validation function rolls out backend-first.",
+          "group": "Core SDK",
           "migration_guide": null,
           "links": []
         }
@@ -1394,6 +1484,24 @@
             "language": "js",
             "snippet": "const yuno = await Yuno.initialize(PUBLIC_API_KEY);\n\nyuno.startCheckout({\n  checkoutSession: '438413b7-4921-41e4-b8f3-28a5a0141638',\n  elementSelector: '#root',\n  countryCode: 'FR',\n  language: 'fr',\n  showLoading: true,\n  issuersFormEnable: true,\n  showPaymentStatus: true,\n  card: {\n    isCreditCardProcessingOnly: true,\n  },\n  onLoading: (args) => {\n    console.log(args);\n  },\n  yunoPaymentResult: (status) => {\n    console.log('Payment result:', status);\n  },\n  yunoError: (message, data) => {\n    console.error('Payment error:', message, data);\n  },\n});"
           }
+        }
+      ]
+    },
+    {
+      "version": "1.0.3",
+      "release_date": "2026-05-26",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.0.3",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Resilient Payment Status Updates",
+          "description": "If WebSocket initialization fails (network blip, blocked port, browser restriction), the SDK now logs the error and falls back to HTTP polling for payment status instead of blocking the checkout. No integration change required.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
         }
       ]
     },


### PR DESCRIPTION
## Why

Six sdk-web LTS releases shipped on May 26–27 with no docs entry. All have merchant-facing changes; the webhook would have 502'd on all of them because the corresponding `changelog/{version}.json` was never created in sdk-web at release-cut time.

Reconstructed from the PRs merged into each release tag:

| Public ver | Internal tag | Date | Change |
|---|---|---|---|
| 1.7.4 | v11.0.4 | 2026-05-26 | YSHUB-4762 — document validation regex fallback (backport) |
| 1.6.22 | v10.1.20 | 2026-05-27 | YSHUB-4707 — Cybersource fraud session_id from provider |
| 1.6.21 | v10.1.19 | 2026-05-26 | YSHUB-4762 — document validation regex fallback (backport) |
| 1.5.26 | v9.15.25 | 2026-05-27 | CORECM-15210 — compact form variant (backport) |
| 1.5.25 | v9.15.24 | 2026-05-26 | YSHUB-4762 — document validation regex fallback (backport) |
| 1.0.3 | v8.58.18 | 2026-05-26 | CORECM-17500 — WebSocket → polling fallback |

1.8.2 (v12.0.2) is intentionally skipped per the decision in yuno-payments/sdk-web#2144 — its commits were either internal fixes or covered by existing entries.

## Test plan
- [x] All 6 versions inserted in semver order (newest first per major.minor.patch)
- [x] Existing entries on the page untouched
- [x] Per-version `upgrade.snippet` set to `npm install @yuno-payments/sdk-web@<version>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Mintlify ignore-only changes; no runtime or integration code.
> 
> **Overview**
> **Backfills six sdk-web LTS releases** (1.0.3, 1.5.25, 1.5.26, 1.6.21, 1.6.22, 1.7.4) into `changelog/source/web.json`, each with release date, `npm install` upgrade snippet, and merchant-facing notes that were missing at release-cut time.
> 
> Documented fixes span **document validation** (regex fallback when the SDK does not recognize a backend `validationFunction`), **Cybersource fraud** (provider `session_id` when available), **1.5.x compact form** backport via `slimmerFormEnabled`, and **1.0.3 payment status** resilience (HTTP polling when WebSocket init fails). Entries are inserted in semver order without altering existing release blocks.
> 
> **Mintlify:** `.mintignore` now excludes `./docs/sdks/resources/release-notes` so legacy release-notes pages are not published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f3dfd63317f25e6431f718edb00389922623f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->