### PR TITLE
docs(payments): add image_url field to additional_data.order.items[]

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -169,7 +169,8 @@ The next JSON object presents an example of a data structure related to a paymen
                             "category": "services",
                             "brand": null,
                             "sku_code": null,
-                            "manufacture_part_number": null
+                            "manufacture_part_number": null,
+                            "image_url": null
                         }
                     ],
                     "taxes": []
@@ -455,7 +456,8 @@ The next JSON object presents an example of a data structure related to a paymen
                   "category":"Clothes",
                   "brand":"XYZ",
                   "sku_code":"8765432109",
-                  "manufacture_part_number":"XYZ123456"
+                  "manufacture_part_number":"XYZ123456",
+                  "image_url":null
                }
             ]
          },
@@ -688,7 +690,8 @@ The next JSON object presents an example of a data structure related to a paymen
                      "category":"others",
                      "brand":null,
                      "sku_code":"26609",
-                     "manufacture_part_number":null
+                     "manufacture_part_number":null,
+                     "image_url":null
                   }
                ],
                "taxes":[
@@ -1178,7 +1181,8 @@ The next JSON object presents an example of a data structure related to a paymen
                   "category":"Clothes",
                   "brand":"XYZ",
                   "sku_code":"8765432109",
-                  "manufacture_part_number":"XYZ123456"
+                  "manufacture_part_number":"XYZ123456",
+                  "image_url":null
                }
             ]
          },
@@ -2169,7 +2173,8 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
             "category": "Clothes",
             "brand": "XYZ",
             "sku_code": "8765432109",
-            "manufacture_part_number": "XYZ123456"
+            "manufacture_part_number": "XYZ123456",
+            "image_url": null
           }
         ],
         "taxes": [],

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -328,6 +328,12 @@
                                 "url": {
                                   "type": "string",
                                   "description": "The item's URL available to the buyer (MAX 512; MIN 3)."
+                                },
+                                "image_url": {
+                                  "type": "string",
+                                  "description": "URL of the product image. Complements the existing url field, which points to the product page (MAX 512; MIN 3).",
+                                  "minLength": 3,
+                                  "maxLength": 512
                                 }
                               },
                               "required": [
@@ -3100,6 +3106,7 @@
                             "category": "Clothes",
                             "id": "123AD",
                             "manufacture_part_number": "XYZ123456",
+                            "image_url": "https://cdn.example.com/img/skirt-01.jpg",
                             "name": "Skirt",
                             "quantity": 1,
                             "sku_code": "8765432109",
@@ -3582,6 +3589,7 @@
                             "category": "Clothes",
                             "id": "123AD",
                             "manufacture_part_number": "XYZ123456",
+                            "image_url": "https://cdn.example.com/img/skirt-01.jpg",
                             "name": "Skirt",
                             "quantity": 1,
                             "sku_code": "8765432109",
@@ -3852,7 +3860,8 @@
                             "category": "Clothes",
                             "brand": "XYZ",
                             "sku_code": "8765432109",
-                            "manufacture_part_number": "XYZ123456"
+                            "manufacture_part_number": "XYZ123456",
+                            "image_url": "https://cdn.example.com/img/skirt-01.jpg"
                           }
                         ]
                       },
@@ -3937,6 +3946,7 @@
                             "category": "Clothes",
                             "id": "123AD",
                             "manufacture_part_number": "XYZ123456",
+                            "image_url": "https://cdn.example.com/img/skirt-01.jpg",
                             "name": "Skirt",
                             "quantity": 1,
                             "sku_code": "8765432109",
@@ -5070,7 +5080,8 @@
                               "category": "Clothes",
                               "brand": "XYZ",
                               "sku_code": "8765432109",
-                              "manufacture_part_number": "XYZ123456"
+                              "manufacture_part_number": "XYZ123456",
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
                             }
                           ],
                           "account_funding": null,
@@ -6858,7 +6869,8 @@
                               "category": "Clothes",
                               "brand": "XYZ",
                               "sku_code": "8765432109",
-                              "manufacture_part_number": "XYZ123456"
+                              "manufacture_part_number": "XYZ123456",
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
                             }
                           ],
                           "account_funding": null,
@@ -9407,7 +9419,8 @@
                               "category": "Clothes",
                               "brand": "XYZ",
                               "sku_code": "8765432109",
-                              "manufacture_part_number": "XYZ123456"
+                              "manufacture_part_number": "XYZ123456",
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
                             }
                           ]
                         },
@@ -9940,7 +9953,8 @@
                               "category": "Clothes",
                               "brand": "XYZ",
                               "sku_code": "8765432109",
-                              "manufacture_part_number": "XYZ123456"
+                              "manufacture_part_number": "XYZ123456",
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
                             }
                           ],
                           "account_funding": null,
@@ -11313,6 +11327,10 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "image_url": {
+                                        "type": "string",
+                                        "example": "https://cdn.example.com/img/skirt-01.jpg"
                                       }
                                     }
                                   }
@@ -15707,6 +15725,10 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "image_url": {
+                                        "type": "string",
+                                        "example": "https://cdn.example.com/img/skirt-01.jpg"
                                       }
                                     }
                                   }
@@ -23325,6 +23347,10 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "image_url": {
+                                        "type": "string",
+                                        "example": "https://cdn.example.com/img/skirt-01.jpg"
                                       }
                                     }
                                   }
@@ -26041,6 +26067,10 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "image_url": {
+                                        "type": "string",
+                                        "example": "https://cdn.example.com/img/skirt-01.jpg"
                                       }
                                     }
                                   }

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -1343,7 +1343,8 @@
                               "category": "Clothes",
                               "brand": "XYZ",
                               "sku_code": "8765432109",
-                              "manufacture_part_number": "XYZ123456"
+                              "manufacture_part_number": "XYZ123456",
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
                             }
                           ]
                         },
@@ -6989,6 +6990,10 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "image_url": {
+                                        "type": "string",
+                                        "example": "https://cdn.example.com/img/skirt-01.jpg"
                                       }
                                     }
                                   }


### PR DESCRIPTION
## PR Description
Adds the new `image_url` optional field to `additional_data.order.items[]` across the payment API reference and webhook payload documentation, as requested by Richy. The field accepts a product image URL (string, min 3, max 512 chars), is omitted from API responses when absent (omitempty), and is present as `null` in webhook payloads when absent.

## Changes
- `openapi/payments/create-payment.json` — added `image_url` to the request body schema with `description`, `minLength`, and `maxLength`; added to 4 response schemas and 8 inline response examples
- `openapi/payments/retrieve-payment-by-id.json` — added `image_url` to the response schema and 1 inline response example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI example updates only; no runtime or API implementation changes in this diff.
> 
> **Overview**
> Documents a new optional **`image_url`** on **`additional_data.order.items[]`**, for a product image URL (distinct from the existing **`url`** product-page field).
> 
> **OpenAPI** (`create-payment.json`, `retrieve-payment-by-id.json`): request/response schemas now include **`image_url`** (string, 3–512 chars) and examples use a sample CDN URL where items are shown.
> 
> **Webhooks** (`object-and-examples.mdx`): payment-related JSON samples add **`image_url`** on line items, set to **`null`** when no image is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd515e06f8522fffca823488236f213367d117e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->