### PR TITLE
docs: add Mongolian (mn) locale to supported languages

### DIFF
--- a/docs/sdks/resources/languages-supported.mdx
+++ b/docs/sdks/resources/languages-supported.mdx
@@ -41,6 +41,7 @@ Use these locale codes with Yuno SDKs to specify your desired display language. 
 * Bengali: `bn`
 * Malayalam: `ml`
 * Urdu: `ur`
+* Mongolian: `mn`
 
 ## Americas
 


### PR DESCRIPTION
## What

Adds **Mongolian** (locale code `mn`) to the SDK *Supported Languages* page, under the **South Asia** section as requested.

## Where

`docs/sdks/resources/languages-supported.mdx` → [Supported Languages › South Asia](https://docs.y.uno/docs/sdks/resources/languages-supported#south-asia)

## Diff

```diff
  * Bengali: `bn`
  * Malayalam: `ml`
  * Urdu: `ur`
+ * Mongolian: `mn`
```

`mn` is the ISO 639-1 code for Mongolian, matching the bare-code convention used in this section.

## Note for reviewers

Placed under **South Asia** per the original request. Geographically Mongolian is East/Central Asian, so reviewers may prefer it under the **Asia** section (alongside Japanese, Korean, Chinese, Thai). Easy to move if preferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Documents **Mongolian** as a supported SDK locale (`mn`) on the Supported Languages page, listed under **South Asia** with the same bare ISO 639-1 style as Hindi, Bengali, and the other entries in that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64661ea8668836bea0705b8c1cf338fff99166bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->