### PR TITLE
chore: web sdk changelog 1.9.9

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.9",
+      "release_date": "2026-06-24",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.9",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "SECURITY",
+          "title": "Pass a per-session JWT to challenge.html and add a postMessage handshake with nonce/origin verification for the 3DS frame-restriction flow.",
+          "description": "",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17081"
+      ]
+    },
+    {
       "version": "1.9.8",
       "release_date": "2026-06-23",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.9`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.9

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSON changelog update; no runtime or integration code changes in this repository.
> 
> **Overview**
> Adds **web SDK `1.9.9`** (`2026-06-24`) at the top of `changelog/source/web.json`, including the `npm install @yuno-payments/sdk-web@1.9.9` upgrade snippet.
> 
> Documents one **SECURITY** (Core SDK) item for **CORECM-17081**: per-session JWT passed to `challenge.html`, plus a `postMessage` handshake with nonce and origin checks in the 3DS frame-restriction flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb9f2168d6e796fe0f2b11e00b6105c4d17b861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->