### PR TITLE
chore: web sdk changelog 1.9.2

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,55 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.2",
+      "release_date": "2026-06-11",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Stronger Phone and Document Validation",
+          "description": "Phone and document number fields now block invalid characters as you type, and document numbers run checksum validation — enabled gradually via the real-time validation rollout.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Checkout Completed Event For All Methods",
+          "description": "The checkoutSdk_completed event is now emitted for every payment method that completes through the shared payment-action router (card, Google Pay, APMs), matching the existing Apple Pay and PayPal behavior. It fires once per checkout.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Revolut Pay Support",
+          "description": "Adds Revolut Pay as an external payment button. Supports both seamless and merchant-driven checkout flows, with a configurable button (variant, size, radius, action, and locale).",
+          "group": "Revolut Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed Slim Variant Card Form Styles",
+          "description": "Fixed an issue in SDK 1.9 where the slim input variant rendered incorrectly in the card form and address fields: grouped border radius, focus and error border colors, and hidden inline error messages were not applied.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17143",
+        "CORECM-17218",
+        "CORECM-17717",
+        "CORECM-17739",
+        "CORECM-17779"
+      ]
+    },
+    {
       "version": "1.9.1",
       "release_date": "2026-06-03",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,29 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.2
+*June 11, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Stronger Phone and Document Validation**  
+  Phone and document number fields now block invalid characters as you type, and document numbers run checksum validation — enabled gradually via the real-time validation rollout.
+
+**Payment Actions**
+
+- <ChangelogBadge type="fixed" /> **Checkout Completed Event For All Methods**  
+  The `checkoutSdk_completed` event is now emitted for every payment method that completes through the shared payment-action router (card, Google Pay, APMs), matching the existing Apple Pay and PayPal behavior. It fires once per checkout.
+
+**Revolut Pay**
+
+- <ChangelogBadge type="added" /> **Revolut Pay Support**  
+  Adds Revolut Pay as an external payment button. Supports both seamless and merchant-driven checkout flows, with a configurable button (variant, size, radius, action, and locale).
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Fixed Slim Variant Card Form Styles**  
+  Fixed an issue in SDK 1.9 where the slim input variant rendered incorrectly in the card form and address fields: grouped border radius, focus and error border colors, and hidden inline error messages were not applied.
+
 ## v1.9.1
 *June 3, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.2`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.2

4 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or API changes in this repository.
> 
> **Overview**
> **Documents Web SDK v1.9.2** (June 11, 2026) by prepending a new release block to `changelog/source/web.json` and adding the matching **v1.9.2** section at the top of `changelog/web.mdx`.
> 
> The new entries cover **stronger phone/document validation** (real-time rollout), **`checkoutSdk_completed` for all payment methods** routed through the shared payment-action router, **Revolut Pay** as a configurable external button, and a **slim card-form styling fix** (border radius, focus/error borders, inline errors). The JSON block also records upgrade npm snippet and consumed tickets (CORECM-17143, CORECM-17218, CORECM-17717, CORECM-17739, CORECM-17779).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ab7d118b3ff965f62abdb6749bca2d3966323b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->