### PR TITLE
Revert "Update Checkout Builder API reference as Beta"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -349,7 +349,7 @@
             ]
           },
           {
-            "dropdown": "Checkout Builder (Beta)",
+            "dropdown": "Checkout Builder",
             "icon": "sliders",
             "pages": [
               "reference/checkout-builder/overview",

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Fetch Checkout Configuration"
-openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /checkouts/{checkoutCode}"
+openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /v1/checkouts/{checkout_code}"
+hidden: true
 ---
-
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/fetch-styling-settings.mdx
+++ b/reference/checkout-builder/fetch-styling-settings.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Fetch Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/fetch-styling-settings.json GET /v1/checkouts/builder/settings"
+hidden: true
 ---
-
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/get-country-data.mdx
+++ b/reference/checkout-builder/get-country-data.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Get Country Data"
-openapi: "/openapi/checkout-builder/get-country-data.json GET /checkouts/country-data"
+openapi: "/openapi/checkout-builder/get-country-data.json GET /v1/checkouts/country-data"
+hidden: true
 ---
-
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/get-required-fields.mdx
+++ b/reference/checkout-builder/get-required-fields.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Get Required Fields"
-openapi: "/openapi/checkout-builder/get-required-fields.json GET /checkouts/payment-methods/{paymentMethodType}/required-fields"
+openapi: "/openapi/checkout-builder/get-required-fields.json GET /v1/checkouts/payment-methods/{payment_method_type}/required-fields"
+hidden: true
 ---
-
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -1,11 +1,12 @@
 ---
 title: "Checkout Builder"
-description: "Programmatically configure your Yuno checkout — payment methods, conditions, required fields, and styling — via the same API the Checkout Builder UI uses."
+description: "Programmatically configure your Yuno checkout — payment methods, conditions, required fields, and styling — via Yuno's public B2B API."
+hidden: true
 ---
 
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>
-
-The Checkout Builder Management API lets you read and update a merchant's checkout configuration programmatically. It is the same API the Checkout Builder UI in the Yuno dashboard uses internally — if a configuration is possible in the dashboard, it is possible via this API.
+<Warning>
+**BETA.** Endpoints are stable in shape but subject to additive changes during the BETA window. Access is limited to allowlisted merchants. Contact your Yuno TAM to enable this product for your account.
+</Warning>
 
 The Checkout Builder Management API lets you read and update a merchant's checkout configuration:
 

--- a/reference/checkout-builder/publish-checkout-configuration.mdx
+++ b/reference/checkout-builder/publish-checkout-configuration.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Publish Checkout Configuration"
-openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /checkouts/publish"
+openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /v1/checkouts/{checkout_code}/publish"
+hidden: true
 ---
-
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/update-styling-settings.mdx
+++ b/reference/checkout-builder/update-styling-settings.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Update Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/update-styling-settings.json PATCH /v1/checkouts/builder/settings"
+hidden: true
 ---
-
-<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>


### PR DESCRIPTION
Reverts yuno-payments/yuno-docs#453

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Mintlify navigation only; integrators relying on old unversioned paths in copied examples could need to update URLs.
> 
> **Overview**
> Reverts the prior Checkout Builder “Beta” reference refresh by reshaping how that section appears in Mintlify and how endpoints are wired to OpenAPI.
> 
> The API Reference nav dropdown label changes from **Checkout Builder (Beta)** to **Checkout Builder**, while the overview and every Checkout Builder endpoint page gain **`hidden: true`**, so those pages are no longer surfaced the same way in navigation (the section can still exist in `docs.json`).
> 
> OpenAPI frontmatter paths are updated to **`/v1/...`** routes with snake_case path parameters (e.g. `checkout_code`, `payment_method_type`), including publish moving to **`PATCH /v1/checkouts/{checkout_code}/publish`**. Inline per-page **Beta** `<Note>` blocks are removed.
> 
> On the overview, the description now points at Yuno’s **public B2B API**, beta expectations move into a single **`<Warning>`** (additive changes, allowlisted access, contact TAM), and the intro line about parity with the dashboard UI is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd9f036398d77827c772b24913b64831d753a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->