### PR TITLE
docs(recipients-for-marketplace): add DRIVERS_LICENCE_BACK content_category option

### DIFF
--- a/openapi/recipients-for-marketplace/continue-onboarding.json
+++ b/openapi/recipients-for-marketplace/continue-onboarding.json
@@ -767,6 +767,7 @@
                             "CANCEL_POLICY",
                             "CUSTOMER_INTERACTION",
                             "DRIVERS_LICENCE",
+                            "DRIVERS_LICENCE_BACK",
                             "IDENTIFICATION_DOCUMENT",
                             "IDENTIFICATION_DOCUMENT_BACK",
                             "IDENTIFICATION_DOCUMENT_FRONT",


### PR DESCRIPTION
New content_category value added for recipient documents in the Continue Onboarding flow