### PR TITLE
docs(organizations): clarify create-user auth/dashboard access instead of internal implementation detail

### DIFF
--- a/openapi/organizations/create-user.json
+++ b/openapi/organizations/create-user.json
@@ -21,7 +21,7 @@
       "post": {
         "summary": "Create User",
         "operationId": "create-user",
-        "description": "Creates a new user. Users are created in DB only (no Auth0/WorkOS). The user must be created with at least one permission assignment: either account_permissions, account_group_permissions, or both.",
+        "description": "Creates a new user. Users created this way are not granted access to the Dashboard, and can only be authenticated using the [Authenticate Whitelabel User](/reference/organizations/authenticate-whitelabel-user) api. The user must be created with at least one permission assignment: either account_permissions, account_group_permissions, or both.",
         "requestBody": {
           "required": true,
           "content": {

--- a/reference/organizations/create-user.mdx
+++ b/reference/organizations/create-user.mdx
@@ -2,7 +2,3 @@
 title: "Create User"
 openapi: "/openapi/organizations/create-user.json POST /organizations/users"
 ---
-
-Creates a new user within your organization. Users created via this API are stored directly in the Yuno database and are not managed via external identity providers like SAML or WorkOS. 
-
-Every user must be created with at least one permission assignment at either the account or account group level.


### PR DESCRIPTION
## PR Description
Flagged that the Create User endpoint description exposed an internal implementation detail ("Users are created in DB only (no Auth0/WorkOS)") without explaining what it actually means for the reader. This PR replaces that sentence with reader-facing guidance on the practical effect: no Dashboard access, and authentication only via the Authenticate Whitelabel User endpoint.

## Changes
- `openapi/organizations/create-user.json` — replaced the `description` sentence "Users are created in DB only (no Auth0/WorkOS)." with "Users created this way are not granted access to the Dashboard, and can only be authenticated using the [Authenticate Whitelabel User](/reference/organizations/authenticate-whitelabel-user) api." on the `create-user` operation.