### PR TITLE
chore: web sdk changelog 1.9.11

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.11",
+      "release_date": "2026-07-02",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.11",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Payment retry in Lite checkout",
+          "description": "Payment retry now works in the Lite checkout flow (`mountCheckoutLite`). A declined or errored card payment shows inline field errors and retries without restarting checkout, gated by `settings.card.enable_payment_retry`.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18010"
+      ]
+    },
+    {
       "version": "1.9.10",
       "release_date": "2026-06-30",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.11
+*July 2, 2026*
+
+**Payment Actions**
+
+- <ChangelogBadge type="added" /> **Payment retry in Lite checkout**  
+  Payment retry now works in the Lite checkout flow (`mountCheckoutLite`). A declined or errored card payment shows inline field errors and retries without restarting checkout, gated by `settings.card.enable_payment_retry`.
+
 ## v1.9.10
 *June 30, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.11`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.11

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync; no runtime or integration code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.11** (July 2, 2026) by prepending a release record to `changelog/source/web.json` and adding a matching **v1.9.11** section at the top of `changelog/web.mdx`.
> 
> The new entry describes **payment retry in Lite checkout**: declined or errored card payments in `mountCheckoutLite` can show inline field errors and retry without restarting checkout when `settings.card.enable_payment_retry` is enabled. Upgrade snippet: `npm install @yuno-payments/sdk-web@1.9.11` (ticket CORECM-18010).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3d9ad775dcc1c64be1d21ed704ec8515603091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->