### PR TITLE
Update iOS SDK release notes for version 2.17.1

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.17.1
+*June 2, 2026*
+
+- <ChangelogBadge type="fixed" /> **Render Mode and Apple Pay Form Issues**  
+  Resolved issues with the render mode loader and the Apple Pay form view to ensure proper functionality.
+
 ## v2.17.0
 *May 25, 2026*
 

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,32 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.17.1",
+      "release_date": "2026-06-02",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.17.1\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.17.1'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Render Mode and Apple Pay Form Issues",
+          "description": "Resolved issues with the render mode loader and the Apple Pay form view to ensure proper functionality.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.17.0",
       "release_date": "2026-05-25",
       "upgrade": [

--- a/docs/sdks/resources/release-notes/ios.mdx
+++ b/docs/sdks/resources/release-notes/ios.mdx
@@ -10,6 +10,11 @@ The iOS SDK release notes provide a comprehensive overview of the updates, impro
 
 | Version | Changes                                                                                                                                                                                                           |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.17.1  | **FIX**: Resolved issues with the render mode loader and the Apple Pay form view to ensure proper functionality. |
+| 2.17.0  | **NEW**: Netcetera Native 3DS SDK support. |
+|         | **NEW**: Slim form variant — compact card and address layout, opt-in. |
+|         | **CHANGE**: Secure payment badge visibility — opt-in setting to hide the badge. |
+| 2.16.0  | **NEW**: Flexible actions in enrollment — PIN, image, payment code, OTP, and info screens. |
 | 2.15.0  | **CHANGE**: Make `delegate.viewController` optional. |
 |         | **NEW**: Apple Pay contact field support — requests billing/shipping address, name, email, and phone based on required fields. |
 |         | **NEW**: Shipping address support in card and APM forms with billing/shipping toggle and validation. |


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.17.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to changelog JSON/MDX and release notes; no application or SDK code changes.
> 
> **Overview**
> Documents **iOS SDK v2.17.1** (June 2, 2026) across the changelog pipeline and SDK release-notes page.
> 
> **`changelog/source/ios.json`** gains a new top-level release with SPM/CocoaPods upgrade snippets pinned to `2.17.1` and a single **FIXED** entry for render-mode loader and Apple Pay form view issues. **`changelog/ios.mdx`** adds the matching **v2.17.1** section with a fixed badge and the same wording.
> 
> **`docs/sdks/resources/release-notes/ios.mdx`** inserts table rows for **2.17.1** and also adds **2.17.0** and **2.16.0** summaries that were missing from the compact release-notes table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e780b0c34d8ccacc1eaf75054e67dae449fc44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->