### PR TITLE
Add subscription.resume and subscription.close_to_renewal payload examples

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1730,10 +1730,6 @@ Sent when a subscription reaches its end date or total billing cycles and transi
 
 Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification_days` on the subscription.
 
-<Note>
-This payload is code-derived. The `renewal_notification_days` field (set to `3` in this example) is what triggers the event — it has not yet fired in production as of June 2026.
-</Note>
-
 ```json JSON
 {
   "type": "subscription",

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1576,6 +1576,98 @@ Sent when a subscription is paused. Use this event to update the status in your 
 }
 ```
 
+### subscription.resume
+
+Sent when a paused subscription is resumed and transitions back to the `ACTIVE` status.
+
+```json JSON
+{
+  "type": "subscription",
+  "type_event": "subscription.resume",
+  "account_id": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
+  "retry": 0,
+  "version": 2,
+  "data": {
+    "subscription": {
+      "code": "e98ef674-9baa-4f7a-8da4-4c812c4749a4",
+      "name": "Monthly Plan",
+      "description": "Monthly subscription",
+      "country": "US",
+      "account_code": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
+      "merchant_reference": "subscription-ref-merchant-002",
+      "status": "ACTIVE",
+      "amount": {
+        "currency": "USD",
+        "type": "FIXED",
+        "value": 42.46
+      },
+      "frequency": {
+        "type": "MONTH",
+        "value": 1,
+        "monthly_billing_day": null,
+        "execution": "YUNO"
+      },
+      "billing_date": null,
+      "billing_cycles": {
+        "total": null,
+        "current": 2,
+        "next_at": "2026-07-14T19:19:31.914Z"
+      },
+      "customer_payer": {
+        "code": "a9f9140a-1216-481c-8356-1a125078f905"
+      },
+      "payment_method": {
+        "type": "CARD",
+        "vaulted_token": "4ba74a56-14d4-4161-a0ba-8036e9b8abf6",
+        "card": {
+          "installments": null,
+          "network_transaction_id": "000000000000000",
+          "usage": "USED"
+        }
+      },
+      "availability": {
+        "start_at": "2026-06-14T19:19:31.914Z",
+        "finish_at": null
+      },
+      "retries": {
+        "retry_on_decline": true,
+        "amount": 4,
+        "strategy": "DEFAULT",
+        "schedule": null,
+        "stop_on_hard_decline": null
+      },
+      "metadata": [
+        {
+          "key": "plan_id",
+          "value": "monthly_plan"
+        }
+      ],
+      "additional_data": null,
+      "payments": [],
+      "trial_period": {
+        "billing_cycles": 1,
+        "amount": {
+          "currency": null,
+          "value": null
+        }
+      },
+      "initial_payment_validation": false,
+      "provider_subscription_id": null,
+      "reason": null,
+      "subscription_agreement_id": null,
+      "soft_descriptor": null,
+      "renewal_notification_days": null,
+      "cancellation_time": null,
+      "cancellation_source": null,
+      "ending_time": null,
+      "created_at": "2026-05-14T19:19:32.117629Z",
+      "updated_at": "2026-06-15T07:11:52.504031Z",
+      "history": null
+    }
+  }
+}
+```
+
 ### subscription.cancel
 
 Sent when a subscription is canceled. Once canceled, the subscription is terminated and cannot be reactivated.
@@ -1629,6 +1721,102 @@ Sent when a subscription reaches its end date or total billing cycles and transi
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       }
+    }
+  }
+}
+```
+
+### subscription.close_to_renewal
+
+Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification_days` on the subscription.
+
+<Note>
+This payload is code-derived. The `renewal_notification_days` field (set to `3` in this example) is what triggers the event — it has not yet fired in production as of June 2026.
+</Note>
+
+```json JSON
+{
+  "type": "subscription",
+  "type_event": "subscription.close_to_renewal",
+  "account_id": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
+  "retry": 0,
+  "version": 2,
+  "data": {
+    "subscription": {
+      "code": "e98ef674-9baa-4f7a-8da4-4c812c4749a4",
+      "name": "Monthly Plan",
+      "description": "Monthly subscription",
+      "country": "US",
+      "account_code": "c24d6c92-99a7-40bb-bc7b-efc40337f9f4",
+      "merchant_reference": "subscription-ref-merchant-002",
+      "status": "ACTIVE",
+      "amount": {
+        "currency": "USD",
+        "type": "FIXED",
+        "value": 42.46
+      },
+      "frequency": {
+        "type": "MONTH",
+        "value": 1,
+        "monthly_billing_day": null,
+        "execution": "YUNO"
+      },
+      "billing_date": null,
+      "billing_cycles": {
+        "total": null,
+        "current": 2,
+        "next_at": "2026-07-14T19:19:31.914Z"
+      },
+      "customer_payer": {
+        "code": "a9f9140a-1216-481c-8356-1a125078f905"
+      },
+      "payment_method": {
+        "type": "CARD",
+        "vaulted_token": "4ba74a56-14d4-4161-a0ba-8036e9b8abf6",
+        "card": {
+          "installments": null,
+          "network_transaction_id": "000000000000000",
+          "usage": "USED"
+        }
+      },
+      "availability": {
+        "start_at": "2026-06-14T19:19:31.914Z",
+        "finish_at": null
+      },
+      "retries": {
+        "retry_on_decline": true,
+        "amount": 4,
+        "strategy": "DEFAULT",
+        "schedule": null,
+        "stop_on_hard_decline": null
+      },
+      "metadata": [
+        {
+          "key": "plan_id",
+          "value": "monthly_plan"
+        }
+      ],
+      "additional_data": null,
+      "payments": [],
+      "trial_period": {
+        "billing_cycles": 1,
+        "amount": {
+          "currency": null,
+          "value": null
+        }
+      },
+      "initial_payment_validation": false,
+      "provider_subscription_id": null,
+      "reason": null,
+      "subscription_agreement_id": null,
+      "soft_descriptor": null,
+      "renewal_notification_days": 3,
+      "cancellation_time": null,
+      "cancellation_source": null,
+      "ending_time": null,
+      "created_at": "2026-05-14T19:19:32.117629Z",
+      "updated_at": "2026-06-15T07:11:52.504031Z",
+      "history": null
     }
   }
 }


### PR DESCRIPTION
## PR Description:
Adds the two missing webhook payload examples for subscription.resume and subscription.close_to_renewal to docs/webhooks/object-and-examples.mdx. These events were already listed in the event table but had no corresponding example payloads. Payloads were provided by Caio and verified by Steban against the codebase, as a follow-up to PR #481.

## Changes:

- docs/webhooks/object-and-examples.mdx — added ### subscription.resume section after subscription.pause, with full prod payload (PII scrubbed, pulled from organization-webhook-ms)
- docs/webhooks/object-and-examples.mdx — added ### subscription.close_to_renewal section after subscription.complete, with code-derived payload (renewal_notification_days: 3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime, API, or security impact.
> 
> **Overview**
> Adds the missing **subscription webhook payload examples** for `subscription.resume` and `subscription.close_to_renewal` in `object-and-examples.mdx`, matching events already listed in the webhook index.
> 
> **`subscription.resume`** is documented after `subscription.pause` with a full v2 envelope and an `ACTIVE` subscription object (billing cycles, payment method, retries, etc.). **`subscription.close_to_renewal`** is documented after `subscription.complete` with the same shape, including `renewal_notification_days: 3` to show how renewal lead time appears in the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2b17cdb4f80860f737f0f8ccd797e930c3c5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->