### PR TITLE
Switch docs theme to Mintlify maple (Yuno brand)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,11 +1,23 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "mint",
+  "theme": "maple",
   "name": "Yuno API Documentation",
   "colors": {
     "primary": "#3E4FE0",
-    "light": "#E8EAF5",
-    "dark": "#3E4FE0"
+    "light": "#6B78EB",
+    "dark": "#2F3EB8"
+  },
+  "appearance": {
+    "default": "light",
+    "strict": true
+  },
+  "styling": {
+    "codeblocks": {
+      "theme": {
+        "light": "github-dark",
+        "dark": "github-dark"
+      }
+    }
   },
   "search": {
     "prompt": "Search..."
@@ -23,16 +35,16 @@
   },
   "favicon": "/favicon.svg",
   "logo": {
-    "light": "/logo/yuno-docs.svg",
-    "dark": "/logo/yuno-docs.svg"
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg"
   },
   "fonts": {
     "heading": {
-      "family": "Geist",
-      "weight": 400
+      "family": "Inter",
+      "weight": 500
     },
     "body": {
-      "family": "Geist",
+      "family": "Inter",
       "weight": 400
     }
   },

--- a/style.css
+++ b/style.css
@@ -1,166 +1,150 @@
-/* ============================================
-   Yuno Docs — Brand Guidelines Theme
-   Colors: Yuno Blue #3E4FE0, Unity Black #282A30,
-           Harmony Lilac #E8EAF5, Innovation Green #E0ED80
-   ============================================ */
+/* Yuno Docs — custom CSS
+   docs.json covers the config. This file holds the few overrides
+   Mintlify doesn't expose natively: banner color, unified radius, code surface. */
 
-/* ============================================
-   Text contrast — Light mode
-   ============================================ */
-
-body {
-  color: #282a30;
+:root {
+  --yuno-blue: #3e4fe0;
+  --radius: 10px;
 }
 
-p,
-li,
-td {
-  color: #282a30;
+/* Top banner — solid brand blue, full-bleed */
+body > div:has(> [class*="banner" i]),
+div:has(> #banner) {
+  padding: 0 !important;
+  max-width: none !important;
+  width: 100% !important;
 }
 
-h1,
-h2,
-h3,
-h4 {
-  color: #282a30 !important;
-}
-
-.text-gray-500,
-.text-gray-600 {
-  color: #5c5e66 !important;
-}
-
-/* ============================================
-   Text contrast — Dark mode
-   ============================================ */
-
-html.dark body,
-html.dark p,
-html.dark li,
-html.dark td {
-  color: #d4d5da;
-}
-
-html.dark h1,
-html.dark h2,
-html.dark h3,
-html.dark h4 {
-  color: #ededf0 !important;
-}
-
-html.dark .text-gray-500,
-html.dark .text-gray-600 {
-  color: #9899a3 !important;
-}
-
-/* ============================================
-   Code blocks — Always dark (Unity Black base)
-   ============================================ */
-
-.code-block,
-pre,
-[data-component-part="code-block-root"] {
-  background-color: transparent !important;
-  border-radius: 6px !important;
-}
-
-html.dark .code-block,
-html.dark pre,
-html.dark [data-component-part="code-block-root"] {
-  border-color: #3a3c44 !important;
-}
-
-[data-component-part="code-block-header"],
-.code-block>div:first-child {
-  background-color: transparent !important;
-  border-bottom: 1px solid #e2e5eb !important;
-  border-radius: 6px 6px 0 0 !important;
-  color: #5c5e66 !important;
-}
-
-html.dark [data-component-part="code-block-header"],
-html.dark .code-block>div:first-child {
-  border-bottom-color: #3a3c44 !important;
-  color: #9899a3 !important;
-}
-
-/* Copy button */
-.code-block button[aria-label="Copy"],
-[data-testid="copy-code-button"] {
-  color: #9899a3 !important;
-}
-
-.code-block button[aria-label="Copy"]:hover,
-[data-testid="copy-code-button"]:hover {
-  color: #e8eaf5 !important;
-}
-
-/* Line numbers */
-span[class*="line"]::before,
-.line-number {
-  color: #5c5e66 !important;
-}
-
-/* Inline code — light mode */
-code:not(pre code) {
-  background-color: #e8eaf5 !important;
-  color: #282a30 !important;
-  padding: 2px 6px !important;
-  border: 1px solid #d0d3e3 !important;
-  font-size: 13px !important;
-}
-
-/* Inline code — dark mode */
-html.dark code:not(pre code) {
-  background-color: rgba(62, 79, 224, 0.12) !important;
-  color: #b8bdde !important;
-  border: 1px solid rgba(62, 79, 224, 0.2) !important;
-}
-
-/* ============================================
-   Tables
-   ============================================ */
-
-table th {
-  color: #282a30 !important;
+#banner,
+[class*="banner" i]:not(nav):not(header) {
+  background: var(--yuno-blue) !important;
+  color: #fff !important;
+  border: 0 !important;
+  border-radius: 0 !important;
   font-weight: 500 !important;
 }
 
-html.dark table th {
-  color: #ededf0 !important;
+#banner a,
+[class*="banner" i] a:not(nav a):not(header a) {
+  color: #fff !important;
+  text-decoration-color: rgba(255, 255, 255, 0.6) !important;
+  text-underline-offset: 3px !important;
 }
 
-html.dark table td {
-  border-bottom-color: rgba(255, 255, 255, 0.06) !important;
+#banner a:hover,
+[class*="banner" i] a:not(nav a):not(header a):hover {
+  text-decoration-color: #fff !important;
 }
 
-/* Horizontal scroll when table overflows viewport */
-table {
-  display: block;
-  overflow-x: auto;
+/* Sidebar nav items — flat. Rounded list items look wrong against the rail. */
+#sidebar ul li a,
+#sidebar ul li button {
+  border-radius: 0 !important;
 }
 
-/* Prevent inline code from breaking across lines inside table cells */
-table td code:not(pre code),
-table th code:not(pre code) {
-  white-space: nowrap;
+/* Search trigger / input — share the component radius */
+[role="search"],
+[role="search"] > *,
+input[type="search"],
+button[aria-label*="search" i] {
+  border-radius: var(--radius) !important;
 }
 
-/* Sticky first column */
-table td:first-child,
-table th:first-child {
-  position: sticky;
-  left: 0;
-  z-index: 1;
-  background-color: #ffffff !important;
-  box-shadow: 1px 0 0 #d0d3e3;
+/* Inline code chips */
+code:not(pre code) {
+  background: #f4f4f5;
+  color: #18181b;
+  padding: 2px 6px;
+  border: 1px solid #e4e4e7;
+  border-radius: 4px;
+  font-size: 13px;
 }
 
-html.dark table td:first-child,
-html.dark table th:first-child {
-  background-color: #0d0e12 !important;
-  box-shadow: 1px 0 0 #3a3c44;
+/* CardGroup tiles — opt-in via .mdx-card-tiles wrapper */
+.mdx-card-tiles [class*="grid"] > *,
+.mdx-card-tiles [class*="grid"] > div > a {
+  padding: 1.15rem 1.25rem !important;
+  border-radius: var(--radius) !important;
 }
+
+.mdx-card-tiles [class*="grid"] svg {
+  width: 1.4rem !important;
+  height: 1.4rem !important;
+}
+
+/* API overview hero — custom MDX component */
+.api-overview-hero {
+  margin: 0 0 1.35rem;
+  padding: 1.5rem 1.6rem;
+  border: 1px solid #e4e4e7;
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, #fafafa 0%, #f4f4f5 45%, #eef0f2 100%);
+}
+
+.api-overview-hero__eyebrow {
+  margin: 0 0 0.4rem;
+  color: #71717a;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.api-overview-hero__title {
+  margin: 0 0 0.5rem;
+  color: #09090b;
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.api-overview-hero__lede {
+  margin: 0;
+  max-width: 52rem;
+  color: #52525b;
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+/* ============================================
+   Changelog status badges (ChangelogBadge component)
+   Used in changelog pages: ADDED, CHANGED, DEPRECATED,
+   REMOVED, FIXED, SECURITY, BREAKING.
+   ============================================ */
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  margin-right: 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  line-height: 1.4;
+  border: 1px solid transparent;
+}
+
+.status-success   { background: #dcfce7; color: #166534; border-color: #86efac; }
+.status-warning   { background: #fef3c7; color: #92400e; border-color: #fcd34d; }
+.status-alert     { background: #ffedd5; color: #9a3412; border-color: #fdba74; }
+.status-error     { background: #fee2e2; color: #991b1b; border-color: #fca5a5; }
+.status-info      { background: #dbeafe; color: #1e40af; border-color: #93c5fd; }
+.status-security  { background: #ede9fe; color: #5b21b6; border-color: #c4b5fd; }
+.status-breaking  { background: #fce7f3; color: #9d174d; border-color: #f9a8d4; }
+.status-secondary { background: #f1f5f9; color: #475569; border-color: #cbd5e1; }
+
+html.dark .status-success   { background: #052e16; color: #86efac; border-color: #166534; }
+html.dark .status-warning   { background: #422006; color: #fcd34d; border-color: #92400e; }
+html.dark .status-alert     { background: #431407; color: #fdba74; border-color: #9a3412; }
+html.dark .status-error     { background: #450a0a; color: #fca5a5; border-color: #991b1b; }
+html.dark .status-info      { background: #172554; color: #93c5fd; border-color: #1e40af; }
+html.dark .status-security  { background: #2e1065; color: #c4b5fd; border-color: #5b21b6; }
+html.dark .status-breaking  { background: #500724; color: #f9a8d4; border-color: #9d174d; }
+html.dark .status-secondary { background: #1e293b; color: #cbd5e1; border-color: #475569; }
+
+/* === Imported from docs.y.uno: payment-status-table === */
 
 /* Payment status table: continuation rows have no first-column cell due to rowspan.
    Their td:first-child is actually the Substatus column — undo the sticky from it. */
@@ -170,51 +154,26 @@ html.dark table th:first-child {
   box-shadow: none !important;
 }
 
-
 .payment-status-table td {
   vertical-align: top !important;
   text-align: left;
   padding: 12px 8px !important;
 }
 
-
-
 .payment-status-table th {
   text-align: left;
   padding: 12px 8px !important;
 }
 
-
-/* Ensure status and substatus columns are centered if desired, 
-   but left-aligned usually looks cleaner with badges. */
+/* Ensure status and substatus columns are left-aligned with min-width for badges */
 .payment-status-table td.status,
 .payment-status-table td.substatus {
   min-width: 110px;
 }
 
+/* === Imported from docs.y.uno: expandable left-border accent === */
 
-
-/* ============================================
-   API reference params
-   ============================================ */
-
-.param-head .text-primary {
-  color: #3e4fe0 !important;
-}
-
-html.dark .param-head .text-primary {
-  color: #7a8aef !important;
-}
-
-html.dark .param-head {
-  border-color: rgba(255, 255, 255, 0.08) !important;
-}
-
-/* ============================================
-   API reference — nested child attributes
-   ============================================ */
-
-/* A. Replace full-border box with left-border accent */
+/* Replace full-border box with left-border accent on nested attribute blocks */
 details[data-component-part="expandable"] {
   border: none !important;
   border-left: 3px solid #3e4fe0 !important;
@@ -223,7 +182,7 @@ details[data-component-part="expandable"] {
 }
 
 html.dark details[data-component-part="expandable"] {
-  border-left-color: rgba(122, 138, 239, 0.5) !important;
+  border-left-color: rgba(62, 79, 224, 0.4) !important;
 }
 
 [data-component-part="expandable-button"] {
@@ -237,373 +196,47 @@ html.dark details[data-component-part="expandable"] {
   padding-right: 0 !important;
 }
 
-/* B. Reduce per-row padding inside nested blocks: py-6 (24px) → 12px */
-.expandable-content .primitive-param-field > div {
-  padding-top: 12px !important;
-  padding-bottom: 12px !important;
+/* === API Reference: shift code rail (cURL + response) toward the content === */
+/* Maple theme by default anchors the code panel to the right edge of the viewport,
+   which leaves a wide gap between the page text and the code samples. Pull the
+   right column closer to the content column so requests and responses sit
+   alongside the description rather than off in the wing. */
+
+/* 1. Reduce the right padding on the API reference content container */
+main:has([class*="api" i][class*="reference" i]),
+[class*="api-reference" i] {
+  padding-right: 0 !important;
 }
 
-/* C. Prevent badges from wrapping to a second line */
-.expandable-content .param-head > div > div {
-  flex-wrap: nowrap !important;
+/* 2. Pull the right-hand code rail left. Mintlify uses several selectors
+      depending on page type; we cover the common ones. */
+aside:has([data-component-part="code-block"]),
+[class*="api-playground" i],
+[data-component-part="api-playground"],
+[class*="request-example" i],
+[class*="response-example" i] {
+  margin-right: 0 !important;
 }
 
-.expandable-content [data-component-part="field-name"] {
-  min-width: 0 !important;
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
+/* 3. The two-column layout container — reduce the gap between content and rail */
+[data-component-part="api-reference-layout"],
+[class*="api-reference-page" i] > div,
+.api-reference-layout {
+  gap: 1.5rem !important;
+  padding-right: 1.5rem !important;
 }
 
-/* D. Tighten description-to-divider gap: mt-4 (16px) → 8px */
-.expandable-content .param-head + div {
-  margin-top: 8px !important;
+/* 4. Shift the sticky code rail itself ~90px toward the content */
+[data-component-part="code-block-sticky"],
+.sticky:has([data-component-part="code-block"]),
+aside.sticky:has(pre) {
+  transform: translateX(-90px);
 }
 
-/* ============================================
-   Links
-   ============================================ */
-
-a {
-  color: #3e4fe0;
-}
-
-html.dark a {
-  color: #7a8aef;
-}
-
-html.dark a:hover {
-  color: #9eabf5 !important;
-}
-
-/* ============================================
-   Sidebar
-   ============================================ */
-
-#sidebar-title {
-  font-family: "Geist", sans-serif;
-  font-weight: 400;
-  font-size: 15px;
-  line-height: 24px;
-  color: #282a30;
-}
-
-html.dark #sidebar-title {
-  color: #d4d5da;
-}
-
-#sidebar a[class*="bg-primary/10"],
-#sidebar button[class*="bg-primary/10"] {
-  background: #e8eaf5;
-}
-
-#sidebar a:hover,
-#sidebar button:hover {
-  background: #f6f7fa;
-}
-
-html.dark #sidebar a[class*="bg-primary/10"],
-html.dark #sidebar button[class*="bg-primary/10"] {
-  background: rgba(62, 79, 224, 0.1);
-}
-
-html.dark #sidebar a:hover,
-html.dark #sidebar button:hover {
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.sidebar-group-icon {
-  display: none;
-}
-
-.nav-logo {
-  height: 20px;
-  width: auto;
-}
-
-/* ============================================
-   Typography — base
-   ============================================ */
-
-body {
-  font-family:
-    "Geist",
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    sans-serif !important;
-  font-size: 15px;
-  line-height: 24px;
-  font-weight: 400;
-}
-
-body,
-p,
-li,
-td,
-th,
-span,
-div,
-a,
-label,
-input,
-button,
-select,
-textarea {
-  font-family:
-    "Geist",
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    sans-serif !important;
-}
-
-.mdx-content {
-  font-size: 15px;
-  line-height: 24px;
-}
-
-.mdx-content li {
-  font-size: 15px;
-  line-height: 24px;
-}
-
-/* ============================================
-   Typography — headings
-   ============================================ */
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family:
-    "Geist",
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    sans-serif !important;
-  font-weight: 400 !important;
-}
-
-#page-title {
-  font-weight: 400;
-  letter-spacing: 0%;
-}
-
-h2 {
-  font-size: 24px !important;
-  line-height: 32px !important;
-  margin-top: 32px !important;
-  margin-bottom: 12px !important;
-}
-
-h3 {
-  font-size: 20px !important;
-  line-height: 28px !important;
-  margin-top: 24px !important;
-  margin-bottom: 8px !important;
-}
-
-h2 span,
-h3 span {
-  font-size: inherit !important;
-  line-height: inherit !important;
-}
-
-/* ============================================
-   Code — font
-   ============================================ */
-
-code,
-pre,
-pre *,
-code *,
-.mono,
-[class*="font-mono"],
-kbd,
-samp {
-  font-family: "Fira Code", monospace !important;
-}
-
-span[class*="line"],
-span[class*="line"] * {
-  font-family: "Fira Code", monospace !important;
-  font-size: 12px;
-  line-height: 20px;
-}
-
-.code-block,
-.code-block:has([data-component-part="code-block-header"]),
-:not(.code-block)>[data-component-part="code-block-root"] {
-  --code-padding-right: 48px;
-}
-
-/* ============================================
-   Border-radius — sharp corners
-   ============================================ */
-
-*:not(a):not(.code-block):not(pre):not([data-component-part="code-block-root"]):not([data-component-part="code-block-header"]) {
-  border-radius: 2px !important;
-}
-
-* {
-  text-shadow: none !important;
-}
-
-#sidebar a {
-  border-radius: 2px !important;
-}
-
-/* ============================================
-   API context menu
-   ============================================ */
-
-#page-context-menu-button {
-  border-radius: 2px 0 0 2px !important;
-  font-size: 13px;
-  line-height: 20px;
-}
-
-#page-context-menu-button+button {
-  border-radius: 0 2px 2px 0 !important;
-}
-
-/* ============================================
-   API method badges — Yuno Blue
-   ============================================ */
-
-.method-badge.post,
-.tag.post,
-.http-method.post {
-  background-color: #3e4fe0 !important;
-  color: white !important;
-  border-color: #2d3bb8 !important;
-}
-
-.card.block {
-  border-radius: 0 !important;
-}
-
-.company_card_wrapper .card>div {
-  padding: 18px 20px;
-}
-
-.card h2 {
-  margin: 0 !important;
-  margin-top: 10px;
-  font-size: 16px !important;
-}
-
-.company_card_wrapper h2 {
-  font-size: 16px !important;
-  margin: 0 !important;
-}
-
-/* ============================================
-   Status Badges — Dashboard Sync
-   ============================================ */
-
-.status-badge {
-  padding: 2px 10px !important;
-  border-radius: 4px !important;
-  font-size: 12px !important;
-  font-weight: 500 !important;
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  white-space: nowrap !important;
-  line-height: 1.2 !important;
-  min-height: 24px !important;
-  margin-top: 2px !important;
-  pointer-events: none !important;
-}
-
-
-/* Success status — green-600 */
-.status-success {
-  color: #16a34a !important;
-  background-color: #16a34a1a !important;
-}
-
-html.dark .status-success {
-  color: #4ade80 !important;
-  background-color: rgba(74, 222, 128, 0.15) !important;
-}
-
-/* Error status — gray-500 */
-.status-error {
-  color: #6b7280 !important;
-  background-color: #6b72801a !important;
-}
-
-html.dark .status-error {
-  color: #9ca3af !important;
-  background-color: rgba(156, 163, 175, 0.15) !important;
-}
-
-/* Warning status — yellow-500 */
-.status-warning {
-  color: #eab308 !important;
-  background-color: #eab3081a !important;
-}
-
-html.dark .status-warning {
-  color: #facc15 !important;
-  background-color: rgba(250, 204, 21, 0.15) !important;
-}
-
-/* Info status — blue-600 */
-.status-info {
-  color: #2563eb !important;
-  background-color: #2563eb1a !important;
-}
-
-html.dark .status-info {
-  color: #60a5fa !important;
-  background-color: rgba(96, 165, 250, 0.15) !important;
-}
-
-/* Alert status — orange-600 */
-.status-alert {
-  color: #ea580c !important;
-  background-color: #ea580c1a !important;
-}
-
-html.dark .status-alert {
-  color: #fb923c !important;
-  background-color: rgba(251, 146, 60, 0.15) !important;
-}
-
-/* Secondary status — generic gray / neutral */
-.status-secondary {
-  color: #5c5e66 !important;
-  background-color: #5c5e661a !important;
-}
-
-html.dark .status-secondary {
-  color: #9899a3 !important;
-  background-color: rgba(255, 255, 255, 0.08) !important;
-}
-
-/* Security status — purple-600 */
-.status-security {
-  color: #9333ea !important;
-  background-color: #9333ea1a !important;
-}
-
-html.dark .status-security {
-  color: #c084fc !important;
-  background-color: rgba(192, 132, 252, 0.15) !important;
-}
-
-/* Breaking status — rose-600 */
-.status-breaking {
-  color: #e11d48 !important;
-  background-color: #e11d481a !important;
-}
-
-html.dark .status-breaking {
-  color: #fb7185 !important;
-  background-color: rgba(251, 113, 133, 0.15) !important;
+@media (max-width: 1280px) {
+  [data-component-part="code-block-sticky"],
+  .sticky:has([data-component-part="code-block"]),
+  aside.sticky:has(pre) {
+    transform: none;
+  }
 }


### PR DESCRIPTION
## What

Applies the theme previewed at https://yn-c9bb3266.mintlify.app/ — the same Mintlify setup Coinbase uses for https://docs.cdp.coinbase.com. No external theme or build step involved; everything is native Mintlify config.

## Changes

**`docs.json`** (theme keys only — navigation and content untouched):
- `theme`: `mint` → `maple`
- `colors`: brand ramp `#3E4FE0` / `#6B78EB` / `#2F3EB8`
- `appearance`: default light, strict
- `fonts`: Geist → Inter (headings 500, body 400)
- `styling.codeblocks`: `github-dark` in both modes
- `logo`: switch to existing `/logo/light.svg` + `/logo/dark.svg` variants

**`style.css`**: replaces the mint-tuned overrides with the maple-tuned set (solid brand-blue banner, flat sidebar items, inline code chips, changelog status badges, expandable left-border accent, payment-status table fixes, API reference code-rail positioning). The old file's rules (sharp corners, Geist sizing, text-contrast fixes) were written against the mint theme and don't apply under maple.

Logos and favicon already in the repo are byte-identical to the preview's — no asset changes needed.

## How to verify

Mintlify's preview deployment for this branch will render it directly — compare against https://yn-c9bb3266.mintlify.app/.

## Notes

- Targets `main` (the live branch). The repo's GitHub default branch is still `master`, which is ~1 year stale — worth updating the default branch setting separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Mintlify config and CSS; no API or app logic. Main review risk is visual regression on API reference layout and changelog badges after the large CSS swap.
> 
> **Overview**
> Switches the Yuno API docs site from Mintlify **mint** to **maple**, with navigation and content unchanged.
> 
> **`docs.json`** updates theme branding: `theme` → `maple`; primary color ramp (`#3E4FE0` / `#6B78EB` / `#2F3EB8`); **`appearance`** default light + strict; **Inter** fonts (headings 500); **`github-dark`** code blocks in both modes; logos → `/logo/light.svg` and `/logo/dark.svg`.
> 
> **`style.css`** is largely rewritten for maple: drops mint-era global typography, contrast, table sticky-column, sidebar, and sharp-corner rules; adds focused overrides (full-bleed brand-blue banner, flat sidebar links, 10px radius, inline code chips, `.mdx-card-tiles`, `.api-overview-hero`). Changelog **`status-badge`** styles are reworked (including dark mode) for `ChangelogBadge`. Keeps payment-status table and expandable API param accents; adds **API reference** layout tweaks to pull the sticky code rail ~90px toward the prose (disabled below 1280px).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad8f98e40f13c7a01f5e4d6a8073ba80165c9f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->