### PR TITLE
docs(webhooks): add de-duplication section covering idempotency_key and retry handling

### DIFF
--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -61,7 +61,7 @@ async function handleWebhookEvent(event) {
 }
 ```
 
-Keep in mind that not every event type carries `data.idempotency_key` yet (see Coverage above) — for event types without it, fall back to your own de-duplication key, such as the resource ID and event type combined.
+Keep in mind that not every event type carries `data.idempotency_key` yet (see Coverage above) — for event types without it, fall back to your own de-duplication key, such as the combination of resource ID and event type.
 
 ## Common Webhook Events
 

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -20,6 +20,49 @@ Yuno webhooks expects to receive an **HTTP 200 OK** status as a response to conf
 
 If no response is received within the specified time, Yuno will retry sending the event notification up to seven times to ensure no information is lost. Refer to the [Receipt Confirmation Process](/docs/webhooks/configure-webhooks#receipt-confirmation-process) section for details on the notification schedule and confirmation waiting times for each retry.
 
+## De-duplication
+
+Because Yuno retries delivery when it doesn't receive a confirmation, your endpoint can receive the same event more than once. This is expected behavior, not a bug — your integration should be able to identify and skip duplicates.
+
+### The identifier
+
+Every event payload includes `data.idempotency_key`, a unique identifier for that event. It stays stable across every retry of the same event, so you can use it to tell a duplicate delivery apart from a genuinely new event.
+
+### Coverage
+
+`data.idempotency_key` is currently included in:
+
+- `payment` events (including chargebacks)
+- `refund` events
+
+<Note>
+Support for `enrollment` events is landing on July 11, 2026. Until then, enrollment payloads do not include `data.idempotency_key`.
+</Note>
+
+### Why you might see the same event twice
+
+Each payload also includes a top-level `retry` field with the number of delivery attempts made for that event (`0` on the first attempt). If your endpoint doesn't return an HTTP 200 OK in time, Yuno resends the same event — same `data.idempotency_key`, incremented `retry` — following the schedule described in [Webhooks delivery and response requirements](#webhooks-delivery-and-response-requirements) above. Treat any event carrying an idempotency key you've already processed as a duplicate, regardless of its `retry` value.
+
+### Recommended handling
+
+Store every `data.idempotency_key` you've successfully processed, and check incoming events against that store before acting on them:
+
+```js
+async function handleWebhookEvent(event) {
+  const key = event.data.idempotency_key;
+
+  if (await store.has(key)) {
+    // Already processed — acknowledge and skip.
+    return;
+  }
+
+  await processEvent(event);
+  await store.add(key);
+}
+```
+
+Keep in mind that not every event type carries `data.idempotency_key` yet (see Coverage above) — for event types without it, fall back to your own de-duplication key, such as the resource ID and event type combined.
+
 ## Common Webhook Events
 
 Yuno sends event notifications for various activities within the payment ecosystem. Below are the available event categories and their corresponding events.

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -32,8 +32,9 @@ Every event payload includes `data.idempotency_key`, a unique identifier for tha
 
 `data.idempotency_key` is currently included in:
 
-- `payment` events (including chargebacks)
+- `payment` events
 - `refund` events
+- `chargeback` events
 
 <Note>
 Support for `enrollment` events is landing on July 11, 2026. Until then, enrollment payloads do not include `data.idempotency_key`.


### PR DESCRIPTION
## PR Description
Zuora (via Veera, escalated 2026-06-26) flagged that the webhooks docs never explained how merchants should identify and skip duplicate event deliveries. This adds a new "De-duplication" section to the Webhooks Overview page, requested by Mau Madrigal and tied to ticket CORECM-17592 (Core adding `data.idempotency_key` to enrollment events, shipping 2026-07-11) — docs and code ship together as part of that ticket's Definition of Done. Andrea Bautista's team should validate technical accuracy before merge.

## Changes
- `docs/webhooks/index.mdx` — added a new "De-duplication" section (between "Webhooks delivery and response requirements" and "Common Webhook Events") covering: the `data.idempotency_key` identifier and its stability across retries; current coverage (payment, refund events today; enrollment landing 2026-07-11, called out in a `<Note>`); the `retry` payload field and why duplicates are expected by design; and a recommended "store the key, skip if already seen" JS handling snippet.