### PR TITLE
Revert "chore: web sdk changelog 1.9.1"

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,24 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.1",
-      "release_date": "2026-05-27",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.1",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Faster Locale Resolution",
-          "description": "Cached the locale lookup chain so the initial dictionary load no longer re-evaluates the fallback path on every render. Cuts a few ms off the first paint for non-English locales.",
-          "group": "Core SDK",
-          "migration_guide": null,
-          "links": []
-        }
-      ]
-    },
-    {
       "version": "1.9.0",
       "release_date": "2026-05-26",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,14 +5,6 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
-## v1.9.1
-*May 27, 2026*
-
-**Core SDK**
-
-- <ChangelogBadge type="fixed" /> **Faster Locale Resolution**  
-  Cached the locale lookup chain so the initial dictionary load no longer re-evaluates the fallback path on every render. Cuts a few ms off the first paint for non-English locales.
-
 ## v1.9.0
 *May 26, 2026*
 


### PR DESCRIPTION
Reverts yuno-payments/yuno-docs#434

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only revert with no SDK or runtime changes; only affects published release history.
> 
> **Overview**
> Reverts the Web SDK **v1.9.1** changelog that was added in yuno-payments/yuno-docs#434.
> 
> **`changelog/source/web.json`** no longer lists v1.9.1 (May 27, 2026, `@yuno-payments/sdk-web@1.9.1`, Core SDK fix **Faster Locale Resolution**). **`changelog/web.mdx`** drops the matching **v1.9.1** section so the published Web SDK changelog again leads with **v1.9.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9faffc58f76f7a9acd99e99b555a5c84fb1be47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->