### PR TITLE
fix(payment-methods): fix ACH enrollment doc gaps

### DIFF
--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -193,6 +193,24 @@
                       "organization_customer_external_id": {
                         "type": "string",
                         "description": "Customer identifier in the merchant’s own system, scoped to the organization. MIN 3 / MAX 255."
+                      },
+                      "email": {
+                        "type": "string",
+                        "description": "Email address of the customer."
+                      },
+                      "ip_address": {
+                        "type": "string",
+                        "description": "IP address of the customer at the time of enrollment. Required by the provider for the online ACH mandate."
+                      },
+                      "browser_info": {
+                        "type": "object",
+                        "description": "Browser metadata. Required by the provider for the online ACH mandate.",
+                        "properties": {
+                          "user_agent": {
+                            "type": "string",
+                            "description": "Full user-agent string of the customer’s browser."
+                          }
+                        }
                       }
                     }
                   },
@@ -214,6 +232,7 @@
                         "properties": {
                           "bank_transfer": {
                             "type": "object",
+                            "required": ["beneficiary_name", "routing_number"],
                             "properties": {
                               "account_type": {
                                 "type": "string",
@@ -222,7 +241,7 @@
                               },
                               "account_holder_type": {
                                 "type": "string",
-                                "description": "Type of account holder.",
+                                "description": "Type of account holder (e.g. `INDIVIDUAL`, `ENTITY`). Accepted and stored, but not forwarded to the provider for ACH — does not control individual vs. company treatment for ACH enrollment.",
                                 "enum": ["INDIVIDUAL", "ENTITY"]
                               },
                               "bank_id": {
@@ -280,7 +299,7 @@
                       },
                       "token_source": {
                         "type": "string",
-                        "description": "Origin of the provided token.",
+                        "description": "Origin of the provided token. Note: `PROVIDER_TOKEN` is only supported when the top-level `type` is `CARD`. Using it with `ACH_ENROLLMENT` returns an error.",
                         "enum": ["PROVIDER_API", "MIGRATION_FILE", "PROVIDER_TOKEN"]
                       },
                       "payment_method_token": {
@@ -378,40 +397,26 @@
                 "ACH Enrollment": {
                   "value": {
                     "account_id": "dbf0c133-86bc-4be0-94a5-ca2ff6778451",
-                    "country": "BR",
+                    "country": "US",
                     "type": "ACH_ENROLLMENT",
                     "workflow": "DIRECT",
                     "customer_payer": {
-                      "code": "cust-123"
+                      "code": "<customer_code>",
+                      "email": "john@example.com",
+                      "ip_address": "203.0.113.5",
+                      "browser_info": {
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
+                      }
                     },
                     "payment_method": {
-                      "type": "ACH_ENROLLMENT",
                       "vault_on_success": true,
                       "detail": {
                         "bank_transfer": {
-                          "account_type": "CHECKINGS",
-                          "account_holder_type": "INDIVIDUAL",
-                          "bank_id": "001",
-                          "bank_name": "Banco do Brasil",
-                          "bank_account": "00012345-6",
+                          "bank_account": "000123456789",
+                          "routing_number": "110000000",
                           "beneficiary_name": "John Doe",
-                          "branch": "1234",
-                          "branch_digit": "5",
-                          "routing_number": "001",
-                          "code": "001",
-                          "reference": "REF-001"
+                          "account_type": "CHECKINGS"
                         }
-                      }
-                    },
-                    "recurring_payment": {
-                      "regular_billing": {
-                        "label": "Monthly Plan",
-                        "amount": {
-                          "currency": "BRL",
-                          "value": 49.90
-                        },
-                        "interval_unit": "MONTH",
-                        "interval_count": 1
                       }
                     }
                   }
@@ -500,6 +505,14 @@
                         "vault_on_success": false,
                         "payment": null
                       }
+                    }
+                  },
+                  "ACH Enrollment": {
+                    "value": {
+                      "type": "ACH_ENROLLMENT",
+                      "status": "READY_TO_ENROLL",
+                      "action": "REDIRECT_URL",
+                      "redirect_url": "https://payments.stripe.com/microdeposit/pacreq_test_placeholder"
                     }
                   },
                   "With Verify": {


### PR DESCRIPTION
## PR description
Fixes blocking gaps and applies clarity improvements to the ACH enrollment spec, based on a doc review. A merchant following the previous doc could have their ACH enrollment declined due to missing required fields in the request, and had no response example to understand the verification flow.

## Changes
openapi/payment-methods-direct-workflow/enroll-payment-method-api.json

- Added ip_address, email, and browser_info.user_agent to customer_payer schema and ACH request example — required by the provider for the online ACH mandate
- Marked beneficiary_name and routing_number as required in bank_transfer
- Added ACH Enrollment response example to 201 responses with READY_TO_ENROLL status and redirect_url
- Updated ACH request example to US rails: country: US, routing_number: 110000000, bank_account: 000123456789
- Removed unused fields from ACH request example: bank_id, bank_name, branch, branch_digit, code, account_holder_type
- Added note to token_source description that PROVIDER_TOKEN only works with type: CARD
- Clarified account_holder_type description: field is accepted and stored but has no effect on ACH enrollment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI changes; no runtime API or application code is modified.
> 
> **Overview**
> Updates the **Enroll Payment Method** OpenAPI spec so ACH enrollment matches provider mandate requirements and US rails.
> 
> **Request schema & example:** Documents `customer_payer.email`, `ip_address`, and `browser_info.user_agent` as needed for the online ACH mandate. Marks `bank_transfer.beneficiary_name` and `routing_number` as **required**. The ACH example switches from BR-style data to **US** (`country: US`, realistic routing/account numbers), adds mandate fields, and drops misleading extras (e.g. `recurring_payment`, redundant bank metadata).
> 
> **Clarity:** Notes that `PROVIDER_TOKEN` applies only when `type` is `CARD`, and that `account_holder_type` is stored but not used for ACH provider behavior.
> 
> **Response:** Adds a **201** example for ACH with `READY_TO_ENROLL`, `action: REDIRECT_URL`, and `redirect_url` so integrators can see the verification redirect flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f4d23af5f919d0688884b602be4e2b2f176ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->