### PR TITLE
Add missing v1.9.9 MDX changelog entry

### DIFF
--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.9
+*June 24, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="security" /> **Hardened 3DS Frame-Restriction Flow**  
+  A per-session JWT is now passed to `challenge.html`, and the 3DS frame-restriction flow includes a postMessage handshake with nonce and origin verification to prevent unauthorized frame interactions.
+
 ## v1.9.8
 *June 23, 2026*
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no runtime or SDK code is modified in this PR.
> 
> **Overview**
> Adds the **v1.9.9** section (June 24, 2026) at the top of `changelog/web.mdx`, documenting a **Core SDK** security change for the 3DS frame-restriction flow.
> 
> The new entry describes a per-session JWT passed to `challenge.html` and a **postMessage** handshake with nonce and origin checks to block unauthorized iframe interactions, labeled with the `security` changelog badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843b2bbc7eb5d429b420314c878047d04797f793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->