### PR TITLE
chore: vtex sdk changelog 4.2.305

### DIFF
--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.305",
+      "release_date": "2026-06-01",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.305",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Release-flow demo helper",
+          "description": "Adds an isolated example helper used to validate the automated changelog publishing pipeline end to end; it has no effect on payment processing or merchant-facing behavior.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.304",
       "release_date": "2026-05-28",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.305`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.305

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog JSON update with no runtime or payment logic changes.
> 
> **Overview**
> Inserts a new **4.2.305** release block at the top of `changelog/source/vtex.json`, ahead of **4.2.304**, with release date **2026-06-01** and upgrade snippet `vtex install yunopartnerbr.yuno@4.2.305`.
> 
> The single **ADDED** entry documents **Release-flow demo helper**: an isolated example helper for end-to-end validation of the automated changelog publishing pipeline, with no impact on payment processing or merchant-facing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f71b6b8e03166890dbee7d82067dd2b921fcbf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->