### PR TITLE
chore: web sdk changelog 1.9.5

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.5",
+      "release_date": "2026-06-15",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Card Field Console Error",
+          "description": "The card form no longer throws an uncaught error when entering a card whose network does not require a card PIN.",
+          "group": "Secure Fields",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-5074"
+      ]
+    },
+    {
       "version": "1.9.4",
       "release_date": "2026-06-15",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.5
+*June 15, 2026*
+
+**Secure Fields**
+
+- <ChangelogBadge type="fixed" /> **Fixed Card Field Console Error**  
+  The card form no longer throws an uncaught error when entering a card whose network does not require a card PIN.
+
 ## v1.9.4
 *June 15, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.5`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/13.0.6

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync; no runtime or integration code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.5** (June 15, 2026) in the docs changelog by adding a new release at the top of `changelog/source/web.json` and a matching **v1.9.5** section in `changelog/web.mdx`.
> 
> The only noted change is a **Secure Fields** fix: the card form no longer throws an uncaught console error when the shopper enters a card on a network that does not require a card PIN (ticket YSHUB-5074). Upgrade snippet: `npm install @yuno-payments/sdk-web@1.9.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d0a4b26ca19ef64f8686ccb90808ad905cd875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->