### PR TITLE
Fix ids and error message format in API reference

### DIFF
--- a/reference/unreferenced-refunds/create-unreferenced-refund.mdx
+++ b/reference/unreferenced-refunds/create-unreferenced-refund.mdx
@@ -213,7 +213,7 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
 
 ```json 201 - Refund created
 {
-  "id": "urf_01HX31R6QK7E2F4G5H6J7K8M9N",
+  "id": "01HX31R6QK7E2F4G5H6J7K8M9N",
   "account_id": "9f6e0a4c-1d2b-4e3f-8a9b-1c2d3e4f5a6b",
   "merchant_order_id": "REFUND-2026-05-14-001",
   "merchant_reference": "credit-note-7891",
@@ -261,35 +261,19 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
 
 ```json 400 - Validation error
 {
-  "type": "https://docs.y.uno/errors/VALIDATION_ERROR",
   "code": "VALIDATION_ERROR",
-  "title": "Request validation failed",
-  "status": 400,
-  "detail": "One or more fields did not pass validation",
-  "trace_id": "01HX31R6QK7E2F4G5H6J7K8M9N",
-  "errors": [
-    {
-      "field": "payment_method",
-      "code": "INVALID_PAYMENT_METHOD_SOURCE",
-      "message": "Exactly one of 'vaulted_token' or 'detail.<card|wallet|bank_transfer>' must be set."
-    },
-    {
-      "field": "amount.value",
-      "code": "OUT_OF_RANGE",
-      "message": "Value must be greater than 0."
-    }
+  "messages": [
+    "One or more fields did not pass validation."
   ]
 }
 ```
 
 ```json 422 - Routing or permission failure
 {
-  "type": "https://docs.y.uno/errors/UNREFERENCED_REFUND_NOT_SUPPORTED",
   "code": "UNREFERENCED_REFUND_NOT_SUPPORTED",
-  "title": "No provider supports this payment-method for non-referenced refunds",
-  "status": 422,
-  "detail": "Provider 'CHECKOUTCOM' does not define operation_type=Credit for CARD payment-methods in country US.",
-  "trace_id": "01HX31R6QK7E2F4G5H6J7K8M9N"
+  "messages": [
+    "No provider supports this payment method for non-referenced refunds."
+  ]
 }
 ```
 

--- a/reference/unreferenced-refunds/create-unreferenced-refund.mdx
+++ b/reference/unreferenced-refunds/create-unreferenced-refund.mdx
@@ -190,10 +190,10 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
     "id": "STRIPE"
   },
   "payment_method": {
-    "vaulted_token": "vt_01HX2Y3ZP4Q5R6S7T8U9V0W1X2"
+    "vaulted_token": "550e8400-e29b-41d4-a716-446655440000"
   },
   "customer_payer": {
-    "id": "cus_01HX2K9PQR3S4T5U6V7W8X9Y0Z",
+    "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
     "merchant_customer_id": "cust_4521",
     "first_name": "John",
     "last_name": "Doe",
@@ -213,7 +213,7 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
 
 ```json 201 - Refund created
 {
-  "id": "01HX31R6QK7E2F4G5H6J7K8M9N",
+  "id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
   "account_id": "9f6e0a4c-1d2b-4e3f-8a9b-1c2d3e4f5a6b",
   "merchant_order_id": "REFUND-2026-05-14-001",
   "merchant_reference": "credit-note-7891",
@@ -226,7 +226,7 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
   "status": "CREATED",
   "sub_status": "CREATED",
   "payment_method": {
-    "vaulted_token": "vt_01HX2Y3ZP4Q5R6S7T8U9V0W1X2",
+    "vaulted_token": "550e8400-e29b-41d4-a716-446655440000",
     "detail": {
       "card": {
         "card_data": {
@@ -238,7 +238,7 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
     }
   },
   "customer_payer": {
-    "id": "cus_01HX2K9PQR3S4T5U6V7W8X9Y0Z",
+    "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
     "merchant_customer_id": "cust_4521",
     "first_name": "John",
     "last_name": "Doe"
@@ -246,7 +246,7 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
   "provider": {
     "name": "STRIPE",
     "type": "PSP",
-    "connection_id": "conn_01HX0J8FZQK7M3N4P5R6S7T8U9",
+    "connection_id": "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
     "reference": "re_3OqQz92eZvKYlo2C0g6XK1Yj",
     "category": "APPROVED",
     "raw_response_code": "succeeded"

--- a/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
+++ b/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
@@ -15,7 +15,7 @@ The unique private secret key for your account.
 </ParamField>
 
 <ParamField path="unreferenced_refund_id" type="string" required>
-Yuno-generated unique identifier of the unreferenced refund. Prefix `urf_`.
+Yuno-generated unique identifier of the unreferenced refund.
 </ParamField>
 
 <ParamField query="include_raw_responses" type="boolean" default="false">
@@ -29,7 +29,7 @@ When `true`, returns the full list of attempts and intermediate network response
 <RequestExample>
 ```bash Example request
 curl --request GET \
-  --url 'https://api.y.uno/v1/unreferenced-refunds/urf_01HX31R6QK7E2F4G5H6J7K8M9N?include_raw_responses=true' \
+  --url 'https://api.y.uno/v1/unreferenced-refunds/01HX31R6QK7E2F4G5H6J7K8M9N?include_raw_responses=true' \
   --header 'public-api-key: YOUR_PUBLIC_API_KEY' \
   --header 'private-secret-key: YOUR_PRIVATE_SECRET_KEY' \
   --header 'Accept: application/json'
@@ -39,7 +39,7 @@ curl --request GET \
 <ResponseExample>
 ```json 200 - Refund found
 {
-  "id": "urf_01HX31R6QK7E2F4G5H6J7K8M9N",
+  "id": "01HX31R6QK7E2F4G5H6J7K8M9N",
   "account_id": "9f6e0a4c-1d2b-4e3f-8a9b-1c2d3e4f5a6b",
   "merchant_order_id": "REFUND-2026-05-14-001",
   "country": "US",
@@ -72,12 +72,10 @@ curl --request GET \
 
 ```json 404 - Refund not found
 {
-  "type": "https://docs.y.uno/errors/UNREFERENCED_REFUND_NOT_FOUND",
   "code": "UNREFERENCED_REFUND_NOT_FOUND",
-  "title": "Unreferenced refund not found",
-  "status": 404,
-  "detail": "No unreferenced refund with id 'urf_01HX31R6QK7E2F4G5H6J7K8M9N' exists on this account.",
-  "trace_id": "01HX31R6QK7E2F4G5H6J7K8M9N"
+  "messages": [
+    "No unreferenced refund with the provided id exists on this account."
+  ]
 }
 ```
 </ResponseExample>

--- a/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
+++ b/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
@@ -29,7 +29,7 @@ When `true`, returns the full list of attempts and intermediate network response
 <RequestExample>
 ```bash Example request
 curl --request GET \
-  --url 'https://api.y.uno/v1/unreferenced-refunds/01HX31R6QK7E2F4G5H6J7K8M9N?include_raw_responses=true' \
+  --url 'https://api.y.uno/v1/unreferenced-refunds/d290f1ee-6c54-4b01-90e6-d701748f0851?include_raw_responses=true' \
   --header 'public-api-key: YOUR_PUBLIC_API_KEY' \
   --header 'private-secret-key: YOUR_PRIVATE_SECRET_KEY' \
   --header 'Accept: application/json'
@@ -39,7 +39,7 @@ curl --request GET \
 <ResponseExample>
 ```json 200 - Refund found
 {
-  "id": "01HX31R6QK7E2F4G5H6J7K8M9N",
+  "id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
   "account_id": "9f6e0a4c-1d2b-4e3f-8a9b-1c2d3e4f5a6b",
   "merchant_order_id": "REFUND-2026-05-14-001",
   "country": "US",
@@ -47,7 +47,7 @@ curl --request GET \
   "status": "SUCCEEDED",
   "sub_status": "SUCCEEDED",
   "payment_method": {
-    "vaulted_token": "vt_01HX2Y3ZP4Q5R6S7T8U9V0W1X2",
+    "vaulted_token": "550e8400-e29b-41d4-a716-446655440000",
     "detail": {
       "card": {
         "card_data": { "brand": "VISA", "last_four": "1111", "type": "CREDIT" }
@@ -55,7 +55,7 @@ curl --request GET \
     }
   },
   "customer_payer": {
-    "id": "cus_01HX2K9PQR3S4T5U6V7W8X9Y0Z"
+    "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
   },
   "provider": {
     "name": "STRIPE",


### PR DESCRIPTION
## PR description
Fixes two issues in the unreferenced refund API reference pages flagged as P1 by Hora: refund IDs were showing a urf_ prefix that should not appear in the docs, and error responses were using a verbose non-standard format inconsistent with the rest of the API reference.

## Changes
reference/unreferenced-refunds/create-unreferenced-refund.mdx

- Removed urf_ prefix from the refund id in the 201 response example
- Replaced 400 error response with standard { "code", "messages" } format
- Replaced 422 error response with standard { "code", "messages" } format


reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx

- Removed Prefix urf_. from the unreferenced_refund_id path parameter description
- Removed urf_ prefix from the refund ID in the curl request example URL
- Removed urf_ prefix from the refund id in the 200 response example
- Replaced 404 error response with standard { "code", "messages" } format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX examples; no runtime or API behavior.
> 
> **Overview**
> Updates the **create** and **retrieve-by-id** unreferenced refund reference pages so examples match the rest of the API docs.
> 
> **Identifiers:** Removes the documented `urf_` prefix from `unreferenced_refund_id` and swaps example refund, customer, vaulted token, and connection IDs for plain UUID-style values in request/response samples and the GET curl URL.
> 
> **Errors:** Replaces verbose error bodies (`type`, `title`, `status`, `detail`, `trace_id`, field-level `errors`) on **400**, **422**, and **404** with the standard `{ "code", "messages" }` shape used in `response-codes` and other reference pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 012dbd70d4c6b1bfd0075be2779a470d03cd76d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->