### PR TITLE
docs(wallets): add NuPay card to Wallets Overview

### DIFF
--- a/docs/wallets/index.mdx
+++ b/docs/wallets/index.mdx
@@ -10,4 +10,6 @@ Here you find the complete list of Wallets' connections available on Yuno. Walle
   <Card title="Google Pay" icon="https://icons.prod.y.uno/googlepay_logosimbolo.png" href="/docs/wallets/google-pay" />
 
   <Card title="Click to Pay" icon="https://icons.prod.y.uno/clicktopay_logosimbolo.png" href="/docs/wallets/click-to-pay" />
+
+  <Card title="NuPay" icon="https://icons.prod.y.uno/nupay_logosimbolo.png" href="/docs/wallets/nupay" />
 </Columns>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the wallets index; no application or payment logic affected.
> 
> **Overview**
> Adds **NuPay** to the Wallets overview grid so it appears alongside Apple Pay, Google Pay, and Click to Pay.
> 
> The new card uses the NuPay icon and links to `/docs/wallets/nupay`, matching the existing wallet card pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec9a3635a1a9cc9b47dffec06eaf65324d5be75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->