### PR TITLE
docs(webhooks/subscriptions): correct subscription event names, retry cap/strategy, and renewal-charge behavior [OR-953, OR-970]

### DIFF
--- a/docs/payment-features/subscriptions/index.mdx
+++ b/docs/payment-features/subscriptions/index.mdx
@@ -87,7 +87,7 @@ In the response to the [Create Subscription](/reference/create-subscription) end
 
 ## Renewal events
 
-On each renewal cycle, `billing_cycles.current` increments, but NO `subscription.*` webhook fires for the charge itself. The `subscription.active` event fires only once, on initial activation — it is not re-emitted on renewals. The result of each renewal charge is signaled by a `payment.*` webhook tied to the subscription. Cycles billed at $0 (for example, a free trial or a 100% discount) generate no charge event by design.
+`subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewals, and no other `subscription.*` webhook fires for a renewal charge. Track each renewal via the per-cycle `payment.purchase` webhook (outcome in `status`/`sub_status`). `$0`/trial cycles generate no payment webhook by design.
 
 <Note>
 **`code` vs `id` mapping**

--- a/docs/payment-features/subscriptions/index.mdx
+++ b/docs/payment-features/subscriptions/index.mdx
@@ -84,3 +84,13 @@ If a payment from a subscription is declined (including the first payment attemp
 </Danger>
 
 In the response to the [Create Subscription](/reference/create-subscription) endpoint, you receive an `id` which is used to identify the created subscription. You will use the `id` if you decide to pause, resume, or cancel the subscription.
+
+## Renewal events
+
+On each renewal cycle, `billing_cycles.current` increments, but NO `subscription.*` webhook fires for the charge itself. The `subscription.active` event fires only once, on initial activation — it is not re-emitted on renewals. The result of each renewal charge is signaled by a `payment.*` webhook tied to the subscription. Cycles billed at $0 (for example, a free trial or a 100% discount) generate no charge event by design.
+
+<Note>
+**`code` vs `id` mapping**
+
+Subscription webhook payloads use `code` while the API uses `id`, and they are the same values: `subscription.code` equals the `id` returned from `POST /v1/subscriptions`, and `customer_payer.code` equals the customer `id`.
+</Note>

--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -22,11 +22,11 @@ Yuno uses a personalized approach for each unsuccessful payment, guided by conti
 | :---------- | :------------------------------- |
 | First try   | -                                |
 | Second try  | 5 minutes                        |
-| Third try   | 60 minutes                       |
-| Fourth try  | 5 hours                          |
+| Third try   | 5 hours                          |
+| Fourth try  | 12 hours                         |
 | Fifth try   | 24 hours                         |
-| Sixth try   | 48 hours                         |
-| Seventh try | 96 hours                         |
+| Sixth try   | 36 hours                         |
+| Seventh try | 48 hours                         |
 
 ### Customization
 
@@ -34,7 +34,17 @@ Every business model is unique, so we allow merchants to define specific rules t
 
 | Parameter          | Type   | Description                                                                                                                              | Example                            |
 | :----------------- | :----- | :--------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------- |
-| `retry_on_decline` | bool   | Indicates whether to retry a payment after a first decline. Defaults to false.                                                           | TRUE                               |
-| `amount`           | number | Specifies the number of retries the subscription plan will have to completion. If not set, or if higher than 6, the default is 6. Max: 6 | 4                                  |
-| `strategy`         | string | Identifier for the retry strategy used.                                                                                                  | `custom_schedule`                  |
+| `retry_on_decline` | bool   | Indicates whether to retry a payment after a first decline. Defaults to false. This flag is the only switch that enables retries; there is no dashboard toggle. | TRUE |
+| `amount`           | number | Number of retries the subscription will attempt. The maximum equals your environment's configured retry schedule length — 6 in production. Values above the cap are clamped to it. This cap is set per environment and is not configurable per account via the API. | 4 |
+| `strategy`         | string | The retry strategy. Allowed values: DEFAULT and CUSTOM_SCHEDULE. DEFAULT uses the fixed schedule below (NOT ML-based timing). CUSTOM_SCHEDULE uses the per-attempt schedule you provide. | `CUSTOM_SCHEDULE` |
+| `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. The subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. | TRUE |
 | `schedule`         | object | Contains attempt and delay\_seconds fields                                                                                               | Attempt: 2, `delay_seconds`: 86400 |
+
+
+<Note>
+The maximum number of retries equals your environment's configured retry schedule length: 6 in production. Sandbox is currently limited to 5 and is being aligned to match production.
+</Note>
+
+<Note>
+`strategy`: `DEFAULT` applies the fixed schedule above, not ML-based timing. Use `CUSTOM_SCHEDULE` together with the `schedule` array to define custom delays.
+</Note>

--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -204,7 +204,7 @@ Depending on the type of event, you will receive a different type of webhook and
 | banking.transfer.incoming | pending |
 | banking.transfer.incoming | completed |
 
-> `subscription.active` is sent only on the FIRST transition into `ACTIVE`. It is NOT re-emitted on renewal cycles while the subscription is already `ACTIVE`. Each renewal charge is delivered as a `payment.*` webhook, and there is no `subscription.error` event currently emitted.
+> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none. There is no `subscription.error` event currently emitted.
 
 ### Fraud Screening Webhook Behavior
 

--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -158,11 +158,11 @@ Depending on the type of event, you will receive a different type of webhook and
 | payout       | payout           |
 | subscription | create           |
 | subscription | active           |
-| subscription | paused           |
-| subscription | resumed          |
-| subscription | canceled         |
-| subscription | completed        |
-| subscription | error            |
+| subscription | pause            |
+| subscription | resume           |
+| subscription | cancel           |
+| subscription | complete         |
+| subscription | close\_to\_renewal |
 | onboarding   | create           |
 | onboarding   | pending          |
 | onboarding   | pending\_additional\_documentation |
@@ -204,7 +204,7 @@ Depending on the type of event, you will receive a different type of webhook and
 | banking.transfer.incoming | pending |
 | banking.transfer.incoming | completed |
 
-> `subscription.active` is sent only when a subscription transitions from any other valid status into `ACTIVE`. No webhook is emitted if the subscription is already active.
+> `subscription.active` is sent only on the FIRST transition into `ACTIVE`. It is NOT re-emitted on renewal cycles while the subscription is already `ACTIVE`. Each renewal charge is delivered as a `payment.*` webhook, and there is no `subscription.error` event currently emitted.
 
 ### Fraud Screening Webhook Behavior
 

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -39,14 +39,19 @@ Yuno sends event notifications for various activities within the payment ecosyst
 
 ### Subscription events
 
-| Event                    | Description                                                                 |
-| ------------------------ | --------------------------------------------------------------------------- |
-| `subscription.create`    | Sent when a subscription is first created.                                   |
-| `subscription.active`    | Sent when a subscription transitions to the `ACTIVE` status.                |
-| `subscription.paused`    | Sent when a subscription is paused.                                         |
-| `subscription.canceled`  | Sent when a subscription is canceled.                                       |
-| `subscription.completed` | Sent when a subscription reaches its end date or total billing cycles.      |
-| `subscription.error`     | Sent when an error occurs during subscription processing or payment attempt. |
+| Event                           | Description                                                                                                            |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `subscription.create`           | Sent when a subscription is first created.                                                                            |
+| `subscription.active`           | Sent only when a subscription first transitions into `ACTIVE`. It does NOT re-fire on renewals while already `ACTIVE`. |
+| `subscription.pause`            | Sent when a subscription is paused.                                                                                  |
+| `subscription.resume`           | Sent when a paused subscription is resumed.                                                                          |
+| `subscription.cancel`           | Sent when a subscription is canceled. Once canceled it is terminated and cannot be reactivated.                      |
+| `subscription.complete`         | Sent when a subscription reaches its end date or total billing cycles and transitions to `COMPLETED`.               |
+| `subscription.close_to_renewal` | Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification_days`.                             |
+
+<Note>
+The renewal charge is not signaled by a subscription webhook — each rebill arrives as a `payment.*` webhook tied to the subscription — and there is currently no `subscription.error` event.
+</Note>
 
 ### Enrollment events
 

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -42,7 +42,7 @@ Yuno sends event notifications for various activities within the payment ecosyst
 | Event                           | Description                                                                                                            |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `subscription.create`           | Sent when a subscription is first created.                                                                            |
-| `subscription.active`           | Sent only when a subscription first transitions into `ACTIVE`. It does NOT re-fire on renewals while already `ACTIVE`. |
+| `subscription.active`           | Sent once, when the subscription first becomes active (at `billing_cycles.current` = 2). Not re-sent on subsequent renewal cycles. |
 | `subscription.pause`            | Sent when a subscription is paused.                                                                                  |
 | `subscription.resume`           | Sent when a paused subscription is resumed.                                                                          |
 | `subscription.cancel`           | Sent when a subscription is canceled. Once canceled it is terminated and cannot be reactivated.                      |
@@ -50,7 +50,7 @@ Yuno sends event notifications for various activities within the payment ecosyst
 | `subscription.close_to_renewal` | Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification_days`.                             |
 
 <Note>
-The renewal charge is not signaled by a subscription webhook — each rebill arrives as a `payment.*` webhook tied to the subscription — and there is currently no `subscription.error` event.
+Each renewal charge is delivered as a `payment.purchase` webhook tied to the subscription, with the outcome (success or decline) carried in the `status`/`sub_status` fields. `$0`/trial cycles emit no payment webhook, and there is currently no `subscription.error` event.
 </Note>
 
 ### Enrollment events

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1637,11 +1637,11 @@ Sent when a subscription reaches its end date or total billing cycles and transi
 ### Renewal charges and failures (no `subscription.error`)
 
 <Warning>
-There is **no `subscription.error` webhook**. Yuno does not emit a subscription event when a renewal charge fails. Renewal-charge outcomes — successful rebills and failed/declined attempts — are delivered as `payment.*` webhooks tied to the subscription. Subscribe to the relevant `payment.*` events to track renewal results.
+There is **no `subscription.error` webhook**. Yuno does not emit a subscription event when a renewal charge fails. Renewal-charge outcomes — successful rebills and failed/declined attempts — are delivered as `payment.purchase` webhooks tied to the subscription, with the result carried in the `status`/`sub_status` fields. Subscribe to `payment.purchase` to track renewal results. `$0`/trial cycles emit no payment webhook.
 </Warning>
 
 <Note>
-The renewal **charge** itself is always signaled by a payment webhook, never by a subscription webhook. The `payments` array inside the subscription object is currently always empty in webhook payloads.
+The renewal **charge** itself is always signaled by a `payment.purchase` webhook, never by a subscription webhook. The `payments` array inside the subscription object is currently always empty in webhook payloads. `subscription.active` is sent once (at `billing_cycles.current` = 2), not on every renewal.
 </Note>
 
 ## Onboardings

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1547,14 +1547,14 @@ Sent when a subscription transitions from any other valid status into `ACTIVE`. 
 }
 ```
 
-### subscription.paused
+### subscription.pause
 
 Sent when a subscription is paused. Use this event to update the status in your system and pause related services.
 
 ```json JSON
 {
   "type": "subscription",
-  "type_event": "subscription.paused",
+  "type_event": "subscription.pause",
   "account_id": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
   "retry": 0,
   "version": 2,
@@ -1576,14 +1576,14 @@ Sent when a subscription is paused. Use this event to update the status in your 
 }
 ```
 
-### subscription.canceled
+### subscription.cancel
 
 Sent when a subscription is canceled. Once canceled, the subscription is terminated and cannot be reactivated.
 
 ```json JSON
 {
   "type": "subscription",
-  "type_event": "subscription.canceled",
+  "type_event": "subscription.cancel",
   "account_id": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
   "retry": 0,
   "version": 2,
@@ -1605,14 +1605,14 @@ Sent when a subscription is canceled. Once canceled, the subscription is termina
 }
 ```
 
-### subscription.completed
+### subscription.complete
 
 Sent when a subscription reaches its end date or total billing cycles and transitions to the `COMPLETED` status.
 
 ```json JSON
 {
   "type": "subscription",
-  "type_event": "subscription.completed",
+  "type_event": "subscription.complete",
   "account_id": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
   "retry": 0,
   "version": 2,
@@ -1634,34 +1634,15 @@ Sent when a subscription reaches its end date or total billing cycles and transi
 }
 ```
 
-### subscription.error
+### Renewal charges and failures (no `subscription.error`)
 
-Sent when an error occurs during subscription processing.
+<Warning>
+There is **no `subscription.error` webhook**. Yuno does not emit a subscription event when a renewal charge fails. Renewal-charge outcomes — successful rebills and failed/declined attempts — are delivered as `payment.*` webhooks tied to the subscription. Subscribe to the relevant `payment.*` events to track renewal results.
+</Warning>
 
-```json JSON
-{
-  "type": "subscription",
-  "type_event": "subscription.error",
-  "account_id": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
-  "retry": 0,
-  "version": 2,
-  "data": {
-    "subscription": {
-      "code": "e98ef674-9baa-4f7a-8da4-4c812c4749a4",
-      "name": "Subscription",
-      "status": "ERROR",
-      "amount": {
-        "currency": "COP",
-        "type": "FIXED",
-        "value": 36000
-      },
-      "customer_payer": {
-        "code": "a9f9140a-1216-481c-8356-1a125078f905"
-      }
-    }
-  }
-}
-```
+<Note>
+The renewal **charge** itself is always signaled by a payment webhook, never by a subscription webhook. The `payments` array inside the subscription object is currently always empty in webhook payloads.
+</Note>
 
 ## Onboardings
 

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -346,7 +346,11 @@
                       },
                       "strategy": {
                         "type": "string",
-                        "description": "description of the scheduele strategy"
+                        "description": "The retry strategy. Allowed values: DEFAULT (the fixed retry schedule; not ML-based timing) or CUSTOM_SCHEDULE (uses the per-attempt schedule array you provide).",
+                        "enum": [
+                          "DEFAULT",
+                          "CUSTOM_SCHEDULE"
+                        ]
                       },
                       "schedule": {
                         "type": "array",
@@ -367,7 +371,7 @@
                       },
                       "stop_on_hard_decline": {
                         "type": "boolean",
-                        "description": "Flag to define if the retry schedule should stop after a hard retry. "
+                        "description": "When true, the retry schedule stops for the current billing cycle after a hard decline. The subscription remains ACTIVE and billing advances to the next cycle; no subscription is canceled or paused and no subscription webhook is emitted."
                       }
                     }
                   },

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -273,7 +273,7 @@ This object represents a subscription that can be associated with a customer.
     </ParamField>
 
     <ParamField body="amount" type="number">
-      The number of retries that the subscription plan will have to completion. If not set, or higher than 7, 7 will be defined as default. Max: 7
+      The number of retries that the subscription plan will have to completion. The maximum equals your environment's configured retry schedule length (6 in production). Values above the cap are clamped to it. Max: 6
 
       Example: 4
     </ParamField>
@@ -306,6 +306,10 @@ This object represents a subscription that can be associated with a customer.
 
 <ParamField body="payments" type="Array of strings">
   Specifies the payments array.
+
+  <Note>
+    This array is currently always empty in webhook payloads. Subscribe to `payment.*` webhooks to track charges.
+  </Note>
 
   <Expandable title="properties">
     <ParamField body="id*" type="string">


### PR DESCRIPTION
## Summary

Corrects subscription-webhook and retry documentation to match backend behavior. All facts were verified against `subscription-ms` / `organization-webhook-ms` source and the live Kingdom `RETRY_TIMES` config (prod = 6 entries, sandbox = 5 — sandbox drift to be aligned separately under **OR-953**).

> **⚠️ Needs docs-team review before merge.**

### Event names (canonical present-tense)
- Standardized subscription events to: `subscription.create`, `subscription.active`, `subscription.pause`, `subscription.resume`, `subscription.cancel`, `subscription.complete`, `subscription.close_to_renewal`.
- Fixed past/incorrect tenses (`paused`/`canceled`/`completed`/`resumed`) in the overview table, the event-types table, and the example `type_event` strings + section headings in `object-and-examples.mdx`.

### Removal of the never-emitted `subscription.error`
- `subscription.error` is **never emitted** by the backend. Removed it from the overview table and the event-types table, and replaced its example section with a clear "Renewal charges and failures (no `subscription.error`)" warning.

### Renewal / payment-webhook behavior
- Renewal charges are signaled by `payment.*` webhooks, **not** subscription webhooks. Added notes across `index.mdx`, `configure-webhooks.mdx`, `object-and-examples.mdx`, and the subscriptions overview.
- `subscription.active` fires **only** on the first transition into `ACTIVE`; it does not re-fire on renewals while already `ACTIVE`.
- Documented that the subscription `payments` array is currently always empty in webhook payloads.
- `$0` cycles (free trial / 100% discount) emit no charge event by design.

### Retries: cap, strategy, and schedule cadence
- **Cap = 6 in production** (equals the env's configured `RETRY_TIMES` length; sandbox currently 5, being aligned). Corrected the reference object (`Max: 7` → `Max: 6`) and the retries parameter table.
- **`strategy`**: documented allowed values `DEFAULT` (fixed schedule, **not** ML-based) and `CUSTOM_SCHEDULE`; added the enum in the OpenAPI spec.
- **`stop_on_hard_decline`**: documented behavior — halts retries for the current cycle only; subscription stays `ACTIVE`, advances to next cycle; no cancel/pause and no subscription webhook.
- **`retry_on_decline`**: clarified it is the only switch enabling retries (no dashboard toggle).
- **Schedule cadence fix**: corrected the default retry schedule to the actual production cadence — 5 min / 5 h / 12 h / 24 h / 36 h / 48 h (was 5 min / 60 min / 5 h / 24 h / 48 h / 96 h).

### `code` vs `id` mapping
- Documented that webhook payloads use `code` while the API uses `id`, and they are the same values: `subscription.code` == `POST /v1/subscriptions` `id`, and `customer_payer.code` == the customer `id`.

### Tickets
Refs **OR-953** and **OR-970**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI description changes only; no application code or runtime behavior is modified.
> 
> **Overview**
> Aligns **subscription webhook** and **retry** documentation with verified backend behavior (docs, OpenAPI, and reference only).
> 
> **Subscription webhooks:** Event names are standardized to present-tense forms (`subscription.pause`, `resume`, `cancel`, `complete`) and **`subscription.close_to_renewal`** is added to overview and configure tables. **`subscription.error`** is removed everywhere; examples and headings use the corrected `type_event` strings. Docs now state that **`subscription.active` fires once** (first activation at `billing_cycles.current` = 2), renewals are tracked via **`payment.purchase`** (`status`/`sub_status`), **`$0`/trial cycles** emit no payment webhook, and webhook **`code`** fields map to API **`id`**.
> 
> **Retries:** Default schedule cadence is updated to **5 min → 5 h → 12 h → 24 h → 36 h → 48 h**; max retries are **6 in production** (reference was Max 7). **`strategy`** documents `DEFAULT` vs `CUSTOM_SCHEDULE` (fixed schedule, not ML) with OpenAPI enum; **`stop_on_hard_decline`**, **`retry_on_decline`**, and sandbox vs prod cap notes are expanded.
> 
> **Reference:** Subscription object `payments` array note points integrators to **`payment.*`** webhooks for charges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf840aed5499ce18ab60ca4610c9b5b0bad7c6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->