### PR TITLE
Update Step 10 domain registration to Dashboard flow

### DIFF
--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -207,25 +207,15 @@ You will end up with two .cer files — one for Payment Processing and one for M
 
 ## Step 10: Register your merchant domains
 
-1. Go to [Apple Developer Merchant ID list](https://developer.apple.com/account/resources/identifiers/list/merchant).
-2. Select your **Merchant ID** and click **Add Domain** under **Merchant Domains**.
-3. Enter the domain (e.g., `demo.y.uno`) and click **Save**.
+Before the Apple Pay button can appear on your website, every domain that displays it must be registered. With Yuno you do this directly in the Dashboard — Yuno registers each domain with Apple on your behalf, so **you don't need to add domains in the Apple Developer Portal or host a domain-association file.**
 
-<Info>
-  **Note**
+**To register your domains:**
 
-  You must also host Apple's `apple-developer-merchantid-domain-association` file at:
-
-  ```text
-  https://example.com/.well-known/apple-developer-merchantid-domain-association
-  ```
-
-  Replace `example.com` with your actual domain name.
-
-  The file must be served as a static asset so that accessing the URL displays the file contents directly in the browser, rather than triggering a download.
-</Info>
-
-Once all steps are complete, you can proceed with the Dashboard setup.
+1. In the Dashboard, go to **Connections › Certificates & Domains › Apple Pay** and open the **Domains** tab.
+2. Click **Add domain**.
+3. Enter the domains where the Apple Pay button will appear, **one per line** (up to 10 at a time).
+4. Click **Add**. Each domain appears in the table with a status of **Verifying** while Yuno completes registration with Apple.
+5. When registration succeeds, the status changes to **Active** — the domain is ready to show Apple Pay.
 
 ## Step 11: Apple Pay Dashboard connection
 


### PR DESCRIPTION
## PR Description:

This PR updates Step 10 of the Apple Pay prerequisites page to reflect the new self-service domain registration flow in the Yuno Dashboard.

## What changed

  - docs/wallets/apple-pay/prerequisites-apple-pay.mdx:
    - Replaced Step 10 with the new Dashboard-based domain registration flow — merchants now register domains directly in Connections › Certificates & Domains › Apple Pay › Domains, without needing to touch the Apple Developer Portal or host a domain-association file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to merchant setup instructions; no application or security logic is modified.
> 
> **Overview**
> **Step 10** in the Apple Pay prerequisites guide now describes **Dashboard-based merchant domain registration** instead of the Apple Developer Portal workflow.
> 
> Merchants add domains under **Connections › Certificates & Domains › Apple Pay › Domains**, with **Verifying** → **Active** status as Yuno registers with Apple. The doc states they **no longer** add domains in Apple Developer or host `apple-developer-merchantid-domain-association` under `.well-known`. Removed instructions for Apple’s merchant domain list, **Add Domain**, and the static domain-association file note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609ed5f3cc987e309ff011971e6c5235d8deffe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->