### PR TITLE
Add device payer risk data payment links

### DIFF
--- a/openapi/payment-links/create-payment-link.json
+++ b/openapi/payment-links/create-payment-link.json
@@ -504,6 +504,56 @@
                           }
                         }
                       },
+                      "device": {
+                        "type": "object",
+                        "description": "Specifies the device object.",
+                        "properties": {
+                          "locale": {
+                            "type": "string",
+                            "description": "The locale of the device (MAX 20; e.g. es-CL)."
+                          },
+                          "geolocation": {
+                            "type": "string",
+                            "description": "The geolocation of the device in lat,long format (MAX 255)."
+                          },
+                          "event_uuid": {
+                            "type": "string",
+                            "description": "The unique identifier of the event (MAX 64)."
+                          },
+                          "user_agent": {
+                            "type": "string",
+                            "description": "The user agent of the device (MAX 512)."
+                          }
+                        }
+                      },
+                      "payer_risk_data": {
+                        "type": "object",
+                        "description": "Specifies the payer risk data object.",
+                        "properties": {
+                          "login_platform": {
+                            "type": "string",
+                            "description": "The platform used to log in (MAX 64; e.g. WEB)."
+                          },
+                          "approved_transactions_2m": {
+                            "type": "integer",
+                            "description": "Number of approved transactions in the last 2 months (MIN 0).",
+                            "minimum": 0
+                          },
+                          "recent_transactions_3h": {
+                            "type": "integer",
+                            "description": "Number of transactions in the last 3 hours (MIN 0).",
+                            "minimum": 0
+                          },
+                          "is_paid_user": {
+                            "type": "boolean",
+                            "description": "Indicates whether the payer is a paid user."
+                          },
+                          "account_creation_date": {
+                            "type": "string",
+                            "description": "The account creation date in YYYYMMDD format (e.g. 20191005)."
+                          }
+                        }
+                      },
                       "seller_details": {
                         "type": "object",
                         "description": "Specifies the seller's details object. Only mandatory for PSPs with sub_merchant account information.",
@@ -856,7 +906,49 @@
                       "properties": {
                         "airline": {},
                         "order": {},
-                        "seller_details": {}
+                        "seller_details": {},
+                        "device": {
+                          "type": "object",
+                          "properties": {
+                            "locale": {
+                              "type": "string",
+                              "example": "es-CL"
+                            },
+                            "geolocation": {
+                              "type": "string"
+                            },
+                            "event_uuid": {
+                              "type": "string"
+                            },
+                            "user_agent": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "payer_risk_data": {
+                          "type": "object",
+                          "properties": {
+                            "login_platform": {
+                              "type": "string",
+                              "example": "WEB"
+                            },
+                            "approved_transactions_2m": {
+                              "type": "integer",
+                              "default": 0
+                            },
+                            "recent_transactions_3h": {
+                              "type": "integer",
+                              "default": 0
+                            },
+                            "is_paid_user": {
+                              "type": "boolean"
+                            },
+                            "account_creation_date": {
+                              "type": "string",
+                              "example": "20191005"
+                            }
+                          }
+                        }
                       }
                     },
                     "account_id": {

--- a/openapi/payment-links/retrieve-payment-link.json
+++ b/openapi/payment-links/retrieve-payment-link.json
@@ -187,7 +187,49 @@
                       "properties": {
                         "airline": {},
                         "order": {},
-                        "seller_details": {}
+                        "seller_details": {},
+                        "device": {
+                          "type": "object",
+                          "properties": {
+                            "locale": {
+                              "type": "string",
+                              "example": "es-CL"
+                            },
+                            "geolocation": {
+                              "type": "string"
+                            },
+                            "event_uuid": {
+                              "type": "string"
+                            },
+                            "user_agent": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "payer_risk_data": {
+                          "type": "object",
+                          "properties": {
+                            "login_platform": {
+                              "type": "string",
+                              "example": "WEB"
+                            },
+                            "approved_transactions_2m": {
+                              "type": "integer",
+                              "default": 0
+                            },
+                            "recent_transactions_3h": {
+                              "type": "integer",
+                              "default": 0
+                            },
+                            "is_paid_user": {
+                              "type": "boolean"
+                            },
+                            "account_creation_date": {
+                              "type": "string",
+                              "example": "20191005"
+                            }
+                          }
+                        }
                       }
                     },
                     "organization_code": {


### PR DESCRIPTION
## PR Description
Adds `device` and `payer_risk_data` as documented child objects of `additional_data` in the Payment Links OpenAPI specs. Both objects are already live in the API and validated end-to-end, as confirmed by Cesar Rios (Yuno backend team). The `device` object captures locale, geolocation, event UUID, and user agent; `payer_risk_data` captures login platform, transaction history counts, user tier, and account creation date.

## Changes
- `openapi/payment-links/create-payment-link.json` — added `device` and `payer_risk_data` under `additional_data` in both the request body schema and the 200 response schema
- `openapi/payment-links/retrieve-payment-link.json` — added `device` and `payer_risk_data` under `additional_data` in the 200 response schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI-only documentation updates with no runtime or validation logic changes in this diff.
> 
> **Overview**
> Documents **`device`** and **`payer_risk_data`** under **`additional_data`** in the Payment Links OpenAPI specs so they match behavior that is already supported by the API.
> 
> **Create Payment Link** now describes both objects on the request body (with field descriptions and constraints) and on the **200** response schema. **Retrieve Payment Link** adds the same two objects to its **200** response **`additional_data`** schema. **`device`** covers locale, geolocation, event UUID, and user agent; **`payer_risk_data`** covers login platform, recent transaction counts, paid-user flag, and account creation date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808c96f819a5e5a82926797e782b2e17953b3bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->