### PR TITLE
docs(vtex): document subscriptions and split-order support

### DIFF
--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -14,7 +14,7 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
 </Accordion>
 
 <Accordion title="Does Yuno support VTEX subscriptions (recurring payments)?">
-  Yes. Orders created with VTEX's [subscriptions](https://help.vtex.com/docs/tutorials/how-subscriptions-work) feature are supported out of the box. The first purchase is processed like any other card payment. The automatic renewals that follow are charged even though the shopper is not present and no security code (CVV) is entered — Yuno processes them as stored-credential (card-on-file) payments, so recurring charges go through instead of being declined.
+  Yes. Orders created with VTEX's [subscriptions](https://help.vtex.com/docs/tutorials/how-subscriptions-work) feature are supported out of the box. The first purchase is processed like any other card payment. The automatic renewals that follow are charged even though the shopper is not present and no security code (CVV) is entered — Yuno processes them as stored-credential, merchant-initiated (MIT) payments, so recurring charges go through instead of being declined.
 
   There is nothing extra to configure on the Yuno side: as long as you have set up subscriptions in VTEX, the integration handles them automatically, and your regular checkout is unaffected. Subscriptions apply to card payments only.
 </Accordion>

--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -13,6 +13,12 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
   Saved-card flows and Click to Pay both rely on a customer record being created in Yuno. To enable them, set the **Create Customer** field to **Yes** in your Yuno provider configuration. With this option enabled, the plugin creates or updates a Yuno customer record on every payment.
 </Accordion>
 
+<Accordion title="Does Yuno support VTEX subscriptions (recurring payments)?">
+  Yes. Orders created with VTEX's [subscriptions](https://help.vtex.com/docs/tutorials/how-subscriptions-work) feature are supported out of the box. The first purchase is processed like any other card payment. The automatic renewals that follow are charged even though the shopper is not present and no security code (CVV) is entered — Yuno processes them as stored-credential (card-on-file) payments, so recurring charges go through instead of being declined.
+
+  There is nothing extra to configure on the Yuno side: as long as you have set up subscriptions in VTEX, the integration handles them automatically, and your regular checkout is unaffected. Subscriptions apply to card payments only.
+</Accordion>
+
 <Accordion title="How do I switch between sandbox and production?">
   The environment is determined by the prefix of your Yuno **Public API Key**:
   *   `dev_*`, `staging_*`, and `sandbox_*` prefixes connect to test environments.
@@ -31,6 +37,10 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
 
 <Accordion title="I have several Yuno accounts under a single VTEX store. Can I use them all?">
   Yes. You can connect a single VTEX account to multiple Yuno integrations. Configure Yuno as a provider once for each integration with a distinct **Affiliation Name**, then select the correct affiliation when activating each payment method.
+</Accordion>
+
+<Accordion title="How are orders with items from multiple sellers handled?">
+  When a shopper's cart contains products from different sellers or franchises, VTEX splits the purchase into multiple suborders and charges each one independently. Yuno processes every suborder so the whole order is paid — not just the first part — sharing a single antifraud session across all of them. You can control which antifraud providers receive that shared session with the **Antifraud Providers for Split Orders** field. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#advanced-scenarios) for details.
 </Accordion>
 
 <Accordion title="Where can I troubleshoot a specific order?">

--- a/docs/plugins/vtex/index.mdx
+++ b/docs/plugins/vtex/index.mdx
@@ -42,6 +42,13 @@ The plugin is composed of three pieces that work together behind the scenes:
 
 You configure the **Payment Connector** in VTEX. The **Payment App** is installed afterward, and the **SDK Web** is loaded automatically during checkout — there is no separate setup for it.
 
+## Recurring payments and multi-seller orders
+
+Beyond one-off checkout, the Yuno integration also handles two common VTEX scenarios automatically:
+
+*   **VTEX subscriptions (recurring payments)** — for products sold on a recurring basis, Yuno processes both the first purchase and the automatic renewals that follow. See the [FAQs](/docs/plugins/vtex/faqs) for details.
+*   **Multi-seller (split) orders** — when a cart combines products from different sellers or franchises, VTEX splits it into separate orders and Yuno charges every one of them, not just the first. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#advanced-scenarios).
+
 ---
 
 ## Where to next?

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -140,3 +140,9 @@ If your business runs **multiple VTEX accounts** (e.g., a franchise model sharin
 *   **Main Account App key** and **Main Account App token**: Application credentials of that main account.
 
 When these fields are set, the plugin reads catalog and order data from the main account instead of the current one.
+
+### Split orders (multiple sellers)
+
+When a shopper's cart contains products from **different sellers or franchises**, VTEX splits the purchase into multiple suborders and authorizes each one independently. The Yuno integration detects this and processes **every** suborder — so the entire order is paid, not just the first part — while sharing a single antifraud session across all of them.
+
+This works automatically; no extra setup is required. If you want to control which antifraud providers receive the shared session, use the **Antifraud Providers for Split Orders** field in the provider configuration (see the field reference in Step 1). Valid values are `RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, and `CIELO_CYBERSOURCE_FRAUD`; when left empty, it defaults to `RISKIFIED` + `CYBERSOURCE`.


### PR DESCRIPTION
## Summary

Documents two VTEX connector capabilities for merchants, in the existing `docs/plugins/vtex` pages. **Additive only — no existing content was changed or removed.**

### VTEX subscriptions (recurring payments)
- **FAQ** (`faqs.mdx`): new answer "Does Yuno support VTEX subscriptions (recurring payments)?", linking to [VTEX's subscriptions docs](https://help.vtex.com/docs/tutorials/how-subscriptions-work). Explains that the first charge behaves like a normal card payment and the automatic renewals are processed as stored-credential (card-on-file) charges — no extra configuration, card payments only.
- **Overview** (`index.mdx`): brief mention in a new "Recurring payments and multi-seller orders" section.

### Split orders (multiple sellers)
- **Setup** (`set-up-yuno-on-vtex.mdx`): new "Split orders (multiple sellers)" subsection under **Advanced Scenarios**, describing how every suborder is charged with a shared antifraud session and pointing to the existing *Antifraud Providers for Split Orders* field.
- **FAQ** (`faqs.mdx`): new answer "How are orders with items from multiple sellers handled?".
- **Overview** (`index.mdx`): mention in the same new section.

## Why
Both are supported connector capabilities that merchants had no public documentation for. Subscriptions requires no merchant setup (fully automatic); split orders has one optional setting, documented alongside it.

## Preview
Run `mint dev` and check:
- `/docs/plugins/vtex` (overview)
- `/docs/plugins/vtex/faqs`
- `/docs/plugins/vtex/set-up-yuno-on-vtex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to MDX; no application, payment, or security logic is modified.
> 
> **Overview**
> **Adds merchant-facing documentation** for two VTEX connector behaviors that were previously undocumented: **VTEX subscriptions (recurring card payments)** and **multi-seller split orders**.
> 
> On the **overview** (`index.mdx`), a new **Recurring payments and multi-seller orders** section points merchants to the FAQs and Advanced Scenarios. The **FAQs** gain two accordions: one explaining out-of-the-box subscription support (first charge like a normal card payment, renewals as stored-credential/MIT without extra Yuno config, cards only) and one describing split carts (every suborder charged, shared antifraud session, optional **Antifraud Providers for Split Orders**). The **setup guide** adds a **Split orders (multiple sellers)** subsection under Advanced Scenarios that ties behavior to the existing provider field and defaults; it also fixes a missing trailing newline after the multi-account paragraph.
> 
> No runtime or connector code changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caec9e0fb2ef26dbc4904643e5cfcb46f1778a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->