### PR TITLE
feat: add google tag manager

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -886,6 +886,11 @@
       "href": "https://dashboard.y.uno"
     }
   },
+  "integrations": {
+    "gtm": {
+      "tagId": "GTM-N92R97GM"
+    }
+  },
   "redirects": [
     {
       "source": "/guides/sdk/ios-reference",


### PR DESCRIPTION
this is an atempt to add datadog to the doc so we can track the usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Mintlify config entry for third-party scripts; low functional risk, with usual privacy/compliance considerations for client-side tracking.
> 
> **Overview**
> Adds **Google Tag Manager** to the public docs by configuring Mintlify’s `integrations.gtm` block in `docs.json` with container ID `GTM-N92R97GM`, so GTM (and tags managed there, e.g. analytics) load on doc pages.
> 
> This is a **config-only** change: no app code, routes, or content pages are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1038bc422f08d50bf2f903957b6772a0ffab613d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->