### PR TITLE
chore: web sdk changelog 1.9.15

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,36 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.15",
+      "release_date": "2026-07-10",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.15",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "CyberSource Fingerprint Session ID Override",
+          "description": "CyberSource/Cielo CyberSource fingerprint now honors the per-provider session_id override (deviceFingerprints), enabling merchant-specific MID prefixes on the ThreatMetrix session id.",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Consistent Card Field Labels",
+          "description": "The card number, expiration date, and CVV fields now resolve their labels from the same UI copy source across all card form variants, so the full checkout and the Lite SDK render identical texts for the same checkout session configuration.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18224",
+        "CORECM-18233"
+      ]
+    },
+    {
       "version": "1.9.14",
       "release_date": "2026-07-09",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,19 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.15
+*July 10, 2026*
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="fixed" /> **CyberSource Fingerprint Session ID Override**  
+  CyberSource/Cielo CyberSource fingerprint now honors the per-provider session_id override (deviceFingerprints), enabling merchant-specific MID prefixes on the ThreatMetrix session id.
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Consistent Card Field Labels**  
+  The card number, expiration date, and CVV fields now resolve their labels from the same UI copy source across all card form variants, so the full checkout and the Lite SDK render identical texts for the same checkout session configuration.
+
 ## v1.9.14
 *July 9, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.15`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.15

2 entries.