### PR TITLE
Expand enroll request params and add PCI retrieve page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -378,6 +378,7 @@
               "reference/payment-methods-direct-workflow/the-payment-method-object-api",
               "reference/payment-methods-direct-workflow/enroll-payment-method-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api",
+              "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api",
               "reference/payment-methods-direct-workflow/unenroll-payment-method-api"
             ]

--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -99,6 +99,7 @@
                     "description": "The payment method type (MAX 255; MIN 3; [Payment type](/reference/payment-type-list)).",
                     "enum": [
                       "CARD",
+                      "ACH_ENROLLMENT",
                       "NU_PAY_ENROLLMENT"
                     ]
                   },
@@ -110,23 +111,18 @@
                       "DIRECT"
                     ]
                   },
-                  "provider_data": {
-                    "type": "object",
-                    "description": "Specifies the provider_data object. This object should only be sent if the merchant requires a token migration process and as long as this has already been agreed with your commercial advisor in Yuno.",
-                    "required": [
-                      "id",
-                      "payment_method_token"
-                    ],
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "The unique identifier of the payment provider."
-                      },
-                      "payment_method_token": {
-                        "type": "string",
-                        "description": "The payment method token for the provider specified in `id`."
-                      }
-                    }
+                  "callback_url": {
+                    "type": "string",
+                    "description": "URL to return the customer after an enrollment in a provider´s environment. Only necessary for alternative payment methods integrations (MAX 255; MIN 3)."
+                  },
+                  "token": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Pre-generated token used to reference the payment method being enrolled."
+                  },
+                  "parent_type": {
+                    "type": "string",
+                    "description": "Type of the parent payment method, used when enrolling a tokenized/derived method (e.g. `CARD`)."
                   },
                   "card_data": {
                     "type": "object",
@@ -158,12 +154,145 @@
                       "holder_name": {
                         "type": "string",
                         "description": "Cardholder’s full name as it appears on the card (MAX 26; MIN 3) - only available for PCI certified merchants."
+                      },
+                      "brand": {
+                        "type": "string",
+                        "description": "Card brand (e.g. `VISA`, `MASTERCARD`, `AMEX`)."
+                      },
+                      "scheme": {
+                        "type": "string",
+                        "description": "Card scheme used to process the transaction (validated card scheme)."
+                      },
+                      "soft_descriptor": {
+                        "type": "string",
+                        "description": "Statement descriptor shown on the cardholder’s bank statement."
+                      },
+                      "card_pin": {
+                        "type": "string",
+                        "description": "Card PIN, for payment methods that require it."
+                      },
+                      "authentication_method": {
+                        "type": "string",
+                        "description": "Authentication method for Click-to-Pay.",
+                        "enum": [
+                          "FIDO2",
+                          "OWN_CREDENTIALS",
+                          "FEDERATED_ID"
+                        ]
                       }
                     }
                   },
-                  "callback_url": {
-                    "type": "string",
-                    "description": "URL to return the customer after an enrollment in a provider´s environment. Only necessary for alternative payment methods integrations (MAX 255; MIN 3)."
+                  "customer_payer": {
+                    "type": "object",
+                    "description": "Information about the customer/payer associated with the payment method.",
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                        "description": "Yuno customer identifier (customer code). MIN 3 / MAX 255."
+                      },
+                      "organization_customer_external_id": {
+                        "type": "string",
+                        "description": "Customer identifier in the merchant’s own system, scoped to the organization. MIN 3 / MAX 255."
+                      }
+                    }
+                  },
+                  "payment_method": {
+                    "type": "object",
+                    "description": "Payment method wrapper used for non-card methods (e.g. bank transfer / ACH) and vaulting options.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Method type label for the enrolled instrument (e.g. `ACH_ENROLLMENT`). The enrollment type is driven by the top-level `type`; this field is informational."
+                      },
+                      "vault_on_success": {
+                        "type": "boolean",
+                        "description": "When `true`, the payment method is vaulted (saved) after a successful enrollment."
+                      },
+                      "detail": {
+                        "type": "object",
+                        "description": "Method-specific details for the instrument being enrolled.",
+                        "properties": {
+                          "bank_transfer": {
+                            "type": "object",
+                            "properties": {
+                              "account_type": {
+                                "type": "string",
+                                "description": "Bank account type.",
+                                "enum": ["CHECKINGS", "SAVINGS"]
+                              },
+                              "account_holder_type": {
+                                "type": "string",
+                                "description": "Type of account holder.",
+                                "enum": ["INDIVIDUAL", "ENTITY"]
+                              },
+                              "bank_id": {
+                                "type": "string",
+                                "description": "Identifier of the bank. MIN 3 / MAX 255."
+                              },
+                              "bank_name": {
+                                "type": "string",
+                                "description": "Name of the bank. MIN 3 / MAX 255."
+                              },
+                              "bank_account": {
+                                "type": "string",
+                                "description": "Bank account number. MIN 3 / MAX 255."
+                              },
+                              "beneficiary_name": {
+                                "type": "string",
+                                "description": "Name of the account beneficiary. MIN 3 / MAX 255."
+                              },
+                              "branch": {
+                                "type": "string",
+                                "description": "Bank branch code. MIN 1 / MAX 8."
+                              },
+                              "branch_digit": {
+                                "type": "string",
+                                "description": "Branch verification digit. MIN 1 / MAX 2."
+                              },
+                              "routing_number": {
+                                "type": "string",
+                                "description": "Bank routing number. MIN 3 / MAX 255."
+                              },
+                              "code": {
+                                "type": "string",
+                                "description": "Bank code. MIN 1 / MAX 8."
+                              },
+                              "reference": {
+                                "type": "string",
+                                "description": "Reference associated with the bank account. MIN 1 / MAX 255."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "provider_data": {
+                    "type": "object",
+                    "description": "Specifies the provider_data object. This object should only be sent if the merchant requires a token migration process and as long as this has already been agreed with your commercial advisor in Yuno.",
+                    "required": [
+                      "id"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the payment provider."
+                      },
+                      "token_source": {
+                        "type": "string",
+                        "description": "Origin of the provided token.",
+                        "enum": ["PROVIDER_API", "MIGRATION_FILE", "PROVIDER_TOKEN"]
+                      },
+                      "payment_method_token": {
+                        "type": "string",
+                        "description": "Provider’s payment method token. Required when `token_source` is `PROVIDER_TOKEN`."
+                      },
+                      "connection_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Identifier of the provider connection. Required when `token_source` is `PROVIDER_API` or `PROVIDER_TOKEN`."
+                      }
+                    }
                   },
                   "verify": {
                     "type": "object",
@@ -181,6 +310,43 @@
                         "description": "Currency of the card verification. For a full list of currency codes, see [Country reference](/reference/country-reference) (MAX 3; MIN 3; ISO 4217)."
                       }
                     }
+                  },
+                  "recurring_payment": {
+                    "type": "object",
+                    "description": "Recurring / subscription billing metadata associated with the enrolled method.",
+                    "properties": {
+                      "regular_billing": {
+                        "type": "object",
+                        "properties": {
+                          "label": {
+                            "type": "string",
+                            "description": "Display label for the recurring billing plan."
+                          },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string",
+                                "description": "Billing currency, ISO 4217 format (3 letters)."
+                              },
+                              "value": {
+                                "type": "number",
+                                "description": "Billing amount per interval. Range 0 – 9999999999."
+                              }
+                            }
+                          },
+                          "interval_unit": {
+                            "type": "string",
+                            "description": "Billing interval unit.",
+                            "enum": ["DAY", "WEEK", "MONTH", "YEAR"]
+                          },
+                          "interval_count": {
+                            "type": "integer",
+                            "description": "Number of interval units between charges (e.g. `1` = every month when `interval_unit` is `MONTH`)."
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               },
@@ -188,21 +354,64 @@
                 "Card Direct": {
                   "value": {
                     "account_id": "dbf0c133-86bc-4be0-94a5-ca2ff6778451",
-                    "country": "US",
+                    "country": "CO",
                     "type": "CARD",
-                    "callback_url": "www.google.com",
                     "workflow": "DIRECT",
                     "card_data": {
-                      "holder_name": "John Doe",
-                      "expiration_month": 3,
-                      "expiration_year": 26,
                       "number": "4111111111111111",
-                      "security_code": "123"
+                      "holder_name": "JOHN DOE",
+                      "expiration_month": 12,
+                      "expiration_year": 26,
+                      "security_code": "212",
+                      "brand": "VISA"
                     },
                     "customer_payer": {
-                      "document": {
-                        "document_type": "SSN",
-                        "document_number": "123-45-6789"
+                      "code": "12345",
+                      "organization_customer_external_id": "ext-12345"
+                    },
+                    "verify": {
+                      "vault_on_success": true,
+                      "currency": "COP"
+                    }
+                  }
+                },
+                "ACH Enrollment": {
+                  "value": {
+                    "account_id": "dbf0c133-86bc-4be0-94a5-ca2ff6778451",
+                    "country": "BR",
+                    "type": "ACH_ENROLLMENT",
+                    "workflow": "DIRECT",
+                    "customer_payer": {
+                      "code": "cust-123"
+                    },
+                    "payment_method": {
+                      "type": "ACH_ENROLLMENT",
+                      "vault_on_success": true,
+                      "detail": {
+                        "bank_transfer": {
+                          "account_type": "CHECKINGS",
+                          "account_holder_type": "INDIVIDUAL",
+                          "bank_id": "001",
+                          "bank_name": "Banco do Brasil",
+                          "bank_account": "00012345-6",
+                          "beneficiary_name": "John Doe",
+                          "branch": "1234",
+                          "branch_digit": "5",
+                          "routing_number": "001",
+                          "code": "001",
+                          "reference": "REF-001"
+                        }
+                      }
+                    },
+                    "recurring_payment": {
+                      "regular_billing": {
+                        "label": "Monthly Plan",
+                        "amount": {
+                          "currency": "BRL",
+                          "value": 49.90
+                        },
+                        "interval_unit": "MONTH",
+                        "interval_count": 1
                       }
                     }
                   }
@@ -210,12 +419,17 @@
                 "Token migration process": {
                   "value": {
                     "account_id": "dbf0c133-86bc-4be0-94a5-ca2ff6778451",
-                    "country": "US",
+                    "country": "MX",
                     "type": "CARD",
                     "workflow": "DIRECT",
                     "provider_data": {
                       "id": "DLOCAL",
-                      "payment_method_token": "123456"
+                      "token_source": "PROVIDER_TOKEN",
+                      "payment_method_token": "tok_provider_abc123",
+                      "connection_id": "b1a2c3d4-e5f6-7890-abcd-ef1234567890"
+                    },
+                    "verify": {
+                      "vault_on_success": true
                     }
                   }
                 },
@@ -422,6 +636,14 @@
                           "example": "www.example.com"
                         },
                         "action": {},
+                        "redirect_url": {
+                          "type": "string",
+                          "example": null
+                        },
+                        "parent_type": {
+                          "type": "string",
+                          "example": "CARD"
+                        },
                         "created_at": {
                           "type": "string",
                           "example": "2024-06-06T13:32:49.715656Z"

--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -269,7 +269,7 @@
                   },
                   "provider_data": {
                     "type": "object",
-                    "description": "Specifies the provider_data object. This object should only be sent if the merchant requires a token migration process and as long as this has already been agreed with your commercial advisor in Yuno.",
+                    "description": "Provider data used for token migration or provider-token enrollment. Send this object when `token_source` is `PROVIDER_API`, `MIGRATION_FILE`, or `PROVIDER_TOKEN`. Usage must be agreed with your commercial advisor in Yuno.",
                     "required": [
                       "id"
                     ],

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -1,0 +1,512 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "customer-api",
+    "version": "1.0.2"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/customers/{customer_id}/payment-methods/{payment_method_id}": {
+      "get": {
+        "summary": "Retrieve Enrolled Payment Method by Id PCI data",
+        "description": "",
+        "operationId": "retrieve-enrolled-payment-method-by-id-pci-api",
+        "parameters": [
+          {
+            "name": "customer_id",
+            "in": "path",
+            "description": "The unique identifier of the customer, created using the [Create Customer](https://docs.y.uno/reference/create-customer) endpoint (UUID, 36 chars).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "payment_method_id",
+            "in": "path",
+            "description": "The unique identifier of the `payment_method`. This information was received as the `vaulted_token` by enrolling a payment method using [Enroll Payment Method](/reference/enroll-payment-method-api) (UUID, 36 chars).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "idempotency_key": "2ca58c6d-8794-4c8f-a2f6-bba4b7498b74",
+                      "id": "2fd6bf11-2129-4061-9c2a-34e196f89753",
+                      "account_id": "493e9374-510a-4201-9e09-de669d75f256",
+                      "name": "VISA ****1111",
+                      "description": "VISA ****1111",
+                      "type": "CARD",
+                      "category": "CARD",
+                      "country": "US",
+                      "status": "ENROLLED",
+                      "sub_status": null,
+                      "vaulted_token": "7ced7717-f860-4705-a376-58a714953de9",
+                      "action": "FORM",
+                      "redirect_url": null,
+                      "created_at": "2024-06-04T12:47:46.992602Z",
+                      "updated_at": "2024-06-04T12:47:46.992603Z",
+                      "enrollment": {
+                        "session": "",
+                        "sdk_required_action": false
+                      },
+                      "provider": {
+                        "id": "YUNO",
+                        "type": "YUNO",
+                        "token": "e47299a5-269e-42a1-9be1-9f64e400413a",
+                        "provider_status": null
+                      },
+                      "customer_payer": {
+                        "first_name": "John",
+                        "last_name": "Doe",
+                        "email": "john.doe@example.com",
+                        "gender": "M",
+                        "date_of_birth": "1990-02-28",
+                        "document": {
+                          "document_number": "123456789",
+                          "document_type": "SSN"
+                        },
+                        "phone": {
+                          "number": "5551234567",
+                          "country_code": "1"
+                        },
+                        "billing_address": {
+                          "address_line_1": "123 Main St",
+                          "address_line_2": "Apt 4B",
+                          "country": "US",
+                          "state": "NY",
+                          "city": "New York",
+                          "zip_code": "10001"
+                        }
+                      },
+                      "card_data": {
+                        "number": "4111111111111111",
+                        "iin": "41111111",
+                        "lfd": "1111",
+                        "expiration_month": 3,
+                        "expiration_year": 26,
+                        "number_length": 16,
+                        "security_code_length": 3,
+                        "brand": "VISA",
+                        "issuer": "JPMORGAN CHASE BANK N A",
+                        "issuer_code": null,
+                        "category": "CREDIT",
+                        "type": "CREDIT",
+                        "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
+                      },
+                      "last_successfully_used": null,
+                      "last_successfully_used_at": null,
+                      "verify": {
+                        "vault_on_success": false,
+                        "payment": null
+                      },
+                      "preferred": null
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "idempotency_key": {
+                      "type": "string",
+                      "example": "2ca58c6d-8794-4c8f-a2f6-bba4b7498b74"
+                    },
+                    "id": {
+                      "type": "string",
+                      "example": "2fd6bf11-2129-4061-9c2a-34e196f89753"
+                    },
+                    "account_id": {
+                      "type": "string",
+                      "example": "493e9374-510a-4201-9e09-de669d75f256"
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "VISA ****1111"
+                    },
+                    "description": {
+                      "type": "string",
+                      "example": "VISA ****1111"
+                    },
+                    "type": {
+                      "type": "string",
+                      "example": "CARD"
+                    },
+                    "category": {
+                      "type": "string",
+                      "example": "CARD"
+                    },
+                    "country": {
+                      "type": "string",
+                      "example": "US"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ENROLLED"
+                    },
+                    "sub_status": {},
+                    "vaulted_token": {
+                      "type": "string",
+                      "example": "7ced7717-f860-4705-a376-58a714953de9"
+                    },
+                    "action": {
+                      "type": "string",
+                      "example": "FORM"
+                    },
+                    "redirect_url": {},
+                    "created_at": {
+                      "type": "string",
+                      "example": "2024-06-04T12:47:46.992602Z"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "example": "2024-06-04T12:47:46.992603Z"
+                    },
+                    "enrollment": {
+                      "type": "object",
+                      "properties": {
+                        "session": {
+                          "type": "string",
+                          "example": ""
+                        },
+                        "sdk_required_action": {
+                          "type": "boolean",
+                          "example": false,
+                          "default": true
+                        }
+                      }
+                    },
+                    "provider": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "YUNO"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "YUNO"
+                        },
+                        "token": {
+                          "type": "string",
+                          "example": "e47299a5-269e-42a1-9be1-9f64e400413a"
+                        },
+                        "provider_status": {}
+                      }
+                    },
+                    "customer_payer": {
+                      "type": "object",
+                      "properties": {
+                        "first_name": {
+                          "type": "string",
+                          "example": "John"
+                        },
+                        "last_name": {
+                          "type": "string",
+                          "example": "Doe"
+                        },
+                        "email": {
+                          "type": "string",
+                          "example": "john.doe@example.com"
+                        },
+                        "gender": {
+                          "type": "string",
+                          "example": "M"
+                        },
+                        "date_of_birth": {
+                          "type": "string",
+                          "example": "1990-02-28"
+                        },
+                        "document": {
+                          "type": "object",
+                          "properties": {
+                            "document_number": {
+                              "type": "string",
+                              "example": "123456789"
+                            },
+                            "document_type": {
+                              "type": "string",
+                              "example": "SSN"
+                            }
+                          }
+                        },
+                        "phone": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "string",
+                              "example": "5551234567"
+                            },
+                            "country_code": {
+                              "type": "string",
+                              "example": "1"
+                            }
+                          }
+                        },
+                        "billing_address": {
+                          "type": "object",
+                          "properties": {
+                            "address_line_1": {
+                              "type": "string",
+                              "example": "123 Main St"
+                            },
+                            "address_line_2": {
+                              "type": "string",
+                              "example": "Apt 4B"
+                            },
+                            "country": {
+                              "type": "string",
+                              "example": "US"
+                            },
+                            "state": {
+                              "type": "string",
+                              "example": "NY"
+                            },
+                            "city": {
+                              "type": "string",
+                              "example": "New York"
+                            },
+                            "zip_code": {
+                              "type": "string",
+                              "example": "10001"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "card_data": {
+                      "type": "object",
+                      "properties": {
+                        "number": {
+                          "type": "string",
+                          "description": "Full card number. Only returned for PCI-certified merchants.",
+                          "example": "4111111111111111"
+                        },
+                        "iin": {
+                          "type": "string",
+                          "example": "41111111"
+                        },
+                        "lfd": {
+                          "type": "string",
+                          "example": "1111"
+                        },
+                        "expiration_month": {
+                          "type": "integer",
+                          "example": 3,
+                          "default": 0
+                        },
+                        "expiration_year": {
+                          "type": "integer",
+                          "example": 26,
+                          "default": 0
+                        },
+                        "number_length": {
+                          "type": "integer",
+                          "example": 16,
+                          "default": 0
+                        },
+                        "security_code_length": {
+                          "type": "integer",
+                          "example": 3,
+                          "default": 0
+                        },
+                        "brand": {
+                          "type": "string",
+                          "example": "VISA"
+                        },
+                        "issuer": {
+                          "type": "string",
+                          "example": "JPMORGAN CHASE BANK N A"
+                        },
+                        "issuer_code": {},
+                        "category": {
+                          "type": "string",
+                          "example": "CREDIT"
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "CREDIT"
+                        },
+                        "fingerprint": {
+                          "type": "string",
+                          "example": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
+                        }
+                      }
+                    },
+                    "last_successfully_used": {},
+                    "last_successfully_used_at": {},
+                    "verify": {
+                      "type": "object",
+                      "properties": {
+                        "vault_on_success": {
+                          "type": "boolean",
+                          "example": false,
+                          "default": true
+                        },
+                        "payment": {}
+                      }
+                    },
+                    "preferred": {}
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Bad Request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Invalid request"
+                      ]
+                    }
+                  },
+                  "Customer Not Found": {
+                    "value": {
+                      "code": "CUSTOMER_NOT_FOUND",
+                      "messages": [
+                        "Customer not found"
+                      ]
+                    },
+                    "summary": "Customer Not Found"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_CREDENTIALS"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid credentials"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "code": "AUTHORIZATION_REQUIRED",
+                      "messages": [
+                        "The merchant has no authorization to use this API."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "AUTHORIZATION_REQUIRED"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "The merchant has no authorization to use this API."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "key": "charset",
+        "value": "utf-8"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -177,7 +177,12 @@
                       "type": "string",
                       "example": "ENROLLED"
                     },
-                    "sub_status": {},
+                    "sub_status": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Additional status detail.",
+                      "example": null
+                    },
                     "vaulted_token": {
                       "type": "string",
                       "example": "7ced7717-f860-4705-a376-58a714953de9"
@@ -186,7 +191,12 @@
                       "type": "string",
                       "example": "FORM"
                     },
-                    "redirect_url": {},
+                    "redirect_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "URL to redirect the customer to, for redirect workflows.",
+                      "example": null
+                    },
                     "created_at": {
                       "type": "string",
                       "example": "2024-06-04T12:47:46.992602Z"
@@ -224,7 +234,12 @@
                           "type": "string",
                           "example": "e47299a5-269e-42a1-9be1-9f64e400413a"
                         },
-                        "provider_status": {}
+                        "provider_status": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Status returned by the provider.",
+                          "example": null
+                        }
                       }
                     },
                     "customer_payer": {
@@ -351,7 +366,12 @@
                           "type": "string",
                           "example": "JPMORGAN CHASE BANK N A"
                         },
-                        "issuer_code": {},
+                        "issuer_code": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Code of the card-issuing bank.",
+                          "example": null
+                        },
                         "category": {
                           "type": "string",
                           "example": "CREDIT"
@@ -366,8 +386,18 @@
                         }
                       }
                     },
-                    "last_successfully_used": {},
-                    "last_successfully_used_at": {},
+                    "last_successfully_used": {
+                      "type": "boolean",
+                      "nullable": true,
+                      "description": "Whether the payment method was successfully used at least once.",
+                      "example": null
+                    },
+                    "last_successfully_used_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Timestamp of the last successful use (ISO 8601).",
+                      "example": null
+                    },
                     "verify": {
                       "type": "object",
                       "properties": {
@@ -376,10 +406,20 @@
                           "example": false,
                           "default": true
                         },
-                        "payment": {}
+                        "payment": {
+                          "type": "object",
+                          "nullable": true,
+                          "description": "Payment details associated with the verification, if applicable.",
+                          "example": null
+                        }
                       }
                     },
-                    "preferred": {}
+                    "preferred": {
+                      "type": "boolean",
+                      "nullable": true,
+                      "description": "Whether this is the customer's preferred payment method.",
+                      "example": null
+                    }
                   }
                 }
               }
@@ -420,6 +460,39 @@
                       "items": {
                         "type": "string",
                         "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "code": "PAYMENT_METHOD_NOT_FOUND",
+                      "messages": [
+                        "Payment method not found"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "PAYMENT_METHOD_NOT_FOUND"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Payment method not found"
                       }
                     }
                   }

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
@@ -8,5 +8,5 @@ Retrieve a specific payment method that a user has enrolled in.
 <Note>
 **Retrieve Enrolled Payment Method**
 
-To recover the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
+To retrieve the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
 </Note>

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
@@ -8,7 +8,7 @@ Retrieve a specific payment method that a user has enrolled in, including the fu
 <Note>
 **Retrieve Enrolled Payment Method**
 
-To recover the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
+To retrieve the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
 </Note>
 
 <Warning>

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
@@ -1,0 +1,18 @@
+---
+title: "Retrieve Enrolled Payment Method by Id PCI data"
+openapi: "/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json GET /customers/{customer_id}/payment-methods/{payment_method_id}"
+---
+
+Retrieve a specific payment method that a user has enrolled in, including the full card number in the response.
+
+<Note>
+**Retrieve Enrolled Payment Method**
+
+To recover the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
+</Note>
+
+<Warning>
+**PCI merchants only**
+
+This endpoint is only available for PCI-certified merchants. To enable it, contact your Key Account Manager (KAM).
+</Warning>


### PR DESCRIPTION
## PR Description
Updates the Enroll Payment Method API spec with new parameters requested by Palo Menendez Palau, and adds a new PCI-gated variant of the Retrieve Enrolled Payment Method by Id page. The enroll spec now covers ACH enrollment, the full `customer_payer` object, `payment_method`/`bank_transfer`, improved `provider_data`, `verify`, and `recurring_payment`. The new PCI retrieve page uses its own OpenAPI spec so that the `number` field appears natively in the interactive playground.

## Changes
- `openapi/payment-methods-direct-workflow/enroll-payment-method-api.json` — added `ACH_ENROLLMENT` to the `type` enum; added `customer_payer`, `payment_method` (with `bank_transfer` subtree), `recurring_payment` objects; improved `provider_data` with `token_source` and `connection_id`; reordered request schema fields to match Palo's specified order; updated examples (Card Direct, ACH Enrollment, Token Migration)
- `openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json` — new spec, copy of the base retrieve spec with `number` added to `card_data` in schema and example response
- `reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx` — new page titled "Retrieve Enrolled Payment Method by Id PCI data"; includes PCI-only warning with KAM contact instruction; points to new dedicated spec
- `docs.json` — registered the new PCI retrieve page in the navigation under Payment Methods (Direct Workflow)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Documentation-only, but it publishes PCI-sensitive response fields and a larger enroll contract that integrators may implement against; accuracy gaps could mislead payment-method enrollment flows.
> 
> **Overview**
> **Expands Direct Workflow enrollment API reference** and adds a **PCI-only retrieve** doc page wired into API Reference navigation.
> 
> The **Enroll Payment Method** OpenAPI spec now documents **`ACH_ENROLLMENT`**, enrollment helpers (`callback_url`, `token`, `parent_type`), richer **`card_data`**, **`customer_payer`**, **`payment_method`** / **`bank_transfer`**, **`recurring_payment`**, and a revised **`provider_data`** model (`token_source`, `connection_id`, conditional `payment_method_token`). Request examples were refreshed (card direct, ACH, token migration) and the enroll **response** schema adds **`redirect_url`** and **`parent_type`**.
> 
> A **new** OpenAPI file and MDX page document **Retrieve Enrolled Payment Method by Id PCI data**: same GET path as the standard retrieve, but the schema/example include the full **`card_data.number`** for PCI-certified merchants, with a KAM-only warning. **`docs.json`** lists the new page under Payment Methods (Direct Workflow). The non-PCI retrieve page gets a minor wording fix only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff7f00315af57ac0958f8e0fa41e4f314aacb88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->