### PR TITLE
Added account_id to create connection request body

### DIFF
--- a/openapi/organizations/connections/create-connection.json
+++ b/openapi/organizations/connections/create-connection.json
@@ -24,8 +24,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["merchant_connection_id", "provider_id", "flow_type", "payment_methods", "params"],
+                "required": ["account_id", "merchant_connection_id", "provider_id", "flow_type", "payment_methods", "params"],
                 "properties": {
+                  "account_id": { "type": "string", "format": "uuid", "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
                   "merchant_connection_id": { "type": "string", "example": "adyen-us-prod-001" },
                   "provider_id": { "type": "string", "example": "ADYEN" },
                   "flow_type": { "type": "string", "example": "PAYIN" },

--- a/reference/organizations/connections/create-connection.mdx
+++ b/reference/organizations/connections/create-connection.mdx
@@ -14,6 +14,10 @@ Creates a connection in `ACTIVE` status from credentials and configuration you f
 
 ### Body
 
+<ParamField body="account_id" type="string" required>
+  UUID of the account under which this connection will be created.
+</ParamField>
+
 <ParamField body="merchant_connection_id" type="string" required>
   Your label for this connection. Must be unique within the account. Free-form (e.g., `"adyen-us-prod-001"`, `"stripe-eu-test"`).
 </ParamField>
@@ -111,6 +115,7 @@ curl -X POST 'https://api.y.uno/v1/connections' \
   -H 'Content-Type: application/json' \
   -H 'X-Idempotency-Key: <UUID>' \
   -d '{
+    "account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "merchant_connection_id": "stripe-us-prod-001",
     "provider_id": "STRIPE",
     "flow_type": "PAYIN",


### PR DESCRIPTION
# docs(connections): add account_id to create connection request body

## PR Description
Adds the `account_id` UUID field to the Create Connection API reference, requested by Andres. The field was missing from both the OpenAPI spec and the rendered MDX page. It has been added as a required property in the request body schema.

## Changes
- `openapi/organizations/connections/create-connection.json` — added `account_id` (UUID string) to `properties` and to the `required` array
- `reference/organizations/connections/create-connection.mdx` — added `<ParamField>` block for `account_id` and included it in the curl example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to OpenAPI and MDX; no runtime or API implementation changes in this PR.
> 
> **Overview**
> Documents **`account_id`** as a **required** UUID on **POST `/connections`**, aligning the public API reference with the actual request shape.
> 
> The OpenAPI schema in `create-connection.json` now lists `account_id` in `required` and `properties`. The **Create a Connection** MDX page adds a body param description and includes `account_id` in the cURL example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5feac7d1c52f726df8528df45e840fb7734ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->