### PR TITLE
docs(recipients): add onboarding_id field to Update Recipient request

### DIFF
--- a/openapi/recipients-for-marketplace/update-recipient-1.json
+++ b/openapi/recipients-for-marketplace/update-recipient-1.json
@@ -663,6 +663,12 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "onboarding_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "ID of an existing onboarding belonging to the recipient. When set, the identity fields sent in this request (e.g. first_name, email, phone, address) are stored as a per-onboarding override for that onboarding only, without modifying the shared recipient; when omitted, the update applies to the shared recipient and propagates to all non-terminal onboardings. Request-only, not returned in responses or webhooks.",
+                    "example": "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+                  },
                   "merchant_recipient_id": {
                     "type": "string",
                     "description": "Unique identifier of the recipient defined by the merchant (MAX 255; MIN 1)."
@@ -1046,6 +1052,16 @@
                         }
                       }
                     ]
+                  }
+                },
+                "Update Single Onboarding": {
+                  "value": {
+                    "onboarding_id": "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed",
+                    "email": "new.email@example.com",
+                    "phone": {
+                      "country_code": "1",
+                      "number": "5551234567"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## PR Description:

Documents a new optional onboarding_id field on the Update Recipient request, requested by Will via Slack. The field lets merchants scope a recipient-data update to a single onboarding instead of the shared recipient, so identity fields sent in the same request (e.g. first_name, email, phone, address) are stored as a per-onboarding override and propagated only to that onboarding's provider, without modifying the shared recipient record. It is request-only and is not returned in any response or webhook payload.

## Changes:

- openapi/recipients-for-marketplace/update-recipient-1.json — added the onboarding_id property (type string, format: uuid) to the request body schema of PATCH /recipients/{recipient_id} (operation update-recipient), with a description covering validation, scoping behavior, and the request-only note.
- openapi/recipients-for-marketplace/update-recipient-1.json — added a new request example, Update Single Onboarding, showing onboarding_id combined with email and phone to scope the update to a single onboarding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI changes with no runtime or security impact.
> 
> **Overview**
> Documents an optional **`onboarding_id`** (UUID) on **PATCH** `/recipients/{recipient_id}` so merchants can scope identity updates to one onboarding instead of the shared recipient.
> 
> When **`onboarding_id`** is present, fields like **`email`**, **`phone`**, and **`address`** are described as per-onboarding overrides that do not change the shared recipient; when omitted, updates still apply to the shared recipient and propagate to non-terminal onboardings. The spec notes the field is **request-only** (not in responses or webhooks).
> 
> Adds an **Update Single Onboarding** request example pairing **`onboarding_id`** with **`email`** and **`phone`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f5c0da8ac616373f704f08404dc9f72a3de2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->