### PR TITLE
chore: web sdk changelog 1.9.10

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,54 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.10",
+      "release_date": "2026-06-30",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.10",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Localized currency formatting by merchant language",
+          "description": "Amounts now follow the merchant-configured YunoLanguage + per-checkout countryCode (via Intl.NumberFormat) instead of being derived from the currency, fixing decimal/thousand separators, symbol position and spacing for non-English checkouts. The currency still drives symbol vs ISO code and decimals.",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Render the BLIK OTP Input in Every Checkout Display Mode",
+          "description": "BLIK now prompts for its one-time code in all checkout display modes — unfolded, modal (Lite SDK) and render — instead of only the unfolded flow. The entered code is sent in the One Time Token request so the payment can be completed from any integration mode.",
+          "group": "Alternative Payment Methods",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Auto-Select Single Payment Method",
+          "description": "When there is no enrolled payment method and only a single non-button payment method is available, it is now preselected automatically.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Status Action Notification",
+          "description": "The SDK now notifies the onActionExecuted callback with a CHECK_STATUS action when the payment status screen is shown, so merchants can reliably dismiss their own loaders.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17227",
+        "CORECM-17623",
+        "CORECM-17926",
+        "CORECM-17943"
+      ]
+    },
+    {
       "version": "1.9.9",
       "release_date": "2026-06-24",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,29 +5,50 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.10
+*June 30, 2026*
+
+**Checkout**
+
+- <ChangelogBadge type="changed" /> **Localized currency formatting by merchant language**  
+  Amounts now follow the merchant-configured YunoLanguage + per-checkout countryCode (via Intl.NumberFormat) instead of being derived from the currency, fixing decimal/thousand separators, symbol position and spacing for non-English checkouts. The currency still drives symbol vs ISO code and decimals.
+
+**Alternative Payment Methods**
+
+- <ChangelogBadge type="changed" /> **Render the BLIK OTP Input in Every Checkout Display Mode**  
+  BLIK now prompts for its one-time code in all checkout display modes — unfolded, modal (Lite SDK) and render — instead of only the unfolded flow. The entered code is sent in the One Time Token request so the payment can be completed from any integration mode.
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Auto-Select Single Payment Method**  
+  When there is no enrolled payment method and only a single non-button payment method is available, it is now preselected automatically.
+
+**Payment Actions**
+
+- <ChangelogBadge type="fixed" /> **Status Action Notification**  
+  The SDK now notifies the onActionExecuted callback with a CHECK_STATUS action when the payment status screen is shown, so merchants can reliably dismiss their own loaders.
+
 ## v1.9.9
 *June 24, 2026*
 
 **Core SDK**
 
-- <ChangelogBadge type="security" /> **Hardened 3DS Frame-Restriction Flow**  
-  A per-session JWT is now passed to `challenge.html`, and the 3DS frame-restriction flow includes a postMessage handshake with nonce and origin verification to prevent unauthorized frame interactions.
+- <ChangelogBadge type="security" /> **Pass a per-session JWT to challenge.html and add a postMessage handshake with nonce/origin verification for the 3DS frame-restriction flow.**  
+  
 
 ## v1.9.8
 *June 23, 2026*
+
+- <ChangelogBadge type="changed" /> **FIXED: Enable downloading the QR image for client-generated QR codes (`GENERATE_QR`, e.g. QRIS/Xendit). The "Download QR image" button now renders for these payment methods and saves the on-screen code as a PNG generated on the client with `qrcode`. Previously the button only appeared for ready-to-use image QRs (URL/BASE64), so QRIS never showed it even though the backend sent the `download_qr` label.**  
+  
 
 **Card Payments**
 
 - <ChangelogBadge type="added" /> **Per-Scheme Card Number Length Validation**  
   Card number length is now validated per card scheme using backend-driven rules combined with the Luhn check, reducing false rejections of valid cards. Gated behind a feature flag.
 
-- <ChangelogBadge type="fixed" /> **Route SDK iframe Assets Through the Asset Host in Whitelabel Mode**  
-  Secure-field pages, the card form, and the mediator are now resolved against `assetUrl` instead of `apiUrl` in whitelabel mode, so merchants who set a distinct `assetUrl` with a proxy sub-path (e.g. `/hosted-payment-methods/orchestrator`) no longer get the sub-path dropped and secure fields load from the correct path in enrollment and enrolled-card flows.
-
-**QR Payments**
-
-- <ChangelogBadge type="changed" /> **Enable Downloading the QR Image for Client-Generated QR Codes**  
-  The "Download QR image" button now renders for client-generated QR methods (e.g. QRIS/Xendit) and saves the on-screen code as a PNG. Previously the button only appeared for ready-to-use image QRs (URL/BASE64).
+- <ChangelogBadge type="fixed" /> **FIXED: Route sdk-web-card iframe assets (secure-field pages, card form, mediator) through the asset host in whitelabel mode. They were resolved against `apiUrl`, so when a merchant set a distinct `assetUrl` carrying a proxy sub-path (e.g. `/hosted-payment-methods/orchestrator`) the sub-path was dropped and secure fields loaded from the wrong path in enrollment and enrolled-card flows (CORECM-17901).**  
+  
 
 ## v1.9.7
 *June 17, 2026*


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.10`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.10

4 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or API code changes.
> 
> **Overview**
> Adds **Web SDK v1.9.10** (June 30, 2026) to `changelog/source/web.json` and the top of `changelog/web.mdx`, with four release notes: **localized currency formatting** via merchant `YunoLanguage` and checkout `countryCode` (`Intl.NumberFormat`); **BLIK OTP** in unfolded, modal, and render modes; **auto-select** when there is one non-button method and no enrolled card; and **`onActionExecuted`** with `CHECK_STATUS` when the payment status screen appears.
> 
> The MDX file also **reformats older v1.9.9 and v1.9.8 bullets** (shorter security title, QR download and whitelabel iframe fixes moved into title-only entries with less grouped structure than before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21000ccb0e3852892f225b19e5889c974e57d470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->