### PR TITLE
Update contact info section and add free trial note

### DIFF
--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -66,9 +66,24 @@ The SDK handles the Apple Pay flow automatically. When the customer completes th
 
 ### Requesting Contact Information
 
-When the `CARD_HOLDER_AND_ADDRESS_REQUIRED` parameter is enabled in your configuration, the Apple Pay payment sheet will automatically request the customer's **email**, **phone**, and **name**.
+You can configure which contact fields Apple Pay requests from the customer directly from the [Checkout Builder](/docs/using-yuno/dashboard-overview/checkout-builder#required-fields). The available fields are:
 
-The collected `email` and `phone` are forwarded from the `shippingContact` to the backend via `card_data` in the `paymentComplete` event.
+- Email
+- Phone
+- Holder name
+- Billing address
+- Shipping address
+
+When any of these fields are enabled as required in the Checkout Builder, the Apple Pay payment sheet will prompt the customer to provide or confirm that information before completing the payment. The collected data is then included in the OTT response.
+
+<Note>
+  Each additional required field adds an extra step to the Apple Pay payment sheet, increasing friction for the customer. This can negatively impact conversion rates. We recommend enabling only the fields that are strictly necessary for your business or regulatory requirements.
+</Note>
+
+| Platform | Minimum version |
+|----------|-----------------|
+| Web      | 1.8.0           |
+| iOS      | 2.15.0          |
 
 ## Recurring payments with SDK
 
@@ -81,6 +96,8 @@ The SDK streamlines recurring payments by managing both Customer‑Initiated (CI
 ### Create checkout session for recurring payments
 
 Before creating the transaction, you need to create the checkout session with the `recurring_payment` object populated in your checkout session request:
+
+**Free trial:** When offering a free trial period, set the root `amount.value` to `0` and include the `trial_billing` object as shown in the example below. The actual recurring charge is defined in `regular_billing`, which informs the customer of the amount they will be billed once the trial ends.
 
 ```json
 {


### PR DESCRIPTION
## PR description
Updates the "Requesting Contact Information" section in the Apple Pay SDK integration guide with new content from Vivi, and adds a free trial explanation to the recurring payments section.

## Changes
docs/wallets/apple-pay/apple-pay-sdk-integration.mdx

- Replaced "Requesting Contact Information" section with updated content: lists all 5 configurable contact fields, explains Checkout Builder configuration, adds a <Note> about conversion rate impact, and includes a platform availability table (Web 1.8.0 / iOS 2.15.0)
- Added link to the Checkout Builder required fields documentation in the section intro
- Added free trial explanation to ### Create checkout session for recurring payments: instructs developers to set amount.value to 0 and include trial_billing when offering a free trial

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> **Requesting Contact Information** is rewritten to match Checkout Builder–driven configuration instead of a single `CARD_HOLDER_AND_ADDRESS_REQUIRED` flag. It now links to the [Checkout Builder required fields](/docs/using-yuno/dashboard-overview/checkout-builder#required-fields) docs, lists all five configurable fields (email, phone, holder name, billing and shipping address), explains that required fields appear on the Apple Pay sheet and flow into the OTT response, adds a conversion-friction **Note**, and documents minimum SDK versions (Web **1.8.0**, iOS **2.15.0**).
> 
> In **Create checkout session for recurring payments**, a **Free trial** callout tells integrators to set root `amount.value` to `0` and include `trial_billing`, with recurring charges defined in `regular_billing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dca5babb56a711fa9122eb1413daad7d51cba40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->