### PR TITLE
chore: woocommerce sdk changelog 1.0.2

### DIFF
--- a/changelog/source/woocommerce.json
+++ b/changelog/source/woocommerce.json
@@ -2,6 +2,24 @@
   "sdk": "woocommerce",
   "releases": [
     {
+      "version": "1.0.2",
+      "release_date": "2026-06-02",
+      "upgrade": {
+        "snippet": "wp plugin install yuno-payment-gateway --version=1.0.2 --activate",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Release-flow demo helper",
+          "description": "Adds an isolated example helper used to validate the automated changelog publishing pipeline end to end; it has no effect on payments or checkout.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.0.1",
       "release_date": "2026-04-13",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **woocommerce** SDK `1.0.2`.

Source: https://github.com/yuno-payments/sdk-woocommerce/releases/tag/1.0.2

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog JSON with no application or payment logic changes.
> 
> **Overview**
> Adds a **1.0.2** release block at the top of `changelog/source/woocommerce.json` for the WooCommerce SDK, including release date **2026-06-02**, the `wp plugin install yuno-payment-gateway --version=1.0.2 --activate` upgrade snippet, and one **ADDED** entry documenting a release-flow demo helper (pipeline validation only; no payment or checkout impact).
> 
> This matches the auto-generated changelog flow tied to [sdk-woocommerce release 1.0.2](https://github.com/yuno-payments/sdk-woocommerce/releases/tag/1.0.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea28e9e241c061e9184a4a083ac3d1cb9b8849ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->