### PR TITLE
Update Flutter SDK release notes for version 1.0.15

### DIFF
--- a/changelog/flutter.mdx
+++ b/changelog/flutter.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Flutter SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.0.15
+
+- <ChangelogBadge type="fixed" /> **Android OTT and Payment Status Delivery**  
+  Resolved an issue where the Android one-time token and payment status were not delivered to the app when using native Android SDK 2.15.0 or newer.
+
+- <ChangelogBadge type="changed" /> **Native SDK Updates**  
+  Updated native Android SDK to version 2.17.1 and iOS SDK to version 2.18.0.
+
 ## v1.0.14
 
 - <ChangelogBadge type="changed" /> **Android SDK Update**  

--- a/changelog/source/flutter.json
+++ b/changelog/source/flutter.json
@@ -2,6 +2,32 @@
   "sdk": "flutter",
   "releases": [
     {
+      "version": "1.0.15",
+      "release_date": null,
+      "upgrade": {
+        "snippet": "flutter pub add yuno:1.0.15",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Android OTT and Payment Status Delivery",
+          "description": "Resolved an issue where the Android one-time token and payment status were not delivered to the app when using native Android SDK 2.15.0 or newer.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Native SDK Updates",
+          "description": "Updated native Android SDK to version 2.17.1 and iOS SDK to version 2.18.0.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.0.14",
       "release_date": null,
       "upgrade": {


### PR DESCRIPTION
Automated update of Flutter SDK release notes for version 1.0.15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or application code changes.
> 
> **Overview**
> Documents **Flutter SDK v1.0.15** in the public changelog by prepending a new release block to `changelog/source/flutter.json` and the matching **v1.0.15** section at the top of `changelog/flutter.mdx`.
> 
> The release notes call out a **fix** for Android one-time token and payment status not reaching the app on native Android SDK 2.15.0+, and **native dependency bumps** to Android **2.17.1** and iOS **2.18.0**, with upgrade snippet `flutter pub add yuno:1.0.15`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c1674443f5a58802a383f2c4914e62599170620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->