### PR TITLE
feat:[CORECM-17854] add Universal SDK secure fields docs (web)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -803,6 +803,7 @@
             "pages": [
               "docs/yuno-sdk/features/enrollment",
               "docs/yuno-sdk/features/payment-methods-list",
+              "docs/yuno-sdk/features/secure-fields",
               "docs/yuno-sdk/features/handle-deeplinks",
               "docs/yuno-sdk/features/styling"
             ]
@@ -873,6 +874,7 @@
                   "docs/yuno-sdk/migration/web/lite",
                   "docs/yuno-sdk/migration/web/full",
                   "docs/yuno-sdk/migration/web/headless",
+                  "docs/yuno-sdk/migration/web/secure-fields",
                   "docs/yuno-sdk/migration/web/seamless",
                   "docs/yuno-sdk/migration/web/seamless-lite",
                   "docs/yuno-sdk/migration/web/enrollment",

--- a/docs/yuno-sdk/features/secure-fields.mdx
+++ b/docs/yuno-sdk/features/secure-fields.mdx
@@ -1,0 +1,124 @@
+---
+title: "Secure Fields"
+description: "Collect card data in PCI-compliant fields you place and style individually, then pay with start()."
+---
+
+Secure fields are PCI-compliant card inputs — card number, expiry, CVV — that the SDK renders inside isolated iframes. Unlike the SDK's built-in form, you **create and place each field independently** in your own layout, with your own labels and styling. Raw card data never touches your page.
+
+<Note>
+This page covers the **Web** granular, per-field API. If you'd rather embed a single SDK-composed card form, override [`showView`](/docs/yuno-sdk/controllers/show-view) instead — same PCI guarantees, less layout work.
+</Note>
+
+Secure fields work for **both** payment (`checkoutSession`) and enrollment (`customerSession`).
+
+## Before you start
+
+Your backend must have created a `checkoutSession` (payment) or `customerSession` (enrollment), and the `Transaction` must be constructed with that session. See [Get Started](/docs/yuno-sdk/get-started).
+
+## Implementation
+
+Secure fields come from `getPaymentMethodsViews`, the same entry point as the wallet buttons. Request the `secureFields` view, `create` each field you need, and `mount` it into your layout. When the user pays, call `start()` — the SDK tokenizes the fields, creates the payment, and handles 3DS.
+
+```typescript
+const { secureFields } = transaction.getPaymentMethodsViews({
+    types: ['secureFields'],
+})
+
+secureFields.create({ name: 'cardNumber', options: { label: 'Card number' } }).mount('#card-number')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).mount('#expiration')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).mount('#cvv')
+
+// Your own Pay button:
+payButton.onclick = () =>
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { type: 'CARD', holderName: 'Ada Lovelace' } },
+    })
+```
+
+The secure fields supply the card number, expiry, and CVV — those never leave the iframes. Non-PCI details — `holderName`, and optionally the customer document or `vaultOnSuccess` — travel on `start()` via `paymentMethod.data`.
+
+<Note>
+You don't pass `onPaymentSelected` for `secureFields` — there's no method to select. You build the card form and call `start()` yourself.
+</Note>
+
+### Managed vs manual
+
+By default the SDK creates the payment. Provide [`createPayment`](/docs/yuno-sdk/controllers/create-payment) on the config to POST the token from your own backend instead. Either way the SDK handles 3DS and reports the result through [`onStatus`](/docs/yuno-sdk/controllers/on-status).
+
+## Enrollment
+
+With a `customerSession`, secure fields vault a card instead of charging. The flow is identical — `create`, `mount`, `start()`.
+
+```typescript
+const transaction = sdkPayments.transaction({
+    customerSession: 'session-from-backend',
+    countryCode: 'CO',
+})
+
+const { secureFields } = transaction.getPaymentMethodsViews({ types: ['secureFields'] })
+secureFields.create({ name: 'cardNumber' }).mount('#card-number')
+secureFields.create({ name: 'expiration' }).mount('#expiration')
+secureFields.create({ name: 'cvv' }).mount('#cvv')
+
+enrollButton.onclick = () =>
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { type: 'CARD', holderName: 'Ada Lovelace' } },
+    })
+```
+
+<Note>
+On an enrollment (`customerSession`) transaction, `getPaymentMethodsViews` exposes **only** `secureFields`. Wallet types (Apple Pay, Google Pay) are payment-only and are not available.
+</Note>
+
+## Fields
+
+Create each field by name, then mount it into any element in your layout.
+
+| Name | What |
+|---|---|
+| `cardNumber` | Card number (PAN). Emits brand, IIN, and installment data through `onChange`. |
+| `expiration` | Expiration date. |
+| `cvv` | Security code. |
+| `cardLoadPreview` | Optional animated card preview. |
+| `cardPin` | PIN entry, for markets that require it. |
+
+## Field options
+
+Pass `options` to `create` to label, style, and observe a field.
+
+| Option | Type | Purpose |
+|---|---|---|
+| `label` | string | Accessible label. |
+| `placeholder` | string | Placeholder text. |
+| `showError` | boolean | Render validation errors under the field. |
+| `validationType` | string | When to validate (e.g. `on_blur_full`). |
+| `onChange` | function | `({ error, data, isDirty })`. For `cardNumber`, `data` carries brand, IIN, and installments. |
+| `onBlur` / `onFocus` | function | Focus lifecycle — e.g. to flip a card preview. |
+
+## Field methods
+
+Each field returned by `create` (or fetched with `getElement({ name })`) exposes:
+
+| Method | Purpose |
+|---|---|
+| `mount('#sel')` | Render the field into an element. |
+| `focus()` | Focus the field. |
+| `validate()` | Validate on demand; resolves to a boolean. |
+| `clearValue()` | Clear the input. |
+| `setCardType(type)` | Force credit or debit on dual-brand cards. |
+| `setCardHolderName(name)` | Set the holder name on the card preview. |
+| `toggleFrontCardVisibility(visible)` | Flip the card preview. |
+| `resetFields()` | Reset the field's error state. |
+
+## Notes
+
+- **Tokenization and 3DS live in `start()`.** There's no `generateToken` or `continuePayment` on the view — one completion path, no double-charge risk.
+- **PCI scope is unchanged.** Raw card data stays inside the SDK's iframes; your code never reads it.
+- `getPaymentMethodsViews` is synchronous; the secure-field iframes finish loading as you `mount` them.
+
+## Related
+
+- [Payment Methods List](/docs/yuno-sdk/features/payment-methods-list). The same `getPaymentMethodsViews` entry point, for wallets and the methods list.
+- [`showView`](/docs/yuno-sdk/controllers/show-view). Embed a single SDK-composed form instead of placing fields yourself.
+- [`createPayment`](/docs/yuno-sdk/controllers/create-payment). Take over payment creation (manual mode).
+- [`onStatus`](/docs/yuno-sdk/controllers/on-status). Receive the final result.

--- a/docs/yuno-sdk/migration/web/headless.mdx
+++ b/docs/yuno-sdk/migration/web/headless.mdx
@@ -1,16 +1,19 @@
 ---
 title: "Headless mode"
-description: "Migrate Web Headless integrations (yuno.apiClientPayment + yuno.secureFields) to the unified Transaction API."
+description: "Migrate Web Headless (yuno.apiClientPayment) integrations to the unified Transaction API."
 ---
 
-Headless was a pure-tokenization client: the merchant collected card data in their own UI (typically using PCI-compliant `secureFields` iframes), generated a token, and made their own backend call to create the payment.
+Headless was a pure-tokenization client: you collected card data in your own UI, generated a token, and made your own backend call to create the payment.
 
-In the unified API the same scenario maps to **non-seamless headless** mode: pass the pre-collected data inside `paymentMethod.data` on `start()`, override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) to POST to your backend, and let the SDK orchestrate tokenization, 3DS, and status polling automatically.
+In the unified API this maps to **non-seamless headless** mode: pass the pre-collected card data inside `paymentMethod.data` on `start()`, override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) to POST to your backend, and let the SDK orchestrate tokenization, 3DS, and status automatically.
+
+<Note>
+Collected card data with PCI-compliant `secureFields` iframes, so your code never touched the PAN? See the dedicated [Secure Fields](/docs/yuno-sdk/migration/web/secure-fields) migration page instead.
+</Note>
 
 | Before | After |
 |---|---|
 | `yuno.apiClientPayment({ checkoutSession })` + manual backend call | `sdkPayments.transaction({ …, createPayment }).start({ paymentMethod: { type, data } })` |
-| `yuno.secureFields({ countryCode, checkoutSession }).create(...).generateToken(...)` | Pass card data via `paymentMethod.data` (PaymentMethodData) — SDK tokenizes internally |
 | Manual 3DS handling via separate calls | Automatic — SDK handles 3DS once `createPayment` resolves |
 
 ## Side-by-side — Headless API Client
@@ -69,57 +72,6 @@ await transaction.start({
 
 </CodeGroup>
 
-## Side-by-side — Secure Fields
-
-For PCI-compliant collection where the merchant must not touch raw PAN, the legacy `secureFields` flow stays — but tokenization output now feeds the unified `start()` instead of a separate `apiClientPayment` instance.
-
-<CodeGroup>
-
-```typescript Before. Secure Fields headless
-const yuno = await window.Yuno.initialize('your-public-api-key')
-
-const secureFields = await yuno.secureFields({
-    checkoutSession: 'session-from-backend',
-    countryCode: 'CO',
-    installmentEnable: true,
-})
-
-secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
-secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
-secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#exp')
-
-document.getElementById('pay').addEventController('click', async () => {
-    const ott = await secureFields.generateTokenWithInformation({
-        cardHolderName: 'John Doe',
-    })
-    await myBackend.pay({ oneTimeToken: ott.token, checkoutSession })
-    yuno.continuePayment()
-})
-```
-
-```typescript After. Unified Transaction (headless via showView + secure fields)
-const sdkPayments = await SdkPayments.initialize('your-public-api-key')
-
-const transaction = sdkPayments.transaction({
-    checkoutSession: 'session-from-backend',
-    countryCode: 'CO',
-    showView: (view, controls, step) => {
-        document.querySelector('#card-form')!.appendChild(view)
-        document.getElementById('pay')!.onclick = () => controls.onSubmit()
-    },
-    createPayment: async (token) => {
-        await myBackend.pay({ token: token.token })
-    },
-    onStatus: (result) => console.log('done:', result.status),
-})
-
-await transaction.start({ paymentMethod: { type: 'CARD' } })
-```
-
-</CodeGroup>
-
-The SDK provides the secure iframes inside the view it delivers to `showView`. You embed the view, wire your own submit button to `controls.onSubmit()`, and the SDK handles tokenization + 3DS internally before invoking `createPayment`.
-
 ## Field mapping
 
 | Before (Headless) | After (unified) | Notes |
@@ -127,7 +79,6 @@ The SDK provides the secure iframes inside the view it delivers to `showView`. Y
 | `yuno.apiClientPayment({ checkoutSession, countryCode })` | `sdkPayments.transaction({ checkoutSession, countryCode, createPayment })` | The factory consolidates the API-client + Transaction surface. |
 | `apiClientPayment.generateToken(cardData)` | `transaction.start({ paymentMethod: { type: 'CARD', data: CardData } })` | Data goes inline on `start()`. |
 | `apiClientPayment.getThreeDSecureChallenge(...)` (rare) | *(removed — automatic)* | SDK orchestrates 3DS internally once `createPayment` resolves. |
-| `yuno.secureFields({ checkoutSession })` + `.create(...).render(...)` + `.generateTokenWithInformation(...)` | `showView` + SDK-provided secure iframes inside the delivered view | The SDK still uses secure iframes under the hood; you no longer assemble them yourself. |
 | `yuno.continuePayment()` after backend POST | *(automatic)* | Resolve the `createPayment` Promise and the SDK continues. |
 
 ### CardData mapping
@@ -181,21 +132,20 @@ await transaction.start({
 
 - **3DS is automatic.** Headless used to require bespoke 3DS handling per integration. The unified API does it internally once `createPayment` resolves.
 - **`continuePayment()` is gone.** The Promise contract drives progression.
-- **Secure-fields composition.** Instead of assembling per-field iframes yourself, the SDK delivers a single composed form via `showView`. PCI scope is the same (raw PAN never touches your code).
 - **No separate `apiClientPayment` surface.** One factory: `sdkPayments.transaction(config)`.
 
 ## Checklist
 
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
-- [ ] Replace `yuno.apiClientPayment(...)` and `yuno.secureFields(...)` with `sdkPayments.transaction(...)`.
+- [ ] Replace `yuno.apiClientPayment(...)` with `sdkPayments.transaction(...)`.
 - [ ] Provide `createPayment` on `TransactionConfig` to POST to your backend.
 - [ ] If you collected card data in your own UI: pass it via `paymentMethod.data` on `start()` (rename the fields per the mapping table above).
-- [ ] If you used `secureFields` for PCI-compliant collection: wire `showView` and embed the SDK-provided view; call `controls.onSubmit()` from your button.
 - [ ] Drop manual 3DS challenge calls; drop `yuno.continuePayment()`.
 - [ ] Re-run your sandbox test suite.
 
 ## Related
 
+- [Secure Fields migration](/docs/yuno-sdk/migration/web/secure-fields). If you used `secureFields` for PCI-compliant collection.
 - [`createPayment`](/docs/yuno-sdk/controllers/create-payment). The mode-flip callback.
 - [`PaymentMethodData`](/docs/yuno-sdk/reference/transaction-data). Per-method headless data shape.
 - [`OneTimeToken`](/docs/yuno-sdk/reference/one-time-token). Token payload sent to your backend.

--- a/docs/yuno-sdk/migration/web/secure-fields.mdx
+++ b/docs/yuno-sdk/migration/web/secure-fields.mdx
@@ -1,0 +1,103 @@
+---
+title: "Secure Fields"
+description: "Migrate Web Secure Fields (yuno.secureFields) integrations to the unified Transaction API."
+---
+
+Secure Fields collected card data in PCI-compliant iframes — your code never touched the raw PAN. You created each field (`pan`, `cvv`, `expiration`), placed it in your layout, generated a token, and called your own backend to create the payment.
+
+In the unified API secure fields stay **per-field**: you still create and place each field yourself, now as a view from [`getPaymentMethodsViews`](/docs/yuno-sdk/features/payment-methods-list). The finish changes — `generateToken` and `continuePayment` are gone. `start()` tokenizes the mounted fields, creates the payment, and handles 3DS automatically.
+
+| Before | After |
+|---|---|
+| `yuno.secureFields({ checkoutSession, countryCode })` | `sdkPayments.transaction({ checkoutSession, countryCode })` |
+| `.create({ name }).render('#sel')` | `getPaymentMethodsViews({ types: ['secureFields'] })` → `.create({ name }).mount('#sel')` |
+| `.generateTokenWithInformation(...)` + backend POST + `yuno.continuePayment()` | `transaction.start(...)` — tokenize, create, and 3DS in one call |
+
+## Side-by-side
+
+<CodeGroup>
+
+```typescript Before. Secure Fields
+const yuno = await window.Yuno.initialize('your-public-api-key')
+
+const secureFields = await yuno.secureFields({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    installmentEnable: true,
+})
+
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#exp')
+
+document.getElementById('pay').addEventListener('click', async () => {
+    const ott = await secureFields.generateTokenWithInformation({
+        cardHolderName: 'John Doe',
+    })
+    await myBackend.pay({ oneTimeToken: ott.token, checkoutSession })
+    yuno.continuePayment()
+})
+```
+
+```typescript After. Unified Transaction
+const sdkPayments = await SdkPayments.initialize('your-public-api-key')
+
+const transaction = sdkPayments.transaction({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    createPayment: async (token) => {
+        await myBackend.pay({ token: token.token })
+    },
+    onStatus: (result) => console.log('done:', result.status),
+})
+
+const { secureFields } = transaction.getPaymentMethodsViews({ types: ['secureFields'] })
+secureFields.create({ name: 'cardNumber', options: { label: 'Card number' } }).mount('#pan')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).mount('#cvv')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).mount('#exp')
+
+document.getElementById('pay')!.onclick = () =>
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { type: 'CARD', holderName: 'John Doe' } },
+    })
+```
+
+</CodeGroup>
+
+Your layout doesn't change — you still create and place each field. Omit `createPayment` to let the SDK create the payment for you (managed); provide it to POST the token from your backend (manual).
+
+## Field mapping
+
+| Before | After | Notes |
+|---|---|---|
+| `yuno.secureFields({ checkoutSession, countryCode, installmentEnable })` | `sdkPayments.transaction({ checkoutSession, countryCode })` + `getPaymentMethodsViews({ types: ['secureFields'] })` | The session moves to the `Transaction`; request the `secureFields` view. |
+| `field.render('#sel')` | `field.mount('#sel')` | Renamed; same behavior. |
+| `field.name: 'pan'` | `field.name: 'cardNumber'` | Field name normalized. `cvv` / `expiration` are unchanged. |
+| `secureFields.generateTokenWithInformation({ cardHolderName })` | *(removed)* — `start({ paymentMethod: { type: 'CARD', data: { holderName } } })` | Tokenization runs inside `start()`. The holder name and other non-PCI details travel on `start()`. |
+| `yuno.continuePayment()` after backend POST | *(automatic)* | Resolve `createPayment` and the SDK continues, including 3DS. |
+
+Field names: `cardNumber`, `expiration`, `cvv`, `cardLoadPreview`, `cardPin`. See [Secure Fields](/docs/yuno-sdk/features/secure-fields) for the full reference.
+
+## Behavior changes
+
+- **Per-field placement is preserved.** Unlike a single SDK-composed form, you still `create` and `mount` each field independently. PCI scope is unchanged — raw PAN never touches your code.
+- **Tokenization moved into `start()`.** No `generateToken` / `generateTokenWithInformation` on the view.
+- **`continuePayment()` is gone.** `start()` handles 3DS automatically once the payment is created.
+- **3DS is automatic.** Bespoke per-integration 3DS handling is no longer required.
+
+## Checklist
+
+- [ ] Replace `window.Yuno.initialize(...)` with `SdkPayments.initialize(...)`.
+- [ ] Replace `yuno.secureFields({ ... })` with `sdkPayments.transaction({ ... })` + `getPaymentMethodsViews({ types: ['secureFields'] })`.
+- [ ] Swap each field's `.render('#sel')` for `.mount('#sel')`.
+- [ ] Rename the `pan` field to `cardNumber`.
+- [ ] Remove `generateToken*` and `continuePayment()`; finish with `transaction.start(...)`.
+- [ ] Provide `createPayment` if you create the payment on your backend (manual); omit it to let the SDK create it (managed).
+- [ ] Re-run your sandbox test suite.
+
+## Related
+
+- [Secure Fields](/docs/yuno-sdk/features/secure-fields). The full feature reference — fields, options, methods.
+- [`showView`](/docs/yuno-sdk/controllers/show-view). Embed one SDK-composed form instead of placing fields yourself.
+- [`createPayment`](/docs/yuno-sdk/controllers/create-payment). Take over payment creation (manual mode).
+- [`OneTimeToken`](/docs/yuno-sdk/reference/one-time-token). Token payload sent to your backend.


### PR DESCRIPTION
## What

Documents **Secure Fields** for the Universal SDK (web) in the Yuno SDK (alpha) docs.

- **`features/secure-fields`** — the granular model: `getPaymentMethodsViews({ types: ['secureFields'] })` → `create({ name }).mount('#sel')` per field → `start()` drives tokenize / create / 3DS (gated on `sdk_action_required`). Payment **and** enrollment.
- **`migration/web/secure-fields`** — dedicated v1 (`yuno.secureFields`) → unified migration page.
- **`migration/web/headless`** — trimmed to the `apiClientPayment` (raw-data) path; points to the new Secure Fields page. Reconciles away from the previous `showView`-based mapping so the docs are internally consistent.
- **`docs.json`** — nav entries under **Features** and **Migration › Web**.

## Ticket

CORECM-17854

## Notes

- Base is `2026-05-13-universal-sdk-proposal` (the Universal SDK docs branch), not `master`.
- Open design detail flagged on the ticket for tech analysis: the `start()` token-info shape (`cardHolderName` / `customer` / `saveCard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX and docs navigation; no runtime, auth, or payment code is modified.
> 
> **Overview**
> Adds **Yuno SDK (Alpha)** documentation for web **Secure Fields** on the unified `Transaction` API, plus navigation and a cleaner split from the headless migration guide.
> 
> A new **Features** page describes the per-field flow: `getPaymentMethodsViews({ types: ['secureFields'] })`, `create` / `mount` for each iframe field, then **`transaction.start()`** for tokenization, payment creation, and 3DS (with optional **`createPayment`** for manual backend posting). It covers payment and enrollment, field names/options/methods, and contrasts **`showView`** vs granular fields.
> 
> A new **Migration › Web › Secure Fields** page maps legacy `yuno.secureFields` (`render`, `pan`, `generateTokenWithInformation`, `continuePayment`) to the unified API (`mount`, `cardNumber`, `start()`).
> 
> **`migration/web/headless`** is narrowed to the **`apiClientPayment`** / raw card-data path; the old secure-fields + `showView` content is removed and replaced with a link to the dedicated Secure Fields migration page.
> 
> **`docs.json`** registers both pages under **Features** and **Migration › Web**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c622cac3bcd286eed0b60ae299fbe97c1dfdda6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->