### PR TITLE
fix Weglot switcher border-radius when expanded

### DIFF
--- a/style.css
+++ b/style.css
@@ -461,17 +461,17 @@ span[class*="line"] * {
 
 /* Collapsed: full border-radius on trigger */
 .weglot_switcher .wgcurrent {
-  border-radius: 5px !important;
+  border-radius: 10px !important;
 }
 
 /* Expanded (list opens upward): round top of list, flatten junction */
 .weglot_switcher.wg-up .language-list {
-  border-radius: 5px 5px 0 0 !important;
+  border-radius: 10px 10px 0 0 !important;
 }
 
 /* Expanded: trigger gets flat top (junction with list), rounded bottom */
 .weglot_switcher.wg-up .wgcurrent {
-  border-radius: 0 0 5px 5px !important;
+  border-radius: 0 0 10px 10px !important;
 }
 
 /* ============================================

--- a/style.css
+++ b/style.css
@@ -456,6 +456,25 @@ span[class*="line"] * {
 }
 
 /* ============================================
+   Weglot language switcher
+   ============================================ */
+
+/* Collapsed: full border-radius on trigger */
+.weglot_switcher .wgcurrent {
+  border-radius: 5px !important;
+}
+
+/* Expanded (list opens upward): round top of list, flatten junction */
+.weglot_switcher.wg-up .language-list {
+  border-radius: 5px 5px 0 0 !important;
+}
+
+/* Expanded: trigger gets flat top (junction with list), rounded bottom */
+.weglot_switcher.wg-up .wgcurrent {
+  border-radius: 0 0 5px 5px !important;
+}
+
+/* ============================================
    API context menu
    ============================================ */
 


### PR DESCRIPTION
## PR Description
Fixes a visual issue in the Weglot language switcher where enabling `border-radius` caused a black gap between the dropdown list and the trigger element when expanded. Also scopes the border-radius so it only applies to the outer corners (top of list, bottom of trigger) when open.

## Changes
- `style.css`: added Weglot-specific rules to apply full `border-radius` when collapsed, and remove inner-junction radius when the dropdown is expanded (`wg-up` state)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs theme CSS only; no logic, auth, or data changes beyond Weglot widget appearance.
> 
> **Overview**
> Fixes the **Weglot language switcher** looking broken when rounded corners are applied: a visible gap could appear between the open language list and the current-language trigger.
> 
> Adds scoped overrides in `style.css` so **`.weglot_switcher .wgcurrent`** uses **10px** radius when collapsed. When the dropdown opens upward (**`.weglot_switcher.wg-up`**), **`.language-list`** only rounds the top corners and **`.wgcurrent`** only rounds the bottom, flattening the shared edge so list and trigger read as one control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15973ff996f139f62dbb53f09656df4ce840597d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->