### PR TITLE
Revert "docs(checkout-builder): fix openapi-paths"

### DIFF
--- a/openapi/checkout-builder/publish-checkout-configuration.json
+++ b/openapi/checkout-builder/publish-checkout-configuration.json
@@ -44,25 +44,46 @@
         "summary": "Publish Checkout Configuration",
         "description": "Sparse-upsert the checkout's payment method configuration. Payment methods omitted from the array retain their previous state \u2014 they are not removed. To disable a method, include it with is_active: false. Changes take effect immediately on the merchant's live checkout.",
         "operationId": "patch-checkout-publish",
-        "parameters": [
-          {
-            "name": "checkout_code",
-            "in": "path",
-            "description": "The UUID of the checkout to update.",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["paymentMethods"],
+                "required": [
+                  "payment_methods"
+                ],
                 "properties": {
-                  "paymentMethods": {
+                  "general_settings": {
+                    "type": "object",
+                    "description": "General checkout settings.",
+                    "properties": {
+                      "country_documents": {
+                        "type": "array",
+                        "description": "Accepted document types per country. Use GET /checkouts/country-data to fetch valid values.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "country_code": {
+                              "type": "string",
+                              "description": "ISO 3166-1 alpha-2 country code.",
+                              "example": "AR"
+                            },
+                            "documents": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "example": [
+                                "DNI",
+                                "CUIT"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "payment_methods": {
                     "type": "array",
                     "description": "Payment methods to upsert. Only included methods are updated \u2014 omitted methods retain their previous state.",
                     "items": {

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Fetch Checkout Configuration"
 openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /v1/checkouts/{checkout_code}"
+hidden: true
 ---

--- a/reference/checkout-builder/get-country-data.mdx
+++ b/reference/checkout-builder/get-country-data.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Get Country Data"
 openapi: "/openapi/checkout-builder/get-country-data.json GET /v1/checkouts/country-data"
+hidden: true
 ---

--- a/reference/checkout-builder/get-required-fields.mdx
+++ b/reference/checkout-builder/get-required-fields.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Get Required Fields"
 openapi: "/openapi/checkout-builder/get-required-fields.json GET /v1/checkouts/payment-methods/{payment_method_type}/required-fields"
+hidden: true
 ---

--- a/reference/checkout-builder/publish-checkout-configuration.mdx
+++ b/reference/checkout-builder/publish-checkout-configuration.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Publish Checkout Configuration"
 openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /v1/checkouts/{checkout_code}/publish"
+hidden: true
 ---


### PR DESCRIPTION
Reverts yuno-payments/yuno-docs#457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only revert; main impact is published API reference shape (field names and page visibility), not runtime code.
> 
> **Overview**
> Reverts yuno-payments/yuno-docs **#457** (`docs(checkout-builder): fix openapi-paths`).
> 
> **Docs navigation:** Sets `hidden: true` again on the Mintlify reference pages for **Fetch Checkout Configuration**, **Get Country Data**, **Get Required Fields**, and **Publish Checkout Configuration**, so those endpoints stay out of the public sidebar like before #457.
> 
> **Publish OpenAPI spec:** Rolls back the publish request body to **`payment_methods`** (required) instead of **`paymentMethods`**, and restores optional **`general_settings.country_documents`**. It also drops the **`checkout_code` path `parameters`** block that #457 had placed immediately under `operationId` (the reverted shape matches the prior spec layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ebf0e9dc206d958abe3536caa03f94e2b12beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->