### PR TITLE
docs(pci-proxy): destination allowlist and response redaction

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -245,7 +245,8 @@
                 "group": "PCI Proxy",
                 "pages": [
                   "docs/security-and-compliance/pci-proxy/overview",
-                  "docs/security-and-compliance/pci-proxy/forward-proxy"
+                  "docs/security-and-compliance/pci-proxy/forward-proxy",
+                  "docs/security-and-compliance/pci-proxy/allowlist"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -391,7 +391,10 @@
           {
             "group": "PCI Proxy (Beta)",
             "pages": [
-              "reference/pci-proxy/invoke-forward-proxy"
+              "reference/pci-proxy/invoke-forward-proxy",
+              "reference/pci-proxy/register-destination",
+              "reference/pci-proxy/list-destinations",
+              "reference/pci-proxy/remove-destination"
             ]
           },
           {

--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -33,13 +33,18 @@ curl -X POST "https://api.y.uno/v1/pci-proxy/destinations" \
   -H "Content-Type: application/json" \
   -d '{
     "hostname": "api.example-processor.com",
-    "purpose": "Direct acquiring — Processor X"
+    "purpose": "Direct acquiring — Processor X",
+    "account_code": null
   }'
 ```
 
 Returns `201` with the created entry. A hostname that is already registered returns `409`; a
 value that is not a bare public hostname (a URL, a host with a port or path, an IP address,
 or a wildcard) returns `422 INVALID_HOSTNAME`.
+
+`account_code` is optional. Left `null` (the default), the destination is allowed for **every
+account** in your organization. Set it to a specific account id to scope the destination to
+that account only — the host is then usable solely on proxy requests made under that account.
 
 ## List your destinations
 

--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -1,0 +1,70 @@
+---
+title: "Destination Allowlist"
+description: "Register the third-party hosts your PCI Proxy is allowed to call. Every destination must be on your allowlist before the proxy will send card data to it."
+keywords: ["pci proxy", "allowlist", "destination", "security"]
+---
+
+The PCI Proxy only sends card data to hosts you have explicitly registered. This is a
+deliberate safety control: even if your API credentials were stolen, an attacker could not
+forward your stored cards to a server you never approved. There is no "any host" mode.
+
+Managing your allowlist is self-serve — a hostname you add is usable within minutes, no
+support ticket required.
+
+<Warning>
+**A destination not on your allowlist is rejected**
+
+A proxy request to an unregistered host returns `403 DESTINATION_NOT_ALLOWED`. Register the
+host first with the endpoints below.
+</Warning>
+
+## How matching works
+
+Allowlist entries are matched on the **exact hostname**, case-insensitive. Subdomains are not
+implied: allowing `api.example.com` does not allow `sandbox.example.com`. Wildcards are not
+supported. Register each hostname you call.
+
+## Register a destination
+
+```sh
+curl -X POST "https://api.y.uno/v1/pci-proxy/destinations" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "hostname": "api.example-processor.com",
+    "purpose": "Direct acquiring — Processor X"
+  }'
+```
+
+Returns `201` with the created entry. A hostname that is already registered returns `409`; a
+value that is not a bare public hostname (a URL, a host with a port or path, an IP address,
+or a wildcard) returns `422 INVALID_HOSTNAME`.
+
+## List your destinations
+
+```sh
+curl "https://api.y.uno/v1/pci-proxy/destinations" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY"
+```
+
+Returns `{"destinations": [ ... ]}` — only the destinations registered for your account.
+
+## Remove a destination
+
+```sh
+curl -X DELETE "https://api.y.uno/v1/pci-proxy/destinations/{id}" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY"
+```
+
+Returns `204`. Removing a destination takes effect immediately — the next proxy request to
+that host is rejected.
+
+<Note>
+**Treat new-destination alerts seriously**
+
+Adding a destination is a sensitive action: it widens where your cards can be sent. Yuno
+recommends restricting who can manage the allowlist and reviewing any unexpected additions.
+</Note>

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -75,6 +75,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `yuno-proxy-request-id` | Unique identifier of this proxy invocation. Include it in support requests. |
     | `yuno-proxy-destination-status` | The HTTP status returned by the destination. **Present only when the destination was reached** — if it is missing, the failure happened inside Yuno. |
     | `yuno-proxy-replacements` | How many expressions were replaced. `0` on a request you expected to be detokenized means your expressions did not match. |
+    | `yuno-proxy-response-redactions` | How many card numbers were redacted from the destination's response. A non-zero value means the destination returned card data. |
   </Step>
 
   <Step title="Handle errors">
@@ -92,7 +93,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `401` | `NOT_AUTHENTICATED` / `AuthenticationFail` | Missing or invalid API credentials |
     | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
     | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your account, or a referenced field is unavailable |
-    | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected) |
+    | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
     | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -38,6 +38,12 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     Expressions work in the request body and in header values. Everything that is not an expression is forwarded untouched.
 
     The proxy is content-transparent: it forwards your body and `Content-Type` unchanged and resolves expressions anywhere in the raw body, so JSON, form-encoded, and XML payloads all work. The example above is JSON, but the destination receives exactly the format you send.
+
+    <Warning>
+    **No CVV**
+
+    There is no placeholder for the security code (CVV/CVC). Card networks do not allow it to be stored after a payment is authorized, so a stored payment method has none to inject — the available fields are `number`, `expiration_month`, `expiration_year`, and `holder_name`. If your destination requires the CVV, your customer must supply it and you include it in the body yourself; note that transmitting a raw security code keeps that request in your PCI scope.
+    </Warning>
   </Step>
 
   <Step title="Send it through the proxy">
@@ -106,6 +112,26 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     Any `4xx`/`5xx` accompanied by `yuno-proxy-destination-status` is the destination's own error, passed through for you to handle as if you had called it directly.
   </Step>
 </Steps>
+
+## Authenticating to the destination
+
+A proxy request carries two independent sets of credentials:
+
+* **Your Yuno credentials** (`public-api-key` / `private-secret-key`) authenticate you to the proxy. They are consumed by Yuno and never forwarded.
+* **The destination's own credentials** are whatever that third-party API expects. Put them on the request and they are forwarded untouched — Yuno only strips its own headers (the credentials above, `yuno-*` headers, and hop-by-hop headers).
+
+Most authentication schemes work as-is:
+
+* **Bearer tokens** — `Authorization: Bearer <token>` (shown above).
+* **API-key headers** — for example `X-API-Key: <key>`.
+* **Basic auth** — `Authorization: Basic <base64>`.
+* **A key in the body** — include it as a normal field; the body is forwarded byte-for-byte.
+
+<Note>
+**Signed requests and mutual TLS are not yet supported**
+
+Because the proxy substitutes the real card number only inside its secure environment, you cannot pre-compute a request signature (HMAC) over a body that contains a `{{vaulted_token…}}` placeholder, and client-certificate (mTLS) authentication to the destination is not yet available. Destinations that require request signing or mTLS will be supported by managed proxy routes in a later release.
+</Note>
 
 ## Timeouts
 

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -97,6 +97,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
     | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |
+    | `502` | `RESPONSE_BLOCKED` | The destination's response contained card data and your account is configured to reject (rather than redact) such responses |
     | `504` | `DESTINATION_TIMEOUT` | The destination did not respond within the timeout |
     | `500` | `PROXY_ERROR` | An unexpected error inside the proxy |
 

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -14,14 +14,26 @@ The Yuno PCI Proxy lets your servers make HTTPS requests to any third-party API 
 The PCI Proxy works with cards you have already stored with Yuno. Cards are stored when a customer saves a payment method during checkout, or when you enroll one through the [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api) endpoint.
 </Note>
 
+<Warning>
+**Destinations must be allowlisted**
+
+The proxy only calls hosts you have registered on your destination allowlist. A request to an
+unregistered host is rejected with `DESTINATION_NOT_ALLOWED`. Registration is self-serve and
+takes effect in minutes — see [Destination Allowlist](/docs/security-and-compliance/pci-proxy/allowlist).
+</Warning>
+
 ## How it works
 
 1. Your server sends an HTTPS request to `https://api.y.uno/v1/pci-proxy`, authenticated with your standard Yuno API credentials.
 2. You put the full destination URL (including its path and query) in the `yuno-proxy-url` header, and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
 3. Inside Yuno's PCI environment, the proxy resolves each expression to the real card data, then forwards your request — same method, headers, and body — to the destination over TLS.
-4. The destination's response is returned to you unchanged, along with diagnostic headers that tell you what the proxy did.
+4. The destination's response is returned to you, along with diagnostic headers that tell you what the proxy did.
 
 The proxy is a pass-through: Yuno does not store your request or the destination's response, and request and response bodies are never written to logs.
+
+## Card data in responses
+
+If a destination echoes a full card number back in its response, returning it to you would put your systems back in PCI scope. To prevent that, the proxy scans each response and **redacts** any card number it finds — the one it just injected, plus any other valid card number — leaving only the last four digits. The `yuno-proxy-response-redactions` response header reports how many were redacted; a non-zero value is a sign your destination is returning card data you should not receive.
 
 ## Card data you can reference
 

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -33,7 +33,9 @@ The proxy is a pass-through: Yuno does not store your request or the destination
 
 ## Card data in responses
 
-If a destination echoes a full card number back in its response, returning it to you would put your systems back in PCI scope. To prevent that, the proxy scans each response and **redacts** any card number it finds — the one it just injected, plus any other valid card number — leaving only the last four digits. The `yuno-proxy-response-redactions` response header reports how many were redacted; a non-zero value is a sign your destination is returning card data you should not receive.
+If a destination echoes a full card number back in its response, returning it to you would put your systems back in PCI scope. To prevent that, the proxy scans each response for card numbers — the one it just injected, plus any other valid card number.
+
+By default the proxy **redacts** them, leaving only the last four digits, and reports how many in the `yuno-proxy-response-redactions` response header; a non-zero value is a sign your destination is returning card data you should not receive. Depending on your account's configuration, the proxy may instead **reject** any response that contains card data with `502 RESPONSE_BLOCKED` rather than redacting it.
 
 ## Card data you can reference
 

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -26,7 +26,7 @@
             "name": "yuno-proxy-url",
             "in": "header",
             "required": true,
-            "description": "The complete destination URL, including its path and any query string (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Must be a public HTTPS hostname on port 443; IP addresses and internal networks are rejected. It must not contain `{{vaulted_token...}}` expressions (card data must never appear in a URL).",
+            "description": "The complete destination URL, including its path and any query string (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Must be a public HTTPS hostname on port 443, and the host must be registered on your destination allowlist; IP addresses and internal networks are rejected. It must not contain `{{vaulted_token...}}` expressions (card data must never appear in a URL).",
             "schema": {
               "type": "string",
               "example": "https://api.example-processor.com/charges"
@@ -89,6 +89,12 @@
               },
               "yuno-proxy-replacements": {
                 "description": "Number of expressions replaced before forwarding.",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "yuno-proxy-response-redactions": {
+                "description": "Number of card numbers redacted from the destination response (a non-zero value means the destination returned card data).",
                 "schema": {
                   "type": "integer"
                 }
@@ -172,7 +178,7 @@
                     "value": {
                       "code": "DESTINATION_NOT_ALLOWED",
                       "messages": [
-                        "destination must be a public HTTPS hostname"
+                        "destination host is not registered on your allowlist"
                       ]
                     }
                   }

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -227,7 +227,7 @@
             }
           },
           "502": {
-            "description": "The destination could not be reached.",
+            "description": "The destination could not be reached, or (when the account is configured to block) its response contained card data.",
             "content": {
               "application/json": {
                 "schema": {
@@ -239,6 +239,14 @@
                       "code": "DESTINATION_UNREACHABLE",
                       "messages": [
                         "connection to destination failed"
+                      ]
+                    }
+                  },
+                  "Response blocked": {
+                    "value": {
+                      "code": "RESPONSE_BLOCKED",
+                      "messages": [
+                        "destination returned card data"
                       ]
                     }
                   }
@@ -322,6 +330,7 @@
               "TOO_MANY_REQUESTS",
               "DESTINATION_UNREACHABLE",
               "DESTINATION_TIMEOUT",
+              "RESPONSE_BLOCKED",
               "PROXY_ERROR"
             ]
           },

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -40,10 +40,14 @@
                 "example": {
                   "destinations": [
                     {
-                      "id": "dst_5f8c2a1b9e4d",
+                      "id": 4218,
+                      "account_code": null,
                       "hostname": "api.example-processor.com",
+                      "status": "ENABLED",
                       "purpose": "Direct acquiring — Processor X",
-                      "created_at": "2026-07-09T13:05:36Z"
+                      "created_by": "ops@merchant.com",
+                      "created_at": "2026-07-09T13:05:36Z",
+                      "updated_at": "2026-07-09T13:05:36Z"
                     }
                   ]
                 }
@@ -82,10 +86,34 @@
                   "$ref": "#/components/schemas/Destination"
                 },
                 "example": {
-                  "id": "dst_5f8c2a1b9e4d",
+                  "id": 4218,
+                  "account_code": null,
                   "hostname": "api.example-processor.com",
+                  "status": "ENABLED",
                   "purpose": "Direct acquiring — Processor X",
-                  "created_at": "2026-07-09T13:05:36Z"
+                  "created_by": "ops@merchant.com",
+                  "created_at": "2026-07-09T13:05:36Z",
+                  "updated_at": "2026-07-09T13:05:36Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request body could not be parsed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationError"
+                },
+                "examples": {
+                  "Invalid request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "invalid body"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -94,18 +122,18 @@
             "$ref": "#/components/responses/Unauthorized"
           },
           "409": {
-            "description": "The hostname is already registered on your allowlist.",
+            "description": "The hostname is already registered on your allowlist (for this account scope).",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DestinationError"
                 },
                 "examples": {
-                  "Already registered": {
+                  "Destination exists": {
                     "value": {
-                      "code": "DESTINATION_ALREADY_REGISTERED",
+                      "code": "DESTINATION_EXISTS",
                       "messages": [
-                        "hostname is already registered on your allowlist"
+                        "destination already registered"
                       ]
                     }
                   }
@@ -114,7 +142,7 @@
             }
           },
           "422": {
-            "description": "The value is not a bare public hostname (a URL, a host with a port or path, an IP address, or a wildcard).",
+            "description": "The value is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard).",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,7 +153,7 @@
                     "value": {
                       "code": "INVALID_HOSTNAME",
                       "messages": [
-                        "hostname must be a bare public hostname without scheme, port, or path"
+                        "hostname must be a bare public FQDN with no scheme, port, path, or wildcard"
                       ]
                     }
                   }
@@ -146,16 +174,37 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "description": "The `id` of the destination to remove, as returned by [List Destinations](/reference/pci-proxy/list-destinations).",
+            "description": "The numeric `id` of the destination to remove, as returned by [List Destinations](/reference/pci-proxy/list-destinations).",
             "schema": {
-              "type": "string",
-              "example": "dst_5f8c2a1b9e4d"
+              "type": "integer",
+              "format": "int64",
+              "example": 4218
             }
           }
         ],
         "responses": {
           "204": {
             "description": "The destination was removed. No response body."
+          },
+          "400": {
+            "description": "The `id` path parameter is not a valid integer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationError"
+                },
+                "examples": {
+                  "Invalid id": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "invalid id"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -170,9 +219,9 @@
                 "examples": {
                   "Not found": {
                     "value": {
-                      "code": "DESTINATION_NOT_FOUND",
+                      "code": "NOT_FOUND",
                       "messages": [
-                        "no destination with that id is registered for your account"
+                        "destination not found"
                       ]
                     }
                   }
@@ -237,6 +286,12 @@
             "type": "string",
             "description": "An optional human-readable label describing why this host is allowed. Shown when you list destinations.",
             "example": "Direct acquiring — Processor X"
+          },
+          "account_code": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional. Restrict this destination to a single account. Omit (or send `null`) to allow the host for the whole organization.",
+            "example": null
           }
         }
       },
@@ -244,24 +299,47 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
+            "type": "integer",
+            "format": "int64",
             "description": "Unique identifier of the destination. Use it to remove the destination.",
-            "example": "dst_5f8c2a1b9e4d"
+            "example": 4218
+          },
+          "account_code": {
+            "type": "string",
+            "nullable": true,
+            "description": "The account this destination is scoped to, or `null` when it applies to the whole organization.",
+            "example": null
           },
           "hostname": {
             "type": "string",
             "description": "The registered hostname.",
             "example": "api.example-processor.com"
           },
+          "status": {
+            "type": "string",
+            "description": "Whether the destination is active.",
+            "example": "ENABLED"
+          },
           "purpose": {
             "type": "string",
             "description": "The label you provided when registering the destination.",
             "example": "Direct acquiring — Processor X"
           },
+          "created_by": {
+            "type": "string",
+            "description": "The user who registered the destination.",
+            "example": "ops@merchant.com"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "description": "When the destination was registered.",
+            "example": "2026-07-09T13:05:36Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the destination was last changed.",
             "example": "2026-07-09T13:05:36Z"
           }
         }
@@ -275,9 +353,11 @@
             "enum": [
               "NOT_AUTHENTICATED",
               "AuthenticationFail",
+              "INVALID_REQUEST",
               "INVALID_HOSTNAME",
-              "DESTINATION_ALREADY_REGISTERED",
-              "DESTINATION_NOT_FOUND"
+              "DESTINATION_EXISTS",
+              "NOT_FOUND",
+              "INTERNAL_ERROR"
             ]
           },
           "messages": {

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -1,0 +1,293 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "pci-proxy-manage-destinations",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/pci-proxy/destinations": {
+      "get": {
+        "summary": "List Destinations",
+        "description": "Returns the destinations registered on your account's allowlist. Only hosts on this list can be reached by the [forward proxy](/reference/pci-proxy/invoke-forward-proxy); a request to any other host is rejected with `403 DESTINATION_NOT_ALLOWED`.",
+        "operationId": "listPciProxyDestinations",
+        "responses": {
+          "200": {
+            "description": "The destinations registered for your account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "destinations": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Destination"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "destinations": [
+                    {
+                      "id": "dst_5f8c2a1b9e4d",
+                      "hostname": "api.example-processor.com",
+                      "purpose": "Direct acquiring — Processor X",
+                      "created_at": "2026-07-09T13:05:36Z"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Register Destination",
+        "description": "Adds a host to your account's allowlist so the forward proxy can send card data to it. Matching is on the exact hostname, case-insensitive; subdomains and wildcards are not implied. A newly registered host is usable within minutes.",
+        "operationId": "registerPciProxyDestination",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DestinationInput"
+              },
+              "example": {
+                "hostname": "api.example-processor.com",
+                "purpose": "Direct acquiring — Processor X"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The destination was registered.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                },
+                "example": {
+                  "id": "dst_5f8c2a1b9e4d",
+                  "hostname": "api.example-processor.com",
+                  "purpose": "Direct acquiring — Processor X",
+                  "created_at": "2026-07-09T13:05:36Z"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "description": "The hostname is already registered on your allowlist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationError"
+                },
+                "examples": {
+                  "Already registered": {
+                    "value": {
+                      "code": "DESTINATION_ALREADY_REGISTERED",
+                      "messages": [
+                        "hostname is already registered on your allowlist"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The value is not a bare public hostname (a URL, a host with a port or path, an IP address, or a wildcard).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationError"
+                },
+                "examples": {
+                  "Invalid hostname": {
+                    "value": {
+                      "code": "INVALID_HOSTNAME",
+                      "messages": [
+                        "hostname must be a bare public hostname without scheme, port, or path"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pci-proxy/destinations/{id}": {
+      "delete": {
+        "summary": "Remove Destination",
+        "description": "Removes a host from your account's allowlist. This takes effect immediately: the next proxy request to that host is rejected with `403 DESTINATION_NOT_ALLOWED`.",
+        "operationId": "removePciProxyDestination",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The `id` of the destination to remove, as returned by [List Destinations](/reference/pci-proxy/list-destinations).",
+            "schema": {
+              "type": "string",
+              "example": "dst_5f8c2a1b9e4d"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The destination was removed. No response body."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "No destination with that `id` is registered for your account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationError"
+                },
+                "examples": {
+                  "Not found": {
+                    "value": {
+                      "code": "DESTINATION_NOT_FOUND",
+                      "messages": [
+                        "no destination with that id is registered for your account"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication failed. Missing or invalid API credentials.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DestinationError"
+            },
+            "examples": {
+              "Not authenticated": {
+                "value": {
+                  "code": "NOT_AUTHENTICATED",
+                  "messages": [
+                    "not authenticated"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "DestinationInput": {
+        "type": "object",
+        "required": [
+          "hostname"
+        ],
+        "properties": {
+          "hostname": {
+            "type": "string",
+            "description": "The bare public hostname to allow, without scheme, port, or path (for example `api.example-processor.com`). Matched exactly, case-insensitive.",
+            "example": "api.example-processor.com"
+          },
+          "purpose": {
+            "type": "string",
+            "description": "An optional human-readable label describing why this host is allowed. Shown when you list destinations.",
+            "example": "Direct acquiring — Processor X"
+          }
+        }
+      },
+      "Destination": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the destination. Use it to remove the destination.",
+            "example": "dst_5f8c2a1b9e4d"
+          },
+          "hostname": {
+            "type": "string",
+            "description": "The registered hostname.",
+            "example": "api.example-processor.com"
+          },
+          "purpose": {
+            "type": "string",
+            "description": "The label you provided when registering the destination.",
+            "example": "Direct acquiring — Processor X"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the destination was registered.",
+            "example": "2026-07-09T13:05:36Z"
+          }
+        }
+      },
+      "DestinationError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code.",
+            "enum": [
+              "NOT_AUTHENTICATED",
+              "AuthenticationFail",
+              "INVALID_HOSTNAME",
+              "DESTINATION_ALREADY_REGISTERED",
+              "DESTINATION_NOT_FOUND"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/pci-proxy/invoke-forward-proxy.mdx
+++ b/reference/pci-proxy/invoke-forward-proxy.mdx
@@ -19,6 +19,6 @@ The PCI Proxy is in beta and is enabled per account. Contact your Key Account Ma
 Proxy requests detokenize card data and must only be made from your backend. Never expose your `private-secret-key` in client-side code.
 </Warning>
 
-All of `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` are supported — the destination receives the same method you used. Path segments and query strings appended after `/pci-proxy` are appended to the destination URL.
+All of `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` are supported: the destination receives the same method you used. Put the complete destination URL, including its path and any query string, in the `yuno-proxy-url` header; a query string on the `/pci-proxy` request itself is rejected. The destination host must be on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist).
 
 If you are a PCI-certified merchant and need the raw card data itself rather than a pass-through call, use [Retrieve Enrolled Payment Method by ID PCI Data](/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api) instead.

--- a/reference/pci-proxy/list-destinations.mdx
+++ b/reference/pci-proxy/list-destinations.mdx
@@ -1,0 +1,8 @@
+---
+title: "List Destinations"
+description: "Retrieve the third-party hosts currently on your PCI Proxy allowlist."
+keywords: ["pci proxy", "allowlist", "destination", "security"]
+openapi: "/openapi/pci-proxy/manage-destinations.json GET /pci-proxy/destinations"
+---
+
+Returns the destinations registered for your account. Only these hosts can be reached by the [forward proxy](/reference/pci-proxy/invoke-forward-proxy). See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist) for details.

--- a/reference/pci-proxy/register-destination.mdx
+++ b/reference/pci-proxy/register-destination.mdx
@@ -1,0 +1,14 @@
+---
+title: "Register Destination"
+description: "Add a third-party host to your PCI Proxy allowlist so the forward proxy can send card data to it."
+keywords: ["pci proxy", "allowlist", "destination", "security"]
+openapi: "/openapi/pci-proxy/manage-destinations.json POST /pci-proxy/destinations"
+---
+
+Adds a host to your account's destination allowlist. The [forward proxy](/reference/pci-proxy/invoke-forward-proxy) only sends card data to hosts on this list; there is no "any host" mode. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist) for how matching works.
+
+<Note>
+**Adding a destination is sensitive**
+
+Registering a host widens where your stored cards can be sent. Restrict who can manage the allowlist and review any unexpected additions.
+</Note>

--- a/reference/pci-proxy/remove-destination.mdx
+++ b/reference/pci-proxy/remove-destination.mdx
@@ -1,0 +1,8 @@
+---
+title: "Remove Destination"
+description: "Remove a third-party host from your PCI Proxy allowlist. Takes effect immediately."
+keywords: ["pci proxy", "allowlist", "destination", "security"]
+openapi: "/openapi/pci-proxy/manage-destinations.json DELETE /pci-proxy/destinations/{id}"
+---
+
+Removes a host from your account's destination allowlist by its `id` (from [List Destinations](/reference/pci-proxy/list-destinations)). Removal takes effect immediately: the next [forward proxy](/reference/pci-proxy/invoke-forward-proxy) request to that host is rejected with `403 DESTINATION_NOT_ALLOWED`. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).


### PR DESCRIPTION
## docs(pci-proxy): destination allowlist + response redaction

The CTO tightened the PCI Proxy security model; this documents the two merchant-visible changes on `pci-proxy-ms` (PR #3).

- **New page — [Destination Allowlist]**: the proxy only calls hosts you have registered on your allowlist (there is no "any host" mode). Self-serve, exact-hostname match, effective in minutes. Documents the CRUD endpoints (`GET`/`POST /v1/pci-proxy/destinations`, `DELETE .../{id}`) and the fail-closed `DESTINATION_NOT_ALLOWED` behavior.
- **Overview**: a "Destinations must be allowlisted" warning, and a "Card data in responses" section explaining that the proxy redacts card numbers a destination echoes back (so you are not pulled into PCI scope).
- **Forward Proxy guide**: the `yuno-proxy-response-redactions` diagnostic header and the allowlist cause of `DESTINATION_NOT_ALLOWED`.
- **OpenAPI**: response-redactions header, allowlist note on `yuno-proxy-url`, updated 403 example. New page registered in `docs.json`.

Follows #551 (merged/deployed) and #552 (round-2 doc fixes, still open) — this PR builds on #552's branch, so until #552 merges its commits also appear here. Targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
