### PR TITLE
docs(pci-proxy): destination-url header, account_id, enable/disable (follow-up to #561)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -392,6 +392,8 @@
               "reference/pci-proxy/invoke-forward-proxy",
               "reference/pci-proxy/register-destination",
               "reference/pci-proxy/list-destinations",
+              "reference/pci-proxy/enable-destination",
+              "reference/pci-proxy/disable-destination",
               "reference/pci-proxy/remove-destination"
             ]
           },

--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -20,14 +20,15 @@ host first with the endpoints below.
 
 ## How matching works
 
-The proxy only forwards to hosts on your allowlist. Matching is exact on the hostname:
+The proxy only forwards to hosts that are registered **and enabled** on your allowlist.
+Matching is exact on the hostname:
 
 * **Case-insensitive:** `API.Stripe.com` and `api.stripe.com` are the same host.
 * **No wildcards:** `api.example.com` does not authorize `sandbox.example.com`.
 * **Subdomains are registered separately.**
 
-A request to a host that is not on the allowlist is rejected with `403 DESTINATION_NOT_ALLOWED`
-before any card data is read.
+A request to a host that is not registered, or is registered but `DISABLED`, is rejected with
+`403 DESTINATION_NOT_ALLOWED` before any card data is read.
 
 ## Register a destination
 
@@ -39,17 +40,21 @@ curl -X POST "https://api.y.uno/v1/pci-proxy/destinations" \
   -d '{
     "hostname": "api.example-processor.com",
     "purpose": "Direct acquiring — Processor X",
-    "account_code": null
+    "account_id": null
   }'
 ```
 
-Returns `201` with the created entry. A hostname that is already registered returns `409`; a
-value that is not a bare public hostname (a URL, a host with a port or path, an IP address,
-or a wildcard) returns `422 INVALID_HOSTNAME`.
+Returns `201` with the created entry, which starts in the `ENABLED` state. A hostname that is
+already registered returns `409`; a value that is not a bare public hostname (a URL, a host with
+a port or path, an IP address, or a wildcard) returns `422 INVALID_HOSTNAME`.
 
-`account_code` is optional. Left `null` (the default), the destination is allowed for **every
+`account_id` is optional. Left `null` (the default), the destination is allowed for **every
 account** in your organization. Set it to a specific account id to scope the destination to
 that account only — the host is then usable solely on proxy requests made under that account.
+
+The destination object returns `id`, `hostname`, `purpose`, `account_id`, `status`
+(`ENABLED` / `DISABLED`), `created_at`, and `updated_at`. When you call via the API the actor
+is your API key, so the object does not carry a user email.
 
 <Note>
 **Account-scoped API keys**
@@ -81,12 +86,51 @@ curl -X DELETE "https://api.y.uno/v1/pci-proxy/destinations/{id}" \
 Returns `204`. Removing a destination takes effect immediately — the next proxy request to
 that host is rejected.
 
+## Enable or disable a destination
+
+Instead of removing a host, you can **disable** it — the record (and its audit history) is kept,
+but the forward path stops using it. Re-**enable** it to turn it back on. This is useful for
+temporarily suspending a destination without losing its configuration.
+
+```sh
+# Turn a destination off (keeps the record)
+curl -X POST "https://api.y.uno/v1/pci-proxy/destinations/{id}/disable" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY"
+
+# Re-enable a disabled destination
+curl -X POST "https://api.y.uno/v1/pci-proxy/destinations/{id}/enable" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY"
+```
+
+Each returns `200` with the updated destination object (its `status` set to `DISABLED` or
+`ENABLED`). Only `ENABLED` destinations are used by the forward path; a request to a `DISABLED`
+host returns `403 DESTINATION_NOT_ALLOWED`.
+
+A destination moves through three states:
+
+```
+      create
+        │
+        ▼
+   ┌───────────┐   disable    ┌────────────┐
+   │  ENABLED  │ ───────────► │  DISABLED  │
+   │ (usable)  │ ◄─────────── │ (blocked)  │
+   └───────────┘    enable    └────────────┘
+        │                           │
+        └──────────── delete ───────┘
+                       │
+                       ▼
+                   (removed)
+```
+
 ## Audit trail
 
-Every allowlist change — each **add and each remove** — is written to an append-only audit log
-recording who made the change, when, and which hostname. The audit record persists even after
-a destination is removed, so a deletion is never invisible: you can always see who removed a
-host and when. There is no way to alter or erase these audit records through the API.
+Every allowlist change — **add, remove, enable, and disable** — is written to an append-only
+audit log recording who made the change, when, and which hostname. The audit record persists
+even after a destination is removed, so a deletion is never invisible: you can always see who
+removed a host and when. There is no way to alter or erase these audit records through the API.
 
 <Note>
 **Treat new-destination and deletion alerts seriously**

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Forward Proxy"
 description: "Step-by-step guide to calling third-party APIs with real card data through the Yuno PCI Proxy using vaulted token expressions."
-keywords: ["forward proxy", "yuno-proxy-url", "detokenization", "vaulted_token", "expressions"]
+keywords: ["forward proxy", "yuno-proxy-destination-url", "detokenization", "vaulted_token", "expressions"]
 ---
 
 This guide shows how to call a third-party API with real card data through the Yuno PCI Proxy. If you have not read it yet, start with the [PCI Proxy Overview](/docs/security-and-compliance/pci-proxy/overview).
@@ -47,13 +47,13 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
   </Step>
 
   <Step title="Send it through the proxy">
-    Send the request to `https://api.y.uno/v1/pci-proxy/forward` with the destination in the `yuno-proxy-url` header:
+    Send the request to `https://api.y.uno/v1/pci-proxy/forward` with the destination in the `yuno-proxy-destination-url` header:
 
     ```sh
     curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
       -H "public-api-key: $PUBLIC_API_KEY" \
       -H "private-secret-key: $PRIVATE_SECRET_KEY" \
-      -H "yuno-proxy-url: https://api.example-processor.com/charges" \
+      -H "yuno-proxy-destination-url: https://api.example-processor.com/charges" \
       -H "yuno-account-id: acc_123" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $PROCESSOR_API_KEY" \
@@ -73,7 +73,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
 
     The `yuno-account-id` header is optional: include it when you need to scope the request to a specific account. Like all `yuno-*` headers it is removed before forwarding and never reaches the destination. It narrows **which allowlisted destinations** are permitted for the request; it does not affect token resolution — vaulted tokens are always scoped to your organization.
 
-    Put the **complete** destination URL — including its path and any query string — in `yuno-proxy-url` (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Do not add a path or query string to the `/v1/pci-proxy/forward` request itself; a query string on the proxy request is rejected, so that merchant data is never logged.
+    Put the **complete** destination URL — including its path and any query string — in `yuno-proxy-destination-url` (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Do not add a path or query string to the `/v1/pci-proxy/forward` request itself; a query string on the proxy request is rejected, so that merchant data is never logged.
   </Step>
 
   <Step title="Read the response">
@@ -100,7 +100,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | HTTP status | Code | Meaning |
     |---|---|---|
     | `401` | `NOT_AUTHENTICATED` / `AuthenticationFail` | Missing or invalid API credentials |
-    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
+    | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-destination-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
     | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your organization, or a referenced field is unavailable |
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
@@ -128,7 +128,7 @@ The proxy is **content-type agnostic**. It forwards the body verbatim, without p
 curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
   -H "public-api-key: $PUBLIC_API_KEY" \
   -H "private-secret-key: $PRIVATE_SECRET_KEY" \
-  -H "yuno-proxy-url: https://api.legacy-processor.com/gateway" \
+  -H "yuno-proxy-destination-url: https://api.legacy-processor.com/gateway" \
   -H "Content-Type: application/xml" \
   -d '<payment>
         <amount>2500</amount>
@@ -147,7 +147,7 @@ curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
 curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
   -H "public-api-key: $PUBLIC_API_KEY" \
   -H "private-secret-key: $PRIVATE_SECRET_KEY" \
-  -H "yuno-proxy-url: https://api.legacy-processor.com/soap" \
+  -H "yuno-proxy-destination-url: https://api.legacy-processor.com/soap" \
   -H "Content-Type: text/xml; charset=utf-8" \
   -H "SOAPAction: \"ProcessPayment\"" \
   -d '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pay="http://processor.com/pay">
@@ -171,7 +171,7 @@ curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
 curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
   -H "public-api-key: $PUBLIC_API_KEY" \
   -H "private-secret-key: $PRIVATE_SECRET_KEY" \
-  -H "yuno-proxy-url: https://api.legacy-processor.com/charge" \
+  -H "yuno-proxy-destination-url: https://api.legacy-processor.com/charge" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d 'amount=2500&card_number={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}&card_holder={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}&exp_month={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}&exp_year={{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}&cvv=123'
 ```
@@ -216,7 +216,7 @@ Send whatever authentication header your destination requires — it is **not li
 | `Authorization` (and any other destination header) | Yes, unchanged |
 | `Content-Type` | Yes |
 | `public-api-key`, `private-secret-key` | Removed by Yuno |
-| Any `yuno-*` header (e.g. `yuno-proxy-url`, `yuno-account-id`) | Removed by Yuno |
+| Any `yuno-*` header (e.g. `yuno-proxy-destination-url`, `yuno-account-id`) | Removed by Yuno |
 | Internal tracing/infrastructure headers (`traceparent`, `x-datadog-*`, `x-envoy-*`, `x-forwarded-*`, …) | Removed by Yuno |
 
 **Common authentication header names by provider** (examples — always check the destination's docs):
@@ -246,7 +246,7 @@ The proxy waits up to 30 seconds for the destination by default. Override it wit
 curl -X POST "https://api.y.uno/v1/pci-proxy/forward" \
   -H "public-api-key: $PUBLIC_API_KEY" \
   -H "private-secret-key: $PRIVATE_SECRET_KEY" \
-  -H "yuno-proxy-url: https://api.slow-supplier.com/bookings" \
+  -H "yuno-proxy-destination-url: https://api.slow-supplier.com/bookings" \
   -H "yuno-proxy-timeout: 90" \
   -H "Content-Type: application/json" \
   -d '{ "card_number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}" }'

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -25,7 +25,7 @@ takes effect in minutes — see [Destination Allowlist](/docs/security-and-compl
 ## How it works
 
 1. Your server sends an HTTPS request to `https://api.y.uno/v1/pci-proxy/forward`, authenticated with your standard Yuno API credentials.
-2. You put the full destination URL (including its path and query) in the `yuno-proxy-url` header, and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
+2. You put the full destination URL (including its path and query) in the `yuno-proxy-destination-url` header, and reference card data in the request body or headers using expressions such as `{{vaulted_token.<TOKEN>.number}}`.
 3. Inside Yuno's PCI environment, the proxy resolves each expression to the real card data, then forwards your request — same method, headers, and body — to the destination over TLS.
 4. The destination's response is returned to you, along with diagnostic headers that tell you what the proxy did.
 

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -19,11 +19,11 @@
     "/pci-proxy/forward": {
       "post": {
         "summary": "Invoke Forward Proxy",
-        "description": "Forwards your request to the destination indicated in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. The full destination (including its path and query string) is specified in `yuno-proxy-url`; a query string on the `/pci-proxy/forward` request itself is rejected. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
+        "description": "Forwards your request to the destination indicated in the `yuno-proxy-destination-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions in the body and header values with real card data inside Yuno's PCI DSS Level 1 environment. The destination's status code, headers, and body are returned unchanged. `GET`, `PUT`, `PATCH`, and `DELETE` are also supported and forwarded verbatim. The full destination (including its path and query string) is specified in `yuno-proxy-destination-url`; a query string on the `/pci-proxy/forward` request itself is rejected. Every proxy response carries a `yuno-proxy-request-id` header; a `401` returned before the request reaches the proxy is the only exception.",
         "operationId": "invokeForwardProxy",
         "parameters": [
           {
-            "name": "yuno-proxy-url",
+            "name": "yuno-proxy-destination-url",
             "in": "header",
             "required": true,
             "description": "The complete destination URL, including its path and any query string (for example `https://api.example-processor.com/charges/ch_123/capture?expand=true`). Must be a public HTTPS hostname on port 443, and the host must be registered on your destination allowlist; IP addresses and internal networks are rejected. It must not contain `{{vaulted_token...}}` expressions (card data must never appear in a URL).",
@@ -160,7 +160,7 @@
                     "value": {
                       "code": "INVALID_REQUEST",
                       "messages": [
-                        "yuno-proxy-url header is required"
+                        "yuno-proxy-destination-url header is required"
                       ]
                     }
                   },

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -53,11 +53,10 @@
                   "destinations": [
                     {
                       "id": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4",
-                      "account_code": null,
+                      "account_id": null,
                       "hostname": "api.example-processor.com",
                       "status": "ENABLED",
                       "purpose": "Direct acquiring — Processor X",
-                      "created_by": "ops@merchant.com",
                       "created_at": "2026-07-09T13:05:36Z",
                       "updated_at": "2026-07-09T13:05:36Z"
                     }
@@ -80,7 +79,7 @@
             "name": "yuno-account-id",
             "in": "header",
             "required": false,
-            "description": "Optional account scope. When set, the new destination is scoped to that account and a differing `account_code` in the body is rejected. Omit it to register at the organization level (honoring the body `account_code`).",
+            "description": "Optional account scope. When set, the new destination is scoped to that account and a differing `account_id` in the body is rejected. Omit it to register at the organization level (honoring the body `account_id`).",
             "schema": {
               "type": "string",
               "example": "acc_123"
@@ -111,11 +110,10 @@
                 },
                 "example": {
                   "id": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4",
-                  "account_code": null,
+                  "account_id": null,
                   "hostname": "api.example-processor.com",
                   "status": "ENABLED",
                   "purpose": "Direct acquiring — Processor X",
-                  "created_by": "ops@merchant.com",
                   "created_at": "2026-07-09T13:05:36Z",
                   "updated_at": "2026-07-09T13:05:36Z"
                 }
@@ -166,7 +164,7 @@
             }
           },
           "422": {
-            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard), or the `account_code` is not a UUID or does not match the `yuno-account-id` you are scoped to.",
+            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard), or the `account_id` is not a UUID or does not match the `yuno-account-id` you are scoped to.",
             "content": {
               "application/json": {
                 "schema": {
@@ -185,7 +183,7 @@
                     "value": {
                       "code": "INVALID_ACCOUNT_CODE",
                       "messages": [
-                        "account_code must match your yuno-account-id"
+                        "account_id must match your yuno-account-id"
                       ]
                     }
                   }
@@ -273,6 +271,108 @@
           }
         }
       }
+    },
+    "/pci-proxy/destinations/{id}/enable": {
+      "post": {
+        "summary": "Enable Destination",
+        "description": "Re-enables a disabled destination. Only `ENABLED` destinations are used by the forward path.",
+        "operationId": "enablePciProxyDestination",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The `id` (UUID) of the destination to enable.",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
+            }
+          },
+          {
+            "name": "yuno-account-id",
+            "in": "header",
+            "required": false,
+            "description": "Optional account scope. When set, only that account's own destinations can be changed.",
+            "schema": {
+              "type": "string",
+              "example": "acc_123"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The destination was enabled; the updated object is returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidId"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/DestinationNotFound"
+          }
+        }
+      }
+    },
+    "/pci-proxy/destinations/{id}/disable": {
+      "post": {
+        "summary": "Disable Destination",
+        "description": "Turns a destination off without removing it — the record and its audit history are kept, but the forward path rejects it with `403 DESTINATION_NOT_ALLOWED` until it is enabled again.",
+        "operationId": "disablePciProxyDestination",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The `id` (UUID) of the destination to disable.",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
+            }
+          },
+          {
+            "name": "yuno-account-id",
+            "in": "header",
+            "required": false,
+            "description": "Optional account scope. When set, only that account's own destinations can be changed.",
+            "schema": {
+              "type": "string",
+              "example": "acc_123"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The destination was disabled; the updated object is returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidId"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/DestinationNotFound"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -310,6 +410,46 @@
             }
           }
         }
+      },
+      "InvalidId": {
+        "description": "The `id` path parameter is not a valid UUID.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DestinationError"
+            },
+            "examples": {
+              "Invalid id": {
+                "value": {
+                  "code": "INVALID_REQUEST",
+                  "messages": [
+                    "invalid id"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "DestinationNotFound": {
+        "description": "No destination with that `id` is registered for your scope.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DestinationError"
+            },
+            "examples": {
+              "Not found": {
+                "value": {
+                  "code": "NOT_FOUND",
+                  "messages": [
+                    "destination not found"
+                  ]
+                }
+              }
+            }
+          }
+        }
       }
     },
     "schemas": {
@@ -329,7 +469,7 @@
             "description": "An optional human-readable label describing why this host is allowed. Shown when you list destinations.",
             "example": "Direct acquiring — Processor X"
           },
-          "account_code": {
+          "account_id": {
             "type": "string",
             "format": "uuid",
             "nullable": true,
@@ -347,7 +487,7 @@
             "description": "Unique identifier of the destination. Use it to remove the destination.",
             "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
           },
-          "account_code": {
+          "account_id": {
             "type": "string",
             "nullable": true,
             "description": "The account this destination is scoped to, or `null` when it applies to the whole organization.",
@@ -360,18 +500,17 @@
           },
           "status": {
             "type": "string",
-            "description": "Whether the destination is active.",
+            "enum": [
+              "ENABLED",
+              "DISABLED"
+            ],
+            "description": "Whether the destination is active. Only ENABLED destinations are used by the forward path.",
             "example": "ENABLED"
           },
           "purpose": {
             "type": "string",
             "description": "The label you provided when registering the destination.",
             "example": "Direct acquiring — Processor X"
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The user who registered the destination.",
-            "example": "ops@merchant.com"
           },
           "created_at": {
             "type": "string",

--- a/reference/pci-proxy/disable-destination.mdx
+++ b/reference/pci-proxy/disable-destination.mdx
@@ -1,0 +1,8 @@
+---
+title: "Disable Destination"
+description: "Turn a destination off without removing it from your PCI Proxy allowlist."
+keywords: ["pci proxy", "allowlist", "destination", "security"]
+openapi: "/openapi/pci-proxy/manage-destinations.json POST /pci-proxy/destinations/{id}/disable"
+---
+
+Turns a destination off without removing it — the record and its audit history are kept, but the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) rejects it with `403 DESTINATION_NOT_ALLOWED` until it is enabled again. Useful for temporarily suspending a destination without losing its configuration. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).

--- a/reference/pci-proxy/enable-destination.mdx
+++ b/reference/pci-proxy/enable-destination.mdx
@@ -1,0 +1,8 @@
+---
+title: "Enable Destination"
+description: "Re-enable a disabled destination on your PCI Proxy allowlist so the forward proxy can use it again."
+keywords: ["pci proxy", "allowlist", "destination", "security"]
+openapi: "/openapi/pci-proxy/manage-destinations.json POST /pci-proxy/destinations/{id}/enable"
+---
+
+Re-enables a disabled destination so the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) will use it again. Only `ENABLED` destinations are reachable — a request to a `DISABLED` host is rejected with `403 DESTINATION_NOT_ALLOWED`. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).

--- a/reference/pci-proxy/invoke-forward-proxy.mdx
+++ b/reference/pci-proxy/invoke-forward-proxy.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Invoke Forward Proxy"
 description: "Call any third-party HTTPS API with real card data through Yuno's PCI DSS Level 1 environment, referencing stored cards by vaulted_token."
-keywords: ["pci proxy", "forward proxy", "yuno-proxy-url", "vaulted_token", "detokenization"]
-openapi: "/openapi/pci-proxy/invoke-forward-proxy.json POST /pci-proxy"
+keywords: ["pci proxy", "forward proxy", "yuno-proxy-destination-url", "vaulted_token", "detokenization"]
+openapi: "/openapi/pci-proxy/invoke-forward-proxy.json POST /pci-proxy/forward"
 ---
 
-Forwards your request to the destination in the `yuno-proxy-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions with real card data inside Yuno's secure environment. See the [Forward Proxy guide](/docs/security-and-compliance/pci-proxy/forward-proxy) for a step-by-step integration.
+Forwards your request to the destination in the `yuno-proxy-destination-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions with real card data inside Yuno's secure environment. See the [Forward Proxy guide](/docs/security-and-compliance/pci-proxy/forward-proxy) for a step-by-step integration.
 
 <Note>
 **Beta**
@@ -19,6 +19,6 @@ The PCI Proxy is in beta and is enabled per account. Contact your Key Account Ma
 Proxy requests detokenize card data and must only be made from your backend. Never expose your `private-secret-key` in client-side code.
 </Warning>
 
-All of `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` are supported: the destination receives the same method you used. Put the complete destination URL, including its path and any query string, in the `yuno-proxy-url` header; a query string on the `/pci-proxy` request itself is rejected. The destination host must be on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist).
+All of `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` are supported: the destination receives the same method you used. Put the complete destination URL, including its path and any query string, in the `yuno-proxy-destination-url` header; a query string on the `/pci-proxy/forward` request itself is rejected. The destination host must be on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist).
 
 If you are a PCI-certified merchant and need the raw card data itself rather than a pass-through call, use [Retrieve Enrolled Payment Method by ID PCI Data](/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api) instead.


### PR DESCRIPTION
## Why this exists

**#561 was merged with only its first commit.** The two later rounds of merchant-doc changes were pushed to that branch *after* it merged and closed, so they never reached `main` — the live pages still show `account_code`, `created_by`, and `yuno-proxy-url`. This PR brings the remaining changes to `main`.

It is cut fresh from current `main`, so the diff is **only** the pci-proxy files plus two `docs.json` nav lines — no unrelated changes.

## Changes
- **Destination header** `yuno-proxy-url` → **`yuno-proxy-destination-url`** across the guide, overview, OpenAPI, and the `invoke-forward-proxy` **reference page** — including its hardcoded inline copy, its keywords, and its `openapi:` binding (which the `/pci-proxy` → `/pci-proxy/forward` path rename had broken).
- **API object:** account scope field **`account_code` → `account_id`** (request body + response), and **`created_by` (user email) removed** from the response — via the API the actor is the key, not a user. `status` documented with its `ENABLED`/`DISABLED` enum.
- **Enable/disable:** `POST /destinations/{id}/enable` and `/disable` with the `ENABLED`/`DISABLED` state machine (only `ENABLED` hosts are used by the forward path; a `DISABLED` host → `403`). New OpenAPI operations + **Enable/Disable Destination** reference pages and nav entries.

## Verified
- No `account_code` / `created_by` / `yuno-proxy-url` anywhere in the pci-proxy docs, reference pages, or specs.
- All six reference `openapi:` bindings resolve to paths that exist in the specs.
- `docs.json` and both OpenAPI specs are valid JSON.

Pairs with `pci-proxy-ms` PR #3. docs.y.uno auto-publishes on merge to `main`.

Ref: C2-17643, TECH/2940731397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
