### PR TITLE
fix(headless-ios): minor wording fix in deprecation note

### DIFF
--- a/docs/sdks/headless-ios/checkout.mdx
+++ b/docs/sdks/headless-ios/checkout.mdx
@@ -287,7 +287,7 @@ The `onResult` closure can be called more than once: you will receive the interm
 <Warning>
 **Deprecated: `getThreeDSecureChallenge`**
 
-The `getThreeDSecureChallenge` method has been deprecated as of version 2.18.0. Use `continueCardPayment` instead.
+The `getThreeDSecureChallenge` method was deprecated in version 2.18.0. Use `continueCardPayment` instead.
 </Warning>
 
 ## Error handling


### PR DESCRIPTION
## PR Description
Minor wording fix in the deprecation note for `getThreeDSecureChallenge` in the Headless iOS checkout guide. Also serves to retrigger the Mintlify cache invalidation for this page, which failed on the previous deployment.

## Changes
- `docs/sdks/headless-ios/checkout.mdx` — changed "has been deprecated as of version 2.18.0" to "was deprecated in version 2.18.0"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy change with no runtime, API, or SDK behavior impact.
> 
> **Overview**
> Updates the **Deprecated: `getThreeDSecureChallenge`** warning in the Headless iOS checkout guide so it reads **"was deprecated in version 2.18.0"** instead of **"has been deprecated as of version 2.18.0"**. The migration guidance to use **`continueCardPayment`** is unchanged.
> 
> The edit is intended to retrigger Mintlify cache invalidation for this page after a failed deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f95e761c8f2202565c808f4a50aa6f57b5a8031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->