### PR TITLE
Remove outdated subscription.error note and update event types intro

### DIFF
--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -139,7 +139,7 @@ Yuno webhooks expect to receive an HTTP 200 OK status as a response to indicate 
 
 ## Webhooks event types
 
-Depending on the type of event, you will receive a different type of webhook and event. The next table presents the possible event types for enrollments and payments currently available.
+Depending on the type of event, you will receive a different type of webhook and event. The next table presents the possible event types currently available.
 
 | type         | type\_event      |
 | :----------- | :--------------- |
@@ -204,7 +204,7 @@ Depending on the type of event, you will receive a different type of webhook and
 | banking.transfer.incoming | pending |
 | banking.transfer.incoming | completed |
 
-> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none. There is no `subscription.error` event currently emitted.
+> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none.
 
 ### Fraud Screening Webhook Behavior
 


### PR DESCRIPTION
## PR Description
Removes a note in the Webhooks event types section that documented a non-existent event (subscription.error), and updates the section's intro text which incorrectly limited the scope to "enrollments and payments" when the table covers many more event categories. Requested by Caio.

## Changes

- docs/webhooks/configure-webhooks.mdx: removed trailing sentence "There is no subscription.error event currently emitted." from the subscription.active callout
- docs/webhooks/configure-webhooks.mdx: updated intro text to remove "for enrollments and payments" so it no longer misrepresents the scope of the event types table

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API behavior changes.
> 
> **Overview**
> Updates **Configure Webhooks** so the event-types section matches the full table and drops a redundant disclaimer.
> 
> The intro no longer says event types are only for enrollments and payments; it now states they are the types **currently available**, which matches subscription, onboarding, banking, and other rows in the same table.
> 
> The `subscription.active` callout keeps the same behavior notes (one-time active event, renewals as `payment.purchase`, no webhooks on `$0`/trial cycles) but removes the extra sentence that there is no `subscription.error` event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9dae569f7a1a3a7c39e75eb16c0f0e824de9091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->