### PR TITLE
docs(vtex): add 4.2.301 and 4.2.302 changelog entries

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,25 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.302
+*May 26, 2026*
+
+- <ChangelogBadge type="added" /> **Split-order payment support**  
+  Adds payment support for VTEX orders that get split into multiple suborders (carts combining products from different sellers or franchises). Each suborder now settles at the gateway with a shared antifraud session, instead of only the first one being paid.
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **Antifraud providers for split orders setting**  
+  Adds a configuration field so merchants can choose which antifraud providers (RISKIFIED, CYBERSOURCE, SIGNIFYD) receive the shared session. Defaults to RISKIFIED + CYBERSOURCE when left empty.
+
+## v4.2.301
+*May 20, 2026*
+
+**Observability**
+
+- <ChangelogBadge type="changed" /> **Less noise in error monitoring for expected outcomes**  
+  Expected outcomes (cancellation denials, callback retries) are now recorded at debug level instead of as errors. Internal observability change — no impact on merchant-facing flows.
+
 ## v4.2.300
 *May 13, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,50 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.302",
+      "release_date": "2026-05-26",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.302",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Split-order payment support",
+          "description": "Adds payment support for VTEX orders that get split into multiple suborders (carts combining products from different sellers or franchises). Each suborder now settles at the gateway with a shared antifraud session, instead of only the first one being paid.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Antifraud providers for split orders setting",
+          "description": "Adds a configuration field so merchants can choose which antifraud providers (RISKIFIED, CYBERSOURCE, SIGNIFYD) receive the shared session. Defaults to RISKIFIED + CYBERSOURCE when left empty.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.301",
+      "release_date": "2026-05-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.301",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Less noise in error monitoring for expected outcomes",
+          "description": "Expected outcomes (cancellation denials, callback retries) are now recorded at debug level instead of as errors. Internal observability change — no impact on merchant-facing flows.",
+          "group": "Observability",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.300",
       "release_date": "2026-05-13",
       "upgrade": {

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -46,6 +46,7 @@ Have the following ready:
       | **VTEX IO orderPlaced page URL** | Optional | A custom URL where shoppers should be redirected after payment. |
       | **Payment Mode** | Optional | **Payment App** (modern) or **Legacy** (redirect). |
       | **Transaction Identification From** | Optional | **Yuno TID** or **Provider TID**. |
+      | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
     </Accordion>
 
     <Accordion title="Settlement Options">


### PR DESCRIPTION
## Summary

- Adds VTEX plugin changelog entries for **v4.2.302** (split-order payment support + antifraud providers configuration field) and **v4.2.301** (less noise in error monitoring for expected outcomes) in `changelog/source/vtex.json`.
- Regenerates `changelog/plugins/vtex.mdx` via `scripts/generate_changelog.js`.
- Documents the new **Antifraud Providers for Split Orders** custom field in the VTEX setup guide (`docs/plugins/vtex/set-up-yuno-on-vtex.mdx`).

## Test plan

- [ ] Verify v4.2.302 and v4.2.301 render correctly on the Changelog page
- [ ] Confirm the new row appears in the "Field reference" accordion of the VTEX setup guide
- [ ] Mintlify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog metadata only; no application or payment logic changes in this diff.
> 
> **Overview**
> Documents VTEX plugin releases **v4.2.302** and **v4.2.301** by extending `changelog/source/vtex.json` and refreshing the generated `changelog/plugins/vtex.mdx` page.
> 
> **v4.2.302** is called out for split-order payment support (each suborder settles with a shared antifraud session) and a new optional **Antifraud Providers for Split Orders** admin setting (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`; default `RISKIFIED` + `CYBERSOURCE`). **v4.2.301** notes that expected outcomes are logged at debug instead of error for observability only.
> 
> The VTEX setup guide field reference in `set-up-yuno-on-vtex.mdx` adds a row for **Antifraud Providers for Split Orders** so merchants can configure the new setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5dac2d336ed70771abbdda9b1e6021a1196391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->