### PR TITLE
chore: web sdk changelog 1.9.7

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,45 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.7",
+      "release_date": "2026-06-17",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.7",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Report The Executed Payment Action",
+          "description": "continuePayment() now tells you which payment action is running: it resolves with the executed action and accepts a new optional onActionExecuted callback that fires for each action. Use it to keep your loader on screen until a 3DS redirect navigates, avoiding the card-form flash before the challenge.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Card Form Title No Longer Flashes While Loading",
+          "description": "In the slim card form embedded with elementSelector, the \"Card information\" title now appears together with the card fields once they finish loading, instead of showing above an empty form.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Consistent Payment Method Preselection",
+          "description": "Payment method preselection is now consistent between the checkout state and the UI across the expanded and collapsed lists: the selected method is always reflected in the list, and one method is preselected when the backend doesn't specify a preference.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17780",
+        "CORECM-17787",
+        "CORECM-17818"
+      ]
+    },
+    {
       "version": "1.9.5",
       "release_date": "2026-06-15",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -12,7 +12,7 @@
         {
           "type": "CHANGED",
           "title": "Report The Executed Payment Action",
-          "description": "continuePayment() now tells you which payment action is running: it resolves with the executed action and accepts a new optional onActionExecuted callback that fires for each action. Use it to keep your loader on screen until a 3DS redirect navigates, avoiding the card-form flash before the challenge.",
+          "description": "`continuePayment()` now tells you which payment action is running: it resolves with the executed action and accepts a new optional `onActionExecuted` callback that fires for each action. Use it to keep your loader on screen until a 3DS redirect navigates, avoiding the card-form flash before the challenge.",
           "group": "Payment Actions",
           "migration_guide": null,
           "links": []
@@ -20,7 +20,7 @@
         {
           "type": "FIXED",
           "title": "Card Form Title No Longer Flashes While Loading",
-          "description": "In the slim card form embedded with elementSelector, the \"Card information\" title now appears together with the card fields once they finish loading, instead of showing above an empty form.",
+          "description": "In the slim card form embedded with `elementSelector`, the \"Card information\" title now appears together with the card fields once they finish loading, instead of showing above an empty form.",
           "group": "Card Payments",
           "migration_guide": null,
           "links": []

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,24 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.7
+*June 17, 2026*
+
+**Payment Actions**
+
+- <ChangelogBadge type="changed" /> **Report The Executed Payment Action**  
+  continuePayment() now tells you which payment action is running: it resolves with the executed action and accepts a new optional onActionExecuted callback that fires for each action. Use it to keep your loader on screen until a 3DS redirect navigates, avoiding the card-form flash before the challenge.
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Card Form Title No Longer Flashes While Loading**  
+  In the slim card form embedded with elementSelector, the "Card information" title now appears together with the card fields once they finish loading, instead of showing above an empty form.
+
+**Core SDK**
+
+- <ChangelogBadge type="fixed" /> **Consistent Payment Method Preselection**  
+  Payment method preselection is now consistent between the checkout state and the UI across the expanded and collapsed lists: the selected method is always reflected in the list, and one method is preselected when the backend doesn't specify a preference.
+
 ## v1.9.5
 *June 15, 2026*
 

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -11,12 +11,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 **Payment Actions**
 
 - <ChangelogBadge type="changed" /> **Report The Executed Payment Action**  
-  continuePayment() now tells you which payment action is running: it resolves with the executed action and accepts a new optional onActionExecuted callback that fires for each action. Use it to keep your loader on screen until a 3DS redirect navigates, avoiding the card-form flash before the challenge.
+  `continuePayment()` now tells you which payment action is running: it resolves with the executed action and accepts a new optional `onActionExecuted` callback that fires for each action. Use it to keep your loader on screen until a 3DS redirect navigates, avoiding the card-form flash before the challenge.
 
 **Card Payments**
 
 - <ChangelogBadge type="fixed" /> **Card Form Title No Longer Flashes While Loading**  
-  In the slim card form embedded with elementSelector, the "Card information" title now appears together with the card fields once they finish loading, instead of showing above an empty form.
+  In the slim card form embedded with `elementSelector`, the "Card information" title now appears together with the card fields once they finish loading, instead of showing above an empty form.
 
 **Core SDK**
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.7`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.7

3 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or application code changes.
> 
> **Overview**
> Documents **Web SDK v1.9.7** (June 17, 2026) in `changelog/source/web.json` and the top of `changelog/web.mdx`, including the `npm install @yuno-payments/sdk-web@1.9.7` upgrade snippet and tickets CORECM-17780, CORECM-17787, and CORECM-17818.
> 
> The release notes cover **`continuePayment()`** reporting the executed payment action (promise resolution plus optional **`onActionExecuted`**), a slim card form loading fix so the **Card information** title no longer flashes before fields load, and checkout **payment method preselection** staying aligned between state and UI in expanded/collapsed lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be6835a420fe9ba6fedc3a2c96e7f6119ea37daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->