### PR TITLE
fix(routing): add account_id to create-routing OpenAPI schema

### DIFF
--- a/openapi/organizations/routing/create-routing.json
+++ b/openapi/organizations/routing/create-routing.json
@@ -24,8 +24,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["payment_method", "name", "default_route"],
+                "required": ["account_id", "payment_method", "name", "default_route"],
                 "properties": {
+                  "account_id": { "type": "string", "format": "uuid", "example": "7825fc5e-e50a-4248-9ae8-5d3786afb0be" },
                   "payment_method": { "type": "string", "example": "CARD" },
                   "name": { "type": "string", "example": "Card routing" },
                   "default_route": {


### PR DESCRIPTION
account_id was missing from the requestBody schema, causing the auto-generated cURL example to omit this required parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI documentation-only change with no application or runtime behavior impact.
> 
> **Overview**
> Aligns the **Create Routing** OpenAPI `requestBody` with the real API by documenting **`account_id`** as a required UUID field on the JSON body.
> 
> Adds `account_id` to the schema `required` array and defines it under `properties` with a UUID format and example, so generated docs and cURL samples include the parameter that was previously omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd6fdd62b5efb14e7361b9dc4c6b13c155e163ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->