### PR TITLE
docs(pci-proxy): drop CVV field, clarify destination URL and query handling

### DIFF
--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -64,7 +64,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
 
     The HTTP method you use is the method the destination receives. Headers you set for the destination (like `Authorization` above) pass through; Yuno's own credential headers and all `yuno-*` headers are stripped before forwarding.
 
-    To call a sub-path of the destination, append it to the proxy path: a request to `/v1/pci-proxy/charges/ch_123/capture?expand=true` with `yuno-proxy-url: https://api.example-processor.com` is forwarded to `https://api.example-processor.com/charges/ch_123/capture?expand=true`.
+    Put the **complete** destination URL — including its path and any query string — in `yuno-proxy-url` (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Do not add a path or query string to the `/v1/pci-proxy` request itself; a query string on the proxy request is rejected, so that merchant data is never logged.
   </Step>
 
   <Step title="Read the response">
@@ -90,8 +90,8 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | HTTP status | Code | Meaning |
     |---|---|---|
     | `401` | `NOT_AUTHENTICATED` / `AuthenticationFail` | Missing or invalid API credentials |
-    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
-    | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your account, or its `security_code` is no longer available |
+    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
+    | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your account, or a referenced field is unavailable |
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -17,8 +17,8 @@ The PCI Proxy works with cards you have already stored with Yuno. Cards are stor
 ## How it works
 
 1. Your server sends an HTTPS request to `https://api.y.uno/v1/pci-proxy`, authenticated with your standard Yuno API credentials.
-2. You indicate the destination with the `yuno-proxy-url` header and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
-3. Inside Yuno's PCI environment, the proxy resolves each expression to the real card data, then forwards your request — same method, path suffix, query string, headers, and body — to the destination over TLS.
+2. You put the full destination URL (including its path and query) in the `yuno-proxy-url` header, and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
+3. Inside Yuno's PCI environment, the proxy resolves each expression to the real card data, then forwards your request — same method, headers, and body — to the destination over TLS.
 4. The destination's response is returned to you unchanged, along with diagnostic headers that tell you what the proxy did.
 
 The proxy is a pass-through: Yuno does not store your request or the destination's response, and request and response bodies are never written to logs.
@@ -28,16 +28,17 @@ The proxy is a pass-through: Yuno does not store your request or the destination
 | Expression | Resolves to |
 |---|---|
 | `{{vaulted_token.<TOKEN>.number}}` | The card number (PAN) |
-| `{{vaulted_token.<TOKEN>.security_code}}` | The card verification code (CVV/CVC), when available |
 | `{{vaulted_token.<TOKEN>.expiration_month}}` | Two-digit expiration month (`MM`) |
 | `{{vaulted_token.<TOKEN>.expiration_year}}` | Four-digit expiration year (`YYYY`) |
 | `{{vaulted_token.<TOKEN>.holder_name}}` | The cardholder name |
 
-<Warning>
-**Security code availability**
+The `<TOKEN>` must be a `vaulted_token` that belongs to your account. A token that does not exist or belongs to another account is rejected with `EXPRESSION_RESOLUTION_FAILED`, before any card data is read.
 
-Card networks do not allow the security code to be stored after authorization. A `security_code` expression only resolves during the short window after the customer entered it (for example, immediately after enrollment or checkout). Outside that window the proxy rejects the request with `EXPRESSION_RESOLUTION_FAILED`.
-</Warning>
+<Note>
+**Security code (CVV) is not supported**
+
+Card networks do not allow the security code to be stored after a payment is authorized, so a stored payment method has no CVV to inject. The proxy does not support a `security_code` field.
+</Note>
 
 ## Your PCI scope
 

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -19,14 +19,14 @@
     "/pci-proxy": {
       "post": {
         "summary": "Invoke Forward Proxy",
-        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. Path segments and query strings appended after `/pci-proxy` are appended to the destination URL. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
+        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. The full destination (including its path and query string) is specified in `yuno-proxy-url`; a query string on the `/pci-proxy` request itself is rejected. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
         "operationId": "invokeForwardProxy",
         "parameters": [
           {
             "name": "yuno-proxy-url",
             "in": "header",
             "required": true,
-            "description": "The full destination URL, including any path (for example `https://api.example-processor.com/charges`). Must be a public HTTPS hostname on port 443; IP addresses and internal networks are rejected. Any path you append after `/pci-proxy` is appended to this URL's path, and your request's query string is forwarded. For example, calling `/pci-proxy/refunds` with `yuno-proxy-url: https://api.example-processor.com/charges` forwards to `https://api.example-processor.com/charges/refunds`.",
+            "description": "The complete destination URL, including its path and any query string (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Must be a public HTTPS hostname on port 443; IP addresses and internal networks are rejected. It must not contain `{{vaulted_token...}}` expressions (card data must never appear in a URL).",
             "schema": {
               "type": "string",
               "example": "https://api.example-processor.com/charges"
@@ -46,7 +46,7 @@
           }
         ],
         "requestBody": {
-          "description": "The body the destination API expects, with vaulted token expressions where card data belongs. The proxy is content-transparent: it forwards your body and `Content-Type` unchanged and resolves `{{vaulted_token.<TOKEN>.<field>}}` expressions anywhere in the raw body, so any content type is supported (JSON, form-encoded, XML). The JSON object below is illustrative. Supported fields: `number`, `security_code`, `expiration_month`, `expiration_year`, `holder_name`. At most 20 distinct tokens per request; maximum body size 1 MB. Expressions are also resolved in header values. All non-expression content is forwarded untouched.",
+          "description": "The body the destination API expects, with vaulted token expressions where card data belongs. The proxy is content-transparent: it forwards your body and `Content-Type` unchanged and resolves `{{vaulted_token.<TOKEN>.<field>}}` expressions anywhere in the raw body, so any content type is supported (JSON, form-encoded, XML). The JSON object below is illustrative. Supported fields: `number`, `expiration_month`, `expiration_year`, `holder_name` (the security code is not stored and cannot be injected). At most 20 distinct tokens per request; maximum body size 1 MB. Expressions are also resolved in header values. All non-expression content is forwarded untouched.",
           "content": {
             "application/json": {
               "schema": {
@@ -201,7 +201,7 @@
             }
           },
           "429": {
-            "description": "Rate limit exceeded for the account.",
+            "description": "Rate limit exceeded for the account (enforced at the Yuno edge).",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## docs(pci-proxy): drop CVV field, clarify destination URL and query handling

Follow-up to #551 (merged), reconciling the PCI proxy docs with the round-2 review fixes on yuno-payments/pci-proxy-ms#3.

- **Remove `security_code`** from the supported fields. Card networks forbid storing CVV after authorization, so a stored payment method has none to inject — the field was unresolvable. Supported fields are now `number`, `expiration_month`, `expiration_year`, `holder_name`, and a `<Note>` explains the CVV exclusion.
- **Destination URL / query handling.** The complete destination (path + query) goes in `yuno-proxy-url`; a query string on the `/v1/pci-proxy` request is rejected (so arbitrary merchant query data is never accepted or logged), and expressions are not allowed in the URL. Removes the old sub-path/query-forwarding description.
- **429** noted as edge-enforced.
- Tidy the ownership wording and the `INVALID_REQUEST` / `EXPRESSION_RESOLUTION_FAILED` causes to match the implementation.

Touches `docs/security-and-compliance/pci-proxy/{overview,forward-proxy}.mdx` and `openapi/pci-proxy/invoke-forward-proxy.json`. Targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
