### PR TITLE
Remove duplicate H1 headings that repeat frontmatter title

### DIFF
--- a/changelog/migration-guides/flutter.mdx
+++ b/changelog/migration-guides/flutter.mdx
@@ -2,6 +2,4 @@
 title: "Flutter SDK Migration"
 ---
 
-# Flutter SDK Migration
-
 Migration guides for Yuno Flutter SDK.

--- a/docs/direct-integration-use-cases/unreferenced-refunds-overview.mdx
+++ b/docs/direct-integration-use-cases/unreferenced-refunds-overview.mdx
@@ -3,8 +3,6 @@ title: "Refunds"
 description: "Yuno offers a complete suite of refund flows that cover every stage of the customer-money-back journey."
 ---
 
-# Refunds
-
 Yuno offers a complete suite of refund flows that cover every stage of the customer-money-back journey. There are three supported flows, each designed for a different operational need:
 
 - **[Referenced refunds](https://docs.y.uno/docs/direct-integration-use-cases/refund-payments)** — reverse a single Yuno-captured payment through the API. The standard customer-service reimbursement flow.

--- a/docs/sdks/universal-pilot.mdx
+++ b/docs/sdks/universal-pilot.mdx
@@ -4,8 +4,6 @@ description: "Early access preview of the upcoming Universal SDK"
 hidden: true
 ---
 
-# Universal SDK Pilot
-
 Welcome to the early access preview of the Yuno Universal SDK. This single integration will replace all previous SDK versions (Seamless, Lite, Headless) with a unified, highly configurable flow.
 
 ## Overview

--- a/reference/unreferenced-refunds/unreferenced-refund-status.mdx
+++ b/reference/unreferenced-refunds/unreferenced-refund-status.mdx
@@ -3,8 +3,6 @@ title: "Unreferenced Refund Status"
 description: "Lifecycle and state machine of unreferenced refunds."
 ---
 
-# Unreferenced Refund Status
-
 The `status` field reports the current lifecycle stage. The `sub_status` field provides finer-grained context within each top-level state.
 
 | Status      | Sub_status             | Description                                                                                                                                                                                                                                                                         |


### PR DESCRIPTION
## PR Description
Mintlify renders the frontmatter title: field as the page heading automatically, so any explicit # Title H1 in the body creates a duplicate title visible to readers. Reported by Heitor via Slack for the Unreferenced Refund Status page. A full audit of all 474 MDX files found 3 additional occurrences, all fixed in this PR.

## Changes
- reference/unreferenced-refunds/unreferenced-refund-status.mdx — removed # Unreferenced Refund Status H1 (original report)
- changelog/migration-guides/flutter.mdx — removed # Flutter SDK Migration H1
- docs/direct-integration-use-cases/unreferenced-refunds-overview.mdx — removed # Refunds H1
- docs/sdks/universal-pilot.mdx — removed # Universal SDK Pilot H1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only heading cleanup with no runtime, API, or security impact.
> 
> **Overview**
> Fixes **duplicate page titles** in Mintlify by removing body `# …` H1s that matched each file’s frontmatter `title` (Mintlify already renders `title` as the heading).
> 
> Updated four MDX pages: `unreferenced-refund-status.mdx`, `flutter.mdx` migration guide, `unreferenced-refunds-overview.mdx`, and hidden `universal-pilot.mdx`. No other content changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7a3f4e048d66a0b5f1f1d7df7bd957d813af09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->