### PR TITLE
Hide 3DS Standalone page (sidebar + search + AI assistant)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -163,7 +163,6 @@
               "docs/payment-features/payment-amount-details",
               "docs/payment-features/sca-exemptions",
               "docs/payment-features/Cancel-and-capture-flow",
-              "docs/payment-features/3ds-standalone",
               "docs/payment-features/network-token-authentication"
             ]
           },

--- a/docs/payment-features/3ds-standalone.mdx
+++ b/docs/payment-features/3ds-standalone.mdx
@@ -1,6 +1,6 @@
 ---
 title: "3DS Standalone"
-hidden: false
+hidden: true
 ---
 
 3DS Standalone decouples 3DS authentication from payment authorization, allowing you to run 3DS as an independent step and decide **after** authentication whether to proceed with payment. For a conceptual overview of 3D Secure, see the [3DS basic concepts](/docs/basic-concepts/3ds-1).


### PR DESCRIPTION
## What

Hides `docs/payment-features/3ds-standalone` ([live page](https://docs.y.uno/docs/payment-features/3ds-standalone)) **without deleting it**.

## Changes
- `docs/payment-features/3ds-standalone.mdx`: `hidden: false` → `hidden: true`
- `docs.json`: removed the navigation entry for the page

## Effect (per Mintlify [hidden pages](https://www.mintlify.com/docs/organize/hidden-pages))
With `hidden: true`, the page is excluded from:
- the sidebar navigation
- documentation site search
- search-engine indexing (SEO) + sitemap
- AI assistant context

The `.mdx` file is retained and **the URL still resolves** for anyone with the direct link. Nothing is deleted. To unhide later, set `hidden: true` → `false` and re-add the `docs.json` nav entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only visibility change; no runtime or API behavior is modified.
> 
> **Overview**
> **Hides** the **3DS Standalone** doc (`docs/payment-features/3ds-standalone`) from normal discovery **without deleting** the page.
> 
> In `3ds-standalone.mdx`, frontmatter **`hidden`** is set from **`false`** to **`true`**, which (per Mintlify) drops the page from sidebar, site search, SEO/sitemap, and AI assistant context while the URL still loads for direct links.
> 
> In **`docs.json`**, the **Payment Features** nav entry for `docs/payment-features/3ds-standalone` is **removed** so it no longer appears in the sidebar even if listed elsewhere.
> 
> To **unhide**, flip **`hidden`** back to **`false`** and restore the **`docs.json`** nav line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f0e3a3709b980e90fabb803012db3430285222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->