### PR TITLE
chore: web sdk changelog 1.9.14

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,54 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.14",
+      "release_date": "2026-07-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.14",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Backend-driven checkout field labels and required fields",
+          "description": "The checkout form now renders from the configuration returned with each payment method. Field labels, placeholders, validation messages, selection options, and which fields are shown are driven by the backend, so the form always reflects exactly what each payment method and provider requires, displayed in the shopper's language. When this configuration isn't provided, the SDK falls back to its built-in localized text, so existing integrations keep working with no code changes required.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Consistent installment dropdown format",
+          "description": "The installment dropdown now renders every option with the same template (`Nx of {value} - Total {total}`) regardless of whether the option includes financial costs, fixing mixed layouts when a plan combines options with and without `financial_costs`.",
+          "group": "Card",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "ACH Direct Debit Account Fields",
+          "description": "Added two new fields to the bank transfer form: Account Type (Checkings/Savings) and Account Holder Type (Individual/Company).",
+          "group": "APM",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Improved PayPal Braintree Button Loading",
+          "description": "The loading placeholder now matches the button style configured via `externalButtons.paypalBraintree.style` (width, height and border radius), removing the visual mismatch while the button loads",
+          "group": "PayPal",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-16931",
+        "CORECM-17599",
+        "CORECM-18112",
+        "CORECM-18192"
+      ]
+    },
+    {
       "version": "1.9.13",
       "release_date": "2026-07-07",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,29 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.14
+*July 9, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Backend-driven checkout field labels and required fields**  
+  The checkout form now renders from the configuration returned with each payment method. Field labels, placeholders, validation messages, selection options, and which fields are shown are driven by the backend, so the form always reflects exactly what each payment method and provider requires, displayed in the shopper's language. When this configuration isn't provided, the SDK falls back to its built-in localized text, so existing integrations keep working with no code changes required.
+
+**Card**
+
+- <ChangelogBadge type="fixed" /> **Consistent installment dropdown format**  
+  The installment dropdown now renders every option with the same template (`Nx of {value} - Total {total}`) regardless of whether the option includes financial costs, fixing mixed layouts when a plan combines options with and without `financial_costs`.
+
+**APM**
+
+- <ChangelogBadge type="added" /> **ACH Direct Debit Account Fields**  
+  Added two new fields to the bank transfer form: Account Type (Checkings/Savings) and Account Holder Type (Individual/Company).
+
+**PayPal**
+
+- <ChangelogBadge type="fixed" /> **Improved PayPal Braintree Button Loading**  
+  The loading placeholder now matches the button style configured via `externalButtons.paypalBraintree.style` (width, height and border radius), removing the visual mismatch while the button loads
+
 ## v1.9.13
 *July 7, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.14`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.14

4 entries.