### PR TITLE
chore: web sdk changelog 1.9.12

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -12,7 +12,7 @@
         {
           "type": "CHANGED",
           "title": "Improved PayPal Braintree Checkout Flow",
-          "description": "",
+          "description": "Improves the PAYPAL_BRAINTREE external button payment method, now built on braintree-web and PayPal Web SDK v6",
           "group": "PayPal",
           "migration_guide": null,
           "links": []

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.12",
+      "release_date": "2026-07-06",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.12",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Improved PayPal Braintree Checkout Flow",
+          "description": "",
+          "group": "PayPal",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18070"
+      ]
+    },
+    {
       "version": "1.9.11",
       "release_date": "2026-07-02",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.12
+*July 6, 2026*
+
+**PayPal**
+
+- <ChangelogBadge type="changed" /> **Improved PayPal Braintree Checkout Flow**  
+  Improves the PAYPAL_BRAINTREE external button payment method, now built on braintree-web and PayPal Web SDK v6
+
 ## v1.9.11
 *July 2, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.12`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.12

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync; no application or SDK code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.12** (July 6, 2026) in the changelog source and public docs.
> 
> Adds a new top-of-list release in `changelog/source/web.json` with upgrade snippet `npm install @yuno-payments/sdk-web@1.9.12`, ticket **CORECM-18070**, and one **CHANGED** entry under **PayPal**: **Improved PayPal Braintree Checkout Flow** for `PAYPAL_BRAINTREE` external buttons, now implemented with **braintree-web** and **PayPal Web SDK v6**.
> 
> Mirrors the same **v1.9.12** section at the top of `changelog/web.mdx` using the `ChangelogBadge` **changed** styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076ff8c02116e0a2f9905616a11ae2b8db7b4526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->