### PR TITLE
chore: vtex sdk changelog 4.2.307

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.307
+*June 11, 2026*
+
+- <ChangelogBadge type="added" /> **VTEX subscription (recurring) order support**  
+  Adds support for orders created with VTEX subscriptions. The first charge keeps the security code as today, while subsequent recurring charges are authorized without a security code and flagged to the gateway as stored-credential transactions, so automatic renewals no longer fail. Regular checkout is unchanged.
+
 ## v4.2.304
 *May 28, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.307",
+      "release_date": "2026-06-11",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.307",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "VTEX subscription (recurring) order support",
+          "description": "Adds support for orders created with VTEX subscriptions. The first charge keeps the security code as today, while subsequent recurring charges are authorized without a security code and flagged to the gateway as stored-credential transactions, so automatic renewals no longer fail. Regular checkout is unchanged.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.304",
       "release_date": "2026-05-28",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.307`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.307

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or application code changes.
> 
> **Overview**
> Documents **VTEX plugin release 4.2.307** (June 11, 2026) by prepending a new release block to `changelog/source/vtex.json` and adding the matching **v4.2.307** section at the top of `changelog/plugins/vtex.mdx`.
> 
> The entry describes **VTEX subscription (recurring) order support**: first subscription charge still uses the security code; later renewals authorize without CVV and are sent to the gateway as stored-credential transactions so auto-renewals succeed, with regular checkout unchanged. The JSON includes the `vtex install yunopartnerbr.yuno@4.2.307` upgrade snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba43a4e0e0dad52e54cd6fde7d8058fb596236e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->