### PR TITLE
Reapply ACH enrollment doc fixes after merge overwrite

### DIFF
--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -193,6 +193,24 @@
                       "organization_customer_external_id": {
                         "type": "string",
                         "description": "Customer identifier in the merchant’s own system, scoped to the organization. MIN 3 / MAX 255."
+                      },
+                      "email": {
+                        "type": "string",
+                        "description": "Email address of the customer."
+                      },
+                      "ip_address": {
+                        "type": "string",
+                        "description": "IP address of the customer at the time of enrollment. Required by the provider for the online ACH mandate."
+                      },
+                      "browser_info": {
+                        "type": "object",
+                        "description": "Browser metadata. Required by the provider for the online ACH mandate.",
+                        "properties": {
+                          "user_agent": {
+                            "type": "string",
+                            "description": "Full user-agent string of the customer’s browser."
+                          }
+                        }
                       }
                     }
                   },
@@ -214,6 +232,7 @@
                         "properties": {
                           "bank_transfer": {
                             "type": "object",
+                            "required": ["beneficiary_name", "routing_number"],
                             "properties": {
                               "account_type": {
                                 "type": "string",
@@ -225,7 +244,7 @@
                               },
                               "account_holder_type": {
                                 "type": "string",
-                                "description": "Type of account holder.",
+                                "description": "Type of account holder (e.g. `INDIVIDUAL`, `ENTITY`). Accepted and stored, but not forwarded to the provider for ACH — does not control individual vs. company treatment for ACH enrollment.",
                                 "enum": [
                                   "INDIVIDUAL",
                                   "ENTITY"
@@ -286,7 +305,7 @@
                       },
                       "token_source": {
                         "type": "string",
-                        "description": "Origin of the provided token.",
+                        "description": "Origin of the provided token. Note: `PROVIDER_TOKEN` is only supported when the top-level `type` is `CARD`. Using it with `ACH_ENROLLMENT` returns an error.",
                         "enum": [
                           "PROVIDER_API",
                           "MIGRATION_FILE",
@@ -393,40 +412,26 @@
                 "ACH Enrollment": {
                   "value": {
                     "account_id": "dbf0c133-86bc-4be0-94a5-ca2ff6778451",
-                    "country": "BR",
+                    "country": "US",
                     "type": "ACH_ENROLLMENT",
                     "workflow": "DIRECT",
                     "customer_payer": {
-                      "code": "cust-123"
+                      "code": "<customer_code>",
+                      "email": "john@example.com",
+                      "ip_address": "203.0.113.5",
+                      "browser_info": {
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
+                      }
                     },
                     "payment_method": {
-                      "type": "ACH_ENROLLMENT",
                       "vault_on_success": true,
                       "detail": {
                         "bank_transfer": {
-                          "account_type": "CHECKINGS",
-                          "account_holder_type": "INDIVIDUAL",
-                          "bank_id": "001",
-                          "bank_name": "Banco do Brasil",
-                          "bank_account": "00012345-6",
+                          "bank_account": "000123456789",
+                          "routing_number": "110000000",
                           "beneficiary_name": "John Doe",
-                          "branch": "1234",
-                          "branch_digit": "5",
-                          "routing_number": "001",
-                          "code": "001",
-                          "reference": "REF-001"
+                          "account_type": "CHECKINGS"
                         }
-                      }
-                    },
-                    "recurring_payment": {
-                      "regular_billing": {
-                        "label": "Monthly Plan",
-                        "amount": {
-                          "currency": "BRL",
-                          "value": 49.9
-                        },
-                        "interval_unit": "MONTH",
-                        "interval_count": 1
                       }
                     }
                   }
@@ -495,6 +500,14 @@
             "content": {
               "application/json": {
                 "examples": {
+                  "ACH Enrollment": {
+                    "value": {
+                      "type": "ACH_ENROLLMENT",
+                      "status": "READY_TO_ENROLL",
+                      "action": "REDIRECT_URL",
+                      "redirect_url": "https://payments.stripe.com/microdeposit/pacreq_test_placeholder"
+                    }
+                  },
                   "Result": {
                     "value": {
                       "idempotency_key": "2ca58c6d-8794-4c8f-a2f6-bba4b7498b74",


### PR DESCRIPTION
## PR description
Reapplies ACH enrollment doc fixes that were lost in a merge conflict. The changes address blocking gaps identified in a doc review — missing required fields for the ACH mandate and missing ACH response example — plus clarity improvements to reduce developer confusion.

## Changes
openapi/payment-methods-direct-workflow/enroll-payment-method-api.json

- Added ip_address, email, and browser_info.user_agent to customer_payer schema and ACH request example — required by the provider for the online ACH mandate
- Marked beneficiary_name and routing_number as required in bank_transfer
- Added ACH Enrollment response example to 201 responses with READY_TO_ENROLL status and redirect_url
- Updated ACH request example to US rails: country: US, routing_number: 110000000, bank_account: 000123456789
- Removed unused fields from ACH request example: bank_id, bank_name, branch, branch_digit, code, account_holder_type
- Added note to token_source description that PROVIDER_TOKEN only works with type: CARD
- Clarified account_holder_type description: field is accepted and stored but has no effect on ACH enrollment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI JSON changes; no application or API implementation modified.
> 
> **Overview**
> Reapplies **ACH enrollment** documentation fixes in `enroll-payment-method-api.json` after a merge overwrite—no runtime/API behavior changes.
> 
> **Request schema & examples:** `customer_payer` now documents `email`, `ip_address`, and `browser_info.user_agent` (called out as required for the online ACH mandate). `bank_transfer` marks `beneficiary_name` and `routing_number` as required. The ACH request example switches from BR-style fields to **US** (`country: US`, routing/account numbers) and drops misleading extras (e.g. Brazilian bank/branch fields, `recurring_payment`).
> 
> **Clarity:** `account_holder_type` notes it is stored but not sent to the provider for ACH; `token_source` notes `PROVIDER_TOKEN` is **CARD-only** and errors with `ACH_ENROLLMENT`.
> 
> **Responses:** Adds a **201** example for ACH with `READY_TO_ENROLL`, `REDIRECT_URL`, and `redirect_url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7312654de3e23e7c2d11edf0fd92e85b80e3065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->