### PR TITLE
docs(vtex): add 4.2.304 changelog entry

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.304
+*May 28, 2026*
+
+**Configuration**
+
+- <ChangelogBadge type="added" /> **CIELO_CYBERSOURCE_FRAUD antifraud provider for split orders**  
+  Adds CIELO_CYBERSOURCE_FRAUD as an accepted value in the Antifraud Providers for Split Orders setting, alongside RISKIFIED, CYBERSOURCE, and SIGNIFYD.
+
 ## v4.2.302
 *May 26, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.304",
+      "release_date": "2026-05-28",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.304",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "CIELO_CYBERSOURCE_FRAUD antifraud provider for split orders",
+          "description": "Adds CIELO_CYBERSOURCE_FRAUD as an accepted value in the Antifraud Providers for Split Orders setting, alongside RISKIFIED, CYBERSOURCE, and SIGNIFYD.",
+          "group": "Configuration",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.302",
       "release_date": "2026-05-26",
       "upgrade": {

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -46,7 +46,7 @@ Have the following ready:
       | **VTEX IO orderPlaced page URL** | Optional | A custom URL where shoppers should be redirected after payment. |
       | **Payment Mode** | Optional | **Payment App** (modern) or **Legacy** (redirect). |
       | **Transaction Identification From** | Optional | **Yuno TID** or **Provider TID**. |
-      | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
+      | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, `CIELO_CYBERSOURCE_FRAUD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
     </Accordion>
 
     <Accordion title="Settlement Options">


### PR DESCRIPTION
## Summary

- Adds VTEX plugin changelog entry for **v4.2.304** in `changelog/source/vtex.json`: introduces `CIELO_CYBERSOURCE_FRAUD` as an accepted antifraud provider value for the Antifraud Providers for Split Orders setting.
- Regenerates `changelog/plugins/vtex.mdx` via `scripts/generate_changelog.js`.
- Documents `CIELO_CYBERSOURCE_FRAUD` in the **Antifraud Providers for Split Orders** field of the VTEX setup guide (`docs/plugins/vtex/set-up-yuno-on-vtex.mdx`).

## Test plan

- [ ] Verify v4.2.304 renders correctly on the Changelog page
- [ ] Confirm the updated provider list appears in the "Field reference" accordion of the VTEX setup guide
- [ ] Mintlify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to changelog JSON/MDX and the VTEX setup guide; no runtime or payment logic changes.
> 
> **Overview**
> Documents **VTEX plugin v4.2.304**, which adds **`CIELO_CYBERSOURCE_FRAUD`** as an accepted antifraud provider for split orders.
> 
> The release is recorded in `changelog/source/vtex.json` and reflected in the generated `changelog/plugins/vtex.mdx`. The VTEX setup guide field reference for **Antifraud Providers for Split Orders** now lists `CIELO_CYBERSOURCE_FRAUD` alongside the existing provider values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371dc2903a21b0c58d03951937a0acdeff508c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->