### PR TITLE
docs(CORECM-17814): checkout_id on checkout & customer session APIs

### DIFF
--- a/openapi/checkout-sessions/create-checkout-session.json
+++ b/openapi/checkout-sessions/create-checkout-session.json
@@ -281,6 +281,10 @@
                         }
                       }
                     }
+                  },
+                  "checkout_id": {
+                    "type": "string",
+                    "description": "The unique identifier (UUID) of the Custom Checkout to use for this session. Optional. When omitted, the session uses the account's default checkout."
                   }
                 }
               },
@@ -323,7 +327,8 @@
                         "interval_unit": "month",
                         "interval_count": 1
                       }
-                    }
+                    },
+                    "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
                   }
                 },
                 "Checkout Session (min data)": {
@@ -385,7 +390,8 @@
                       "installments": {
                         "plan_id": null,
                         "plan": null
-                      }
+                      },
+                      "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
                     }
                   },
                   "Checkout Session (full data)": {
@@ -411,7 +417,8 @@
                       "installments": {
                         "plan_id": null,
                         "plan": null
-                      }
+                      },
+                      "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
                     }
                   }
                 },
@@ -474,6 +481,10 @@
                             "plan_id": {},
                             "plan": {}
                           }
+                        },
+                        "checkout_id": {
+                          "type": "string",
+                          "example": "6822f80c-684e-41a3-8628-78963d3d60f7"
                         }
                       }
                     },
@@ -549,6 +560,10 @@
                             "plan_id": {},
                             "plan": {}
                           }
+                        },
+                        "checkout_id": {
+                          "type": "string",
+                          "example": "6822f80c-684e-41a3-8628-78963d3d60f7"
                         }
                       }
                     }

--- a/openapi/checkout-sessions/retrieve-checkout-session.json
+++ b/openapi/checkout-sessions/retrieve-checkout-session.json
@@ -72,7 +72,8 @@
                         "plan_id": null,
                         "plan": null
                       },
-                      "used": true
+                      "used": true,
+                      "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
                     }
                   }
                 },
@@ -190,6 +191,10 @@
                       "type": "boolean",
                       "description": "Specifies whether a checkout session was used previously or not.",
                       "example": true
+                    },
+                    "checkout_id": {
+                      "type": "string",
+                      "example": "6822f80c-684e-41a3-8628-78963d3d60f7"
                     }
                   }
                 }

--- a/openapi/customer-sessions-enrollment/create-customer-session.json
+++ b/openapi/customer-sessions-enrollment/create-customer-session.json
@@ -82,6 +82,10 @@
                   "callback_url": {
                     "type": "string",
                     "description": "The url to redirect your customer after the enrollment  is made in the provider's environment (MAX 526; MIN 3)."
+                  },
+                  "checkout_id": {
+                    "type": "string",
+                    "description": "The unique identifier (UUID) of the Custom Checkout to use for this enrollment session. Optional. When omitted, the session uses the account's default checkout."
                   }
                 }
               },
@@ -92,7 +96,8 @@
                     "customer_id": "ae106483-65ee-463b-8782-9794022b3112",
                     "country": "US",
                     "callback_url": "https://www.google.com/?customerSession=7dd71f21-9e4c-439a-9c6d-58f240bd28df",
-                    "created_at": "2025-05-07T20:00:18.721786Z"
+                    "created_at": "2025-05-07T20:00:18.721786Z",
+                    "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
                   }
                 }
               }
@@ -111,7 +116,8 @@
                       "customer_id": "ae106483-65ee-463b-8782-9794022b3112",
                       "country": "US",
                       "callback_url": "https://www.google.com/?customerSession=7dd71f21-9e4c-439a-9c6d-58f240bd28df",
-                      "created_at": "2025-05-07T20:00:18.721786Z"
+                      "created_at": "2025-05-07T20:00:18.721786Z",
+                      "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
                     }
                   }
                 },
@@ -137,6 +143,10 @@
                     "created_at": {
                       "type": "string",
                       "example": "2025-05-07T20:00:18.721786Z"
+                    },
+                    "checkout_id": {
+                      "type": "string",
+                      "example": "6822f80c-684e-41a3-8628-78963d3d60f7"
                     }
                   }
                 }


### PR DESCRIPTION
## What

Documents the optional `checkout_id` field (Custom Checkouts session pin) in the merchant API reference:

| Spec | Change |
|---|---|
| `openapi/checkout-sessions/create-checkout-session.json` | `checkout_id` on the request + both `oneOf` 200 response shapes |
| `openapi/checkout-sessions/retrieve-checkout-session.json` | `checkout_id` on the response |
| `openapi/customer-sessions-enrollment/create-customer-session.json` | `checkout_id` on the request + 201 response |

Semantics: optional UUID pinning the session to a specific Custom Checkout; omitted → the account's **default** checkout (responses return the bound checkout — the stamped default when the merchant sent none; the field may be absent for pre-feature sessions or if default resolution was unavailable at creation).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-17814]: https://yunopayments.atlassian.net/browse/CORECM-17814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Example

`POST /v1/customers/sessions` (same shape on `POST /checkout/sessions`):

```json
{
  "account_id": "c6609b9a-6c90-4efd-9ef0-d1e32a4948b1",
  "customer_id": "67552560-1bdd-46f2-8b1c-2b5766181b26",
  "country": "CO",
  "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
}
```

Response (201):

```json
{
  "customer_session": "752212f0-c06a-4168-91ee-6862e714e6be",
  "customer_id": "67552560-1bdd-46f2-8b1c-2b5766181b26",
  "country": "CO",
  "callback_url": null,
  "created_at": "2026-07-08T01:27:08.587233Z",
  "checkout_id": "6822f80c-684e-41a3-8628-78963d3d60f7"
}
```

Without `checkout_id` in the request, the response still returns it, carrying the account's default checkout (stamped at creation). It may be absent for sessions created before the feature was enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI changes with no runtime code; main risk is publishing before the matching public-api deploy accepts the field.
> 
> **Overview**
> Documents the optional **`checkout_id`** field (Custom Checkout UUID) across checkout and customer enrollment session OpenAPI specs.
> 
> **Create checkout session** adds `checkout_id` on the request (optional; omit → account default checkout) and on both **200** `oneOf` response shapes, with matching examples. **Retrieve checkout session** adds `checkout_id` on the **200** response schema and example. **Create customer session** adds the same optional request field and **`checkout_id`** on the **201** response.
> 
> Also fixes trailing newline / closing brace formatting on two spec files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d89bf2c486e558ca8b15023f51df65d03508ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->