### PR TITLE
fix: repair broken anchor links reported by Gabriel

### DIFF
--- a/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
+++ b/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
@@ -15,7 +15,7 @@ No API keys or credentials are required to connect the Yuno Test Payment Gateway
 | **Countries** | Available for all countries. |
 | **Currencies** | All currencies are available. |
 | **Type of cards** | Credit, Debit, and Prepaid. |
-| **Test data** | See [card information](/docs/direct-integration-use-cases/yuno-testing-gateway#4-4-provide-the-payment-method-information) for test card numbers and expected responses. |
+| **Test data** | See [card information](/docs/direct-integration-use-cases/yuno-testing-gateway#test-card-payments-with-yuno-testing-gateway) for test card numbers and expected responses. |
 
 ## Integration configuration
 

--- a/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
+++ b/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
@@ -45,7 +45,7 @@ You can execute the token migration process using the Yuno API, which is specifi
 <Note>
 **API migration option**
 
-The API migration option allows merchants to manage their customers and their respective payment data. [Learn more](#api-migration)
+The API migration option allows merchants to manage their customers and their respective payment data. [Learn more](/docs/security-and-compliance/data-migration-processes/via-api)
 </Note>
 
 For a detailed guide on performing token migration using the API, click the button below:

--- a/docs/security-and-compliance/data-migration-processes/via-api.mdx
+++ b/docs/security-and-compliance/data-migration-processes/via-api.mdx
@@ -8,7 +8,7 @@ This guide provides a step-by-step process for migrating tokens using the Yuno A
 
 Before proceeding with the steps in this guide, ensure you have:
 
-* Completed the three steps related to the [importing cards from a gateway account](/docs/security-and-compliance/data-migration-processes/token-migration-process#importing-cards-from-a-gateway-account) process.
+* Completed the three steps related to the [importing cards from a gateway account](/docs/security-and-compliance/data-migration-processes/token-migration-process#importing-cards-from-a-gateway-account-steps-1-and-2) process.
 * Accessed your [API credentials](/docs/developers-credentials) on the Yuno Dashboard, which include:
   * `public-api-key`
   * `private-secret-key`

--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -278,4 +278,4 @@ To make Apple Pay available to your end users, you have to enable it on the Chec
 After completing the Dashboard setup, choose your path to integrate via SDK or Direct:
 
 - **SDK Integration**: [one-time](/docs/apple-pay-sdk-integration#one-time-payments-with-sdk) and [recurring](/docs/apple-pay-sdk-integration#recurring-payments-with-sdk)
-- **Direct integration**: [one-time](/docs/apple-pay-direct-integration#one-time-payments-with-direct-api)  and [recurring](/docs/apple-pay-direct-integration#recurring-payments-with-direct-api)
+- **Direct integration**: [one-time](/docs/apple-pay-direct-integration#one-time-payments)  and [recurring](/docs/apple-pay-direct-integration#recurring-payments-with-direct-api)


### PR DESCRIPTION
## PR Description
Fixes four broken internal anchor links reported by Gabriel during the Zuora docs migration. One additional broken anchor was found during investigation (Apple Pay direct integration) that was not in the original report.

## Changes
- `docs/direct-integration-use-cases/yuno-testing-gateway.mdx` — Updated "card information" link anchor from `#4-4-provide-the-payment-method-information` (non-existent) to `#test-card-payments-with-yuno-testing-gateway`
- `docs/security-and-compliance/data-migration-processes/token-migration-process.mdx` — Fixed "Learn more" link from `#api-migration` (non-existent heading) to the via-api page (`/docs/security-and-compliance/data-migration-processes/via-api`)
- `docs/security-and-compliance/data-migration-processes/via-api.mdx` — Updated "importing cards from a gateway account" link anchor from `#importing-cards-from-a-gateway-account` to `#importing-cards-from-a-gateway-account-steps-1-and-2` to match the actual heading
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx` — Fixed "one-time" link for Direct integration from `#one-time-payments-with-direct-api` (non-existent) to `#one-time-payments`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only hyperlink corrections with no runtime, API, or security impact.
> 
> **Overview**
> **Repairs four broken internal documentation links** surfaced during the Zuora docs migration (plus one extra Apple Pay link found in review).
> 
> In **Yuno Testing Gateway**, the **Test data** “card information” link now targets `#test-card-payments-with-yuno-testing-gateway` instead of a removed `#4-4-provide-the-payment-method-information` anchor.
> 
> In **token migration**, the API option **Learn more** link now points to the **Via API** page instead of a non-existent `#api-migration` fragment on the same page. **Via API** requirements now link to `#importing-cards-from-a-gateway-account-steps-1-and-2` to match the real section heading.
> 
> In **Apple Pay prerequisites**, the Direct integration **one-time** link uses `#one-time-payments` instead of `#one-time-payments-with-direct-api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9566ce2c4ad3fabcdd976e87b7b6f5096309bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->