### PR TITLE
docs: white-label static-asset host-swap & proxy routing

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -11,7 +11,7 @@
       "entries": [
         {
           "type": "BREAKING",
-          "title": "Whitelabel Class Name and ID Prefix Change",
+          "title": "Whitelabel Class Names and IDs Prefix Change",
           "description": "`Yuno` class names and IDs prefix changed to `sdk-payments`. For example, `yuno-checkout` becomes `sdk-payments-checkout`.",
           "group": "White Label",
           "migration_guide": null,

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -11,14 +11,22 @@
       "entries": [
         {
           "type": "BREAKING",
-          "title": "Whitelabel-Neutral Public API",
-          "description": "Public-facing CSS class names, DOM ids, and event/callback names have been renamed to neutral, whitelabel-friendly identifiers. Existing `window.Yuno`, the `yuno-sdk-ready` event, and `yuno*` callback aliases continue to work, so existing merchant integrations need no changes. `Yuno` class names prefix changed to `sdk-payments`. `window.Yuno` deprecated in favor of `window.SdkPayments`.",
+          "title": "Whitelabel Class Name and ID Prefix Change",
+          "description": "`Yuno` class names and IDs prefix changed to `sdk-payments`. For example, `yuno-checkout` becomes `sdk-payments-checkout`.",
           "group": "White Label",
           "migration_guide": null,
           "links": []
         },
         {
-          "type": "BREAKING",
+          "type": "ADDED",
+          "title": "Whitelabel-Neutral Public API",
+          "description": "Public-facing CSS class names, DOM ids, and event/callback names have been renamed to neutral, whitelabel-friendly identifiers. Existing `window.Yuno`, the `yuno-sdk-ready` event, and `yuno*` callback aliases continue to work, so existing merchant integrations need no changes. `window.Yuno` deprecated in favor of `window.SdkPayments`.",
+          "group": "White Label",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
           "title": "Custom API and Asset URLs",
           "description": "Added `options.apiUrl` and `options.assetUrl` initialization overrides so the SDK can point at partner-hosted backends, 3DS endpoints, secure-field iframes, and card-form assets instead of the default Yuno URLs. The override is also forwarded to the monitoring layer, mediator, and card-form iframes.",
           "group": "White Label",
@@ -26,7 +34,7 @@
           "links": []
         },
         {
-          "type": "BREAKING",
+          "type": "ADDED",
           "title": "Hide Secure Payment Badge on Custom Hosting",
           "description": "When `apiUrl` or `assetUrl` overrides are set, the `Secure Payment with Yuno` badge is automatically hidden in both the standard checkout and the Click to Pay flow.",
           "group": "White Label",

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -10,13 +10,16 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 **White Label**
 
-- <ChangelogBadge type="breaking" /> **Whitelabel-Neutral Public API**  
-  Public-facing CSS class names, DOM ids, and event/callback names have been renamed to neutral, whitelabel-friendly identifiers. Existing `window.Yuno`, the `yuno-sdk-ready` event, and `yuno*` callback aliases continue to work, so existing merchant integrations need no changes. `Yuno` class names prefix changed to `sdk-payments`. `window.Yuno` deprecated in favor of `window.SdkPayments`.
+- <ChangelogBadge type="breaking" /> **Whitelabel Class Names and IDs Prefix Change**  
+  `Yuno` class names and IDs prefix changed to `sdk-payments`. For example, `yuno-checkout` becomes `sdk-payments-checkout`.
 
-- <ChangelogBadge type="breaking" /> **Custom API and Asset URLs**  
+- <ChangelogBadge type="added" /> **Whitelabel-Neutral Public API**  
+  Public-facing CSS class names, DOM ids, and event/callback names have been renamed to neutral, whitelabel-friendly identifiers. Existing `window.Yuno`, the `yuno-sdk-ready` event, and `yuno*` callback aliases continue to work, so existing merchant integrations need no changes. `window.Yuno` deprecated in favor of `window.SdkPayments`.
+
+- <ChangelogBadge type="added" /> **Custom API and Asset URLs**  
   Added `options.apiUrl` and `options.assetUrl` initialization overrides so the SDK can point at partner-hosted backends, 3DS endpoints, secure-field iframes, and card-form assets instead of the default Yuno URLs. The override is also forwarded to the monitoring layer, mediator, and card-form iframes.
 
-- <ChangelogBadge type="breaking" /> **Hide Secure Payment Badge on Custom Hosting**  
+- <ChangelogBadge type="added" /> **Hide Secure Payment Badge on Custom Hosting**  
   When `apiUrl` or `assetUrl` overrides are set, the `Secure Payment with Yuno` badge is automatically hidden in both the standard checkout and the Click to Pay flow.
 
 **Core SDK**

--- a/docs/sdks/customization/web/white-label-proxy-server.mdx
+++ b/docs/sdks/customization/web/white-label-proxy-server.mdx
@@ -27,16 +27,18 @@ To verify the rename actually shipped, the SDK must be loaded from a host that i
 ## How it works
 
 ```
-┌──────────────────┐      ┌──────────────────────┐      ┌────────────────────┐
-│  Partner page    │────▶ │  white-label-proxy   │────▶ │ Yuno upstreams     │
-│  (browser)       │      │  (Express :9090)     │      │  - sdk-web.*.y.uno │
-│                  │ ◀────│                      │ ◀────│  - sdk-3ds.*.y.uno │
-│ <script src=     │      │  Routes by path:     │      │  - sdk-web-card.*  │
-│  localhost:9090/ │      │   /v1/*  → BACKEND   │      │  - api[-env].y.uno │
-│  v1.7/main.js>   │      │   /v<n>/pages → CARD │      │                    │
-└──────────────────┘      │   /challenge → 3DS   │      └────────────────────┘
-                          │   else       → SDK   │
-                          └──────────────────────┘
+┌──────────────────┐     ┌────────────────────────────┐     ┌─────────────────────┐
+│  Partner page    │───▶ │   white-label-proxy        │───▶ │ Yuno upstreams      │
+│  (browser)       │     │   (Express :9090)          │     │  - sdk-web.*.y.uno  │
+│                  │ ◀───│                            │ ◀───│  - sdk-3ds.*.y.uno  │
+│ <script src=     │     │   Routes by path:          │     │  - sdk-web-card.*   │
+│  localhost:9090/ │     │    /v1/*         → BACKEND  │     │  - sdk.prod.y.uno   │
+│  v1.7/main.js>   │     │    /v<n>/pages    → CARD    │     │  - icons.prod.y.uno │
+│                  │     │    /challenge     → 3DS     │     │  - api[-env].y.uno  │
+│                  │     │    /icons,/css    → STATIC  │     │                     │
+│                  │     │    /flags,/*.png  → ICONS   │     │                     │
+│                  │     │    else           → SDK     │     │                     │
+└──────────────────┘     └────────────────────────────┘     └─────────────────────┘
 ```
 
 Three invariants make the harness useful:
@@ -57,11 +59,15 @@ A single Node.js process built on three libraries:
 
 1. **CORS middleware** runs first. It echoes the caller's `Origin`, handles `OPTIONS` preflight, and sets `Access-Control-Allow-Credentials: true`. The proxy is the CORS authority.
 2. **Local routes** match before anything else: `/`, `/static/*`, `/whitelabel-info`. These never touch an upstream.
-3. **Backend pass-through** matches `/v1/*` and `/v2/*` (the Yuno REST surface used by the SDK) and forwards via `node-fetch` to `BACKEND_URL`. Hop-by-hop headers are stripped; `access-control-*` headers from the upstream are dropped so they cannot override the proxy's own CORS.
-4. **SDK asset catch-all** matches every remaining `GET`/`HEAD`. A small dispatcher picks the right upstream based on path:
+3. **Backend pass-through** matches `/v1/*` and `/v2/*` (the Yuno REST surface used by the SDK) and forwards via `node-fetch` to `BACKEND_URL`. Hop-by-hop headers are stripped; `access-control-*` headers from the upstream are dropped so they cannot override the proxy's own CORS. The browser `Cookie` header is also dropped on these forwards — the partner page's localhost cookies (session, analytics, URL-valued ones, …) don't belong on a cross-origin call to `api.y.uno` and can trip the upstream WAF with a `403`; the API authenticates via the public API key.
+4. **SDK asset catch-all** matches every remaining `GET`/`HEAD`. A small dispatcher (`pickSdkUpstream`) picks the right upstream based on path, checked top to bottom so the 3DS/card rules win first:
    - 3DS micro-app paths (`/challenge.html`, `/redirect.html`, `/session-id.html`, and `/assets/(challenge|redirect|session-id|validate-url)*`) → `SDK_3DS_UPSTREAM`.
    - Card micro-app paths (`/v<semver>/pages/*`, `/v<semver>/assets/*`) → `SDK_CARD_UPSTREAM`.
+   - Static-asset paths (`/icons/*`, `/css/*`, `/brands/*`, `/c2p/*`) → `SDK_STATIC_UPSTREAM` (`sdk.prod.y.uno`).
+   - Icon-asset paths (`/sdk-web/*`, `/flags/*`, and bare root brand images like `/Visa.png`, `/boleto_logosimbolo.png`) → `SDK_ICONS_UPSTREAM` (`icons.prod.y.uno`).
    - Everything else → `SDK_UPSTREAM`.
+
+   The static / icons branches exist because the SDK used to load these straight from `icons.prod.y.uno` / `sdk.prod.y.uno`, bypassing the white-label host. Recent SDK builds host-swap them onto the proxy origin (path preserved), so the proxy must forward them back out to the two CDNs by path prefix. These upstreams are always `*.prod.y.uno` regardless of the target environment.
 5. **WebSocket upgrades** are handled on the underlying `http.Server`, not Express. `/checkout-websocket-notification-ms/ws/*` → `BACKEND_WS_URL`; everything else follows the same SDK / card / 3DS split as HTTP.
 
 ### Version normalization
@@ -77,8 +83,8 @@ The proxy resolves the canonical version once at boot and rewrites every incomin
 
 `SDK_MAIN_JS` decides which build of the SDK every browser loads. It does two related things:
 
-1. **Template injection.** The proxy serves `pages/index.html` with the literal `__SDK_MAIN_JS__` placeholder replaced by this path. A partner page can write `<script src="__SDK_MAIN_JS__">` and get e.g. `/v1.9.0/main.js`.
-2. **Version normalization target.** The proxy parses the `/v<x>/` segment out of `SDK_MAIN_JS` and rewrites any incoming `/v<other>/main.js` (and adjacent `/v<other>/*.js`, `/v<other>/*.css`) request to that same version. So if `SDK_MAIN_JS=/v1.9.0/main.js`, a request for `/v1.5.0/main.js` is silently fetched as `/v1.9.0/main.js` from `SDK_UPSTREAM`.
+1. **Template injection.** The proxy serves `pages/index.html` with the literal `__SDK_MAIN_JS__` placeholder replaced by this path. A partner page can write `<script src="__SDK_MAIN_JS__">` and get e.g. `/v1.9.1/main.js`.
+2. **Version normalization target.** The proxy parses the `/v<x>/` segment out of `SDK_MAIN_JS` and rewrites any incoming `/v<other>/main.js` (and adjacent `/v<other>/*.js`, `/v<other>/*.css`) request to that same version. So if `SDK_MAIN_JS=/v1.9.1/main.js`, a request for `/v1.5.0/main.js` is silently fetched as `/v1.9.1/main.js` from `SDK_UPSTREAM`.
 
 ### Resolution order at boot
 
@@ -101,7 +107,7 @@ SDK_MAIN_JS=/v<semver>/main.js
 | Value | When to use it |
 | :--- | :--- |
 | `/v1.9/main.js` | Pin to a minor line (whatever the upstream publishes there) |
-| `/v1.9.0/main.js` | Pin to an exact patch — most common |
+| `/v1.9.1/main.js` | Pin to an exact patch — most common |
 
 The path **must** start with `/v` and contain `/main.js` for normalization to work. If the regex does not match, the path is used for template injection but version rewriting is disabled.
 
@@ -110,15 +116,15 @@ The path **must** start with `/v` and contain `/main.js` for normalization to wo
 **Test a specific SDK release end-to-end:**
 
 ```shell
-SDK_MAIN_JS=/v1.9.0/main.js npm start
+SDK_MAIN_JS=/v1.9.1/main.js npm start
 ```
 
-Every page now loads `v1.9.0`, and any hardcoded `/v<other>/*.js` in partner pages is silently rewritten to `v1.9.0` against `SDK_UPSTREAM`.
+Every page now loads `v1.9.1`, and any hardcoded `/v<other>/*.js` in partner pages is silently rewritten to `v1.9.1` against `SDK_UPSTREAM`.
 
 **Quiet startup (no upstream `versions.json` call):**
 
 ```shell
-SDK_MAIN_JS=/v1.9.0/main.js npm start
+SDK_MAIN_JS=/v1.9.1/main.js npm start
 ```
 
 Useful in air-gapped environments or when `SDK_UPSTREAM` is a local file server that does not expose `versions.json`.
@@ -160,10 +166,12 @@ npm install express http-proxy node-fetch@2 dotenv
 | `SDK_UPSTREAM` | `/v<x>/main.js` and everything not matched below |
 | `SDK_CARD_UPSTREAM` | `/v<x>/pages/*`, `/v<x>/assets/*` |
 | `SDK_3DS_UPSTREAM` | `/challenge.html`, `/redirect.html`, `/session-id.html`, `/assets/(challenge\|redirect\|session-id\|validate-url)*` |
+| `SDK_STATIC_UPSTREAM` | `/icons/*`, `/css/*`, `/brands/*`, `/c2p/*` (host-swapped CDN assets) |
+| `SDK_ICONS_UPSTREAM` | `/sdk-web/*`, `/flags/*`, bare root brand images (`/Visa.png`, …) |
 | `BACKEND_URL` | `/v1/*`, `/v2/*` (REST API) |
 | `BACKEND_WS_URL` | `/checkout-websocket-notification-ms/ws/{payment,enrollment}` (WebSocket only) |
 
-All but `SDK_UPSTREAM` and `BACKEND_URL` default to their parent when unset — keep this fallback behaviour, it makes single-env testing easier.
+`SDK_CARD_UPSTREAM` and `SDK_3DS_UPSTREAM` default to `SDK_UPSTREAM` when unset, and `BACKEND_WS_URL` defaults to `BACKEND_URL` — keep this fallback behaviour, it makes single-env testing easier. `SDK_STATIC_UPSTREAM` / `SDK_ICONS_UPSTREAM` are the exception: they default to the fixed `sdk.prod.y.uno` / `icons.prod.y.uno` CDNs (the SDK host-swaps these from `*.prod.y.uno` regardless of environment), **not** to `SDK_UPSTREAM`.
 
 ### 3. Set up CORS as the proxy's responsibility
 
@@ -212,6 +220,7 @@ app.all('/v2/*', forwardToBackend)
 async function forwardToBackend(req, res) {
   const targetUrl = `${BACKEND_URL}${req.originalUrl}`
   const headers = pickRequestHeaders(req) // filters HOP_BY_HOP
+  delete headers.cookie                   // partner cookies don't belong on api.y.uno
   const init = { method: req.method, headers }
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     // express.json() consumed the original body; re-serialize it.
@@ -232,6 +241,10 @@ async function forwardToBackend(req, res) {
 
 `express.json()` has already consumed the request body, so for non-GET methods you re-serialize `req.body`. Don't try to `req.pipe(upstream)` after the body is consumed.
 
+<Note>
+  Drop the `Cookie` header before forwarding. The partner page's browser cookies belong to the proxy origin (session, analytics, URL-valued ones like `spage`) and a genuine cross-origin call to `api.y.uno` would never carry them — forwarding them only risks the upstream WAF rejecting the request with a `403`. The API authenticates via the public API key, not cookies. (WebSocket upgrades are the exception — see step 7.)
+</Note>
+
 ### 6. Catch-all proxy for SDK assets
 
 ```javascript
@@ -241,7 +254,7 @@ app.use((req, res, next) => {
 })
 
 async function proxyToUpstream(req, res, next) {
-  const upstreamBase = pickSdkUpstream(req.path)   // returns one of three URLs
+  const upstreamBase = pickSdkUpstream(req.path)   // 3DS / card / static / icons / SDK
   const targetUrl = `${upstreamBase}${normalizePath(req.originalUrl)}`
   const upstream = await fetch(targetUrl, { redirect: 'follow', headers: { /* accept, user-agent */ } })
   if (upstream.status === 404) return next()
@@ -294,8 +307,10 @@ Serve `index.html` at `/` and a `/whitelabel-info` JSON endpoint that returns th
 - **Hop-by-hop headers are bidirectional.** Strip them on both legs. `content-length` is the one that bites.
 - **Body consumption is a one-shot.** Once `express.json()` parses a request, the underlying stream is drained. Re-serialize from `req.body` if you need to forward a `POST`.
 - **Streaming, not buffering, for assets.** `upstream.body.pipe(res)` keeps memory flat even for multi-MB bundles.
-- **Version normalization is `SDK_UPSTREAM`-only.** Card and 3DS micro-apps have their own version segments — rewriting them breaks the upstream URL.
-- **WebSocket auth is whatever headers `http-proxy` sees.** Do **not** strip `cookie` or `authorization` from WS upgrades.
+- **Version normalization is `SDK_UPSTREAM`-only.** Card and 3DS micro-apps have their own version segments — rewriting them breaks the upstream URL. The static / icons CDNs aren't versioned, so they aren't normalized either.
+- **Static CDN assets are host-swapped too.** Recent SDK builds rewrite their hard-coded `icons.prod.y.uno` / `sdk.prod.y.uno` asset URLs onto the white-label host, so the proxy must forward `/icons`, `/css`, `/brands`, `/c2p` → `sdk.prod.y.uno` and `/sdk-web`, `/flags`, bare `/*.png` → `icons.prod.y.uno`. Older SDK builds load these straight from the CDN and never reach the proxy. Exercising this end-to-end needs a recent SDK build **and** a partner page that inits with `{ apiUrl: '<proxy origin>' }` (or `assetUrl`).
+- **Don't forward the partner page's cookies to the API.** Strip `Cookie` on `/v1`/`/v2` forwards — the browser's localhost cookies (session, analytics, URL-valued ones like `spage`) don't belong on a cross-origin call to `api.y.uno` and can trip the upstream WAF with a `403`. The API authenticates via the public API key.
+- **WebSocket auth is whatever headers `http-proxy` sees.** Do **not** strip `cookie` or `authorization` from WS upgrades — the cookie strip applies only to the HTTP `/v1`/`/v2` backend forwards.
 - `.env` is gitignored. Always keep `.env.example` in sync — it is the spec for anyone cloning the repo.
 
 ## Verification checklist
@@ -309,7 +324,7 @@ Once your proxy is running, verify in browser DevTools:
 
 ## Reference implementation
 
-The full source lives in the [`yuno-sdk-web/white-label-proxy-server`](https://github.com/yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server) repository. About 290 lines in `server.js` — the whole thing fits in one file because there is no business logic, just routing and header hygiene.
+The full source lives in the [`yuno-sdk-web/white-label-proxy-server`](https://github.com/yuno-payments/yuno-sdk-web/tree/main/white-label-proxy-server) repository. About 320 lines in `server.js` — the whole thing fits in one file because there is no business logic, just routing and header hygiene.
 
 ## See also
 

--- a/docs/sdks/customization/web/white-label.mdx
+++ b/docs/sdks/customization/web/white-label.mdx
@@ -9,7 +9,7 @@ metadata:
 White-label support lets a partner serve the Yuno Web SDK from their own origin without the string `Yuno` leaking into the merchant page — neither in the DOM, globals, dispatched events, nor outgoing network traffic.
 
 <Tip>
-  Shipped in `sdk-web` 1.9.0 and `sdk-web-core` 7.0.0. The legacy `window.Yuno` global and `yuno-sdk-ready` event remain as backwards-compatibility aliases, so existing integrations continue to work unchanged.
+  Shipped in Web SDK 1.9.1. The legacy `window.Yuno` global and `yuno-sdk-ready` event remain as backwards-compatibility aliases, so existing integrations continue to work unchanged.
 </Tip>
 
 ## What the SDK exposes
@@ -35,8 +35,10 @@ SdkPayments.initialize(publicApiKey, applicationSession, {
   // their internal calls land on the partner origin too.
   apiUrl: 'https://payments.example.com',
 
-  // Overrides the host that serves SDK static assets
-  // (3DS pages, card-form bundle, fonts, images).
+  // Overrides the host that serves SDK static assets — 3DS pages,
+  // card-form bundle, fonts, and (in recent SDK builds) the icons,
+  // brand logos, and country flags that the SDK otherwise loads straight
+  // from icons.prod.y.uno / sdk.prod.y.uno.
   assetUrl: 'https://payments.example.com',
 })
 ```
@@ -46,10 +48,12 @@ What each override affects end-to-end:
 | Option | Affects |
 | :--- | :--- |
 | `apiUrl` | SDK REST calls, WebSocket upgrades, monitoring/Datadog forwarder, secure-fields mediator, card-form iframe API base. |
-| `assetUrl` | 3DS challenge / redirect / session-id pages, card-form micro-app URL, font CSS, runtime `__webpack_public_path__` for code-split chunks. |
+| `assetUrl` | 3DS challenge / redirect / session-id pages, card-form micro-app URL, font CSS, runtime `__webpack_public_path__` for code-split chunks, and the hard-coded icon / brand-logo / country-flag assets on `icons.prod.y.uno` / `sdk.prod.y.uno` (host-swapped, path preserved; recent SDK builds). |
 
 <Note>
   For a typical white-label deployment, pass the same value to both options. The SDK uses the value verbatim — it no longer appends a `/v<x.y>` segment when `assetUrl` already ends with one, and it does not prepend a regional prefix to overrides.
+
+  The static-CDN host-swap (icons, brand logos, flags) routes onto `assetUrl` when set, otherwise falls back to `apiUrl` — so passing both the same value sends every request through a single origin. Only `*.y.uno` asset URLs are rewritten; merchant-supplied icons on external CDNs are left untouched.
 </Note>
 
 ## Neutral merchant callbacks
@@ -93,7 +97,7 @@ After loading the SDK from a non-Yuno origin, none of the following should appea
 
 - Elements with `class="yuno-*"` or `id="yuno-*"`.
 - A resolved font family of `Yuno-Inter`.
-- Network requests to `*.y.uno` hosts.
+- Network requests to `*.y.uno` hosts — including the static CDNs `icons.prod.y.uno` and `sdk.prod.y.uno` for icons, brand logos, and flags. These are host-swapped onto your origin only on recent SDK builds; older builds still fetch them straight from the CDN.
 
 And these should be present:
 

--- a/docs/sdks/resources/references/web.mdx
+++ b/docs/sdks/resources/references/web.mdx
@@ -34,7 +34,7 @@ The hash can be found in [versions-sri.json](https://sdk-web.y.uno/versions-sri.
 
 ```html
 <script
-  src="https://sandbox.y.uno/sdk-static-bundles-ms/sdk-web/v1.9.0/main.js"
+  src="https://sandbox.y.uno/sdk-static-bundles-ms/sdk-web/v1.9.1/main.js"
   integrity="sha384-<paste-hash-here>"
   crossorigin="anonymous"></script>
 ```


### PR DESCRIPTION
## What

Updates the Web SDK white-label docs to cover the static-asset host-swap and the matching proxy-harness routing changes.

- **`white-label.mdx`** — `assetUrl` (falling back to `apiUrl`) now also covers the icon / brand-logo / country-flag assets the SDK otherwise loads from `icons.prod.y.uno` / `sdk.prod.y.uno`; clarified the verification checklist.
- **`white-label-proxy-server.mdx`** — documented the two new asset-CDN upstreams and their path-prefix routing, the dropped `Cookie` header on `/v1`/`/v2` forwards, updated the diagram, upstream-map table, and pitfalls.
- Bumped white-label SDK version references to `1.9.1`.

Public-docs hygiene: no internal repo names or ticket IDs in the rendered content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog edits only; no runtime or API code changes.
> 
> **Overview**
> **Web SDK white-label docs** now describe static-asset **host-swapping** (`icons.prod.y.uno` / `sdk.prod.y.uno` → partner origin via `assetUrl` / `apiUrl`), with updated verification steps and **Web SDK 1.9.1** as the reference version.
> 
> **Proxy harness guide** adds `SDK_STATIC_UPSTREAM` / `SDK_ICONS_UPSTREAM` path routing, documents stripping **`Cookie`** on `/v1`/`/v2` API forwards (WAF/`403` pitfall), and refreshes the architecture diagram and pitfalls.
> 
> **Changelog (v1.9.0)** splits the **`sdk-payments`** class/ID prefix into its own **breaking** entry and re-tags custom URL / badge-hiding items as **added** instead of breaking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e3bcfb4f1d8c5a9ffd6f454f4d63b8481353f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->