### PR TITLE
docs(pci-proxy): add PCI HTTPS Proxy guides and API reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -242,6 +242,13 @@
               "docs/security-and-compliance/co-badged-cards-compliance",
               "docs/security-and-compliance/network-tokens",
               {
+                "group": "PCI Proxy",
+                "pages": [
+                  "docs/security-and-compliance/pci-proxy/overview",
+                  "docs/security-and-compliance/pci-proxy/forward-proxy"
+                ]
+              },
+              {
                 "group": "Data Migration Processes",
                 "pages": [
                   "docs/security-and-compliance/data-migration-processes/token-migration-process",
@@ -378,6 +385,12 @@
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api",
               "reference/payment-methods-direct-workflow/unenroll-payment-method-api"
+            ]
+          },
+          {
+            "group": "PCI Proxy (Beta)",
+            "pages": [
+              "reference/pci-proxy/invoke-forward-proxy"
             ]
           },
           {

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -36,6 +36,8 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     ```
 
     Expressions work in the request body and in header values. Everything that is not an expression is forwarded untouched.
+
+    The proxy is content-transparent: it forwards your body and `Content-Type` unchanged and resolves expressions anywhere in the raw body, so JSON, form-encoded, and XML payloads all work. The example above is JSON, but the destination receives exactly the format you send.
   </Step>
 
   <Step title="Send it through the proxy">
@@ -87,13 +89,17 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
 
     | HTTP status | Code | Meaning |
     |---|---|---|
-    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, malformed expression, or more than 20 tokens in one request |
+    | `401` | `NOT_AUTHENTICATED` / `AuthenticationFail` | Missing or invalid API credentials |
+    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
     | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your account, or its `security_code` is no longer available |
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
     | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |
     | `504` | `DESTINATION_TIMEOUT` | The destination did not respond within the timeout |
+    | `500` | `PROXY_ERROR` | An unexpected error inside the proxy |
+
+    A `401` is returned before your request reaches the proxy, so it does not carry the `yuno-proxy-request-id` header; every other response does.
 
     Any `4xx`/`5xx` accompanied by `yuno-proxy-destination-status` is the destination's own error, passed through for you to handle as if you had called it directly.
   </Step>

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -1,0 +1,124 @@
+---
+title: "Forward Proxy"
+description: "Step-by-step guide to calling third-party APIs with real card data through the Yuno PCI Proxy using vaulted token expressions."
+keywords: ["forward proxy", "yuno-proxy-url", "detokenization", "vaulted_token", "expressions"]
+---
+
+This guide shows how to call a third-party API with real card data through the Yuno PCI Proxy. If you have not read it yet, start with the [PCI Proxy Overview](/docs/security-and-compliance/pci-proxy/overview).
+
+## Requirements
+
+* Your `public-api-key` and `private-secret-key` from the Yuno Dashboard.
+* A card stored with Yuno and its `vaulted_token`. See [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api).
+* The destination API you want to call, reachable over HTTPS on port 443.
+
+<Warning>
+**Server-side only**
+
+Proxy requests detokenize card data and must only be made from your backend. Never expose your `private-secret-key` in client-side code.
+</Warning>
+
+<Steps>
+  <Step title="Build the destination request">
+    Write the request exactly as the destination API expects it — same body shape, same headers — but put vaulted token expressions where the card data belongs:
+
+    ```json
+    {
+      "amount": 2500,
+      "currency": "USD",
+      "card": {
+        "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
+        "exp_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+        "exp_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+        "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+      }
+    }
+    ```
+
+    Expressions work in the request body and in header values. Everything that is not an expression is forwarded untouched.
+  </Step>
+
+  <Step title="Send it through the proxy">
+    Send the request to `https://api.y.uno/v1/pci-proxy` with the destination in the `yuno-proxy-url` header:
+
+    ```sh
+    curl -X POST "https://api.y.uno/v1/pci-proxy" \
+      -H "public-api-key: $PUBLIC_API_KEY" \
+      -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+      -H "yuno-proxy-url: https://api.example-processor.com/charges" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $PROCESSOR_API_KEY" \
+      -d '{
+        "amount": 2500,
+        "currency": "USD",
+        "card": {
+          "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
+          "exp_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+          "exp_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+          "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+        }
+      }'
+    ```
+
+    The HTTP method you use is the method the destination receives. Headers you set for the destination (like `Authorization` above) pass through; Yuno's own credential headers and all `yuno-*` headers are stripped before forwarding.
+
+    To call a sub-path of the destination, append it to the proxy path: a request to `/v1/pci-proxy/charges/ch_123/capture?expand=true` with `yuno-proxy-url: https://api.example-processor.com` is forwarded to `https://api.example-processor.com/charges/ch_123/capture?expand=true`.
+  </Step>
+
+  <Step title="Read the response">
+    The destination's status code, headers, and body are returned to you unchanged. The proxy adds diagnostic headers:
+
+    | Header | Meaning |
+    |---|---|
+    | `yuno-proxy-request-id` | Unique identifier of this proxy invocation. Include it in support requests. |
+    | `yuno-proxy-destination-status` | The HTTP status returned by the destination. **Present only when the destination was reached** — if it is missing, the failure happened inside Yuno. |
+    | `yuno-proxy-replacements` | How many expressions were replaced. `0` on a request you expected to be detokenized means your expressions did not match. |
+  </Step>
+
+  <Step title="Handle errors">
+    Errors produced by the proxy itself use the standard Yuno error format and never include the `yuno-proxy-destination-status` header:
+
+    ```json
+    {
+      "code": "EXPRESSION_RESOLUTION_FAILED",
+      "messages": ["vaulted_token 1a2b3c4d-... could not be resolved"]
+    }
+    ```
+
+    | HTTP status | Code | Meaning |
+    |---|---|---|
+    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, malformed expression, or more than 20 tokens in one request |
+    | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your account, or its `security_code` is no longer available |
+    | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected) |
+    | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
+    | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
+    | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |
+    | `504` | `DESTINATION_TIMEOUT` | The destination did not respond within the timeout |
+
+    Any `4xx`/`5xx` accompanied by `yuno-proxy-destination-status` is the destination's own error, passed through for you to handle as if you had called it directly.
+  </Step>
+</Steps>
+
+## Timeouts
+
+The proxy waits up to 30 seconds for the destination by default. Override it with the `yuno-proxy-timeout` header (seconds, maximum 120):
+
+```sh
+curl -X POST "https://api.y.uno/v1/pci-proxy" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "yuno-proxy-url: https://api.slow-supplier.com/bookings" \
+  -H "yuno-proxy-timeout: 90" \
+  -H "Content-Type: application/json" \
+  -d '{ "card_number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}" }'
+```
+
+## Testing in sandbox
+
+Use `https://api-sandbox.y.uno/v1/pci-proxy` with your sandbox credentials and sandbox `vaulted_token` values. Sandbox tokens resolve to test card numbers, so you can point the proxy at your destination's own sandbox safely.
+
+<Note>
+**Verify your integration**
+
+Check `yuno-proxy-replacements` in the response while integrating: it confirms the proxy found and replaced your expressions before forwarding.
+</Note>

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -55,7 +55,7 @@ When you use the PCI Proxy together with Yuno's SDKs to collect cards, raw card 
 | Limit | Value |
 |---|---|
 | Request and response body size | 1 MB |
-| Vaulted tokens per request | 20 |
+| Distinct vaulted tokens per request | 20 |
 | Destination timeout | 30 seconds by default, configurable up to 120 with the `yuno-proxy-timeout` header |
 | Supported methods | `GET`, `POST`, `PUT`, `PATCH`, `DELETE` |
 

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -1,0 +1,64 @@
+---
+title: "PCI Proxy Overview"
+description: "Send raw card data to any third-party API through Yuno's PCI DSS Level 1 environment, without bringing your own systems into PCI scope."
+keywords: ["pci proxy", "forward proxy", "detokenization", "vaulted_token", "pci compliance"]
+---
+
+Some payment operations require sending raw card data to a third party — a processor Yuno does not orchestrate for you, an airline or hotel supplier API, a fraud or issuer service, or your own acquiring connection. Handling that data directly would pull your systems into full PCI DSS scope.
+
+The Yuno PCI Proxy lets your servers make HTTPS requests to any third-party API **through Yuno's PCI DSS Level 1 environment**. You send a normal API request that references your stored cards by `vaulted_token`; Yuno replaces those references with the real card data inside its secure environment and forwards the request to the destination. The raw card number never touches your infrastructure, so your PCI scope does not change.
+
+<Note>
+**Requirements**
+
+The PCI Proxy works with cards you have already stored with Yuno. Cards are stored when a customer saves a payment method during checkout, or when you enroll one through the [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api) endpoint.
+</Note>
+
+## How it works
+
+1. Your server sends an HTTPS request to `https://api.y.uno/v1/pci-proxy`, authenticated with your standard Yuno API credentials.
+2. You indicate the destination with the `yuno-proxy-url` header and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
+3. Inside Yuno's PCI environment, the proxy resolves each expression to the real card data, then forwards your request — same method, path suffix, query string, headers, and body — to the destination over TLS.
+4. The destination's response is returned to you unchanged, along with diagnostic headers that tell you what the proxy did.
+
+The proxy is a pass-through: Yuno does not store your request or the destination's response, and request and response bodies are never written to logs.
+
+## Card data you can reference
+
+| Expression | Resolves to |
+|---|---|
+| `{{vaulted_token.<TOKEN>.number}}` | The card number (PAN) |
+| `{{vaulted_token.<TOKEN>.security_code}}` | The card verification code (CVV/CVC), when available |
+| `{{vaulted_token.<TOKEN>.expiration_month}}` | Two-digit expiration month (`MM`) |
+| `{{vaulted_token.<TOKEN>.expiration_year}}` | Four-digit expiration year (`YYYY`) |
+| `{{vaulted_token.<TOKEN>.holder_name}}` | The cardholder name |
+
+<Warning>
+**Security code availability**
+
+Card networks do not allow the security code to be stored after authorization. A `security_code` expression only resolves during the short window after the customer entered it (for example, immediately after enrollment or checkout). Outside that window the proxy rejects the request with `EXPRESSION_RESOLUTION_FAILED`.
+</Warning>
+
+## Your PCI scope
+
+When you use the PCI Proxy together with Yuno's SDKs to collect cards, raw card data never enters your systems — it flows from the customer to Yuno, and from Yuno to the destination you choose. Most merchants operating this way qualify for the **SAQ A** self-assessment. See [PCI Compliance](/docs/security-and-compliance/pci-compliance) for the complete picture of how Yuno reduces your PCI scope.
+
+## Security controls
+
+* **HTTPS only.** The proxy connects to destinations over TLS 1.2 or higher, on port 443 only. Destinations must be public DNS hostnames — IP addresses and internal networks are rejected.
+* **Credential isolation.** Your Yuno API credentials and all `yuno-*` headers are stripped before the request is forwarded. The destination only sees the headers you intend it to see.
+* **No storage, no logging.** The proxy holds card data in memory only for the lifetime of the request. Request and response bodies are excluded from logs and traces.
+* **Full audit trail.** Every invocation produces an audit record (who, when, destination, outcome — never card data) and is returned to you with a unique `yuno-proxy-request-id`.
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Request and response body size | 1 MB |
+| Vaulted tokens per request | 20 |
+| Destination timeout | 30 seconds by default, configurable up to 120 with the `yuno-proxy-timeout` header |
+| Supported methods | `GET`, `POST`, `PUT`, `PATCH`, `DELETE` |
+
+## Get started
+
+Follow the [Forward Proxy guide](/docs/security-and-compliance/pci-proxy/forward-proxy) for a step-by-step integration, or go straight to the [API reference](/reference/pci-proxy/invoke-forward-proxy).

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -19,14 +19,14 @@
     "/pci-proxy": {
       "post": {
         "summary": "Invoke Forward Proxy",
-        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. Path segments and query strings appended after `/pci-proxy` are appended to the destination URL.",
+        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. Path segments and query strings appended after `/pci-proxy` are appended to the destination URL. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
         "operationId": "invokeForwardProxy",
         "parameters": [
           {
             "name": "yuno-proxy-url",
             "in": "header",
             "required": true,
-            "description": "Destination base URL. Must be a public HTTPS hostname on port 443. IP addresses and internal networks are rejected.",
+            "description": "The full destination URL, including any path (for example `https://api.example-processor.com/charges`). Must be a public HTTPS hostname on port 443; IP addresses and internal networks are rejected. Any path you append after `/pci-proxy` is appended to this URL's path, and your request's query string is forwarded. For example, calling `/pci-proxy/refunds` with `yuno-proxy-url: https://api.example-processor.com/charges` forwards to `https://api.example-processor.com/charges/refunds`.",
             "schema": {
               "type": "string",
               "example": "https://api.example-processor.com/charges"
@@ -46,7 +46,7 @@
           }
         ],
         "requestBody": {
-          "description": "The body the destination API expects, with vaulted token expressions where card data belongs. Supported fields: `number`, `security_code`, `expiration_month`, `expiration_year`, `holder_name`. At most 20 distinct tokens per request; maximum body size 1 MB. Expressions are also resolved in header values. All non-expression content is forwarded untouched.",
+          "description": "The body the destination API expects, with vaulted token expressions where card data belongs. The proxy is content-transparent: it forwards your body and `Content-Type` unchanged and resolves `{{vaulted_token.<TOKEN>.<field>}}` expressions anywhere in the raw body, so any content type is supported (JSON, form-encoded, XML). The JSON object below is illustrative. Supported fields: `number`, `security_code`, `expiration_month`, `expiration_year`, `holder_name`. At most 20 distinct tokens per request; maximum body size 1 MB. Expressions are also resolved in header values. All non-expression content is forwarded untouched.",
           "content": {
             "application/json": {
               "schema": {
@@ -62,6 +62,11 @@
                     "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
                   }
                 }
+              }
+            },
+            "*/*": {
+              "schema": {
+                "description": "Any other content type (form-encoded, XML, plain text) is forwarded as-is with expressions resolved in the raw body."
               }
             }
           }
@@ -95,6 +100,34 @@
                   "type": "object",
                   "additionalProperties": true,
                   "description": "The destination's response body, unchanged."
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication failed. Returned before the request reaches the proxy, so it carries no `yuno-proxy-*` headers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Not authenticated": {
+                    "value": {
+                      "code": "NOT_AUTHENTICATED",
+                      "messages": [
+                        "not authenticated"
+                      ]
+                    }
+                  },
+                  "Authorization unavailable": {
+                    "value": {
+                      "code": "AuthenticationFail",
+                      "messages": [
+                        "authorization unavailable"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -167,6 +200,26 @@
               }
             }
           },
+          "429": {
+            "description": "Rate limit exceeded for the account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Too many requests": {
+                    "value": {
+                      "code": "TOO_MANY_REQUESTS",
+                      "messages": [
+                        "rate limit exceeded"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
           "502": {
             "description": "The destination could not be reached.",
             "content": {
@@ -199,7 +252,27 @@
                     "value": {
                       "code": "DESTINATION_TIMEOUT",
                       "messages": [
-                        "destination did not respond within 30 seconds"
+                        "destination did not respond within the configured timeout"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected proxy-side error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Proxy error": {
+                    "value": {
+                      "code": "PROXY_ERROR",
+                      "messages": [
+                        "internal error"
                       ]
                     }
                   }
@@ -234,6 +307,8 @@
             "type": "string",
             "description": "Machine-readable error code.",
             "enum": [
+              "NOT_AUTHENTICATED",
+              "AuthenticationFail",
               "INVALID_REQUEST",
               "EXPRESSION_RESOLUTION_FAILED",
               "DESTINATION_NOT_ALLOWED",

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -1,0 +1,257 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "pci-proxy-invoke-forward-proxy",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/pci-proxy": {
+      "post": {
+        "summary": "Invoke Forward Proxy",
+        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. Path segments and query strings appended after `/pci-proxy` are appended to the destination URL.",
+        "operationId": "invokeForwardProxy",
+        "parameters": [
+          {
+            "name": "yuno-proxy-url",
+            "in": "header",
+            "required": true,
+            "description": "Destination base URL. Must be a public HTTPS hostname on port 443. IP addresses and internal networks are rejected.",
+            "schema": {
+              "type": "string",
+              "example": "https://api.example-processor.com/charges"
+            }
+          },
+          {
+            "name": "yuno-proxy-timeout",
+            "in": "header",
+            "required": false,
+            "description": "Destination timeout in seconds. Default 30, maximum 120.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 120,
+              "example": 30
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The body the destination API expects, with vaulted token expressions where card data belongs. Supported fields: `number`, `security_code`, `expiration_month`, `expiration_year`, `holder_name`. At most 20 distinct tokens per request; maximum body size 1 MB. Expressions are also resolved in header values. All non-expression content is forwarded untouched.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "example": {
+                  "amount": 2500,
+                  "currency": "USD",
+                  "card": {
+                    "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
+                    "exp_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+                    "exp_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+                    "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response from the destination, passed through unchanged (the actual status code is whatever the destination returned; check `yuno-proxy-destination-status`).",
+            "headers": {
+              "yuno-proxy-request-id": {
+                "description": "Unique identifier of this proxy invocation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "yuno-proxy-destination-status": {
+                "description": "HTTP status code returned by the destination. Present only when the destination was reached.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "yuno-proxy-replacements": {
+                "description": "Number of expressions replaced before forwarding.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "description": "The destination's response body, unchanged."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Proxy-originated request error. The `yuno-proxy-destination-status` header is absent because the destination was not called.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Invalid request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "yuno-proxy-url header is required"
+                      ]
+                    }
+                  },
+                  "Expression resolution failed": {
+                    "value": {
+                      "code": "EXPRESSION_RESOLUTION_FAILED",
+                      "messages": [
+                        "vaulted_token 1a2b3c4d-5678-90ab-cdef-111213141516 could not be resolved"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The destination is not allowed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Destination not allowed": {
+                    "value": {
+                      "code": "DESTINATION_NOT_ALLOWED",
+                      "messages": [
+                        "destination must be a public HTTPS hostname"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body over 1 MB.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Request too large": {
+                    "value": {
+                      "code": "REQUEST_TOO_LARGE",
+                      "messages": [
+                        "request body exceeds 1 MB"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "The destination could not be reached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Destination unreachable": {
+                    "value": {
+                      "code": "DESTINATION_UNREACHABLE",
+                      "messages": [
+                        "connection to destination failed"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The destination did not respond within the timeout.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProxyError"
+                },
+                "examples": {
+                  "Destination timeout": {
+                    "value": {
+                      "code": "DESTINATION_TIMEOUT",
+                      "messages": [
+                        "destination did not respond within 30 seconds"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    },
+    "schemas": {
+      "ProxyError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code.",
+            "enum": [
+              "INVALID_REQUEST",
+              "EXPRESSION_RESOLUTION_FAILED",
+              "DESTINATION_NOT_ALLOWED",
+              "REQUEST_TOO_LARGE",
+              "TOO_MANY_REQUESTS",
+              "DESTINATION_UNREACHABLE",
+              "DESTINATION_TIMEOUT",
+              "PROXY_ERROR"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/pci-proxy/invoke-forward-proxy.mdx
+++ b/reference/pci-proxy/invoke-forward-proxy.mdx
@@ -1,0 +1,24 @@
+---
+title: "Invoke Forward Proxy"
+description: "Call any third-party HTTPS API with real card data through Yuno's PCI DSS Level 1 environment, referencing stored cards by vaulted_token."
+keywords: ["pci proxy", "forward proxy", "yuno-proxy-url", "vaulted_token", "detokenization"]
+openapi: "/openapi/pci-proxy/invoke-forward-proxy.json POST /pci-proxy"
+---
+
+Forwards your request to the destination in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions with real card data inside Yuno's secure environment. See the [Forward Proxy guide](/docs/security-and-compliance/pci-proxy/forward-proxy) for a step-by-step integration.
+
+<Note>
+**Beta**
+
+The PCI Proxy is in beta and is enabled per account. Contact your Key Account Manager (KAM) to activate it.
+</Note>
+
+<Warning>
+**Server-side only**
+
+Proxy requests detokenize card data and must only be made from your backend. Never expose your `private-secret-key` in client-side code.
+</Warning>
+
+All of `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` are supported — the destination receives the same method you used. Path segments and query strings appended after `/pci-proxy` are appended to the destination URL.
+
+If you are a PCI-certified merchant and need the raw card data itself rather than a pass-through call, use [Retrieve Enrolled Payment Method by ID PCI Data](/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api) instead.


### PR DESCRIPTION
## docs(pci-proxy): PCI HTTPS Proxy — guides + API reference

### Description
Public documentation for the **Yuno PCI Proxy** forward (outbound) proxy: merchants call any third-party HTTPS API with real card data — referenced by `{{vaulted_token.<TOKEN>.<field>}}` expressions — without their systems entering PCI scope. Pairs with the `pci-proxy-ms` implementation (yuno-payments/pci-proxy-ms#3).

### Pages added
- **Guides** (`docs/security-and-compliance/pci-proxy/`)
  - `overview.mdx` — what the proxy is, the PCI-scope story (links to the existing PCI Compliance page and reuses its SAQ‑A framing), available card fields, limits, and security controls.
  - `forward-proxy.mdx` — step-by-step integration: building the destination request, sending through the proxy, reading diagnostic response headers, the full error table, timeouts, and sandbox testing.
- **API Reference** (`reference/pci-proxy/`)
  - `invoke-forward-proxy.mdx` + `openapi/pci-proxy/invoke-forward-proxy.json` — self-contained OpenAPI 3.1 spec. Uses the payments-domain conventions: `https://api-sandbox.y.uno/v1` server and lowercase `public-api-key` / `private-secret-key` security schemes with `x-default` placeholders.

### Navigation
`docs.json` gains a **PCI Proxy** subgroup under *Security and Compliance* (Documentation tab, mirroring the *Data Migration Processes* subgroup pattern) and a **PCI Proxy (Beta)** group under the API Reference tab. Nothing else in `docs.json` is reformatted.

### Conventions followed
Mintlify MDX with quoted Title-Case `title` + `description` frontmatter, no in-body H1, `<Note>/<Warning>` callouts with bold mini-titles, `<Steps>/<Step>`, `sh` curl samples, root-relative links, and Yuno terminology (`account_id`, `vaulted_token`, merchant = "you"). Targets `main` (deploys via the Mintlify GitHub app on merge).

### Notes for reviewers
- Marked **Beta** to match the launch posture in the API reference and the `pci-proxy-ms` PR.
- Cross-links assume existing pages: `/docs/security-and-compliance/pci-compliance`, `/reference/payment-methods-direct-workflow/enroll-payment-method-api`, and the PCI retrieval endpoint — all present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
