### PR TITLE
Revert "Revert "Remove outdated subscription.error note and update event types intro""

### DIFF
--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -139,7 +139,7 @@ Yuno webhooks expect to receive an HTTP 200 OK status as a response to indicate 
 
 ## Webhooks event types
 
-Depending on the type of event, you will receive a different type of webhook and event. The next table presents the possible event types for enrollments and payments currently available.
+Depending on the type of event, you will receive a different type of webhook and event. The next table presents the possible event types currently available.
 
 | type         | type\_event      |
 | :----------- | :--------------- |
@@ -204,7 +204,7 @@ Depending on the type of event, you will receive a different type of webhook and
 | banking.transfer.incoming | pending |
 | banking.transfer.incoming | completed |
 
-> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none. There is no `subscription.error` event currently emitted.
+> `subscription.active` is sent once, when the subscription first becomes active (at `billing_cycles.current` = 2); it is not re-sent on subsequent renewal cycles. Each renewal charge is delivered as a `payment.purchase` webhook (outcome in `status`/`sub_status`); `$0`/trial cycles emit none.
 
 ### Fraud Screening Webhook Behavior
 


### PR DESCRIPTION
Reverts yuno-payments/yuno-docs#485

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in configure-webhooks; no runtime or API behavior changes.
> 
> **Overview**
> Updates **`docs/webhooks/configure-webhooks.mdx`** so the event-types section matches the full webhook catalog instead of calling out only enrollments and payments.
> 
> The intro under **Webhooks event types** now says the table lists event types **currently available** (removed the enrollments/payments-only wording). The callout after **`subscription.active`** no longer states that **`subscription.error`** is not emitted; the rest of that note (one-time `subscription.active`, renewals as `payment.purchase`, `$0`/trial cycles) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35469d81fa47fcd3af8d27002159fa923dc05ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->