### PR TITLE
chore: web sdk changelog 1.9.13

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.13",
+      "release_date": "2026-07-07",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.13",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Address Autofill via Google Places + Brazil ViaCEP",
+          "description": "A single feature flag `address_autofill_enabled` enables a new address autofill experience. For non-Brazilian countries the user gets a Google Places combobox with up to 5 live suggestions, cadence guard, silent fallback to manual entry and analytics events. For Brazil the field collapses to the CEP only, and ViaCEP auto-fires when the postal code matches the regex `/^\\d{5}-?\\d{3}$/` (with blur as fallback); the remaining fields unfold after the attempt succeeds or fails. The form country drives the decision and resets cleanly across switches. 6 new i18n keys translated in 26 locales.",
+          "group": "Address Autofill",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17491"
+      ]
+    },
+    {
       "version": "1.9.12",
       "release_date": "2026-07-06",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.13
+*July 7, 2026*
+
+**Address Autofill**
+
+- <ChangelogBadge type="added" /> **Address Autofill via Google Places + Brazil ViaCEP**  
+  A single feature flag `address_autofill_enabled` enables a new address autofill experience. For non-Brazilian countries the user gets a Google Places combobox with up to 5 live suggestions, cadence guard, silent fallback to manual entry and analytics events. For Brazil the field collapses to the CEP only, and ViaCEP auto-fires when the postal code matches the regex `/^\d{5}-?\d{3}$/` (with blur as fallback); the remaining fields unfold after the attempt succeeds or fails. The form country drives the decision and resets cleanly across switches. 6 new i18n keys translated in 26 locales.
+
 ## v1.9.12
 *July 6, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.13`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.13

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no application or SDK code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.13** (July 7, 2026) in the public changelog by prepending a new release block to `changelog/source/web.json` and adding the matching **v1.9.13** section at the top of `changelog/web.mdx`.
> 
> The new entry describes **Address Autofill** behind `address_autofill_enabled`: Google Places suggestions (non-Brazil) and Brazil CEP lookup via ViaCEP, plus six new i18n keys across 26 locales. Upgrade snippet: `npm install @yuno-payments/sdk-web@1.9.13`. Ticket **CORECM-17491** is listed as consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eae726509b8b217780f15a70c9505daf66041f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->