### PR TITLE
docs: add 3DS2 setup reference and publish page

### DIFF
--- a/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
+++ b/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Create 3DS2 Setup"
-hidden: true
 description: "Register 3D Secure 2 browser and device data for server-to-server integrations and receive a three_d_secure_setup_id to use on the subsequent payment."
 keywords: ["3DS2", "three_d_secure_setup_id", "browser_info", "device_fingerprints", "server-to-server"]
 openapi: "/openapi/three-d-secure-setups/create-three-d-secure-setup.json POST /three-d-secure/setups"
@@ -28,9 +27,25 @@ This endpoint does not call the issuer, does not render a challenge, and does no
 The payment provider uses `browser_info` and `device_fingerprints` to score risk and decide between frictionless flow and challenge when the payment is submitted. Missing or stale fields raise the challenge rate. Send the values exactly as observed in the cardholder's browser at the moment you call this endpoint.
 </Warning>
 
+<Note>
+**How the merchant supplies device data**
+
+The `type` field tells Yuno where the device data was gathered. `MERCHANT_PROVIDED` — currently the only supported value — means you collected the browser environment and device fingerprints on your side and are passing them in directly. Yuno does not run its own collector for this endpoint; if you need Yuno to capture the browser/device data, use the SDK variant instead.
+</Note>
+
 ## How to use the response
 
 1. **Store the id.** Keep `three_d_secure_setup_id` against the order on your side.
 2. **Reference it on the payment.** On the subsequent [Create Payment](/reference/payments/create-payment), pass it under `payment_method.detail.card.three_d_secure.three_d_secure_setup_id` alongside the card or vaulted token. Yuno attaches the registered `browser_info` and `device_fingerprints` to the request it sends to the payment provider.
 
 Note that this request requires an `X-Idempotency-Key`. The same key with the same payload returns the original setup id within a 24-hour replay window. Check the [Authentication](/reference/authentication#idempotency) page for more information.
+
+## Field rules and edge cases
+
+| Rule | Behavior |
+|---|---|
+| `type` set to a value other than `MERCHANT_PROVIDED` | `400 INVALID_PARAMETERS`. Other values are reserved for future use. |
+| `browser_info.platform` set to an unsupported value | `400 INVALID_PARAMETERS`. Allowed: `WEB`, `IOS`, `ANDROID`. |
+| `device_fingerprints` omitted | Accepted. Yuno will skip device-fingerprint enrichment for any provider that wasn't pre-supplied. |
+| `device_fingerprints[*].provider_id` not found in your account | Entry is dropped silently; setup proceeds with the remaining entries. |
+| `account_id` not owned by the API key | Treated as an authorization failure (`403`). |

--- a/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
+++ b/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
@@ -30,7 +30,7 @@ The payment provider uses `browser_info` and `device_fingerprints` to score risk
 <Note>
 **How the merchant supplies device data**
 
-The `type` field tells Yuno where the device data was gathered. `MERCHANT_PROVIDED` — currently the only supported value — means you collected the browser environment and device fingerprints on your side and are passing them in directly. Yuno does not run its own collector for this endpoint; if you need Yuno to capture the browser/device data, use the SDK variant instead.
+The `type` field tells Yuno where the device data was gathered. `MERCHANT_PROVIDED` — currently the only supported value — means you collected the browser environment and device fingerprints on your side and are passing them in directly. Yuno does not run its own collector for this endpoint; if you need Yuno to capture the browser/device data, use the [SDK variant](/docs/payment-features/3ds-standalone) instead.
 </Note>
 
 ## How to use the response


### PR DESCRIPTION
## PR Description
Requested by Palo Menendez Palau. The `POST /v1/three-d-secure/setups` reference page existed but was hidden (`hidden: true`). This PR publishes the page and adds two sections from Palo's spec that were missing: a note explaining the `MERCHANT_PROVIDED` type and a field rules/edge cases table.

## Changes
- `reference/three-d-secure-setups/create-three-d-secure-setup.mdx` — removed `hidden: true` to publish the page
- `reference/three-d-secure-setups/create-three-d-secure-setup.mdx` — added `<Note>` explaining the `MERCHANT_PROVIDED` type and how the merchant supplies device data
- `reference/three-d-secure-setups/create-three-d-secure-setup.mdx` — added "Field rules and edge cases" section with a table covering validation errors, silent drops, and authorization failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security behavior changes.
> 
> **Overview**
> Publishes the **Create 3DS2 Setup** reference (`POST /three-d-secure/setups`) by removing `hidden: true` so the page appears in the docs nav.
> 
> Adds integration guidance that was missing from the spec: a **Note** on how merchants supply device data via `MERCHANT_PROVIDED` (vs the SDK path), and a **Field rules and edge cases** table documenting `400`/`403` validation, optional `device_fingerprints`, and silent drops for unknown `provider_id` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3b7b1496be65261d5b1743a1d6da8aa532ab08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->