### PR TITLE
feat(subscriptions): add subscription_agreement_id field

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1460,6 +1460,7 @@ The next JSON object presents an example of a data structure related to a paymen
         }
       },
       "initial_payment_validation": true,
+      "subscription_agreement_id": null,
       "created_at": "2025-05-21T15:33:16.662026Z",
       "updated_at": "2025-05-21T15:33:16.662026Z"
     }
@@ -1540,6 +1541,7 @@ Sent when a subscription transitions from any other valid status into `ACTIVE`. 
       },
       "initial_payment_validation": true,
       "provider_subscription_id": null,
+      "subscription_agreement_id": null,
       "created_at": "2025-12-04T00:29:25.485281Z",
       "updated_at": "2025-12-04T00:29:59.216998Z"
     }

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -392,6 +392,10 @@
                         "description": "[Conditional] The day of the month to charge the subscription if type is DAY. Default is 1. Range 1 - 31."
                       }
                     }
+                  },
+                  "subscription_agreement_id": {
+                    "type": "string",
+                    "description": "Links this subscription to the initial payment created with the same agreement ID. Used for tracking, reconciliation, and chargeback handling. Must exactly match the `subscription_agreement_id` sent in `payment_method.detail.card.stored_credentials.subscription_agreement_id` on the originating payment (MAX 255)."
                   }
                 }
               },
@@ -633,6 +637,10 @@
                       }
                     },
                     "metadata": {},
+                    "subscription_agreement_id": {
+                      "type": "string",
+                      "example": "sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa"
+                    },
                     "created_at": {
                       "type": "string",
                       "example": "2024-09-30T12:04:23.265372Z"

--- a/openapi/subscriptions/retrieve-subscription.json
+++ b/openapi/subscriptions/retrieve-subscription.json
@@ -114,6 +114,7 @@
                       "payments": [
                         "5104911d-5df9-229e-8468-bd41abea1a4s"
                       ],
+                      "subscription_agreement_id": null,
                       "created_at": "2023-12-16T20:46:54.786342Z",
                       "updated_at": "2023-12-16T21:00:54.786342Z"
                     }
@@ -320,6 +321,10 @@
                         "type": "string",
                         "example": "5104911d-5df9-229e-8468-bd41abea1a4s"
                       }
+                    },
+                    "subscription_agreement_id": {
+                      "type": "string",
+                      "example": "sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa"
                     },
                     "created_at": {
                       "type": "string",

--- a/openapi/yuno_sandbox_tested.json
+++ b/openapi/yuno_sandbox_tested.json
@@ -1196,7 +1196,8 @@
                 "availability": {
                   "start_at": "2026-04-01T00:00:00Z",
                   "finish_at": "2027-03-31T23:59:59Z"
-                }
+                },
+                "subscription_agreement_id": "sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa"
               }
             }
           }
@@ -2951,6 +2952,11 @@
           },
           "additional_data": {
             "$ref": "#/components/schemas/AdditionalData"
+          },
+          "subscription_agreement_id": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Links this subscription to the initial payment created with the same agreement ID. Used for tracking, reconciliation, and chargeback handling. Must exactly match the `subscription_agreement_id` sent in `payment_method.detail.card.stored_credentials.subscription_agreement_id` on the originating payment."
           }
         }
       },
@@ -3025,6 +3031,10 @@
                 "type": "integer"
               }
             }
+          },
+          "subscription_agreement_id": {
+            "type": "string",
+            "description": "Links this subscription to the initial payment created with the same agreement ID. Used for tracking, reconciliation, and chargeback handling."
           },
           "created_at": {
             "type": "string",

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -304,6 +304,14 @@ This object represents a subscription that can be associated with a customer.
   </Expandable>
 </ParamField>
 
+<ParamField body="subscription_agreement_id" type="string">
+  Links this subscription to the initial payment created with the same agreement ID. Used for tracking, reconciliation, and chargeback handling (MAX 255).
+
+  The value must exactly match the `subscription_agreement_id` sent in `payment_method.detail.card.stored_credentials.subscription_agreement_id` on the originating payment.
+
+  Example: sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa
+</ParamField>
+
 <ParamField body="payments" type="Array of strings">
   Specifies the payments array.
 


### PR DESCRIPTION
## PR Description

Adds optional subscription_agreement_id field (string, max 255) to the subscription creation endpoint, GET response, and webhook examples. Links a subscription to the originating payment for tracking, reconciliation, and chargeback handling. Requested by Richy (Slack, June 23 2026).

## Changes:

- openapi/subscriptions/create-subscription.json — field added to request body and 200 response schema
- openapi/subscriptions/retrieve-subscription.json — field added to response schema and example
- openapi/yuno_sandbox_tested.json — field added to CreateSubscriptionRequest and Subscription schemas
- reference/subscriptions/the-subscription-object.mdx — ParamField added with description and constraint note
- docs/webhooks/object-and-examples.mdx — field added to subscription.create and subscription.active examples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI-only changes with no application logic in the diff; integrators may start sending a new optional field once the API supports it.
> 
> **Overview**
> Documents an optional **`subscription_agreement_id`** (string, max 255) on subscriptions so merchants can tie a plan to the initial card payment for tracking, reconciliation, and chargebacks.
> 
> The field is added to **create** request/response and **retrieve** schemas in OpenAPI (`create-subscription.json`, `retrieve-subscription.json`, `yuno_sandbox_tested.json`), described on **The Subscription Object** reference page, and shown as `null` or an example value in **`subscription.create`** and **`subscription.active`** webhook payloads. Docs state the value must **exactly match** `payment_method.detail.card.stored_credentials.subscription_agreement_id` on the originating payment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832fb4b999efb3968e6bd64c27145779bfe1e9d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->