### PR TITLE
Revert "Remove outdated subscription.error note and update event types intro"

### DIFF
--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -139,7 +139,7 @@ Yuno webhooks expect to receive an HTTP 200 OK status as a response to indicate 
 
 ## Webhooks event types
 
-Depending on the type of event, you will receive a different type of webhook and event. The next table presents the possible event types currently available.
+Depending on the type of event, you will receive a different type of webhook and event. The next table presents the possible event types for enrollments and payments currently available.
 
 | type         | type\_event      |
 | :----------- | :--------------- |
@@ -204,7 +204,7 @@ Depending on the type of event, you will receive a different type of webhook and
 | banking.transfer.incoming | pending |
 | banking.transfer.incoming | completed |
 
-> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none.
+> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none. There is no `subscription.error` event currently emitted.
 
 ### Fraud Screening Webhook Behavior
 


### PR DESCRIPTION
Reverts yuno-payments/yuno-docs#484

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only revert with no runtime or API behavior changes.
> 
> **Overview**
> Reverts documentation edits from yuno-payments/yuno-docs#484 in **Configure Webhooks**.
> 
> The **Webhooks event types** intro again scopes the table to **enrollments and payments** (“for enrollments and payments currently available”) instead of the generic “currently available” wording.
> 
> The **`subscription.active`** callout again states that **no `subscription.error` event is currently emitted**, alongside the existing renewal/`payment.purchase` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ab14548f3b24ea735abcf14667de738b88ebe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->