### PR TITLE
feat: add reference documentation for Checkout Builder API endpoints

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -349,7 +349,7 @@
             ]
           },
           {
-            "dropdown": "Checkout Builder",
+            "dropdown": "Checkout Builder (Beta)",
             "icon": "sliders",
             "pages": [
               "reference/checkout-builder/overview",

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fetch Checkout Configuration"
 openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /v1/checkouts/{checkout_code}"
-hidden: true
 ---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/fetch-styling-settings.mdx
+++ b/reference/checkout-builder/fetch-styling-settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fetch Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/fetch-styling-settings.json GET /v1/checkouts/builder/settings"
-hidden: true
 ---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/get-country-data.mdx
+++ b/reference/checkout-builder/get-country-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get Country Data"
 openapi: "/openapi/checkout-builder/get-country-data.json GET /v1/checkouts/country-data"
-hidden: true
 ---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/get-required-fields.mdx
+++ b/reference/checkout-builder/get-required-fields.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get Required Fields"
 openapi: "/openapi/checkout-builder/get-required-fields.json GET /v1/checkouts/payment-methods/{payment_method_type}/required-fields"
-hidden: true
 ---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -1,6 +1,8 @@
 ---
-title: "Checkout Builder"
+title: "Overview"
+sidebarTitle: "Overview"
 description: "Programmatically configure your Yuno checkout — payment methods, conditions, required fields, and styling — via Yuno's public B2B API."
+badge: "Beta"
 ---
 
 <Warning>

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -6,7 +6,7 @@ badge: "Beta"
 ---
 
 <Warning>
-**BETA.** Endpoints are stable in shape but subject to additive changes during the BETA window. Access is limited to allowlisted merchants. Contact your Yuno TAM to enable this product for your account.
+**BETA.** Endpoints are stable in shape but subject to additive changes during the BETA window.
 </Warning>
 
 The Checkout Builder Management API lets you read and update a merchant's checkout configuration:

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Checkout Builder"
 description: "Programmatically configure your Yuno checkout — payment methods, conditions, required fields, and styling — via Yuno's public B2B API."
-hidden: true
 ---
 
 <Warning>

--- a/reference/checkout-builder/publish-checkout-configuration.mdx
+++ b/reference/checkout-builder/publish-checkout-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Publish Checkout Configuration"
 openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /v1/checkouts/{checkout_code}/publish"
-hidden: true
 ---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/update-styling-settings.mdx
+++ b/reference/checkout-builder/update-styling-settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/update-styling-settings.json PATCH /v1/checkouts/builder/settings"
-hidden: true
 ---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>


### PR DESCRIPTION
## PR description  
  Publishes the Checkout Builder API reference as Beta. Removes hidden: true from all 7 pages (overview + 6 endpoints), adds a Beta disclaimer note to each endpoint, and renames the sidebar dropdown to "Checkout Builder (Beta)". The OpenAPI specs and paths were already correct in the upstream repo.

## Changes

  - docs.json — renamed dropdown from "Checkout Builder" to "Checkout Builder (Beta)"
  - reference/checkout-builder/overview.mdx — removed hidden: true
  - reference/checkout-builder/fetch-checkout-configuration.mdx — removed hidden: true, added Beta note
  - reference/checkout-builder/publish-checkout-configuration.mdx — removed hidden: true, added Beta note
  - reference/checkout-builder/get-required-fields.mdx — removed hidden: true, added Beta note
  - reference/checkout-builder/get-country-data.mdx — removed hidden: true, added Beta note
  - reference/checkout-builder/fetch-styling-settings.mdx — removed hidden: true, added Beta note
  - reference/checkout-builder/update-styling-settings.mdx — removed hidden: true, added Beta note

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only visibility and disclaimer updates; no runtime or API behavior changes.
> 
> **Overview**
> Publishes the **Checkout Builder** API reference in the docs by making all seven pages visible and labeling the surface as **Beta**.
> 
> Navigation in `docs.json` now shows **Checkout Builder (Beta)** instead of **Checkout Builder**. The overview page drops `hidden: true`, adds a **Beta** badge, and retitles to **Overview**; the prior allowlist-only access note is removed from the warning. Each of the six endpoint reference pages also removes `hidden: true` and adds a Beta `<Note>` that endpoints and schemas may change without notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2559b949afc1fe6c482c9db01b1cfc37c757051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->