### PR TITLE
chore: web sdk changelog 1.8.7

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,24 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.8.7",
-      "release_date": "2026-07-09",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.8.7",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Consistent installment dropdown format",
-          "description": "The installment dropdown now renders every option with the same template (`Nx of {value} - Total {total}`) regardless of whether the option includes financial costs, fixing mixed layouts when a plan combines options with and without `financial_costs`.",
-          "group": "Card",
-          "migration_guide": null,
-          "links": []
-        }
-      ]
-    },
-    {
       "version": "1.9.13",
       "release_date": "2026-07-07",
       "upgrade": {
@@ -423,6 +405,24 @@
           "title": "More Resilient Asset Resolution",
           "description": "Guard the webpack public path when running under Vite, skip duplicate `/v<x.y>` suffixes when the asset URL already includes one, and use the configured `apiUrl` directly as the API client base URL to avoid region-prefix corruption.",
           "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.8.7",
+      "release_date": "2026-07-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.7",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Consistent installment dropdown format",
+          "description": "The installment dropdown now renders every option with the same template (`Nx of {value} - Total {total}`) regardless of whether the option includes financial costs, fixing mixed layouts when a plan combines options with and without `financial_costs`.",
+          "group": "Card",
           "migration_guide": null,
           "links": []
         }

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.8.7",
+      "release_date": "2026-07-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.8.7",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Consistent installment dropdown format",
+          "description": "The installment dropdown now renders every option with the same template (`Nx of {value} - Total {total}`) regardless of whether the option includes financial costs, fixing mixed layouts when a plan combines options with and without `financial_costs`.",
+          "group": "Card",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.9.13",
       "release_date": "2026-07-07",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -177,6 +177,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="fixed" /> **More Resilient Asset Resolution**  
   Guard the webpack public path when running under Vite, skip duplicate `/v<x.y>` suffixes when the asset URL already includes one, and use the configured `apiUrl` directly as the API client base URL to avoid region-prefix corruption.
 
+## v1.8.7
+*July 9, 2026*
+
+**Card**
+
+- <ChangelogBadge type="fixed" /> **Consistent installment dropdown format**  
+  The installment dropdown now renders every option with the same template (`Nx of {value} - Total {total}`) regardless of whether the option includes financial costs, fixing mixed layouts when a plan combines options with and without `financial_costs`.
+
 ## v1.8.1
 *May 22, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.8.7`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v12.0.7

1 entry.