### PR TITLE
Update iOS SDK release notes for version 2.18.0

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.18.0
+*June 12, 2026*
+
+- <ChangelogBadge type="added" /> **Headless Resume Card Payment**  
+  Introduced a new method to resume a server-side created card payment, handle remaining actions such as post-3DS challenge, and deliver results through a closure.
+
 ## v2.17.2
 *June 10, 2026*
 

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -19,7 +19,7 @@
       "entries": [
         {
           "type": "ADDED",
-          "title": "Resume Card Payment",
+          "title": "Headless Resume Card Payment",
           "description": "Introduced a new method to resume a server-side created card payment, handle remaining actions such as post-3DS challenge, and deliver results through a closure.",
           "group": null,
           "migration_guide": null,

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,32 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.18.0",
+      "release_date": "2026-06-12",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.18.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.18.0'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Resume Card Payment",
+          "description": "Introduced a new method to resume a server-side created card payment, handle remaining actions such as post-3DS challenge, and deliver results through a closure.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.17.2",
       "release_date": "2026-06-10",
       "upgrade": [


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.18.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or SDK code changes.
> 
> **Overview**
> Documents **iOS SDK v2.18.0** (June 12, 2026) in the public changelog and structured release source.
> 
> **v2.18.0** adds one **Headless Resume Card Payment** entry: a new API to resume server-side card payments, run follow-up steps (e.g. post-3DS), and return outcomes via a closure. `changelog/source/ios.json` also lists SPM and CocoaPods upgrade snippets pinned to `2.18.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5135e6fb65f3d98361dd57f108cc1a404f587a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->