### PR TITLE
chore: web sdk changelog 1.9.8

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,45 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.8",
+      "release_date": "2026-06-23",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.8",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Per-Scheme Card Number Length Validation",
+          "description": "Card number length is now validated per card scheme using backend-driven rules combined with the Luhn check, reducing false rejections of valid cards. Gated behind a feature flag.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "FIXED: Enable downloading the QR image for client-generated QR codes (`GENERATE_QR`, e.g. QRIS/Xendit). The \"Download QR image\" button now renders for these payment methods and saves the on-screen code as a PNG generated on the client with `qrcode`. Previously the button only appeared for ready-to-use image QRs (URL/BASE64), so QRIS never showed it even though the backend sent the `download_qr` label.",
+          "description": "",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "FIXED: Route sdk-web-card iframe assets (secure-field pages, card form, mediator) through the asset host in whitelabel mode. They were resolved against `apiUrl`, so when a merchant set a distinct `assetUrl` carrying a proxy sub-path (e.g. `/hosted-payment-methods/orchestrator`) the sub-path was dropped and secure fields loaded from the wrong path in enrollment and enrolled-card flows (CORECM-17901).",
+          "description": "",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17153",
+        "CORECM-17471",
+        "CORECM-17901"
+      ]
+    },
+    {
       "version": "1.9.7",
       "release_date": "2026-06-17",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,22 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.8
+*June 23, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Per-Scheme Card Number Length Validation**  
+  Card number length is now validated per card scheme using backend-driven rules combined with the Luhn check, reducing false rejections of valid cards. Gated behind a feature flag.
+
+- <ChangelogBadge type="fixed" /> **Route SDK iframe Assets Through the Asset Host in Whitelabel Mode**  
+  Secure-field pages, the card form, and the mediator are now resolved against `assetUrl` instead of `apiUrl` in whitelabel mode, so merchants who set a distinct `assetUrl` with a proxy sub-path (e.g. `/hosted-payment-methods/orchestrator`) no longer get the sub-path dropped and secure fields load from the correct path in enrollment and enrolled-card flows.
+
+**QR Payments**
+
+- <ChangelogBadge type="changed" /> **Enable Downloading the QR Image for Client-Generated QR Codes**  
+  The "Download QR image" button now renders for client-generated QR methods (e.g. QRIS/Xendit) and saves the on-screen code as a PNG. Previously the button only appeared for ready-to-use image QRs (URL/BASE64).
+
 ## v1.9.7
 *June 17, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.8`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.8

3 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog ingest with no runtime or integration code changes in this repo.
> 
> **Overview**
> This PR **publishes** the auto-generated Web SDK **v1.9.8** changelog (from sdk-web release **v13.0.8**). It prepends a new release block to `changelog/source/web.json` and inserts the formatted **v1.9.8** section at the top of `changelog/web.mdx`, including upgrade snippet `npm install @yuno-payments/sdk-web@1.9.8` and tickets **CORECM-17153**, **CORECM-17471**, **CORECM-17901**.
> 
> The new release notes cover three shipped changes: **per-scheme card number length validation** (backend rules + Luhn, feature-flagged), **QR image download** for client-generated QR flows such as QRIS/Xendit, and **whitelabel iframe asset routing** so secure-field/card iframe URLs use `assetUrl` instead of `apiUrl` when a proxy sub-path is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4365eedddf184f73a15051e3dac2e5e58938928c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->