### PR TITLE
Standardize page titles to Title Case across API Reference

### DIFF
--- a/reference/airline-information.mdx
+++ b/reference/airline-information.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Airline information"
+title: "Airline Information"
 ---
 
 On this page, you will find airline information you may need when using Yuno API endpoints. It covers passenger types, fare class codes, and loyalty tiers. Use this page to understand and have access to standard values for each information category.

--- a/reference/dry-run/register-dry-run-provider-event.mdx
+++ b/reference/dry-run/register-dry-run-provider-event.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Register a dry-run provider event"
+title: "Register a Dry-Run Provider Event"
 description: "Register provider request, response, or webhook payloads for pre-production validation."
 openapi: "/openapi/dry-run/register-dry-run-provider-event.json POST /dry-run/provider-events"
 ---

--- a/reference/eci-indicators-list.mdx
+++ b/reference/eci-indicators-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ECI indicators list"
+title: "ECI Indicators List"
 ---
 
 import { HTMLBlock } from "/snippets/HTMLBlock.jsx";

--- a/reference/industry-category-list.mdx
+++ b/reference/industry-category-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Industry category"
+title: "Industry Category"
 ---
 
 On this page, you will find the industry category information you need when using Yuno API endpoints. The table below provides codes for each industry category available on the Yuno API and their descriptions. Use this page to understand better when to use each category.

--- a/reference/items-category-list.mdx
+++ b/reference/items-category-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Items category"
+title: "Items Category"
 ---
 
 On this page, you will find the items category information you need when using Yuno API endpoints. The table below provides codes for each item category available on the Yuno API and their descriptions. Use this page to understand better when to use each category.

--- a/reference/payment-methods-checkout/retrieve-payment-method-by-id-checkout.mdx
+++ b/reference/payment-methods-checkout/retrieve-payment-method-by-id-checkout.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Retrieve Payment Method By ID"
+title: "Retrieve Payment Method by ID"
 openapi: "/openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json GET /payment-methods/{payment_method_id}"
 ---
 

--- a/reference/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.mdx
+++ b/reference/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Retrieve Payment Methods To Enroll"
+title: "Retrieve Payment Methods to Enroll"
 openapi: "/openapi/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.json GET /checkout/customers/sessions/{customer_session}/payment-methods"
 ---
 

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Retrieve Enrolled Payment Method by Id"
+title: "Retrieve Enrolled Payment Method by ID"
 openapi: "/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json GET /customers/{customer_id}/payment-methods/{payment_method_id}"
 ---
 

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Retrieve Enrolled Payment Method by Id PCI data"
+title: "Retrieve Enrolled Payment Method by ID PCI Data"
 openapi: "/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json GET /customers/{customer_id}/payment-methods/{payment_method_id}"
 ---
 

--- a/reference/payment-type-list.mdx
+++ b/reference/payment-type-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Payment type"
+title: "Payment Type"
 ---
 
 This reference lists all payment methods supported by Yuno's API, organized by category and provider. Use the `payment_method_type`, `category`, and `provider` values when creating payments or enrolling payment methods.

--- a/reference/payments/cancel-or-refund-payment-with-transaction.mdx
+++ b/reference/payments/cancel-or-refund-payment-with-transaction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Cancel or Refund a Payment with transaction"
+title: "Cancel or Refund a Payment with Transaction"
 openapi: "/openapi/payments/cancel-or-refund-payment-with-transaction.json POST /payments/{payment_id}/transactions/{transaction_id}/cancel-or-refund"
 ---
 

--- a/reference/payments/disputes.mdx
+++ b/reference/payments/disputes.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Dispute a chargeback"
+title: "Dispute a Chargeback"
 openapi: "/openapi/payments/disputes.json POST /payments/{payment_id}/transactions/{transaction_id}/dispute"
 ---
 

--- a/reference/payments/update-dispute.mdx
+++ b/reference/payments/update-dispute.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Update a chargeback dispute"
+title: "Update a Chargeback Dispute"
 openapi: "/openapi/payments/update-dispute.json PATCH /payments/{payment_id}/transactions/{transaction_id}/dispute"
 ---
 

--- a/reference/purposes-list.mdx
+++ b/reference/purposes-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Purposes list"
+title: "Purposes List"
 ---
 
 On this page, you will find the purposes list available on the Yuno system. The purpose information is used to identify the reason for the payout. The below table provides all ENUM accepted for the payout purpose.

--- a/reference/shipping-reference.mdx
+++ b/reference/shipping-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Shipping reference"
+title: "Shipping Reference"
 ---
 
 On this page, you will find shipping information you may need when using Yuno API endpoints. It covers types and carriers. Use this page to understand and have access to standard values for each information category.

--- a/reference/transaction-category-list.mdx
+++ b/reference/transaction-category-list.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Transaction category"
+title: "Transaction Category"
 ---
 
 Yuno organizes the available payment methods into distinct transaction categories. On this page, you will find all transaction categories used on the Yuno API and their descriptions. Note that every payment method is associated with one of these transaction categories.


### PR DESCRIPTION
## PR Description
Standardizes all page titles in the API Reference section to follow Title Case consistently. Previously, 16 pages had incorrect casing — either sentence case (e.g. "Airline information"), lowercase nouns after articles (e.g. "Dispute a chargeback"), incorrectly capitalized prepositions (e.g. "Retrieve Payment Method By ID"), or inconsistent abbreviations (e.g. "Id" instead of "ID").

## Changes
- `reference/airline-information.mdx` — "Airline information" → "Airline Information"
- `reference/dry-run/register-dry-run-provider-event.mdx` — "Register a dry-run provider event" → "Register a Dry-Run Provider Event"
- `reference/eci-indicators-list.mdx` — "ECI indicators list" → "ECI Indicators List"
- `reference/industry-category-list.mdx` — "Industry category" → "Industry Category"
- `reference/items-category-list.mdx` — "Items category" → "Items Category"
- `reference/payment-methods-checkout/retrieve-payment-method-by-id-checkout.mdx` — "Retrieve Payment Method By ID" → "Retrieve Payment Method by ID"
- `reference/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.mdx` — "Retrieve Payment Methods To Enroll" → "Retrieve Payment Methods to Enroll"
- `reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx` — "Retrieve Enrolled Payment Method by Id" → "Retrieve Enrolled Payment Method by ID"
- `reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx` — "Retrieve Enrolled Payment Method by Id PCI data" → "Retrieve Enrolled Payment Method by ID PCI Data"
- `reference/payment-type-list.mdx` — "Payment type" → "Payment Type"
- `reference/payments/cancel-or-refund-payment-with-transaction.mdx` — "Cancel or Refund a Payment with transaction" → "Cancel or Refund a Payment with Transaction"
- `reference/payments/disputes.mdx` — "Dispute a chargeback" → "Dispute a Chargeback"
- `reference/payments/update-dispute.mdx` — "Update a chargeback dispute" → "Update a Chargeback Dispute"
- `reference/purposes-list.mdx` — "Purposes list" → "Purposes List"
- `reference/shipping-reference.mdx` — "Shipping reference" → "Shipping Reference"
- `reference/transaction-category-list.mdx` — "Transaction category" → "Transaction Category"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic frontmatter title updates only; no runtime, API, or behavioral changes.
> 
> **Overview**
> Updates the frontmatter **`title`** on **16** API Reference MDX pages so navigation and page headings follow a consistent **Title Case** style.
> 
> Reference list pages move from sentence case (e.g. **Airline Information**, **Industry Category**, **Purposes List**). Endpoint pages get clearer capitalization for articles/prepositions and abbreviations—**by ID** instead of **By ID** or **Id**, **Transaction** instead of **transaction**, and chargeback titles like **Dispute a Chargeback** / **Update a Chargeback Dispute**. Dry-run and PCI retrieve titles are aligned the same way (**Register a Dry-Run Provider Event**, **Retrieve Enrolled Payment Method by ID PCI Data**).
> 
> No OpenAPI paths, request/response content, or body copy change—only display titles in YAML frontmatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2efaa7a2fc7568b468e83c40d31dd27ec497d5cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->