### PR TITLE
Update Flutter SDK release notes for version 1.0.16

### DIFF
--- a/changelog/flutter.mdx
+++ b/changelog/flutter.mdx
@@ -5,6 +5,11 @@ description: "Latest updates and version history for the Yuno Flutter SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.0.16
+
+- <ChangelogBadge type="changed" /> **Native Android SDK Update**  
+  Updated the native Android SDK to version 2.17.2.
+
 ## v1.0.15
 
 - <ChangelogBadge type="fixed" /> **Android OTT and Payment Status Delivery**  

--- a/changelog/source/flutter.json
+++ b/changelog/source/flutter.json
@@ -2,6 +2,24 @@
   "sdk": "flutter",
   "releases": [
     {
+      "version": "1.0.16",
+      "release_date": null,
+      "upgrade": {
+        "snippet": "flutter pub add yuno:1.0.16",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Native Android SDK Update",
+          "description": "Updated the native Android SDK to version 2.17.2.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.0.15",
       "release_date": null,
       "upgrade": {


### PR DESCRIPTION
Automated update of Flutter SDK release notes for version 1.0.16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or integration code changes.
> 
> **Overview**
> Documents **Flutter SDK v1.0.16** in the public changelog by prepending a new release to `changelog/source/flutter.json` and the matching **`changelog/flutter.mdx`** section.
> 
> The only noted change for this version is a **native Android SDK bump to 2.17.2** (marked as changed). The JSON also includes the usual upgrade snippet `flutter pub add yuno:1.0.16`; `release_date` is still `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3293d286cb40ccbd371c4d3752a9f8a70828c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->