### PR TITLE
Restructure domain registration and update step numbering

### DIFF
--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -16,6 +16,10 @@ This guide provides a comprehensive process to integrate Apple Pay with Yuno SDK
   Apple Pay is not supported in the iOS Simulator. To test Apple Pay functionality, you must use a physical iOS device.
 </Note>
 
+<Note>
+  Apple Pay supports third-party browsers such as Google Chrome for users with iOS 18 or higher.
+</Note>
+
 ## Apple Pay overview
 
 1. Customer initiates payment on their iOS device

--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -2,13 +2,9 @@
 title: "Prerequisites (Apple Pay)"
 ---
 
-<Note>
-  Apple Pay supports third-party browsers such as Google Chrome for users with iOS 18 or higher.
-</Note>
-
 Use this guide to prepare and configure Apple Pay with Yuno.
 
-- [**Apple Developer prerequisites**](#step-1-register-a-merchant-identifier): Create a merchant ID, generate and convert the required certificates/keys, and verify your merchant domains.
+- [**Apple Developer prerequisites**](#apple-pay-certificate-options): Depending on your certificate path, you may need to create a merchant ID and generate certificates/keys (Own), or simply register your merchant domains (Yuno).
 - [**Yuno Dashboard setup**](#finish-in-the-dashboard): Add the Apple Pay connection, set up routing, and enable Apple Pay in Checkout Builder.
 
 When finished, you'll be ready to [choose your integration path](#next-steps)  (SDK or Direct) for one-time and recurring payments.
@@ -17,8 +13,8 @@ When finished, you'll be ready to [choose your integration path](#next-steps)  (
 
 In the Yuno Dashboard, you will find three options for Apple Pay certificates:
 
-- **Yuno**: This option is for merchants who do not have an Apple Developer account or a mobile app (i.e., they are web-only). In these cases, you must register your merchant domains in order to use Yuno's certificates. [→ Register your merchant domains](#register-your-merchant-domains)
-- **Own**: This option is for merchants who have an Apple Developer account and prefer to manage their own private keys. You generate and convert the certificates manually using Keychain Access and OpenSSL (Steps 2–9), then paste the PEM values into the Yuno Dashboard. [→ Own certificates (manual)](#own-certificates-manual)
+- **Yuno**: This option is for merchants who do not have an Apple Developer account or a mobile app (i.e., they are web-only). In these cases, you must register your merchant domains in order to use Yuno's certificates. [→ Yuno certificates: register your merchant domains](#yuno-certificates-register-your-merchant-domains)
+- **Own (manual)**: This option is for merchants who have an Apple Developer account and prefer to manage their own private keys. You generate and convert the certificates manually using Keychain Access and OpenSSL (Steps 2–9), then paste the PEM values into the Yuno Dashboard. [→ Own certificates (manual)](#own-certificates-manual)
 - **Own — Yuno generates the CSRs**: This option is for merchants who have an Apple Developer account but don't want to generate private keys or run OpenSSL commands. Yuno generates the Certificate Signing Requests for you — you upload them to Apple and return the signed certificates. [→ Own certificates with Yuno-generated CSRs](#own-certificates-with-yuno-generated-csrs)
 
 ## Own certificates (manual)
@@ -201,7 +197,7 @@ You will end up with two .cer files — one for Payment Processing and one for M
   ![](/images/reference/prerequisites-apple-pay/image7.png)
 </Frame>
 
-## Register your merchant domains
+## Yuno certificates: register your merchant domains
 
 Before the Apple Pay button can appear on your website, every domain that displays it must be registered. You have two options:
 
@@ -226,14 +222,14 @@ Use the following endpoints to manage your domain registration:
 
 ## Finish in the Dashboard
 
-All three certificate paths — Yuno, Own, and Own — Yuno generates the CSRs — converge here to complete the setup in the Yuno Dashboard.
+All three certificate paths, Yuno, Own, and Own (Yuno-generated CSRs), converge here to complete the setup in the Yuno Dashboard.
 
 ### Step 1: Connect Apple Pay
 
 1. Log in to your [Yuno Dashboard](https://dashboard.y.uno/connections).
 2. Navigate to **Connections › Certificates & Domains › Apple Pay** and click **Connect**.
 3. Provide a **Name** for the connection, select **Apple Pay** as **Payment method**, and in the **Use certificates** dropdown, select the option that matches your setup:
-   - **Yuno**: select this option — Yuno manages the certificates on your behalf. No additional certificate configuration is required.
+   - **Yuno**: Yuno manages the certificates on your behalf automatically. No additional certificate configuration is required.
    - **Own** (manual): paste the PEM values you generated in the previous steps.
    - **Own — Yuno generates the CSRs**: select this option and upload the `.cer` files issued by Apple as described in the [Own certificates with Yuno-generated CSRs](#own-certificates-with-yuno-generated-csrs) section.
 4. Click **Next**, configure set up costs (optional) and accounts in the following two steps.

--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -9,7 +9,7 @@ title: "Prerequisites (Apple Pay)"
 Use this guide to prepare and configure Apple Pay with Yuno.
 
 - [**Apple Developer prerequisites**](#step-1-register-a-merchant-identifier): Create a merchant ID, generate and convert the required certificates/keys, and verify your merchant domains.
-- [**Yuno Dashboard setup**](#step-10-apple-pay-dashboard-connection): Add the Apple Pay connection, set up routing, and enable Apple Pay in Checkout Builder.
+- [**Yuno Dashboard setup**](#finish-in-the-dashboard): Add the Apple Pay connection, set up routing, and enable Apple Pay in Checkout Builder.
 
 When finished, you'll be ready to [choose your integration path](#next-steps)  (SDK or Direct) for one-time and recurring payments.
 
@@ -21,7 +21,11 @@ In the Yuno Dashboard, you will find three options for Apple Pay certificates:
 - **Own**: This option is for merchants who have an Apple Developer account and prefer to manage their own private keys. You generate and convert the certificates manually using Keychain Access and OpenSSL (Steps 2–9), then paste the PEM values into the Yuno Dashboard. [→ Own certificates (manual)](#own-certificates-manual)
 - **Own — Yuno generates the CSRs**: This option is for merchants who have an Apple Developer account but don't want to generate private keys or run OpenSSL commands. Yuno generates the Certificate Signing Requests for you — you upload them to Apple and return the signed certificates. [→ Own certificates with Yuno-generated CSRs](#own-certificates-with-yuno-generated-csrs)
 
-## Step 1: Register a merchant identifier
+## Own certificates (manual)
+
+This path is for merchants who have an Apple Developer account and want to generate and manage their certificates manually using Keychain Access and OpenSSL.
+
+### Step 1: Register a merchant identifier
 
 <Note>
   If you're using VTEX as your e-commerce platform, you'll need to configure your Apple Pay Merchant ID. For detailed instructions, check out the [official VTEX documentation](https://developers.vtex.com/docs/guides/setting-up-merchant-id-in-apple-pay).
@@ -33,11 +37,7 @@ In the Apple Developer dashboard:
 2. Choose **Merchant IDs**.
 3. Enter a **Description** (e.g., `Apple Pay Integration`) and an **Identifier** in the format `merchant.com.y.uno.YourBusinessName`.
 
-## Own certificates (manual)
-
-The following steps (2–9) apply if you selected the **Own** option and want to generate and manage your certificates manually using Keychain Access and OpenSSL.
-
-## Step 2: Generate a payment processing certificate
+### Step 2: Generate a payment processing certificate
 
 1. Create a new directory (e.g., `Downloads/ApplePayFiles`) to store the certificate files.
 2. Open **Keychain Access** on your Mac.
@@ -59,7 +59,7 @@ The following steps (2–9) apply if you selected the **Own** option and want to
    - **Key Size**: 256-bit
    - **Algorithm**: ECDSA
 
-## Step 3: Retrieve and convert the payment processing certificate
+### Step 3: Retrieve and convert the payment processing certificate
 
 1. Go to the [Apple Developer Merchant ID list](https://developer.apple.com/account/resources/identifiers/list/merchant).
 2. Select your Merchant ID and click **Create Certificate** under **Apple Pay Payment Processing Certificate**.
@@ -72,7 +72,7 @@ The following steps (2–9) apply if you selected the **Own** option and want to
 openssl x509 -inform DER -in apple_pay.cer -out apple_pay.pem
 ```
 
-## Step 4: Export the private key
+### Step 4: Export the private key
 
 1. In **Keychain Access**, find the key you created (e.g., `John Doe ProcessingCertificate`).
 2. Right-click and choose **Export**.
@@ -86,7 +86,7 @@ openssl pkcs12 -in JohnDoeProcessingCertificate.p12 -nocerts -nodes | sed -ne '/
 
 The private key will be stored in `ProcessingCertificatePrivateKey.pem`.
 
-## Step 5: Upload the certificate and key to Yuno
+### Step 5: Upload the certificate and key to Yuno
 
 1. Open the [Yuno Dashboard](https://dashboard.y.uno/auth/login) **\> Connections \> Apple Pay \> Connect**
 2. Enter the contents of `ProcessingCertificatePrivateKey.pem` to the **Payment processing key** field.
@@ -96,7 +96,7 @@ The private key will be stored in `ProcessingCertificatePrivateKey.pem`.
   ![](/images/reference/prerequisites-apple-pay/image2.png)
 </Frame>
 
-## Step 6: Generate a merchant identity certificate
+### Step 6: Generate a merchant identity certificate
 
 1. Open **Keychain Access**, navigate to **Certificate Assistant \> Request a Certificate From a Certificate Authority**, and enter:
 
@@ -107,7 +107,7 @@ The private key will be stored in `ProcessingCertificatePrivateKey.pem`.
 
 2. Save as `CertificateSigningRequestMerchantIdentityCertificate.certSigningRequest`.
 
-## Step 7: Retrieve and convert the merchant identity certificate
+### Step 7: Retrieve and convert the merchant identity certificate
 
 1. Go to the [Apple Developer Merchant ID list](https://developer.apple.com/account/resources/identifiers/list/merchant).
 2. Select your Merchant ID and click **Create Certificate** under **Apple Pay Merchant Identity Certificate**.
@@ -119,7 +119,7 @@ The private key will be stored in `ProcessingCertificatePrivateKey.pem`.
 openssl x509 -inform DER -in merchant_id.cer -out merchant_id.pem
 ```
 
-## Step 8: Export the merchant identity private key
+### Step 8: Export the merchant identity private key
 
 1. In **Keychain Access**, find the certificate created in step 6, e.g. `John Doe MerchantIdentityCertificate`.
 2. Right-click and export as `JohnDoeMerchantIdentityCertificate.p12`.
@@ -132,7 +132,7 @@ openssl pkcs12 -in JohnDoeMerchantIdentityCertificate.p12 -nocerts -nodes | sed 
 
 The private key will be available as `MerchantIdentityCertificatePrivateKey.pem`.
 
-## Step 9: Upload the merchant identity certificate and key
+### Step 9: Upload the merchant identity certificate and key
 
 1. Return to your Apple Pay connection in the [Yuno Dashboard](https://dashboard.y.uno/auth/login).
 2. Copy the contents of `MerchantIdentityCertificatePrivateKey.pem` and paste them into the **Merchant Identity key** field.
@@ -207,7 +207,7 @@ Before the Apple Pay button can appear on your website, every domain that displa
 
 ### Dashboard (recommended)
 
-Register your domains directly in the Yuno Dashboard — Yuno registers each domain with Apple on your behalf, so **you don't need to add domains in the Apple Developer Portal or host a domain-association file.**
+Register your domains directly in the Yuno Dashboard — Yuno registers each domain with Apple on your behalf.
 
 1. In the Dashboard, go to **Connections › Certificates & Domains › Apple Pay** and open the **Domains** tab.
 2. Click **Add domain**.
@@ -224,22 +224,26 @@ Use the following endpoints to manage your domain registration:
 - [Delete domain](/reference/domains/delete-domain)
 - [Domain webhooks](/reference/domains/webhooks-domains)
 
-## Step 10: Apple Pay Dashboard connection
+## Finish in the Dashboard
+
+All three certificate paths — Yuno, Own, and Own — Yuno generates the CSRs — converge here to complete the setup in the Yuno Dashboard.
+
+### Step 1: Connect Apple Pay
 
 1. Log in to your [Yuno Dashboard](https://dashboard.y.uno/connections).
-2. Navigate to the **Connections** section.
-3. Locate and select the **Apple Pay** option and click **Connect**.
-4. Provide a **Name** for the connection, select **Apple Pay** as **Payment method**, and in the **Use certificates** dropdown, select the option that matches your setup:
-   - **Yuno** or **Own** (manual): paste the PEM values you generated in the previous steps.
+2. Navigate to **Connections › Certificates & Domains › Apple Pay** and click **Connect**.
+3. Provide a **Name** for the connection, select **Apple Pay** as **Payment method**, and in the **Use certificates** dropdown, select the option that matches your setup:
+   - **Yuno**: select this option — Yuno manages the certificates on your behalf. No additional certificate configuration is required.
+   - **Own** (manual): paste the PEM values you generated in the previous steps.
    - **Own — Yuno generates the CSRs**: select this option and upload the `.cer` files issued by Apple as described in the [Own certificates with Yuno-generated CSRs](#own-certificates-with-yuno-generated-csrs) section.
-5. Click **Next**, configure set up costs (optional) and accounts in the following two steps.
-6. Click **Save**. Apple Pay will be added to your connections.
+4. Click **Next**, configure set up costs (optional) and accounts in the following two steps.
+5. Click **Save**. Apple Pay will be added to your connections.
 
 <Frame>
   ![](/images/reference/prerequisites-apple-pay/image4.png)
 </Frame>
 
-## Step 11: Configure Dashboard routing
+### Step 2: Configure routing
 
 Set up a new route to control how payments are processed through Apple Pay.
 
@@ -260,7 +264,7 @@ Here's a simple route processing all payments through Apple Pay.
   ![](/images/reference/prerequisites-apple-pay/image5.png)
 </Frame>
 
-## Step 12: Enable Apple Pay in Checkout Builder
+### Step 3: Enable Apple Pay in Checkout Builder
 
 <Note>
   Visit the [Checkout Builder](/docs/checkout-builder) page for additional information on this step.

--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -9,7 +9,7 @@ title: "Prerequisites (Apple Pay)"
 Use this guide to prepare and configure Apple Pay with Yuno.
 
 - [**Apple Developer prerequisites**](#step-1-register-a-merchant-identifier): Create a merchant ID, generate and convert the required certificates/keys, and verify your merchant domains.
-- [**Yuno Dashboard setup**](#step-11-apple-pay-dashboard-connection): Add the Apple Pay connection, set up routing, and enable Apple Pay in Checkout Builder.
+- [**Yuno Dashboard setup**](#step-10-apple-pay-dashboard-connection): Add the Apple Pay connection, set up routing, and enable Apple Pay in Checkout Builder.
 
 When finished, you'll be ready to [choose your integration path](#next-steps)  (SDK or Direct) for one-time and recurring payments.
 
@@ -17,13 +17,9 @@ When finished, you'll be ready to [choose your integration path](#next-steps)  (
 
 In the Yuno Dashboard, you will find three options for Apple Pay certificates:
 
-- **Yuno**: This option is for merchants who do not have an Apple Developer account or a mobile app (i.e., they are web-only). In these cases, you must register your domain via the API in order to use Yuno's certificates. Use the following endpoints to manage your domain registration:
-  - [Register domain](/reference/domains/register-domain)
-  - [Get domain](/reference/domains/get-domain)
-  - [Delete domain](/reference/domains/delete-domain)
-  - [Domain webhooks](/reference/domains/webhooks-domains)
-- **Own**: This option is for merchants who have an Apple Developer account and prefer to manage their own private keys. You generate and convert the certificates manually using Keychain Access and OpenSSL (Steps 2–9), then paste the PEM values into the Yuno Dashboard.
-- **Own — Yuno generates the CSRs**: This option is for merchants who have an Apple Developer account but don't want to generate private keys or run OpenSSL commands. Yuno generates the Certificate Signing Requests for you — you upload them to Apple and return the signed certificates.
+- **Yuno**: This option is for merchants who do not have an Apple Developer account or a mobile app (i.e., they are web-only). In these cases, you must register your merchant domains in order to use Yuno's certificates. [→ Register your merchant domains](#register-your-merchant-domains)
+- **Own**: This option is for merchants who have an Apple Developer account and prefer to manage their own private keys. You generate and convert the certificates manually using Keychain Access and OpenSSL (Steps 2–9), then paste the PEM values into the Yuno Dashboard. [→ Own certificates (manual)](#own-certificates-manual)
+- **Own — Yuno generates the CSRs**: This option is for merchants who have an Apple Developer account but don't want to generate private keys or run OpenSSL commands. Yuno generates the Certificate Signing Requests for you — you upload them to Apple and return the signed certificates. [→ Own certificates with Yuno-generated CSRs](#own-certificates-with-yuno-generated-csrs)
 
 ## Step 1: Register a merchant identifier
 
@@ -205,11 +201,13 @@ You will end up with two .cer files — one for Payment Processing and one for M
   ![](/images/reference/prerequisites-apple-pay/image7.png)
 </Frame>
 
-## Step 10: Register your merchant domains
+## Register your merchant domains
 
-Before the Apple Pay button can appear on your website, every domain that displays it must be registered. With Yuno you do this directly in the Dashboard — Yuno registers each domain with Apple on your behalf, so **you don't need to add domains in the Apple Developer Portal or host a domain-association file.**
+Before the Apple Pay button can appear on your website, every domain that displays it must be registered. You have two options:
 
-**To register your domains:**
+### Dashboard (recommended)
+
+Register your domains directly in the Yuno Dashboard — Yuno registers each domain with Apple on your behalf, so **you don't need to add domains in the Apple Developer Portal or host a domain-association file.**
 
 1. In the Dashboard, go to **Connections › Certificates & Domains › Apple Pay** and open the **Domains** tab.
 2. Click **Add domain**.
@@ -217,7 +215,16 @@ Before the Apple Pay button can appear on your website, every domain that displa
 4. Click **Add**. Each domain appears in the table with a status of **Verifying** while Yuno completes registration with Apple.
 5. When registration succeeds, the status changes to **Active** — the domain is ready to show Apple Pay.
 
-## Step 11: Apple Pay Dashboard connection
+### API
+
+Use the following endpoints to manage your domain registration:
+
+- [Register domain](/reference/domains/register-domain)
+- [Get domain](/reference/domains/get-domain)
+- [Delete domain](/reference/domains/delete-domain)
+- [Domain webhooks](/reference/domains/webhooks-domains)
+
+## Step 10: Apple Pay Dashboard connection
 
 1. Log in to your [Yuno Dashboard](https://dashboard.y.uno/connections).
 2. Navigate to the **Connections** section.
@@ -232,7 +239,7 @@ Before the Apple Pay button can appear on your website, every domain that displa
   ![](/images/reference/prerequisites-apple-pay/image4.png)
 </Frame>
 
-## Step 12: Configure Dashboard routing
+## Step 11: Configure Dashboard routing
 
 Set up a new route to control how payments are processed through Apple Pay.
 
@@ -253,7 +260,7 @@ Here's a simple route processing all payments through Apple Pay.
   ![](/images/reference/prerequisites-apple-pay/image5.png)
 </Frame>
 
-## Step 13: Enable Apple Pay in Checkout Builder
+## Step 12: Enable Apple Pay in Checkout Builder
 
 <Note>
   Visit the [Checkout Builder](/docs/checkout-builder) page for additional information on this step.


### PR DESCRIPTION
## PR Description
Restructures the Apple Pay prerequisites page. The domain registration step (previously Step 10) is moved into a new dedicated section with two sub-options (Dashboard and API). Each certificate option bullet now links to its corresponding section, and the remaining steps are renumbered accordingly.

## Changes
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx` — added anchor links to each of the three certificate option bullets
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx` — created new `## Register your merchant domains` section with `### Dashboard (recommended)` and `### API` sub-options
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx` — removed Step 10 from its original location (content moved to new section)
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx` — renumbered steps 11→10, 12→11, 13→12 and updated the intro anchor link