### PR TITLE
fix(changelog): correct iOS 2.17.2 release date to June 10

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -6,7 +6,7 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 ## v2.17.2
-*June 11, 2026*
+*June 10, 2026*
 
 - <ChangelogBadge type="fixed" /> **Bug Fix with Card Forms**  
   Resolves a crash issue that occurred with unfolded card forms when using multiple payment methods.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only date correction in the iOS changelog with no runtime or API impact.
> 
> **Overview**
> Updates the **v2.17.2** release line in `changelog/ios.mdx` so the displayed date is **June 10, 2026** instead of June 11, 2026.
> 
> This aligns the public changelog with the source metadata in `changelog/source/ios.json` (`release_date: 2026-06-10`). No SDK behavior or release notes content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a34e67e9b67b69e9cd23e94ccb26f2e144fb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->