### PR TITLE
Correct Payvalida card anchor from #mercado-pago-checkout-pro to #payvalida

### DIFF
--- a/reference/payments/payment-examples/payment-link.mdx
+++ b/reference/payments/payment-examples/payment-link.mdx
@@ -17,7 +17,7 @@ Some payment methods and providers may only be available in specific countries a
 
 
 <CardGroup cols={3}>
-  <Card title="Payvalida" icon="https://icons.prod.y.uno/payvalida_logosimbolo.png" href="/reference/payments/payment-examples/payment-link#mercado-pago-checkout-pro" />
+  <Card title="Payvalida" icon="https://icons.prod.y.uno/payvalida_logosimbolo.png" href="/reference/payments/payment-examples/payment-link#payvalida" />
   <Card title="Tarjeta Clave" icon="https://icons.prod.y.uno/tarjetaclave_logosimbolo.png" href="/reference/payments/payment-examples/payment-link#tarjeta-clave" />
   <Card title="Webpay" icon="https://icons.prod.y.uno/webpay_logosimbolo.png" href="/reference/payments/payment-examples/payment-link#webpay" />
   <Card title="Pago Efectivo" icon="https://icons.prod.y.uno/pagoefectivo_logosimbolo.png" href="/reference/payments/payment-examples/payment-link#pago-efectivo" />


### PR DESCRIPTION
## PR Description:
The Payvalida card in reference/payments/payment-examples/payment-link.mdx had a wrong anchor (#mercado-pago-checkout-pro) that redirected users to the wrong section. Fixed to point to #payvalida.

## Changes:

reference/payments/payment-examples/payment-link.mdx — corrected Payvalida card href from #mercado-pago-checkout-pro to #payvalida

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation link fix with no runtime or API impact.
> 
> **Overview**
> Fixes the **Payvalida** navigation card on the Payment Link examples page so it jumps to the Payvalida section instead of an unrelated anchor.
> 
> The card `href` is updated from `#mercado-pago-checkout-pro` to `#payvalida`, matching the `### Payvalida` heading on the same page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db44771fc83ad742621de333eff242db0eeb9f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->