### PR TITLE
fix(click-to-pay): reduce and center first image size

### DIFF
--- a/docs/wallets/click-to-pay.mdx
+++ b/docs/wallets/click-to-pay.mdx
@@ -4,7 +4,7 @@ title: "Click to Pay"
 
 Click to Pay is an online payment solution designed to streamline and secure online transactions. It's based on the EMVCo secure payment standard, a global consortium comprising major card companies like Visa, MasterCard, American Express, and Discover.
 
-<Frame><img src="/images/reference/click-to-pay/image1.png" /></Frame>
+<div style={{width: "400px", margin: "0 auto"}}><Frame><img src="/images/reference/click-to-pay/image1.png" width="400" /></Frame></div>
 
 *Networks available in Yuno*: [MasterCard](https://www.mastercard.us/en-us/personal/ways-to-pay/click-to-pay.html)
 


### PR DESCRIPTION
## PR Description
The first image on the Click to Pay page was rendering too large. Reported by Heitor. The image is now constrained to 400px wide and centered using a wrapping `<div>` with inline styles, keeping the existing `<Frame>` component intact.

## Changes
- `docs/wallets/click-to-pay.mdx` — wrapped the first image (`image1.png`) in a `<div style={{width: "400px", margin: "0 auto"}}>` and added `width="400"` to the `<img>` tag to reduce and center it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only presentation change with no runtime or API impact.
> 
> **Overview**
> The hero image on the **Click to Pay** docs page (`click-to-pay.mdx`) was displaying too large. It is now limited to **400px** width and **centered** by wrapping the existing `<Frame>` in a `<div>` with `width: 400px` and `margin: 0 auto`, and setting `width="400"` on the `<img>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4e6dca90a7f1396baf30ca1478fb69da50644c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->