### PR TITLE
docs(pci-proxy): align with C2-17643 technical definition (/forward, yuno-account-id, content types, audit)

### DIFF
--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -20,9 +20,14 @@ host first with the endpoints below.
 
 ## How matching works
 
-Allowlist entries are matched on the **exact hostname**, case-insensitive. Subdomains are not
-implied: allowing `api.example.com` does not allow `sandbox.example.com`. Wildcards are not
-supported. Register each hostname you call.
+The proxy only forwards to hosts on your allowlist. Matching is exact on the hostname:
+
+* **Case-insensitive:** `API.Stripe.com` and `api.stripe.com` are the same host.
+* **No wildcards:** `api.example.com` does not authorize `sandbox.example.com`.
+* **Subdomains are registered separately.**
+
+A request to a host that is not on the allowlist is rejected with `403 DESTINATION_NOT_ALLOWED`
+before any card data is read.
 
 ## Register a destination
 
@@ -46,6 +51,15 @@ or a wildcard) returns `422 INVALID_HOSTNAME`.
 account** in your organization. Set it to a specific account id to scope the destination to
 that account only — the host is then usable solely on proxy requests made under that account.
 
+<Note>
+**Account-scoped API keys**
+
+If you call the allowlist endpoints with a `yuno-account-id` header (an account-scoped key), the
+new destination is automatically scoped to that account, and `List` and `Remove` only see and
+affect that account's entries plus the organization-wide ones. Org-level keys omit the header and
+manage all of the organization's destinations.
+</Note>
+
 ## List your destinations
 
 ```sh
@@ -67,9 +81,18 @@ curl -X DELETE "https://api.y.uno/v1/pci-proxy/destinations/{id}" \
 Returns `204`. Removing a destination takes effect immediately — the next proxy request to
 that host is rejected.
 
-<Note>
-**Treat new-destination alerts seriously**
+## Audit trail
 
-Adding a destination is a sensitive action: it widens where your cards can be sent. Yuno
-recommends restricting who can manage the allowlist and reviewing any unexpected additions.
+Every allowlist change — each **add and each remove** — is written to an append-only audit log
+recording who made the change, when, and which hostname. The audit record persists even after
+a destination is removed, so a deletion is never invisible: you can always see who removed a
+host and when. There is no way to alter or erase these audit records through the API.
+
+<Note>
+**Treat new-destination and deletion alerts seriously**
+
+Adding or removing a destination is a sensitive action: it changes where your cards can be sent.
+Yuno recommends restricting who can manage the allowlist, enabling notifications on allowlist
+changes, and reviewing any unexpected additions or deletions — they are the tripwire for a
+compromised dashboard account.
 </Note>

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -10,7 +10,7 @@ This guide shows how to call a third-party API with real card data through the Y
 
 * Your `public-api-key` and `private-secret-key` from the Yuno Dashboard.
 * A card stored with Yuno and its `vaulted_token`. See [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api).
-* The destination API you want to call, reachable over HTTPS on port 443.
+* The destination API you want to call, reachable over HTTPS on port 443, and registered on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist).
 
 <Warning>
 **Server-side only**
@@ -28,32 +28,33 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
       "currency": "USD",
       "card": {
         "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
-        "exp_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
-        "exp_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
-        "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+        "expiration_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+        "expiration_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+        "holder_name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
       }
     }
     ```
 
-    Expressions work in the request body and in header values. Everything that is not an expression is forwarded untouched.
+    The four fields you can reference are `number`, `expiration_month`, `expiration_year`, and `holder_name`. They resolve to the stored **card (PAN) data** — this flow is specifically for retrieving card data from a vaulted token, not provider tokens or network tokens.
 
-    The proxy is content-transparent: it forwards your body and `Content-Type` unchanged and resolves expressions anywhere in the raw body, so JSON, form-encoded, and XML payloads all work. The example above is JSON, but the destination receives exactly the format you send.
+    Expressions work in the request body and in header values. Everything that is not an expression is forwarded untouched.
 
     <Warning>
     **No CVV**
 
-    There is no placeholder for the security code (CVV/CVC). Card networks do not allow it to be stored after a payment is authorized, so a stored payment method has none to inject — the available fields are `number`, `expiration_month`, `expiration_year`, and `holder_name`. If your destination requires the CVV, your customer must supply it and you include it in the body yourself; note that transmitting a raw security code keeps that request in your PCI scope.
+    There is no placeholder for the security code (CVV/CVC). Card networks do not allow it to be stored after a payment is authorized, so a stored payment method has none to inject — the available fields are `number`, `expiration_month`, `expiration_year`, and `holder_name`. If your destination requires the CVV, your customer must supply it and you include it directly in the body yourself (the proxy forwards it without storing it); note that transmitting a raw security code keeps that request in your PCI scope.
     </Warning>
   </Step>
 
   <Step title="Send it through the proxy">
-    Send the request to `https://api.y.uno/v1/pci-proxy` with the destination in the `yuno-proxy-url` header:
+    Send the request to `https://api.y.uno/v1/pci-proxy/forward` with the destination in the `yuno-proxy-url` header:
 
     ```sh
-    curl -X POST "https://api.y.uno/v1/pci-proxy" \
+    curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
       -H "public-api-key: $PUBLIC_API_KEY" \
       -H "private-secret-key: $PRIVATE_SECRET_KEY" \
       -H "yuno-proxy-url: https://api.example-processor.com/charges" \
+      -H "yuno-account-id: acc_123" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $PROCESSOR_API_KEY" \
       -d '{
@@ -61,20 +62,22 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
         "currency": "USD",
         "card": {
           "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
-          "exp_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
-          "exp_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
-          "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+          "expiration_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+          "expiration_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+          "holder_name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
         }
       }'
     ```
 
     The HTTP method you use is the method the destination receives. Headers you set for the destination (like `Authorization` above) pass through; Yuno's own credential headers and all `yuno-*` headers are stripped before forwarding.
 
-    Put the **complete** destination URL — including its path and any query string — in `yuno-proxy-url` (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Do not add a path or query string to the `/v1/pci-proxy` request itself; a query string on the proxy request is rejected, so that merchant data is never logged.
+    The `yuno-account-id` header is optional: include it when you need to scope the request to a specific account. Like all `yuno-*` headers it is removed before forwarding and never reaches the destination. It narrows **which allowlisted destinations** are permitted for the request; it does not affect token resolution — vaulted tokens are always scoped to your organization.
+
+    Put the **complete** destination URL — including its path and any query string — in `yuno-proxy-url` (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Do not add a path or query string to the `/v1/pci-proxy/forward` request itself; a query string on the proxy request is rejected, so that merchant data is never logged.
   </Step>
 
   <Step title="Read the response">
-    The destination's status code, headers, and body are returned to you unchanged. The proxy adds diagnostic headers:
+    The destination's status code, headers, and body are returned to you unchanged, except that any card number the destination echoes back is redacted first (see [Card data in responses](#card-data-in-responses) below). The proxy adds diagnostic headers:
 
     | Header | Meaning |
     |---|---|
@@ -98,7 +101,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     |---|---|---|
     | `401` | `NOT_AUTHENTICATED` / `AuthenticationFail` | Missing or invalid API credentials |
     | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
-    | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your account, or a referenced field is unavailable |
+    | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your organization, or a referenced field is unavailable |
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
@@ -113,24 +116,126 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
   </Step>
 </Steps>
 
+## Content types
+
+The proxy is **content-type agnostic**. It forwards the body verbatim, without parsing or coercing it to JSON. Expression resolution is a text substitution over the raw body bytes, so a `vaulted_token` expression is replaced wherever it appears — JSON, XML, SOAP, or form key-value pairs. Place the expressions inside your payload and send the `Content-Type` your destination expects.
+
+**JSON** is shown above. The examples below cover the other common formats.
+
+**XML**
+
+```sh
+curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "yuno-proxy-url: https://api.legacy-processor.com/gateway" \
+  -H "Content-Type: application/xml" \
+  -d '<payment>
+        <amount>2500</amount>
+        <card>
+          <number>{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}</number>
+          <holderName>{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}</holderName>
+          <expiry>{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}/{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}</expiry>
+          <securityCode>123</securityCode>
+        </card>
+      </payment>'
+```
+
+**SOAP** — an XML envelope plus the destination's own `SOAPAction` header, forwarded unchanged:
+
+```sh
+curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "yuno-proxy-url: https://api.legacy-processor.com/soap" \
+  -H "Content-Type: text/xml; charset=utf-8" \
+  -H "SOAPAction: \"ProcessPayment\"" \
+  -d '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pay="http://processor.com/pay">
+        <soapenv:Body>
+          <pay:ProcessPayment>
+            <pay:amount>2500</pay:amount>
+            <pay:card>
+              <pay:number>{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}</pay:number>
+              <pay:holderName>{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}</pay:holderName>
+              <pay:expiry>{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}/{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}</pay:expiry>
+              <pay:securityCode>123</pay:securityCode>
+            </pay:card>
+          </pay:ProcessPayment>
+        </soapenv:Body>
+      </soapenv:Envelope>'
+```
+
+**Form key-value pairs** (`application/x-www-form-urlencoded`):
+
+```sh
+curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "yuno-proxy-url: https://api.legacy-processor.com/charge" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d 'amount=2500&card_number={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}&card_holder={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}&exp_month={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}&exp_year={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}&cvv=123'
+```
+
+<Warning>
+**Special characters in `holder_name`**
+
+Because substitution is literal, a `holder_name` containing markup or delimiter characters can break the payload structure at the destination:
+
+* **XML / SOAP:** a name with `&`, `<`, or `>` (for example `Doe & Sons`) can break well-formedness. The `number`, `expiration_month`, and `expiration_year` fields are digits only, so they are unaffected — the risk is limited to `holder_name`.
+* **Form key-value pairs:** a name with `&`, `=`, or spaces can break the key/value structure. Send `holder_name` URL-encoded, or use a JSON/XML payload if the holder name may contain special characters.
+</Warning>
+
+## Card data in responses
+
+If a destination echoes a card number back in its response, the proxy redacts it before returning the response to you — keeping only the last four digits — so raw card numbers never reach your systems. The number of redactions is reported in the `yuno-proxy-response-redactions` response header:
+
+```http
+HTTP/1.1 200 OK
+yuno-proxy-request-id: 7b3f...
+yuno-proxy-destination-status: 200
+yuno-proxy-response-redactions: 1
+
+{ "status": "approved", "card": { "number": "XXXXXXXXXXXX1111" } }
+```
+
+A non-zero `yuno-proxy-response-redactions` is a signal that your destination is returning card data you should not receive. Depending on your account configuration, the proxy may instead **reject** any response containing card data with `502 RESPONSE_BLOCKED`.
+
 ## Authenticating to the destination
 
 A proxy request carries two independent sets of credentials:
 
 * **Your Yuno credentials** (`public-api-key` / `private-secret-key`) authenticate you to the proxy. They are consumed by Yuno and never forwarded.
-* **The destination's own credentials** are whatever that third-party API expects. Put them on the request and they are forwarded untouched — Yuno only strips its own headers (the credentials above, `yuno-*` headers, and hop-by-hop headers).
+* **The destination's own credentials** are whatever that third-party API expects. Put them on the request and they are forwarded untouched — Yuno only strips its own headers.
 
-Most authentication schemes work as-is:
+Send whatever authentication header your destination requires — it is **not limited to `Authorization`**. The header name is defined by the destination provider's API, not by Yuno; take it from that provider's own documentation.
 
-* **Bearer tokens** — `Authorization: Bearer <token>` (shown above).
-* **API-key headers** — for example `X-API-Key: <key>`.
-* **Basic auth** — `Authorization: Basic <base64>`.
-* **A key in the body** — include it as a normal field; the body is forwarded byte-for-byte.
+**What Yuno forwards vs. removes:**
+
+| Header | Forwarded to destination? |
+|---|---|
+| `Authorization` (and any other destination header) | Yes, unchanged |
+| `Content-Type` | Yes |
+| `public-api-key`, `private-secret-key` | Removed by Yuno |
+| Any `yuno-*` header (e.g. `yuno-proxy-url`, `yuno-account-id`) | Removed by Yuno |
+| Internal tracing/infrastructure headers (`traceparent`, `x-datadog-*`, `x-envoy-*`, `x-forwarded-*`, …) | Removed by Yuno |
+
+**Common authentication header names by provider** (examples — always check the destination's docs):
+
+| Provider (example) | Authentication header |
+|---|---|
+| Stripe and many REST APIs | `Authorization: Bearer <token>` |
+| Some gateways | `X-Api-Key: <key>` or `apikey: <key>` |
+| Others | `Api-Token: <token>`, `X-Auth-Token: <token>` |
+| Basic auth | `Authorization: Basic base64(user:pass)` |
 
 <Note>
 **Signed requests and mutual TLS are not yet supported**
 
-Because the proxy substitutes the real card number only inside its secure environment, you cannot pre-compute a request signature (HMAC) over a body that contains a `{{vaulted_token…}}` placeholder, and client-certificate (mTLS) authentication to the destination is not yet available. Destinations that require request signing or mTLS will be supported by managed proxy routes in a later release.
+Because the proxy substitutes the real card number only inside its secure environment, you cannot pre-compute a request signature (HMAC) over a body that contains a `{{vaulted_token…}}` placeholder — the signature would have to be calculated over the resolved body containing the real PAN, which you never see.
+
+Similarly, destinations that require **mutual TLS** (a client certificate) are not supported inline: the certificate is presented by Yuno during the TLS handshake, not sent in your request, so it must be configured with Yuno per destination rather than passed in the body or a header.
+
+Both request signing and mTLS are planned for a later release via managed proxy routes.
 </Note>
 
 ## Timeouts
@@ -138,7 +243,7 @@ Because the proxy substitutes the real card number only inside its secure enviro
 The proxy waits up to 30 seconds for the destination by default. Override it with the `yuno-proxy-timeout` header (seconds, maximum 120):
 
 ```sh
-curl -X POST "https://api.y.uno/v1/pci-proxy" \
+curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
   -H "public-api-key: $PUBLIC_API_KEY" \
   -H "private-secret-key: $PRIVATE_SECRET_KEY" \
   -H "yuno-proxy-url: https://api.slow-supplier.com/bookings" \
@@ -149,7 +254,7 @@ curl -X POST "https://api.y.uno/v1/pci-proxy" \
 
 ## Testing in sandbox
 
-Use `https://api-sandbox.y.uno/v1/pci-proxy` with your sandbox credentials and sandbox `vaulted_token` values. Sandbox tokens resolve to test card numbers, so you can point the proxy at your destination's own sandbox safely.
+Use `https://api-sandbox.y.uno/v1/pci-proxy/forward` with your sandbox credentials and sandbox `vaulted_token` values. Sandbox tokens resolve to test card numbers, so you can point the proxy at your destination's own sandbox safely.
 
 <Note>
 **Verify your integration**

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -24,7 +24,7 @@ takes effect in minutes — see [Destination Allowlist](/docs/security-and-compl
 
 ## How it works
 
-1. Your server sends an HTTPS request to `https://api.y.uno/v1/pci-proxy`, authenticated with your standard Yuno API credentials.
+1. Your server sends an HTTPS request to `https://api.y.uno/v1/pci-proxy/forward`, authenticated with your standard Yuno API credentials.
 2. You put the full destination URL (including its path and query) in the `yuno-proxy-url` header, and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
 3. Inside Yuno's PCI environment, the proxy resolves each expression to the real card data, then forwards your request — same method, headers, and body — to the destination over TLS.
 4. The destination's response is returned to you, along with diagnostic headers that tell you what the proxy did.
@@ -46,7 +46,13 @@ By default the proxy **redacts** them, leaving only the last four digits, and re
 | `{{vaulted_token.<TOKEN>.expiration_year}}` | Four-digit expiration year (`YYYY`) |
 | `{{vaulted_token.<TOKEN>.holder_name}}` | The cardholder name |
 
-The `<TOKEN>` must be a `vaulted_token` that belongs to your account. A token that does not exist or belongs to another account is rejected with `EXPRESSION_RESOLUTION_FAILED`, before any card data is read.
+The `<TOKEN>` must be a `vaulted_token` that belongs to your organization. A token that does not exist or belongs to another organization is rejected with `EXPRESSION_RESOLUTION_FAILED`, before any card data is read.
+
+<Note>
+**Card (PAN) data only**
+
+These expressions resolve a vaulted token to the stored **card** data — the PAN, expiration, and holder name. Yuno also issues provider tokens and network tokens, but this forward-proxy flow is specifically for retrieving the card (PAN) data from a vaulted token; it does not resolve provider or network tokens.
+</Note>
 
 <Note>
 **Security code (CVV) is not supported**

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -16,10 +16,10 @@
     }
   ],
   "paths": {
-    "/pci-proxy": {
+    "/pci-proxy/forward": {
       "post": {
         "summary": "Invoke Forward Proxy",
-        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. The full destination (including its path and query string) is specified in `yuno-proxy-url`; a query string on the `/pci-proxy` request itself is rejected. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
+        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. The full destination (including its path and query string) is specified in `yuno-proxy-url`; a query string on the `/pci-proxy/forward` request itself is rejected. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
         "operationId": "invokeForwardProxy",
         "parameters": [
           {
@@ -43,6 +43,16 @@
               "maximum": 120,
               "example": 30
             }
+          },
+          {
+            "name": "yuno-account-id",
+            "in": "header",
+            "required": false,
+            "description": "Optional account scope. Narrows which allowlisted destinations are permitted for this request; it does not affect token resolution (vaulted tokens are always scoped to your organization). Like all `yuno-*` headers it is removed before forwarding and never reaches the destination.",
+            "schema": {
+              "type": "string",
+              "example": "acc_123"
+            }
           }
         ],
         "requestBody": {
@@ -57,9 +67,9 @@
                   "currency": "USD",
                   "card": {
                     "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
-                    "exp_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
-                    "exp_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
-                    "name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+                    "expiration_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+                    "expiration_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+                    "holder_name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
                   }
                 }
               }

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -21,6 +21,18 @@
         "summary": "List Destinations",
         "description": "Returns the destinations registered on your account's allowlist. Only hosts on this list can be reached by the [forward proxy](/reference/pci-proxy/invoke-forward-proxy); a request to any other host is rejected with `403 DESTINATION_NOT_ALLOWED`.",
         "operationId": "listPciProxyDestinations",
+        "parameters": [
+          {
+            "name": "yuno-account-id",
+            "in": "header",
+            "required": false,
+            "description": "Optional account scope. When set, the response contains only that account's destinations plus the organization-wide ones. Omit it to list all of the organization's destinations.",
+            "schema": {
+              "type": "string",
+              "example": "acc_123"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The destinations registered for your account.",
@@ -40,7 +52,7 @@
                 "example": {
                   "destinations": [
                     {
-                      "id": 4218,
+                      "id": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4",
                       "account_code": null,
                       "hostname": "api.example-processor.com",
                       "status": "ENABLED",
@@ -63,6 +75,18 @@
         "summary": "Register Destination",
         "description": "Adds a host to your account's allowlist so the forward proxy can send card data to it. Matching is on the exact hostname, case-insensitive; subdomains and wildcards are not implied. A newly registered host is usable within minutes.",
         "operationId": "registerPciProxyDestination",
+        "parameters": [
+          {
+            "name": "yuno-account-id",
+            "in": "header",
+            "required": false,
+            "description": "Optional account scope. When set, the new destination is scoped to that account and a differing `account_code` in the body is rejected. Omit it to register at the organization level (honoring the body `account_code`).",
+            "schema": {
+              "type": "string",
+              "example": "acc_123"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -86,7 +110,7 @@
                   "$ref": "#/components/schemas/Destination"
                 },
                 "example": {
-                  "id": 4218,
+                  "id": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4",
                   "account_code": null,
                   "hostname": "api.example-processor.com",
                   "status": "ENABLED",
@@ -142,7 +166,7 @@
             }
           },
           "422": {
-            "description": "The value is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard).",
+            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard), or the `account_code` is not a UUID or does not match the `yuno-account-id` you are scoped to.",
             "content": {
               "application/json": {
                 "schema": {
@@ -154,6 +178,14 @@
                       "code": "INVALID_HOSTNAME",
                       "messages": [
                         "hostname must be a bare public FQDN with no scheme, port, path, or wildcard"
+                      ]
+                    }
+                  },
+                  "Invalid account code": {
+                    "value": {
+                      "code": "INVALID_ACCOUNT_CODE",
+                      "messages": [
+                        "account_code must match your yuno-account-id"
                       ]
                     }
                   }
@@ -174,11 +206,21 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "description": "The numeric `id` of the destination to remove, as returned by [List Destinations](/reference/pci-proxy/list-destinations).",
+            "description": "The `id` (UUID) of the destination to remove, as returned by [List Destinations](/reference/pci-proxy/list-destinations).",
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 4218
+              "type": "string",
+              "format": "uuid",
+              "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
+            }
+          },
+          {
+            "name": "yuno-account-id",
+            "in": "header",
+            "required": false,
+            "description": "Optional account scope. When set, only that account's own destinations can be removed (organization-wide entries and other accounts' entries are not visible).",
+            "schema": {
+              "type": "string",
+              "example": "acc_123"
             }
           }
         ],
@@ -187,7 +229,7 @@
             "description": "The destination was removed. No response body."
           },
           "400": {
-            "description": "The `id` path parameter is not a valid integer.",
+            "description": "The `id` path parameter is not a valid UUID.",
             "content": {
               "application/json": {
                 "schema": {
@@ -289,8 +331,9 @@
           },
           "account_code": {
             "type": "string",
+            "format": "uuid",
             "nullable": true,
-            "description": "Optional. Restrict this destination to a single account. Omit (or send `null`) to allow the host for the whole organization.",
+            "description": "Optional. Restrict this destination to a single account (a UUID). Omit (or send `null`) to allow the host for the whole organization. If you send a `yuno-account-id` header, this must match it or be omitted.",
             "example": null
           }
         }
@@ -299,10 +342,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int64",
+            "type": "string",
+            "format": "uuid",
             "description": "Unique identifier of the destination. Use it to remove the destination.",
-            "example": 4218
+            "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
           },
           "account_code": {
             "type": "string",
@@ -355,6 +398,7 @@
               "AuthenticationFail",
               "INVALID_REQUEST",
               "INVALID_HOSTNAME",
+              "INVALID_ACCOUNT_CODE",
               "DESTINATION_EXISTS",
               "NOT_FOUND",
               "INTERNAL_ERROR"


### PR DESCRIPTION
## Summary

Aligns the merchant-facing PCI Proxy docs with the reviewed Technical Definition in **[C2-17643](https://yunopayments.atlassian.net/browse/C2-17643)** and applies the team's Documentation Change List. Pairs with `pci-proxy-ms` PR #3 (which now implements this contract) and the public-api PROXY-2 passthrough.

### What changed
- **Endpoint rename** `/v1/pci-proxy` → **`/v1/pci-proxy/forward`** across the guide and both OpenAPI specs (the direction is now explicit; v2 inbound fits as `/v1/pci-proxy/inbound`). Destinations CRUD stays `/v1/pci-proxy/destinations`.
- **Overview:** scope note — expressions resolve to **card (PAN) data only**, not provider/network tokens.
- **Forward guide:**
  - Documents the optional **`yuno-account-id`** header (narrows the allowlist; tokens stay org-scoped; stripped before forwarding).
  - New **Content types** section — JSON, XML, SOAP, and form key-value examples, with the `holder_name` special-character caveat.
  - **Card data in responses** — redaction example (`XXXXXXXXXXXX1111`, `yuno-proxy-response-redactions`).
  - Expanded **destination auth** — auth is *not limited to* `Authorization`; forwarded-vs-removed and provider header tables; HMAC/mTLS note retained.
  - `holder_name` / `expiration_month` / `expiration_year` used consistently in examples.
- **Allowlist:** explicit exact-match rules, account-scoped API key behavior, and a new **Audit trail** section (append-only; deletions never invisible).
- **OpenAPI:** uuid destination `id`s, `yuno-account-id` header on all three operations, `422 INVALID_ACCOUNT_CODE`.

### Deploy note
docs.y.uno auto-publishes on merge to `main`. The current published pages describe the old `/v1/pci-proxy` path, which the shipped service will **not** expose — this PR corrects them. Since the feature is not yet live, either path is safe to publish, but ideally land this **alongside `pci-proxy-ms` #3** so the docs match production on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[C2-17643]: https://yunopayments.atlassian.net/browse/C2-17643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ