### PR TITLE
fix(subscriptions): stored-credential field is card.usage — store_credentials wrapper is silently dropped

### DIFF
--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -250,19 +250,13 @@
                             "type": "string",
                             "description": "The ID provided by Visa/Mastercard in the response of the initial payment (MAX 256; MIN 1)."
                           },
-                          "store_credentials": {
-                            "type": "object",
-                            "description": "Specifies the credential usage for the card.",
-                            "properties": {
-                              "usage": {
-                                "type": "string",
-                                "description": "Indicates whether this is the first or a subsequent use. Required if a CIT payment was created before the subscription.",
-                                "enum": [
-                                  "FIRST",
-                                  "USED"
-                                ]
-                              }
-                            }
+                          "usage": {
+                            "type": "string",
+                            "description": "Specifies the credential usage for the card. Indicates whether this is the first or a subsequent use. Required if a CIT payment was created before the subscription.",
+                            "enum": [
+                              "FIRST",
+                              "USED"
+                            ]
                           }
                         }
                       }

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -196,19 +196,13 @@
                               }
                             }
                           },
-                          "store_credentials": {
-                            "type": "object",
-                            "description": "Specifies the credential usage for the card.",
-                            "properties": {
-                              "usage": {
-                                "type": "string",
-                                "description": "Indicates whether this is the first or a subsequent use. Required if a CIT payment was created before the subscription.",
-                                "enum": [
-                                  "FIRST",
-                                  "USED"
-                                ]
-                              }
-                            }
+                          "usage": {
+                            "type": "string",
+                            "description": "Specifies the credential usage for the card. Indicates whether this is the first or a subsequent use. Required if a CIT payment was created before the subscription.",
+                            "enum": [
+                              "FIRST",
+                              "USED"
+                            ]
                           }
                         }
                       },

--- a/reference/subscriptions/create-subscription.mdx
+++ b/reference/subscriptions/create-subscription.mdx
@@ -12,7 +12,9 @@ The fields `billing_cycles` and `availability.finish_at` have an impact on each 
 <Warning>
 **Credential Usage for Previous CIT**
 
-If you create a CIT payment (e.g. Apple Pay or card) *before* creating the subscription and pass the resulting vaulted token into the subscription, you **must** include `store_credentials.usage` to indicate whether this is the first or a subsequent use. Without this, rebills will be treated as CITs and declined by the provider.
+If you create a CIT payment (e.g. Apple Pay or card) *before* creating the subscription and pass the resulting vaulted token into the subscription, you **must** include `card.usage` to indicate whether this is the first or a subsequent use. Without this, rebills can be treated as CITs and declined by the provider.
+
+The field is `usage`, set directly on the `card` object — there is no `store_credentials` wrapper on this endpoint (unknown fields are ignored, so a wrapped value is silently dropped). If you have the `network_transaction_id` from the initial CIT response, pass it in `card.network_transaction_id` alongside `usage: "USED"`.
 
 Required payload for new subscriptions:
 
@@ -22,9 +24,8 @@ Required payload for new subscriptions:
     "type": "CARD",
     "vaulted_token": "{{vaulted_token}}",
     "card": {
-      "store_credentials": {
-        "usage": "USED"
-      }
+      "usage": "USED",
+      "network_transaction_id": "{{network_transaction_id_from_cit}}"
     }
   }
 }

--- a/reference/subscriptions/update-subscription.mdx
+++ b/reference/subscriptions/update-subscription.mdx
@@ -12,5 +12,5 @@ The fields `billing_cycles` and `availability.finish_at` have an impact on each 
 <Note>
 **Retroactive Credential Update**
 
-If you have existing subscriptions that are failing rebills because of missing credential usage (e.g. from an initial CIT payment), you can use this `PATCH` endpoint to add the `store_credentials` object retroactively to fix the issue.
+If you have existing subscriptions that are failing rebills because of missing credential usage (e.g. from an initial CIT payment), you can use this `PATCH` endpoint to set `payment_method.card.usage` (and optionally `payment_method.card.network_transaction_id`) retroactively to fix the issue. Note the field is `usage` directly on the `card` object — there is no `store_credentials` wrapper on this endpoint.
 </Note>


### PR DESCRIPTION
## What

The Create Subscription and Update Subscription pages document the stored-credential indicator as:

```json
"card": { "store_credentials": { "usage": "USED" } }
```

That does not match the API. `subscription-ms` deserializes the field as `usage` **directly under `card`**:

- [`CreateSubscriptionRequest.kt`](https://github.com/yuno-payments/subscription-ms/blob/master/src/main/kotlin/com/yuno/subscriptionms/domain/requests/CreateSubscriptionRequest.kt) → `PaymentMethod.Card(installments, networkTransactionId, usage)`
- [`UpdateSubscriptionRequest.kt`](https://github.com/yuno-payments/subscription-ms/blob/master/src/main/kotlin/com/yuno/subscriptionms/domain/requests/UpdateSubscriptionRequest.kt) → same shape

Because unknown properties are not rejected, the documented `store_credentials` wrapper is **silently dropped**: `card.usage` stays null, the engine resolves the rebill as a first use, and MIT rebills get mis-signaled / declined — the exact failure the "Credential Usage for Previous CIT" warning tells merchants to avoid. A merchant following the docs verbatim hits the bug with zero error feedback.

## Changes

- `reference/subscriptions/create-subscription.mdx` — corrected warning payload to `card.usage`, added note that the wrapper is ignored, documented `card.network_transaction_id` alongside it
- `reference/subscriptions/update-subscription.mdx` — corrected the retroactive-fix note
- `openapi/subscriptions/create-subscription.json` / `update-subscription.json` — flattened the `store_credentials` object to the real `usage` enum property

## Context

Found while verifying guidance given to a merchant in ticket `c93ea4f3-86b8-4966-a008-f59c13a10b99` (wallet CIT → subscription flow). The support agent quoted this docs section verbatim as authoritative, propagating the wrong field to the merchant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI schema only; no runtime or payment-processing code changes in this repo.
> 
> **Overview**
> **Aligns subscription API docs with the real request shape for stored credentials:** `payment_method.card.usage` (`FIRST` / `USED`), not `card.store_credentials.usage`.
> 
> Create and update subscription **OpenAPI** specs drop the nested `store_credentials` object and document `usage` as a string enum on `card`. **Reference pages** update the CIT→subscription warning and sample JSON to use `card.usage`, note that a `store_credentials` wrapper is ignored (so values are silently dropped), and call out pairing `usage: "USED"` with `card.network_transaction_id`. The update-subscription note now describes retroactive fixes via `payment_method.card.usage` (and optional `network_transaction_id`) instead of `store_credentials`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8fd156d164d13e2106ad4e4ed52dcf57c3b9645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->