### PR TITLE
Remove divider causing extra space and trim sentence in Step 6

### DIFF
--- a/docs/sdks/headless-ios/checkout.mdx
+++ b/docs/sdks/headless-ios/checkout.mdx
@@ -235,11 +235,9 @@ A payment with 3DS may require an additional challenge to check the customer's i
 
 To perform the challenge and finish the payment, use the following integration option:
 
----
-
 ### Complete the 3DS challenge
 
-To complete the 3DS challenge of a card payment you created from your server, call the `continueCardPayment` function on your Headless client. The SDK will retrieve the payment state, present the 3DS challenge to your customer, and report every payment status update back to you — you no longer need to fetch the challenge URL or build your own web view.
+To complete the 3DS challenge of a card payment you created from your server, call the `continueCardPayment` function on your Headless client. The SDK will retrieve the payment state, present the 3DS challenge to your customer, and report every payment status update back to you.
 
 <Note>
 `continueCardPayment` only supports `CARD` payments.


### PR DESCRIPTION
## PR Description
Minor fixes to Step 6 of the Headless iOS checkout guide, reported by Vivi Amezquita after reviewing the rendered page. Removes the horizontal rule that was causing a large visual gap before the "Complete the 3DS challenge" heading, and trims the trailing clause from the `continueCardPayment` intro sentence.

## Changes
- `docs/sdks/headless-ios/checkout.mdx` — removed `---` divider between the intro paragraph and the "Complete the 3DS challenge" subheading
- `docs/sdks/headless-ios/checkout.mdx` — removed "— you no longer need to fetch the challenge URL or build your own web view." from the `continueCardPayment` description sentence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and formatting in a single MDX file; no code or API behavior changes.
> 
> **Overview**
> **Step 6** of the Headless iOS checkout guide (`checkout.mdx`) is adjusted for how the page renders: the horizontal rule (`---`) before **Complete the 3DS challenge** is removed so the heading no longer sits below a large gap.
> 
> The intro to `continueCardPayment` is shortened by dropping the clause that said merchants no longer need to fetch the challenge URL or build their own web view; the rest of the Step 6 content is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1f04235bcd9ec31312f92ad3759853d26d69ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->