### PR TITLE
chore: web sdk changelog 1.9.4

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,36 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.4",
+      "release_date": "2026-06-15",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Prepend the configured whitelabel base path to host-overridden asset, iframe and WebSocket URLs so the SDK stays under a proxy mounted at a sub-path (e.g. `.../orchestrator`) instead of dropping to the bare origin. The 3DS postMessage origin opts out.",
+          "description": "",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Revolut Pay Mobile Return Support",
+          "description": "Revolut Pay now returns shoppers to the checkout reliably on mobile after the redirect or app-to-app handoff.",
+          "group": "Revolut Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17664",
+        "CORECM-17807"
+      ]
+    },
+    {
       "version": "1.9.2",
       "release_date": "2026-06-11",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -13,7 +13,7 @@
           "type": "CHANGED",
           "title": "Prepend the configured whitelabel base path to host-overridden asset, iframe and WebSocket URLs so the SDK stays under a proxy mounted at a sub-path (e.g. `.../orchestrator`) instead of dropping to the bare origin. The 3DS postMessage origin opts out.",
           "description": "",
-          "group": null,
+          "group": "Core SDK",
           "migration_guide": null,
           "links": []
         },

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,17 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.4
+*June 15, 2026*
+
+- <ChangelogBadge type="changed" /> **Prepend the configured whitelabel base path to host-overridden asset, iframe and WebSocket URLs so the SDK stays under a proxy mounted at a sub-path (e.g. `.../orchestrator`) instead of dropping to the bare origin. The 3DS postMessage origin opts out.**  
+  
+
+**Revolut Pay**
+
+- <ChangelogBadge type="added" /> **Revolut Pay Mobile Return Support**  
+  Revolut Pay now returns shoppers to the checkout reliably on mobile after the redirect or app-to-app handoff.
+
 ## v1.9.2
 *June 11, 2026*
 
@@ -16,7 +27,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 **Payment Actions**
 
 - <ChangelogBadge type="fixed" /> **Checkout Completed Event For All Methods**  
-  The `checkoutSdk_completed` event is now emitted for every payment method that completes through the shared payment-action router (card, Google Pay, APMs), matching the existing Apple Pay and PayPal behavior. It fires once per checkout.
+  The checkoutSdk_completed event is now emitted for every payment method that completes through the shared payment-action router (card, Google Pay, APMs), matching the existing Apple Pay and PayPal behavior. It fires once per checkout.
 
 **Revolut Pay**
 

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -8,6 +8,8 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 ## v1.9.4
 *June 15, 2026*
 
+**Core SDK**
+
 - <ChangelogBadge type="changed" /> **Prepend the configured whitelabel base path to host-overridden asset, iframe and WebSocket URLs so the SDK stays under a proxy mounted at a sub-path (e.g. `.../orchestrator`) instead of dropping to the bare origin. The 3DS postMessage origin opts out.**  
   
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.4`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.4

2 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or API code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.4** (June 15, 2026) by adding a new release block to `changelog/source/web.json` and a matching **v1.9.4** section at the top of `changelog/web.mdx`, including the `npm install @yuno-payments/sdk-web@1.9.4` upgrade snippet and tickets CORECM-17664 / CORECM-17807.
> 
> The release notes cover a **Core SDK** change for whitelabel/proxy setups: host-overridden asset, iframe, and WebSocket URLs now prepend the configured base path so traffic stays under a sub-path proxy (3DS postMessage origin excluded). **Revolut Pay** adds mobile return support after redirect or app handoff.
> 
> `web.mdx` also drops backticks around `checkoutSdk_completed` in the older v1.9.2 Payment Actions bullet (formatting only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0618daa986dc5e580efa87a04e10ca69217c8fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->