### PR TITLE
chore: web sdk changelog 1.9.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.1",
+      "release_date": "2026-05-27",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Faster Locale Resolution",
+          "description": "Cached the locale lookup chain so the initial dictionary load no longer re-evaluates the fallback path on every render. Cuts a few ms off the first paint for non-English locales.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.9.0",
       "release_date": "2026-05-26",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.1
+*May 27, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="fixed" /> **Faster Locale Resolution**  
+  Cached the locale lookup chain so the initial dictionary load no longer re-evaluates the fallback path on every render. Cuts a few ms off the first paint for non-English locales.
+
 ## v1.9.0
 *May 26, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.1`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.1

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync; no runtime or integration code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.1** (May 27, 2026) by prepending a release block to `changelog/source/web.json` and mirroring it at the top of `changelog/web.mdx`.
> 
> The release notes one **Core SDK** fix: **Faster Locale Resolution** — the locale lookup chain is cached so the initial dictionary load does not re-run the fallback path on every render, trimming a few milliseconds off first paint for non-English locales. The npm upgrade snippet is `npm install @yuno-payments/sdk-web@1.9.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2202e3588a5f297ad4d41cc2749d4d7e4a584a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->