### PR TITLE
Update iOS SDK release notes for version 2.17.2

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.17.2
+*June 11, 2026*
+
+- <ChangelogBadge type="fixed" /> **Bug Fix with Card Forms**  
+  Resolves a crash issue that occurred with unfolded card forms when using multiple payment methods.
+
 ## v2.17.1
 *June 2, 2026*
 

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,32 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.17.2",
+      "release_date": "2026-06-10",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.17.2\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.17.2'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Bug Fix with Card Forms",
+          "description": "Resolved a crash issue that occurred with unfolded card forms when using multiple payment methods.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.17.1",
       "release_date": "2026-06-02",
       "upgrade": [


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.17.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or API changes in this repo.
> 
> **Overview**
> Documents **iOS SDK v2.17.2** at the top of the public changelog by prepending a new release block to `changelog/source/ios.json` and the matching section in `changelog/ios.mdx`.
> 
> The release notes describe one **fixed** item: a crash with **unfolded card forms** when **multiple payment methods** are shown. The JSON also adds SPM (`from: "2.17.2"`) and CocoaPods (`pod 'YunoSDK', '2.17.2'`) upgrade snippets for integrators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965a54f9ed35a345b9a0eea72b9aed02857002e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->