### PR TITLE
Document body params in update-routing PATCH endpoint

### DIFF
--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -19,21 +19,6 @@
           { "name": "routing_id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } },
           { "name": "X-Idempotency-Key", "in": "header", "required": true, "schema": { "type": "string", "format": "uuid" } }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": { "type": "string", "example": "Updated Card routing" },
-                  "default_route": { "type": "object" },
-                  "condition_sets": { "type": "array", "items": { "type": "object" } }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "OK",

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -14,6 +14,64 @@ Replaces the routing's full configuration. The body has the same shape as [Creat
   The id returned by [Create a Routing](/reference/organizations/routing/create-routing).
 </ParamField>
 
+### Body
+
+<ParamField body="name" type="string" required>
+  Free-form label.
+</ParamField>
+
+<ParamField body="default_route" type="object" required>
+  The route used when no `condition_sets[]` matches.
+  <Expandable title="properties">
+    <ParamField body="steps" type="object[]" required>
+      Each step is one provider attempt. `index` values are contiguous starting at 1.
+      <Expandable title="item">
+        <ParamField body="index" type="integer" required>
+            Step ordinal.
+        </ParamField>
+        <ParamField body="provider_id" type="string" required>
+            Must match the provider of the connection.
+        </ParamField>
+        <ParamField body="connection_id" type="UUID" required>
+            Must be `ACTIVE` and support the `payment_method`.
+        </ParamField>
+        <ParamField body="output" type="object[]">
+          Defines how to handle each possible outcome of this step.
+          <Expandable title="item">
+            <ParamField body="status" type="string" required>
+              The outcome status that triggers this rule (e.g., `APPROVED`, `DECLINED`, `DECLINE_GROUP`, `TIMEOUT`, `INTERNAL_ERROR`).
+            </ParamField>
+            <ParamField body="decline_types" type="string[]">
+              Required when `status` is `DECLINE_GROUP`. Specifies which decline subtypes trigger this rule (e.g., `INSUFFICIENT_FUNDS`, `DECLINED_BY_BANK`).
+            </ParamField>
+            <ParamField body="next" type="integer">
+              The `index` of the next step to execute. Omit if no fallback is needed.
+            </ParamField>
+          </Expandable>
+        </ParamField>
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="condition_sets" type="object[]">
+  Optional. Ordered by `sort_number` — first matching set wins.
+  <Expandable title="item">
+    <ParamField body="sort_number" type="integer" required>
+        Priority of the condition set.
+    </ParamField>
+    <ParamField body="name" type="string" required>
+        Label for the set.
+    </ParamField>
+    <ParamField body="conditions" type="object[]" required>
+        List of [Conditions](/reference/organizations/routing/routing-conditions) that must match.
+    </ParamField>
+    <ParamField body="route" type="object" required>
+        The steps to execute if this set matches.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
 ### Response
 
 <ResponseField name="id" type="string">


### PR DESCRIPTION
## PR Description

Fixes a gap reported by Jairo (2026-06-16) where the Update Routing (PATCH) endpoint had no body parameters documented, leaving condition_sets and default_route objects unexplained. Added a full ### Body section with nested ParamField components matching the manual documentation pattern already used in create-routing.mdx. The shallow requestBody in the OpenAPI spec was removed to avoid a duplicate Body section in the rendered page.

## Changes:

- reference/organizations/routing/update-routing.mdx — Added ### Body section with ParamField components for name, default_route (with full nested steps/output structure), and condition_sets (with sort_number, name, conditions, route).
- openapi/organizations/routing/update-routing.json — Removed shallow requestBody definition to prevent Mintlify from rendering a duplicate auto-generated Body section alongside the manual one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX and OpenAPI; no runtime or API behavior changes.
> 
> **Overview**
> **Documents the Update Routing `PATCH` request body** that was previously missing, so `name`, `default_route` (steps, `output` rules), and `condition_sets` are explained on the reference page.
> 
> Adds a manual **### Body** section in `update-routing.mdx` with nested `ParamField` / `Expandable` blocks aligned with **Create a Routing**, and removes the shallow `requestBody` from `update-routing.json` so Mintlify does not render a second, auto-generated Body section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea6f34f895ed57cf75713cacaf7ab247206115c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->