### PR TITLE
chore: web sdk changelog 1.9.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,55 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.1",
+      "release_date": "2026-06-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "When only one regular payment method is available, it is now automatically pre-selected and its radio button appears checked on render — regardless of whether the backend marks it as preferred.",
+          "description": "",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "QR codes for QR-based payment methods (like Nequi) now render with extra whitespace around the pattern, improving scan reliability on phones that auto-crop the camera view.",
+          "description": "",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Yuno-hosted static assets (such as brand logos) now can be served via the proxy. Only Yuno hosts are rewritten, leaving external asset URLs untouched.",
+          "description": "",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "In whitelabel mode (when `apiUrl` or `assetUrl` is set at `initialize()`), the data privacy / terms-and-conditions text is hidden, matching the \"Secure by Yuno\" badge behavior.",
+          "description": "",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17057",
+        "CORECM-17218",
+        "CORECM-17414",
+        "CORECM-17664",
+        "YSHUB-4824"
+      ]
+    },
+    {
       "version": "1.9.0",
       "release_date": "2026-05-26",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,25 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.1
+*June 3, 2026*
+
+**Checkout**
+
+- <ChangelogBadge type="fixed" /> **When only one regular payment method is available, it is now automatically pre-selected and its radio button appears checked on render — regardless of whether the backend marks it as preferred.**  
+  
+
+- <ChangelogBadge type="fixed" /> **In whitelabel mode (when `apiUrl` or `assetUrl` is set at `initialize()`), the data privacy / terms-and-conditions text is hidden, matching the "Secure by Yuno" badge behavior.**  
+  
+
+**Core SDK**
+
+- <ChangelogBadge type="fixed" /> **QR codes for QR-based payment methods (like Nequi) now render with extra whitespace around the pattern, improving scan reliability on phones that auto-crop the camera view.**  
+  
+
+- <ChangelogBadge type="fixed" /> **Yuno-hosted static assets (such as brand logos) now can be served via the proxy. Only Yuno hosts are rewritten, leaving external asset URLs untouched.**  
+  
+
 ## v1.9.0
 *May 26, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.1`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.1

4 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or API changes in this repository.
> 
> **Overview**
> Documents **Web SDK v1.9.1** (June 3, 2026) by prepending a new release block to `changelog/source/web.json` and mirroring it at the top of `changelog/web.mdx`, including the `npm install @yuno-payments/sdk-web@1.9.1` upgrade snippet and linked ticket IDs.
> 
> The release lists four **fixed** items: checkout auto-selects and shows a checked radio when only one regular payment method exists; whitelabel (`apiUrl` / `assetUrl` at `initialize()`) hides privacy/terms copy like the Secure badge; QR payments get extra quiet-zone padding for scanning; Yuno-hosted assets can load through the proxy without rewriting external URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b060f3220e46cdf3db7a66263fe44369eecbf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->