### PR TITLE
fix(payments): remove paymentPspReference and pspReference from all specs and examples

### DIFF
--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -232,7 +232,10 @@
                         "properties": {
                           "bank_transfer": {
                             "type": "object",
-                            "required": ["beneficiary_name", "routing_number"],
+                            "required": [
+                              "beneficiary_name",
+                              "routing_number"
+                            ],
                             "properties": {
                               "account_type": {
                                 "type": "string",
@@ -623,7 +626,6 @@
                                     "threeds2.cardEnrolled": "false"
                                   },
                                   "merchantReference": "VERIFY_CARD_9c298b36-b005-42ed-92e1-808b2a785e5f",
-                                  "pspReference": "SKCN8ZR5S8NKGK82",
                                   "refusalReason": "FRAUD-CANCELLED",
                                   "refusalReasonCode": "22",
                                   "resultCode": "Cancelled"
@@ -1046,10 +1048,6 @@
                                               "merchantReference": {
                                                 "type": "string",
                                                 "example": "VERIFY_CARD_9c298b36-b005-42ed-92e1-808b2a785e5f"
-                                              },
-                                              "pspReference": {
-                                                "type": "string",
-                                                "example": "SKCN8ZR5S8NKGK82"
                                               },
                                               "refusalReason": {
                                                 "type": "string",

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -2837,8 +2837,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -2921,8 +2919,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -3858,8 +3854,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4056,8 +4050,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4273,8 +4265,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4451,8 +4441,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4629,8 +4617,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4807,8 +4793,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4985,8 +4969,6 @@
                               "value": 5000
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -5649,14 +5631,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -5931,14 +5905,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -8666,14 +8632,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -9319,14 +9277,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -10037,14 +9987,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -10610,14 +10552,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -11188,14 +11122,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -11762,14 +11688,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -12335,14 +12253,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -4259,8 +4259,6 @@
                             "value": 2100
                           },
                           "merchantAccount": "YunoPaymentsECOM",
-                          "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                          "pspReference": "VKJTCWZ9575ZGN82",
                           "reference": "34343434",
                           "status": "received"
                         },
@@ -4357,8 +4355,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -4617,8 +4613,6 @@
                             "value": 2100
                           },
                           "merchantAccount": "YunoPaymentsECOM",
-                          "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                          "pspReference": "VKJTCWZ9575ZGN82",
                           "reference": "34343434",
                           "status": "received"
                         },
@@ -4715,8 +4709,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -5160,8 +5152,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -5258,8 +5248,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -5509,8 +5497,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -5607,8 +5593,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -5905,8 +5889,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -6003,8 +5985,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -6237,8 +6217,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -6335,8 +6313,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -6581,8 +6557,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -6679,8 +6653,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -6949,8 +6921,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -7047,8 +7017,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -7270,8 +7238,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -7368,8 +7334,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -7591,8 +7555,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -7689,8 +7651,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -7916,8 +7876,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -8018,8 +7976,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -8246,8 +8202,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -8344,8 +8298,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -8589,8 +8541,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -8687,8 +8637,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -8932,8 +8880,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -9030,8 +8976,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -9490,8 +9434,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -9577,8 +9519,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -10031,8 +9971,6 @@
                               "value": 2100
                             },
                             "merchantAccount": "YunoPaymentsECOM",
-                            "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                            "pspReference": "VKJTCWZ9575ZGN82",
                             "reference": "34343434",
                             "status": "received"
                           },
@@ -10129,8 +10067,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -11576,14 +11512,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -11874,14 +11802,6 @@
                                       "merchantAccount": {
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
-                                      },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
                                       },
                                       "reference": {
                                         "type": "string",
@@ -12530,14 +12450,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -12813,14 +12725,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -13753,14 +13657,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -14036,14 +13932,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -14828,14 +14716,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -15111,14 +14991,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -15967,14 +15839,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -16250,14 +16114,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -16959,14 +16815,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -17242,14 +17090,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -17951,14 +17791,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -18234,14 +18066,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -18959,14 +18783,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -19258,14 +19074,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -19964,14 +19772,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -20247,14 +20047,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -20960,14 +20752,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -21243,14 +21027,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -21964,14 +21740,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -22251,14 +22019,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -23585,14 +23345,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -23868,14 +23620,6 @@
                                     "merchantAccount": {
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
-                                    },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
                                     },
                                     "reference": {
                                       "type": "string",
@@ -25130,14 +24874,6 @@
                                       "type": "string",
                                       "example": "YunoPaymentsECOM"
                                     },
-                                    "paymentPspReference": {
-                                      "type": "string",
-                                      "example": "ZKHXKZGXMLBX8N82"
-                                    },
-                                    "pspReference": {
-                                      "type": "string",
-                                      "example": "VKJTCWZ9575ZGN82"
-                                    },
                                     "reference": {
                                       "type": "string",
                                       "example": "34343434"
@@ -25416,14 +25152,6 @@
                                       "merchantAccount": {
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
-                                      },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
                                       },
                                       "reference": {
                                         "type": "string",

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -1194,8 +1194,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -1425,8 +1423,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -1637,8 +1633,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -1849,8 +1843,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -2061,8 +2053,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -2275,8 +2265,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -2489,8 +2477,6 @@
                                 "value": 2100
                               },
                               "merchantAccount": "YunoPaymentsECOM",
-                              "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                              "pspReference": "VKJTCWZ9575ZGN82",
                               "reference": "34343434",
                               "status": "received"
                             },
@@ -6495,14 +6481,6 @@
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
                                       },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
-                                      },
                                       "reference": {
                                         "type": "string",
                                         "example": "34343434"
@@ -7254,14 +7232,6 @@
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
                                       },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
-                                      },
                                       "reference": {
                                         "type": "string",
                                         "example": "34343434"
@@ -7950,14 +7920,6 @@
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
                                       },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
-                                      },
                                       "reference": {
                                         "type": "string",
                                         "example": "34343434"
@@ -8645,14 +8607,6 @@
                                       "merchantAccount": {
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
-                                      },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
                                       },
                                       "reference": {
                                         "type": "string",
@@ -9344,14 +9298,6 @@
                                       "merchantAccount": {
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
-                                      },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
                                       },
                                       "reference": {
                                         "type": "string",
@@ -10055,14 +10001,6 @@
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
                                       },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
-                                      },
                                       "reference": {
                                         "type": "string",
                                         "example": "34343434"
@@ -10764,14 +10702,6 @@
                                       "merchantAccount": {
                                         "type": "string",
                                         "example": "YunoPaymentsECOM"
-                                      },
-                                      "paymentPspReference": {
-                                        "type": "string",
-                                        "example": "ZKHXKZGXMLBX8N82"
-                                      },
-                                      "pspReference": {
-                                        "type": "string",
-                                        "example": "VKJTCWZ9575ZGN82"
                                       },
                                       "reference": {
                                         "type": "string",

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -1104,8 +1104,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -1337,8 +1335,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -1551,8 +1547,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -1765,8 +1759,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -1979,8 +1971,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -2195,8 +2185,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -2411,8 +2399,6 @@
                                   "value": 2100
                                 },
                                 "merchantAccount": "YunoPaymentsECOM",
-                                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                                "pspReference": "VKJTCWZ9575ZGN82",
                                 "reference": "34343434",
                                 "status": "received"
                               },
@@ -6225,14 +6211,6 @@
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
                                         },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
-                                        },
                                         "reference": {
                                           "type": "string",
                                           "example": "34343434"
@@ -6956,14 +6934,6 @@
                                         "merchantAccount": {
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
-                                        },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
                                         },
                                         "reference": {
                                           "type": "string",
@@ -7759,14 +7729,6 @@
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
                                         },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
-                                        },
                                         "reference": {
                                           "type": "string",
                                           "example": "34343434"
@@ -8427,14 +8389,6 @@
                                         "merchantAccount": {
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
-                                        },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
                                         },
                                         "reference": {
                                           "type": "string",
@@ -9099,14 +9053,6 @@
                                         "merchantAccount": {
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
-                                        },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
                                         },
                                         "reference": {
                                           "type": "string",
@@ -9783,14 +9729,6 @@
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
                                         },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
-                                        },
                                         "reference": {
                                           "type": "string",
                                           "example": "34343434"
@@ -10465,14 +10403,6 @@
                                         "merchantAccount": {
                                           "type": "string",
                                           "example": "YunoPaymentsECOM"
-                                        },
-                                        "paymentPspReference": {
-                                          "type": "string",
-                                          "example": "ZKHXKZGXMLBX8N82"
-                                        },
-                                        "pspReference": {
-                                          "type": "string",
-                                          "example": "VKJTCWZ9575ZGN82"
                                         },
                                         "reference": {
                                           "type": "string",

--- a/reference/payments/payment-examples/cards.mdx
+++ b/reference/payments/payment-examples/cards.mdx
@@ -267,8 +267,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -365,8 +363,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },
@@ -838,8 +834,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -936,8 +930,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },
@@ -1208,8 +1200,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -1306,8 +1296,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },
@@ -1672,8 +1660,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -1770,8 +1756,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },
@@ -2066,8 +2050,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -2164,8 +2146,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },
@@ -2449,8 +2429,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -2547,8 +2525,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },
@@ -2844,8 +2820,6 @@ curl --request POST \
                     "value": 2100
                 },
                 "merchantAccount": "YunoPaymentsECOM",
-                "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                "pspReference": "VKJTCWZ9575ZGN82",
                 "reference": "34343434",
                 "status": "received"
             },
@@ -2942,8 +2916,6 @@ curl --request POST \
                         "value": 2100
                     },
                     "merchantAccount": "YunoPaymentsECOM",
-                    "paymentPspReference": "ZKHXKZGXMLBX8N82",
-                    "pspReference": "VKJTCWZ9575ZGN82",
                     "reference": "34343434",
                     "status": "received"
                 },


### PR DESCRIPTION
## PR Description
Reported by Jairo: the fields paymentPspReference and pspReference appear in payment API response examples but do not exist in the actual Yuno API. This PR removes both fields from all example values and schema definitions across the affected OpenAPI specs and MDX example files.

## Changes
- openapi/payments/create-payment.json — removed paymentPspReference and pspReference from all response examples and schema definitions
- openapi/payments/retrieve-payment-by-id.json — same
- openapi/payments/retrieve-payment-by-merchant-order-id.json — same
- openapi/payments/authorize-payment.json — same
- openapi/payment-methods-direct-workflow/enroll-payment-method-api.json — removed pspReference from response example and schema definition
- reference/payments/payment-examples/cards.mdx — removed both fields from all inline code block examples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no runtime or API contract changes; integrators who relied on those example fields may need to stop expecting them in responses.
> 
> **Overview**
> Aligns payment and enrollment API docs with the real Yuno API by dropping **`paymentPspReference`** and **`pspReference`** everywhere they were documented but not returned.
> 
> Those keys are removed from **`provider_data.raw_response`** in response examples and from the matching OpenAPI schema properties across **`create-payment`**, **`authorize-payment`**, **`retrieve-payment-by-id`**, **`retrieve-payment-by-merchant-order-id`**, and **`enroll-payment-method-api`**. The verify-card enrollment example and schema no longer include **`pspReference`** inside the Adyen-style **`raw_response`**. **`reference/payments/payment-examples/cards.mdx`** is updated the same way.
> 
> Minor formatting-only edits appear in **`enroll-payment-method-api.json`** (multiline **`required`** for bank transfer, EOF newline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9425a1a56c802ac37e1f0301806c0aa9761cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->