### PR TITLE
docs: update web SDK CDN version to v1.9

### DIFF
--- a/docs/sdks/full-checkout/web-payments.mdx
+++ b/docs/sdks/full-checkout/web-payments.mdx
@@ -45,7 +45,7 @@ const yuno = await loadScript({
 
 ```html
 <script 
-  src="https://sdk-web.y.uno/v1.6/main.js"
+  src="https://sdk-web.y.uno/v1.9/main.js"
   integrity="sha384-..."
   crossorigin="anonymous"
   async
@@ -61,7 +61,7 @@ Find the latest SRI hashes for each version in [versions-sri.json](https://sdk-w
 
 ```javascript
 const script = document.createElement('script');
-script.src = 'https://sdk-web.y.uno/v1.6/main.js';
+script.src = 'https://sdk-web.y.uno/v1.9/main.js';
 script.integrity = 'sha384-...';
 script.crossOrigin = 'anonymous';
 script.async = true;

--- a/docs/sdks/overview/quickstart.mdx
+++ b/docs/sdks/overview/quickstart.mdx
@@ -21,7 +21,7 @@ Choose your platform and follow the steps to start process your first payments w
     Or include via CDN:
 
     ```html
-    <script src="https://sdk-web.y.uno/v1.5/main.js"></script>
+    <script src="https://sdk-web.y.uno/v1.9/main.js"></script>
     ```
 
     ### 2. Initialize and process payment

--- a/docs/sdks/resources/references/web.mdx
+++ b/docs/sdks/resources/references/web.mdx
@@ -24,7 +24,7 @@ This browser security feature lets you ensure a loaded script has not been tampe
 When implementing SRI, use the full semantic version URL format to ensure immutable, tamper-evident integrations.
 
 * **Full (immutable) URL with SRI**: Full semantic version path used for locked, tamper-evident integrations with an SRI hash.
-* **Partial (mutable) URL**: Version with major and minor (e.g., v1.5).  This version will receive patch improvements.  This is useful if you like to avoid updates in your code base.
+* **Partial (mutable) URL**: Version with major and minor (e.g., v1.9).  This version will receive patch improvements.  This is useful if you like to avoid updates in your code base.
 
 ### How to integrate the SDK with SRI
 
@@ -34,7 +34,7 @@ The hash can be found in [versions-sri.json](https://sdk-web.y.uno/versions-sri.
 
 ```html
 <script
-  src="https://sandbox.y.uno/sdk-static-bundles-ms/sdk-web/v1.5.0/main.js"
+  src="https://sandbox.y.uno/sdk-static-bundles-ms/sdk-web/v1.9.0/main.js"
   integrity="sha384-<paste-hash-here>"
   crossorigin="anonymous"></script>
 ```


### PR DESCRIPTION
## Summary
Update the web SDK CDN script reference in the quickstart guide from v1.5 to v1.9.

## Changes
- `docs/sdks/overview/quickstart.mdx`: bump CDN URL `v1.5/main.js` → `v1.9/main.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL version bumps with no application, API, or security logic changes.
> 
> **Overview**
> Updates **Web SDK CDN and SRI examples** across integration docs so copy-paste snippets point at **v1.9** instead of older **v1.5/v1.6** lines.
> 
> In **quickstart** and **full-checkout (web payments)**, the HTML script tag and dynamic `script.src` URLs change to `https://sdk-web.y.uno/v1.9/main.js`. In the **Web reference**, the partial mutable URL example and the full immutable sandbox SRI sample move to **v1.9** / **v1.9.0** (`sdk-web/v1.9.0/main.js`). No runtime or package code changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895bc1c9250a944348d982277abbfb481aeb3644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->