### PR TITLE
docs(payment-status): add explanatory text and subtitles for sync and async flow diagrams

### DIFF
--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -296,6 +296,16 @@ The payments can have the following status and sub status.
 
 ### Possible states for sync and async flows
 
+Use the diagram that matches your integration type to understand which payment states and transitions to expect.
+
+#### Synchronous flow
+
+In a synchronous flow, the payment moves from `CREATED` directly to a terminal status — such as `SUCCEEDED`, `DECLINED`, or `REJECTED` — within the same API response. There is no intermediate `PENDING` phase. `ERROR` is transversal and can occur at any point in the flow.
+
 <Frame><img src="/images/reference/payment/image2.png" /></Frame>
+
+#### Asynchronous flow
+
+In an asynchronous flow, the payment passes through a `PENDING` phase after creation before reaching a terminal status. During this phase, substates such as `IN_PROCESS`, `AUTHORIZED`, and `WAITING_ADDITIONAL_STEP` reflect ongoing processing. The final status is delivered via webhook once processing completes. Payments initiated via direct async APMs may also enter a `READY_TO_PAY` state, which can transition to `EXPIRED` if not completed. `ERROR` is transversal and can occur at any point in the flow.
 
 <Frame><img src="/images/reference/payment/image3.png" /></Frame>


### PR DESCRIPTION
## PR Description
The bottom of the payment status page had two diagrams under the heading "Possible states for sync and async flows" with no supporting text, leaving readers without context. This PR adds an intro sentence, splits the section into two labeled subsections, and adds a short explanation for each diagram based on what the diagrams actually show.

## Changes
- `reference/payments/status-and-response-codes/payment.mdx` — added intro sentence before the diagrams; added `#### Synchronous flow` and `#### Asynchronous flow` subtitles; added a 2–3 sentence explanation under each subtitle describing the payment lifecycle for that flow type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a reference MDX page with no runtime, API, or security impact.
> 
> **Overview**
> The **Possible states for sync and async flows** section on the payment status reference page previously showed two lifecycle diagrams with no surrounding explanation.
> 
> This PR adds a short intro directing readers to pick the diagram that matches their integration type, splits the section into **Synchronous flow** and **Asynchronous flow** with `####` headings, and adds a brief paragraph before each diagram. The sync copy explains direct `CREATED` → terminal transitions in one API response (no `PENDING`) and that `ERROR` can happen anywhere. The async copy covers the `PENDING` phase and substates (`IN_PROCESS`, `AUTHORIZED`, `WAITING_ADDITIONAL_STEP`), webhook-delivered finals, `READY_TO_PAY` / `EXPIRED` for direct async APMs, and transversal `ERROR`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c727de44ed234cbdf60e8f97f4c552116102e910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->