### PR TITLE
Hide Create 3DS2 Setup page

### DIFF
--- a/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
+++ b/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create 3DS2 Setup"
+hidden: true
 description: "Register 3D Secure 2 browser and device data for server-to-server integrations and receive a three_d_secure_setup_id to use on the subsequent payment."
 keywords: ["3DS2", "three_d_secure_setup_id", "browser_info", "device_fingerprints", "server-to-server"]
 openapi: "/openapi/three-d-secure-setups/create-three-d-secure-setup.json POST /three-d-secure/setups"


### PR DESCRIPTION
## PR Description
Hides the "Create 3DS2 Setup" API reference page from the documentation. Requested by Caio, who confirmed the endpoint is no longer required. The `hidden: true` flag is added to the page's frontmatter so it stops appearing in navigation and search results without deleting the file.

## Changes
- `reference/three-d-secure-setups/create-three-d-secure-setup.mdx` — added `hidden: true` to frontmatter to remove the page from public navigation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter change with no runtime or API behavior impact.
> 
> **Overview**
> The **Create 3DS2 Setup** reference page is removed from public docs navigation and search by adding **`hidden: true`** to its frontmatter in `create-three-d-secure-setup.mdx`. The MDX file and OpenAPI wiring stay in the repo; only discoverability changes, matching how other deprecated or internal reference pages are handled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb0f6b5f6646bac47910314df2bfda26868ead1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->