### PR TITLE
Move Basic Concepts to nested sidebar group under How Yuno Works

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -63,22 +63,22 @@
               "docs/how-yuno-works/what-is-yuno",
               "docs/how-yuno-works/how-yuno-payment-flow-works",
               "docs/how-yuno-works/step-1-set-up-your-account",
-              "docs/how-yuno-works/step-2-your-first-payment"
-            ]
-          },
-          {
-            "group": "Basic Concepts",
-            "pages": [
-              "docs/basic-concepts/index",
-              "docs/basic-concepts/customers",
-              "docs/basic-concepts/sessions",
-              "docs/basic-concepts/payments-1",
-              "docs/basic-concepts/transactions",
-              "docs/basic-concepts/tokens",
-              "docs/basic-concepts/payment-methods",
-              "docs/basic-concepts/webhooks-1",
-              "docs/basic-concepts/fraud",
-              "docs/basic-concepts/3ds-1"
+              "docs/how-yuno-works/step-2-your-first-payment",
+              {
+                "group": "Basic Concepts",
+                "pages": [
+                  "docs/basic-concepts/index",
+                  "docs/basic-concepts/customers",
+                  "docs/basic-concepts/sessions",
+                  "docs/basic-concepts/payments-1",
+                  "docs/basic-concepts/transactions",
+                  "docs/basic-concepts/tokens",
+                  "docs/basic-concepts/payment-methods",
+                  "docs/basic-concepts/webhooks-1",
+                  "docs/basic-concepts/fraud",
+                  "docs/basic-concepts/3ds-1"
+                ]
+              }
             ]
           },
           {

--- a/docs/basic-concepts/index.mdx
+++ b/docs/basic-concepts/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Basic Concepts"
+title: "Overview"
 ---
 
 To understand how Yuno operates, you need to grasp some fundamental concepts about its architecture. This guide covers the essential elements required for integration:


### PR DESCRIPTION
## PR Description
Restructures the sidebar navigation so that "Basic Concepts" is no longer a standalone top-level group. It now appears as a collapsible nested group called "Basic Concepts" inside "How Yuno Works", positioned immediately after "Create Your First Payment With SDK". The landing page of the group (index.mdx) has been renamed to "Overview" to better reflect its introductory role within the expanded section.

## Changes
- docs.json — removed standalone "Basic Concepts" group; added it as a nested group under "How Yuno Works" after step-2-your-first-payment, keeping the group label "Basic Concepts"
- docs/basic-concepts/index.mdx — updated frontmatter title from "Basic Concepts" to "Overview"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only sidebar and page title changes; no runtime, API, or URL path changes.
> 
> **Overview**
> **Basic Concepts** is no longer a top-level Documentation sidebar group. In `docs.json`, the same page list is now a **nested collapsible group** inside **How Yuno Works**, placed after `step-2-your-first-payment`; page URLs are unchanged.
> 
> The Basic Concepts landing page (`docs/basic-concepts/index.mdx`) frontmatter **title** is renamed from **Basic Concepts** to **Overview** so the nested section reads as an intro page under the parent group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54b4cdfeb558e28fb7bcdb1d07b239bb48ab91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->