### PR TITLE
docs: add Web SDK white-label and proxy-server guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -769,7 +769,14 @@
             "pages": [
               "docs/sdks/customization/android",
               "docs/sdks/customization/ios",
-              "docs/sdks/customization/web"
+              {
+                "group": "Web",
+                "pages": [
+                  "docs/sdks/customization/web/styling",
+                  "docs/sdks/customization/web/white-label",
+                  "docs/sdks/customization/web/white-label-proxy-server"
+                ]
+              }
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -5601,6 +5601,10 @@
     {
       "source": "/yunopayments/api-next/v2/versions/1.0.2/sidebar?page_type=guide",
       "destination": "/"
+    },
+    {
+      "source": "/docs/sdks/customization/web",
+      "destination": "/docs/sdks/customization/web/styling"
     }
   ]
 }

--- a/docs/sdks/customization/web/styling.mdx
+++ b/docs/sdks/customization/web/styling.mdx
@@ -1,5 +1,6 @@
 ---
 title: Web Styling
+sidebarTitle: Styling
 description: Customize the appearance and behavior of the Yuno Web SDK to match your brand's identity and integration needs.
 hidden: false
 metadata:

--- a/docs/sdks/customization/web/white-label-proxy-server.mdx
+++ b/docs/sdks/customization/web/white-label-proxy-server.mdx
@@ -85,7 +85,7 @@ The proxy resolves the canonical version once at boot and rewrites every incomin
 ```
 1. process.env.SDK_MAIN_JS                          (if set, used as-is, no upstream call)
 2. <SDK_UPSTREAM>/versions.json → latest.version    (auto-detect, 5s timeout)
-3. /v1.9/main.js                                    (hard-coded fallback)
+3. /v1.7/main.js                                    (hard-coded fallback)
 ```
 
 If steps 1 and 2 both fail, you get the fallback and a warning is logged. Setting `SDK_MAIN_JS` explicitly is the only way to skip the upstream fetch entirely — useful when `versions.json` is unreachable, you want a deterministic startup, or the upstream's `latest` is not what you want to test against.

--- a/docs/sdks/customization/web/white-label-proxy-server.mdx
+++ b/docs/sdks/customization/web/white-label-proxy-server.mdx
@@ -1,0 +1,319 @@
+---
+title: White Label Proxy Server
+description: A local Express harness that loads the Yuno Web SDK from a non-Yuno origin so the white-label code paths can be verified end-to-end.
+hidden: false
+metadata:
+  robots: noindex
+---
+
+A small Express server that lets the Yuno Web SDK be loaded from a **non-Yuno origin**, so the white-label code paths — renamed globals, events, and DOM tokens — can be exercised end-to-end before shipping a partner-hosted integration.
+
+<Tip>
+  This is a companion to the [White Label](/docs/sdks/customization/white-label) page. Read it first for the SDK-side overrides this harness is built to verify.
+</Tip>
+
+## Why this server exists
+
+The Yuno Web SDK historically ships with a `yuno-` prefixed surface: `window.Yuno`, the `yuno-sdk-ready` event, and `yuno-*` CSS classes and data attributes. The white-label release introduces a parallel surface:
+
+| Legacy | White-label |
+| :--- | :--- |
+| `window.Yuno` | `window.SdkPayments` |
+| `yuno-sdk-ready` event | `sdk-payments-ready` event |
+| `yuno-*` DOM tokens | `sdk-payments-*` DOM tokens |
+
+To verify the rename actually shipped, the SDK must be loaded from a host that is **not** `*.y.uno`. If it loads from a Yuno origin, branded leaks would slip through unnoticed. This server is the harness: it serves the SDK from `localhost:9090` (or any non-Yuno hostname you point it at) and forwards every request to the real Yuno upstreams transparently.
+
+## How it works
+
+```
+┌──────────────────┐      ┌──────────────────────┐      ┌────────────────────┐
+│  Partner page    │────▶ │  white-label-proxy   │────▶ │ Yuno upstreams     │
+│  (browser)       │      │  (Express :9090)     │      │  - sdk-web.*.y.uno │
+│                  │ ◀────│                      │ ◀────│  - sdk-3ds.*.y.uno │
+│ <script src=     │      │  Routes by path:     │      │  - sdk-web-card.*  │
+│  localhost:9090/ │      │   /v1/*  → BACKEND   │      │  - api[-env].y.uno │
+│  v1.7/main.js>   │      │   /v<n>/pages → CARD │      │                    │
+└──────────────────┘      │   /challenge → 3DS   │      └────────────────────┘
+                          │   else       → SDK   │
+                          └──────────────────────┘
+```
+
+Three invariants make the harness useful:
+
+1. **The browser only ever talks to the proxy origin.** No `*.y.uno` request originates from the page itself — otherwise the SDK is not really being tested against a foreign host.
+2. **All upstream domains are reachable from the proxy.** SDK assets, the card-form micro-app, the 3DS micro-app, the REST API, and the WebSocket service are all separate hostnames that must each be configurable.
+3. **CORS is owned by the proxy, not the upstream.** Upstream CORS would respond with `api.y.uno` origins; the proxy strips those and writes its own, echoing the caller.
+
+## Architecture
+
+A single Node.js process built on three libraries:
+
+- `express` — routing and middleware for HTTP.
+- `node-fetch` — outbound HTTP to upstreams, for streaming bodies and header control.
+- `http-proxy` — WebSocket upgrades, because Express middleware never sees `Upgrade` requests.
+
+### Request lifecycle
+
+1. **CORS middleware** runs first. It echoes the caller's `Origin`, handles `OPTIONS` preflight, and sets `Access-Control-Allow-Credentials: true`. The proxy is the CORS authority.
+2. **Local routes** match before anything else: `/`, `/static/*`, `/whitelabel-info`. These never touch an upstream.
+3. **Backend pass-through** matches `/v1/*` and `/v2/*` (the Yuno REST surface used by the SDK) and forwards via `node-fetch` to `BACKEND_URL`. Hop-by-hop headers are stripped; `access-control-*` headers from the upstream are dropped so they cannot override the proxy's own CORS.
+4. **SDK asset catch-all** matches every remaining `GET`/`HEAD`. A small dispatcher picks the right upstream based on path:
+   - 3DS micro-app paths (`/challenge.html`, `/redirect.html`, `/session-id.html`, and `/assets/(challenge|redirect|session-id|validate-url)*`) → `SDK_3DS_UPSTREAM`.
+   - Card micro-app paths (`/v<semver>/pages/*`, `/v<semver>/assets/*`) → `SDK_CARD_UPSTREAM`.
+   - Everything else → `SDK_UPSTREAM`.
+5. **WebSocket upgrades** are handled on the underlying `http.Server`, not Express. `/checkout-websocket-notification-ms/ws/*` → `BACKEND_WS_URL`; everything else follows the same SDK / card / 3DS split as HTTP.
+
+### Version normalization
+
+The main SDK bundle is versioned (`/v1.7.4/main.js`). Two complications:
+
+- Partner pages may hardcode a version that the upstream no longer publishes.
+- The "current" version drifts over time.
+
+The proxy resolves the canonical version once at boot and rewrites every incoming `/v<x>/*` SDK request to that version before sending it upstream. Card-app and 3DS paths are **not** rewritten — they have their own publish cadences.
+
+## `SDK_MAIN_JS` — pinning the SDK version
+
+`SDK_MAIN_JS` decides which build of the SDK every browser loads. It does two related things:
+
+1. **Template injection.** The proxy serves `pages/index.html` with the literal `__SDK_MAIN_JS__` placeholder replaced by this path. A partner page can write `<script src="__SDK_MAIN_JS__">` and get e.g. `/v1.9.0/main.js`.
+2. **Version normalization target.** The proxy parses the `/v<x>/` segment out of `SDK_MAIN_JS` and rewrites any incoming `/v<other>/main.js` (and adjacent `/v<other>/*.js`, `/v<other>/*.css`) request to that same version. So if `SDK_MAIN_JS=/v1.9.0/main.js`, a request for `/v1.5.0/main.js` is silently fetched as `/v1.9.0/main.js` from `SDK_UPSTREAM`.
+
+### Resolution order at boot
+
+```
+1. process.env.SDK_MAIN_JS                          (if set, used as-is, no upstream call)
+2. <SDK_UPSTREAM>/versions.json → latest.version    (auto-detect, 5s timeout)
+3. /v1.9/main.js                                    (hard-coded fallback)
+```
+
+If steps 1 and 2 both fail, you get the fallback and a warning is logged. Setting `SDK_MAIN_JS` explicitly is the only way to skip the upstream fetch entirely — useful when `versions.json` is unreachable, you want a deterministic startup, or the upstream's `latest` is not what you want to test against.
+
+### Format
+
+```
+SDK_MAIN_JS=/v<semver>/main.js
+```
+
+`<semver>` matches `[\d.]+(?:-[\w.]+)?` — dot-separated numbers with an optional pre-release suffix.
+
+| Value | When to use it |
+| :--- | :--- |
+| `/v1.9/main.js` | Pin to a minor line (whatever the upstream publishes there) |
+| `/v1.9.0/main.js` | Pin to an exact patch — most common |
+
+The path **must** start with `/v` and contain `/main.js` for normalization to work. If the regex does not match, the path is used for template injection but version rewriting is disabled.
+
+### Common use cases
+
+**Test a specific SDK release end-to-end:**
+
+```shell
+SDK_MAIN_JS=/v1.9.0/main.js npm start
+```
+
+Every page now loads `v1.9.0`, and any hardcoded `/v<other>/*.js` in partner pages is silently rewritten to `v1.9.0` against `SDK_UPSTREAM`.
+
+**Quiet startup (no upstream `versions.json` call):**
+
+```shell
+SDK_MAIN_JS=/v1.9.0/main.js npm start
+```
+
+Useful in air-gapped environments or when `SDK_UPSTREAM` is a local file server that does not expose `versions.json`.
+
+**Reproduce a customer bug on an older version:**
+
+```shell
+SDK_MAIN_JS=/v1.7.4/main.js npm start
+```
+
+As long as `v1.7.4` is still published on `SDK_UPSTREAM`, every browser that hits the proxy loads it — no rebuild required.
+
+### Gotchas
+
+- **Card and 3DS upstreams are not affected.** `SDK_MAIN_JS` only pins the main SDK bundle's version. The card micro-app (`/v<x>/pages/*`) and the 3DS micro-app keep their own version segments.
+- **Setting it disables auto-detection.** If a newer SDK version is published upstream, you keep loading the pinned version until you change the env var and restart.
+- **Restart required.** The value is read once at boot. No hot reload.
+- **Mismatch with upstream is silent.** Pinning to a version the upstream does not publish results in a `404` for `/v<your-pin>/main.js`. Check the network tab to spot it.
+- **No query strings or hash.** Path only.
+
+## Building a server like this
+
+### 1. Bootstrap the project
+
+```shell
+mkdir my-proxy && cd my-proxy
+npm init -y
+npm install express http-proxy node-fetch@2 dotenv
+```
+
+<Note>
+  Use `node-fetch@2` (CommonJS) unless you have a build step — v3 is ESM-only.
+</Note>
+
+### 2. Define your upstream map
+
+| Upstream var | Owns these paths |
+| :--- | :--- |
+| `SDK_UPSTREAM` | `/v<x>/main.js` and everything not matched below |
+| `SDK_CARD_UPSTREAM` | `/v<x>/pages/*`, `/v<x>/assets/*` |
+| `SDK_3DS_UPSTREAM` | `/challenge.html`, `/redirect.html`, `/session-id.html`, `/assets/(challenge\|redirect\|session-id\|validate-url)*` |
+| `BACKEND_URL` | `/v1/*`, `/v2/*` (REST API) |
+| `BACKEND_WS_URL` | `/checkout-websocket-notification-ms/ws/{payment,enrollment}` (WebSocket only) |
+
+All but `SDK_UPSTREAM` and `BACKEND_URL` default to their parent when unset — keep this fallback behaviour, it makes single-env testing easier.
+
+### 3. Set up CORS as the proxy's responsibility
+
+```javascript
+app.use((req, res, next) => {
+  const origin = req.headers.origin
+  if (origin) {
+    res.set('access-control-allow-origin', origin)
+    res.set('access-control-allow-credentials', 'true')
+    res.set('vary', 'origin')
+  } else {
+    res.set('access-control-allow-origin', '*')
+  }
+  res.set('access-control-allow-methods', req.headers['access-control-request-method'] || 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS')
+  res.set('access-control-allow-headers', req.headers['access-control-request-headers'] || '*')
+  res.set('access-control-expose-headers', '*')
+  res.set('access-control-max-age', '86400')
+  if (req.method === 'OPTIONS') return res.status(204).end()
+  next()
+})
+```
+
+Echo the caller's origin (not `*`) so credentialed requests work, and short-circuit preflights. When you later forward upstream responses, strip every `access-control-*` header from the upstream or it will override yours.
+
+### 4. Filter hop-by-hop headers in both directions
+
+Per [RFC 7230 §6.1](https://datatracker.ietf.org/doc/html/rfc7230#section-6.1):
+
+```javascript
+const HOP_BY_HOP = new Set([
+  'host', 'connection', 'keep-alive',
+  'proxy-authenticate', 'proxy-authorization',
+  'te', 'trailer', 'transfer-encoding', 'upgrade',
+  'content-length', // node-fetch sets this itself
+])
+```
+
+Filter these out of both inbound (request to upstream) and outbound (upstream to client) headers. Forgetting `content-length` is the classic bug — node-fetch sets it, but if you also copy the original value the response truncates.
+
+### 5. Forward the API surface
+
+```javascript
+app.all('/v1/*', forwardToBackend)
+app.all('/v2/*', forwardToBackend)
+
+async function forwardToBackend(req, res) {
+  const targetUrl = `${BACKEND_URL}${req.originalUrl}`
+  const headers = pickRequestHeaders(req) // filters HOP_BY_HOP
+  const init = { method: req.method, headers }
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    // express.json() consumed the original body; re-serialize it.
+    init.body = req.body && Object.keys(req.body).length ? JSON.stringify(req.body) : undefined
+    if (init.body && !headers['content-type']) headers['content-type'] = 'application/json'
+  }
+  const upstream = await fetch(targetUrl, init)
+  res.status(upstream.status)
+  for (const [k, v] of upstream.headers.entries()) {
+    const lk = k.toLowerCase()
+    if (HOP_BY_HOP.has(lk)) continue
+    if (lk.startsWith('access-control-')) continue   // proxy owns CORS
+    res.set(k, v)
+  }
+  res.send(await upstream.text())
+}
+```
+
+`express.json()` has already consumed the request body, so for non-GET methods you re-serialize `req.body`. Don't try to `req.pipe(upstream)` after the body is consumed.
+
+### 6. Catch-all proxy for SDK assets
+
+```javascript
+app.use((req, res, next) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') return next()
+  proxyToUpstream(req, res, next)
+})
+
+async function proxyToUpstream(req, res, next) {
+  const upstreamBase = pickSdkUpstream(req.path)   // returns one of three URLs
+  const targetUrl = `${upstreamBase}${normalizePath(req.originalUrl)}`
+  const upstream = await fetch(targetUrl, { redirect: 'follow', headers: { /* accept, user-agent */ } })
+  if (upstream.status === 404) return next()
+  res.status(upstream.status)
+  for (const h of ['content-type', 'cache-control', 'etag', 'last-modified']) {
+    const v = upstream.headers.get(h)
+    if (v) res.set(h, v)
+  }
+  upstream.body.pipe(res)   // stream — don't buffer, assets can be big
+}
+```
+
+<Warning>
+  Register the catch-all last. It matches everything, so any middleware added after it is unreachable unless you guard it explicitly.
+</Warning>
+
+### 7. Handle WebSocket upgrades on the http.Server
+
+Express middleware does not see `Upgrade` requests. Hook into the http server directly:
+
+```javascript
+const wsProxy = httpProxy.createProxyServer({ changeOrigin: true, ws: true })
+const server = app.listen(PORT)
+server.on('upgrade', (req, socket, head) => {
+  const target = pickWsTarget(req.url)   // BACKEND_WS_URL or SDK_UPSTREAM
+  wsProxy.ws(req, socket, head, { target })
+})
+```
+
+`http-proxy` negotiates `ws://` vs `wss://` from the target URL scheme.
+
+### 8. Wire up environment variables
+
+Use `dotenv`. Document **per-environment** values, not just defaults. For Yuno:
+
+- SDK services follow `<service>[.<env>].y.uno` — `sdk-web.y.uno`, `sdk-web.staging.y.uno`, `sdk-web.dev.y.uno`.
+- API surface uses `api[-<env>].y.uno` — `api.y.uno`, `api-staging.y.uno`, `api-dev.y.uno`. **Note the hyphen, not a dot.**
+- The WebSocket service has **no** `api-` prefix — `<env>.y.uno` directly (`y.uno`, `staging.y.uno`, `dev.y.uno`).
+
+These naming inconsistencies cause more 404s than any other class of bug. Encode them in your `.env.example` so users don't guess.
+
+### 9. Ship a minimal landing page
+
+Serve `index.html` at `/` and a `/whitelabel-info` JSON endpoint that returns the resolved upstream config. The landing page calls the JSON endpoint and renders it — anyone debugging the proxy sees exactly what's routed where without grepping logs.
+
+## Pitfalls and edge cases
+
+- **Route order matters.** The SDK catch-all is registered last. Anything you `app.use` after it never runs.
+- **CORS authority must be the proxy.** Letting upstream `access-control-*` headers through means credentialed cross-origin requests randomly fail when the upstream's allow-list does not include `localhost`.
+- **Hop-by-hop headers are bidirectional.** Strip them on both legs. `content-length` is the one that bites.
+- **Body consumption is a one-shot.** Once `express.json()` parses a request, the underlying stream is drained. Re-serialize from `req.body` if you need to forward a `POST`.
+- **Streaming, not buffering, for assets.** `upstream.body.pipe(res)` keeps memory flat even for multi-MB bundles.
+- **Version normalization is `SDK_UPSTREAM`-only.** Card and 3DS micro-apps have their own version segments — rewriting them breaks the upstream URL.
+- **WebSocket auth is whatever headers `http-proxy` sees.** Do **not** strip `cookie` or `authorization` from WS upgrades.
+- `.env` is gitignored. Always keep `.env.example` in sync — it is the spec for anyone cloning the repo.
+
+## Verification checklist
+
+Once your proxy is running, verify in browser DevTools:
+
+1. **Network tab** — no requests to any `*.y.uno` host originate from the merchant page. All traffic is to the proxy origin.
+2. `window.SdkPayments` is defined; `window.Yuno` is either undefined or a legacy alias.
+3. `sdk-payments-ready` event fires on `document` after the SDK boots.
+4. No `yuno-*` DOM tokens in the rendered output, except for the trust-mark allow-list (`yuno-badge`, `secure-by-yuno`, `yuno-typography-provider`, `yuno-c2p`, `yuno-redirect`, `yuno-debug`, `data-yuno-session-id`).
+
+## Reference implementation
+
+The full source lives in the [`yuno-sdk-web/white-label-proxy-server`](https://github.com/yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server) repository. About 290 lines in `server.js` — the whole thing fits in one file because there is no business logic, just routing and header hygiene.
+
+## See also
+
+- [White Label (Web SDK)](/docs/sdks/customization/web/white-label) — the SDK-side overrides this harness verifies.
+- [yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server](https://github.com/yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server) — full source.
+- [RFC 7230 §6.1 — Connection-specific headers](https://datatracker.ietf.org/doc/html/rfc7230#section-6.1)
+- [http-proxy WebSocket docs](https://github.com/http-party/node-http-proxy#proxying-websockets)

--- a/docs/sdks/customization/web/white-label-proxy-server.mdx
+++ b/docs/sdks/customization/web/white-label-proxy-server.mdx
@@ -9,7 +9,7 @@ metadata:
 A small Express server that lets the Yuno Web SDK be loaded from a **non-Yuno origin**, so the white-label code paths — renamed globals, events, and DOM tokens — can be exercised end-to-end before shipping a partner-hosted integration.
 
 <Tip>
-  This is a companion to the [White Label](/docs/sdks/customization/white-label) page. Read it first for the SDK-side overrides this harness is built to verify.
+  This is a companion to the [White Label](/docs/sdks/customization/web/white-label) page. Read it first for the SDK-side overrides this harness is built to verify.
 </Tip>
 
 ## Why this server exists

--- a/docs/sdks/customization/web/white-label.mdx
+++ b/docs/sdks/customization/web/white-label.mdx
@@ -1,0 +1,115 @@
+---
+title: White Label
+description: Host and serve the Yuno Web SDK from your own origin without exposing Yuno branding in the merchant page.
+hidden: false
+metadata:
+  robots: noindex
+---
+
+White-label support lets a partner serve the Yuno Web SDK from their own origin without the string `Yuno` leaking into the merchant page — neither in the DOM, globals, dispatched events, nor outgoing network traffic.
+
+<Tip>
+  Shipped in `sdk-web` 1.9.0 and `sdk-web-core` 7.0.0. The legacy `window.Yuno` global and `yuno-sdk-ready` event remain as backwards-compatibility aliases, so existing integrations continue to work unchanged.
+</Tip>
+
+## What the SDK exposes
+
+| Concern | Primary (white-label) | Legacy alias (still works) |
+| :--- | :--- | :--- |
+| Global object | `window.SdkPayments` | `window.Yuno` |
+| Ready event | `'sdk-payments-ready'` | `'yuno-sdk-ready'` |
+| CSS class prefix | `sdk-payments-*` | — |
+| DOM `id`, `data-testid`, font link id | `sdk-payments-*` | — |
+| Font family | `Sdk-Payments-Inter` | `Yuno-Inter` (kept as fallback) |
+
+Both the new and legacy globals reference the same object, and both events are dispatched on bundle load — you can mix them during a migration without breaking either form.
+
+## Runtime URL overrides
+
+Partners hosting the SDK on their own origin point the SDK at custom endpoints at `initialize()` time, instead of relying on the compile-time defaults.
+
+```javascript
+SdkPayments.initialize(publicApiKey, applicationSession, {
+  // Overrides the API base URL the SDK calls (REST + WebSocket).
+  // Also forwarded into the card-form and secure-fields iframes so
+  // their internal calls land on the partner origin too.
+  apiUrl: 'https://payments.example.com',
+
+  // Overrides the host that serves SDK static assets
+  // (3DS pages, card-form bundle, fonts, images).
+  assetUrl: 'https://payments.example.com',
+})
+```
+
+What each override affects end-to-end:
+
+| Option | Affects |
+| :--- | :--- |
+| `apiUrl` | SDK REST calls, WebSocket upgrades, monitoring/Datadog forwarder, secure-fields mediator, card-form iframe API base. |
+| `assetUrl` | 3DS challenge / redirect / session-id pages, card-form micro-app URL, font CSS, runtime `__webpack_public_path__` for code-split chunks. |
+
+<Note>
+  For a typical white-label deployment, pass the same value to both options. The SDK uses the value verbatim — it no longer appends a `/v<x.y>` segment when `assetUrl` already ends with one, and it does not prepend a regional prefix to overrides.
+</Note>
+
+## Neutral merchant callbacks
+
+Callback names gained whitelabel-neutral aliases. The legacy `yuno*` names are still accepted and forwarded internally, but are deprecated and will be removed in a future major release.
+
+| Legacy callback | New neutral name |
+| :--- | :--- |
+| `yunoCreatePayment` | `createPayment` |
+| `yunoPaymentMethodSelected` | `paymentMethodSelected` |
+| `yunoPaymentResult` | `paymentResult` |
+| `yunoError` | `error` |
+
+## Integration example
+
+```html
+<!-- Loaded from the partner origin, not sdk-web.y.uno -->
+<script src="https://payments.example.com/v1.9/main.js"></script>
+<script>
+  window.addEventListener('sdk-payments-ready', async () => {
+    const sdk = SdkPayments.initialize(PUBLIC_API_KEY, APPLICATION_SESSION, {
+      apiUrl: 'https://payments.example.com',
+      assetUrl: 'https://payments.example.com',
+    })
+
+    await sdk.startCheckout({
+      checkoutSession: CHECKOUT_SESSION,
+      createPayment:  (ott, info) => { /* ... */ },
+      paymentResult:  (status)    => { /* ... */ },
+      error:          (msg, data) => { /* ... */ },
+    })
+
+    sdk.mountCheckout()
+  })
+</script>
+```
+
+## Verifying a white-label setup
+
+After loading the SDK from a non-Yuno origin, none of the following should appear in the merchant page:
+
+- Elements with `class="yuno-*"` or `id="yuno-*"`.
+- A resolved font family of `Yuno-Inter`.
+- Network requests to `*.y.uno` hosts.
+
+And these should be present:
+
+- `window.SdkPayments` resolves to the SDK instance factory.
+- `'sdk-payments-ready'` fires once on bundle load.
+- DOM nodes use `class="sdk-payments-*"` / `id="sdk-payments-*"`.
+
+## Local test harness
+
+A throwaway proxy server lives in the [`yuno-payments/yuno-sdk-web`](https://github.com/yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server) repo under `white-label-proxy-server/`. It listens on `http://localhost:9090`, serves a landing page from a non-Yuno origin, and transparently proxies SDK asset / API / WebSocket traffic upstream — point a partner test page's `<script src>` at `http://localhost:9090/v1.7/main.js` to exercise the white-label code paths end-to-end.
+
+```shell
+cd yuno-sdk-web/white-label-proxy-server
+cp .env.example .env   # tweak SDK_UPSTREAM / BACKEND_URL if needed
+npm install
+npm start              # http://localhost:9090
+```
+
+See [White Label Proxy Server](/docs/sdks/customization/web/white-label-proxy-server) for the full architecture, the `SDK_MAIN_JS` version-pinning behaviour, the env-var matrix (prod / staging / dev upstreams), and the routing table.


### PR DESCRIPTION
## Summary
- Add `docs/sdks/customization/web/white-label.mdx` documenting the partner-hosted Web SDK rename (`window.SdkPayments`, `sdk-payments-ready`, `apiUrl` / `assetUrl` overrides, neutral `on*` callbacks, and what is intentionally kept `yuno-*`).
- Add `docs/sdks/customization/web/white-label-proxy-server.mdx` documenting the local Express proxy harness used to verify the white-label code paths end-to-end, including the `SDK_MAIN_JS` version-pinning behaviour and the upstream-routing rules.
- Move the existing Web customization page to `web/styling.mdx` and group all three pages under a new **Web** subgroup in `docs.json` so the SDKs → Customization tab now reads: Android, iOS, Web → (Styling, White Label, White Label Proxy Server).

Source: [PYORK-26](https://yunopayments.atlassian.net/browse/PYORK-26) — sdk-web [#2086](https://github.com/yuno-payments/sdk-web/pull/2086), sdk-web-core [#890](https://github.com/yuno-payments/sdk-web-core/pull/890).

## Test plan
- [ ] `mint dev` renders the three pages under SDKs → Customization → Web with no broken internal links.
- [ ] `/docs/sdks/customization/web/white-label` resolves and links to `/docs/sdks/customization/web/white-label-proxy-server`.
- [ ] The proxy-server page's GitHub link points at `yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server`.
- [ ] No pages outside this PR link to the old `/docs/sdks/customization/web` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PYORK-26]: https://yunopayments.atlassian.net/browse/PYORK-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation/redirect changes only; no application or SDK runtime code is modified.
> 
> **Overview**
> Expands **SDKs → Customization → Web** into three pages—**Styling**, **White Label**, and **White Label Proxy Server**—and adds a redirect from `/docs/sdks/customization/web` to the styling URL so old links keep working.
> 
> The new **White Label** guide documents partner-hosted Web SDK usage: `SdkPayments` / `sdk-payments-ready`, `apiUrl` and `assetUrl`, neutral checkout callbacks, verification expectations, and a pointer to the local proxy harness.
> 
> The **White Label Proxy Server** guide explains the Express test proxy (routing to SDK, card, 3DS, API, and WebSocket upstreams), **`SDK_MAIN_JS`** version pinning, and how to build or validate a similar server.
> 
> The existing web customization content is renamed in the sidebar to **Styling** via `sidebarTitle` on `web/styling.mdx`; body content is unchanged aside from that frontmatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e84f569da4d0ad65a9b1d8b0ac5c2d6ad87393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->