### PR TITLE
Removed binary size warning from iOS and Android pages

### DIFF
--- a/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
@@ -21,10 +21,6 @@ The Yuno Android SDK supports running 3-D Secure (3DS) challenges natively insid
 - **Yuno Payments SDK 2.16.0 or higher** already installed in your app (`com.yuno.payments:android-sdk`).
 - The Netcetera 3DS provider module (`com.yuno.payments:yuno-sdk-3ds-netcetera`), installed via Gradle (see below).
 
-<Warning>
-  The Netcetera provider bundles a full 3DS challenge UI and the vendor's root certificates, which adds to your final app binary. This is why it ships as a separate module — merchants who don't use 3DS don't pay this cost.
-</Warning>
-
 ## Compatibility
 
 Each release of this module is built and tested against a minimum version of the Yuno Payments SDK. The module's POM does not pin a specific core version, leaving you in full control of which `com.yuno.payments:android-sdk` version your app runs against — but versions below the minimum may not expose the APIs this module relies on and can fail at runtime with `NoSuchMethodError` / `NoSuchFieldError`.

--- a/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
@@ -21,10 +21,6 @@ The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside yo
 - **YunoSDK 2.17.0 or higher** already installed in your app.
 - The Netcetera 3DS provider package ([`Yuno3DSNetcetera`](https://github.com/yuno-payments/yuno-3DS-netcetera-iOS)), installed via Swift Package Manager or CocoaPods (see below).
 
-<Warning>
-  The Netcetera provider adds approximately **5 MB** to your final app binary (it bundles a full 3DS challenge UI and the vendor's root certificates). This is why it lives in a separate package — merchants who don't use 3DS don't pay this cost.
-</Warning>
-
 ## Installation
 
 <Tabs>


### PR DESCRIPTION
## PR Description:

 Removed binary size warning from iOS and Android pages.
 
 ## Changes
  - Removed the <Warning> callout about binary size (~5 MB) from the Netcetera 3DS iOS page.
  - Removed the equivalent <Warning> callout from the Netcetera 3DS Android page.

Both blocks explained that the Netcetera provider adds to the app binary and ships as a separate package for that reason. Removed per Vivi's request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or SDK behavior changes.
> 
> **Overview**
> Removes the **Requirements**-section `<Warning>` callouts on the Netcetera 3DS **Android** and **iOS** docs that described extra app binary size (including ~5 MB on iOS) and why the provider ships as a separate module/package.
> 
> All other content on those pages—requirements, compatibility, installation, and activation—is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02cff57fb8cb35b0d4166928d3bced5fd245fa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->