### PR TITLE
docs(react-native): regenerate changelog MDX for v1.3.0

### DIFF
--- a/changelog/react-native.mdx
+++ b/changelog/react-native.mdx
@@ -8,6 +8,23 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 <Info>
   Release notes for the React Native SDK are published here as new versions are released. Check back after each SDK update for a detailed summary of changes, new features, and migration guidance.
 </Info>
+## v1.3.0
+*July 2, 2026*
+
+- <ChangelogBadge type="changed" /> **Native SDK Bumps**  
+  Updated the underlying native SDKs to Android `2.17.2` and iOS `2.18.0`.
+
+- <ChangelogBadge type="fixed" /> **Android Compilation Failure in v1.2.0**  
+  Fixed an issue where v1.2.0 failed to compile on Android projects.
+
+**Payments**
+
+- <ChangelogBadge type="breaking" /> **getThreeDSecureChallenge Removed**  
+  Removed `YunoSdk.getThreeDSecureChallenge()` and the `ThreeDSecureChallengeResponse` type. Use the new `continueCardPayment()` method instead — the SDK now handles the 3DS challenge internally and returns the final payment state.
+
+- <ChangelogBadge type="added" /> **continueCardPayment Headless Method**  
+  Added `YunoSdk.continueCardPayment(checkoutSession, countryCode?, showPaymentStatus?)` to complete headless card payments that require an additional action, such as a 3DS challenge. It resolves with the final payment state (`CardPaymentResult`). Supports CARD payments only.
+
 ## v1.2.0
 *May 19, 2026*
 
@@ -39,7 +56,8 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 *March 10, 2026*
 
 - <ChangelogBadge type="breaking" /> **CardFlow Configuration Removed**  
-  The `CardFlow` enum and the `cardFlow` property in `YunoConfig` have been removed. Card form type is now configured from the Yuno Dashboard instead of the client SDK. Remove any `CardFlow` import and `cardFlow` references from your initialization code before upgrading.
+  The `CardFlow` enum and the `cardFlow` property in `YunoConfig` have been removed. Card form type is now configured from the Yuno Dashboard instead of the client SDK. Remove any `CardFlow` import and `cardFlow` references from your initialization code before upgrading.  
+  [Migration guide →](https://github.com/yuno-payments/yuno-sdk-react-native#breaking-changes-v110)
 
 - <ChangelogBadge type="changed" /> **Native SDK Bumps**  
   Bumped the underlying native SDKs to Android `2.11.0` and iOS `2.12.9-RC`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or API code changes in this PR.
> 
> **Overview**
> Documents **React Native SDK v1.3.0** (July 2, 2026) at the top of `changelog/react-native.mdx`, including native bumps to Android `2.17.2` and iOS `2.18.0`, a fix for Android compile failures in v1.2.0, and **Payments** notes for the headless API shift: removal of `getThreeDSecureChallenge` / `ThreeDSecureChallengeResponse` in favor of `continueCardPayment()`.
> 
> Also adds a **migration guide** link on the v1.1.0 **CardFlow** breaking entry and lightly normalizes formatting on several v1.2.0 changelog bullets (description line indentation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14ff92e980db530ca37457b9ec6304dbec1cf49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->