### PR TITLE
Update iOS SDK release notes for version 2.19.0

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.19.0
+*July 6, 2026*
+
+- <ChangelogBadge type="changed" /> **Installments Dropdown Display**  
+  The total amount is now shown for each option in the installments dropdown.
+
 ## v2.18.0
 *June 12, 2026*
 
@@ -15,7 +21,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 *June 10, 2026*
 
 - <ChangelogBadge type="fixed" /> **Bug Fix with Card Forms**  
-  Resolves a crash issue that occurred with unfolded card forms when using multiple payment methods.
+  Resolved a crash issue that occurred with unfolded card forms when using multiple payment methods.
 
 ## v2.17.1
 *June 2, 2026*

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,32 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.19.0",
+      "release_date": "2026-07-06",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.19.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.19.0'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Installments Dropdown Display",
+          "description": "The total amount is now shown for each option in the installments dropdown.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.18.0",
       "release_date": "2026-06-12",
       "upgrade": [


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.19.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or API changes in this repo.
> 
> **Overview**
> Adds **iOS SDK v2.19.0** (July 6, 2026) to the public changelog by updating `changelog/source/ios.json` and the generated `changelog/ios.mdx`.
> 
> The release notes one **changed** behavior: the installments dropdown now shows the **total amount** for each plan option. The JSON entry also includes Swift Package Manager and CocoaPods upgrade snippets pinned to `2.19.0`.
> 
> A small copy edit in the v2.17.2 bullet rephrases the card-form crash fix (“Resolved…” instead of “Resolves…”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 788a0b45d3d578c9e6d868fa5c3e2053e9d9a819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->