### PR TITLE
docs(C2-17645): new field number (DPAN) in card_data.network_token — Get Customer Payment Method (PCI)

### DIFF
--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -126,7 +126,24 @@
                         "issuer_code": null,
                         "category": "CREDIT",
                         "type": "CREDIT",
-                        "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
+                        "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76",
+                        "network_token": {
+                          "network": "VISA",
+                          "number": "4895370000004321",
+                          "status": "ACTIVE",
+                          "par": "V0010013022182956191212272716",
+                          "network_token_id": "DM4MMC1GB000000011cdd1c11c874e27",
+                          "token_data": {
+                            "iin": "489537",
+                            "lfd": "4321",
+                            "expiration_month": 9,
+                            "expiration_year": 2030
+                          },
+                          "response": {
+                            "code": "00",
+                            "message": "Approved"
+                          }
+                        }
                       },
                       "last_successfully_used": null,
                       "last_successfully_used_at": null,
@@ -383,6 +400,71 @@
                         "fingerprint": {
                           "type": "string",
                           "example": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
+                        },
+                        "network_token": {
+                          "type": "object",
+                          "description": "Network token details for the card. Only returned when a network token has been provisioned for the card.",
+                          "properties": {
+                            "network": {
+                              "type": "string",
+                              "description": "Card network that provisioned the token.",
+                              "example": "VISA"
+                            },
+                            "number": {
+                              "type": "string",
+                              "description": "The DPAN: the full network token number provisioned by the network, read from the vault. Only returned for PCI-certified merchants.",
+                              "example": "4895370000004321"
+                            },
+                            "status": {
+                              "type": "string",
+                              "description": "Status of the network token.",
+                              "example": "ACTIVE"
+                            },
+                            "par": {
+                              "type": "string",
+                              "description": "Payment Account Reference (PAR) associated with the underlying card.",
+                              "example": "V0010013022182956191212272716"
+                            },
+                            "network_token_id": {
+                              "type": "string",
+                              "description": "Token reference assigned by the card network.",
+                              "example": "DM4MMC1GB000000011cdd1c11c874e27"
+                            },
+                            "token_data": {
+                              "type": "object",
+                              "properties": {
+                                "iin": {
+                                  "type": "string",
+                                  "example": "489537"
+                                },
+                                "lfd": {
+                                  "type": "string",
+                                  "example": "4321"
+                                },
+                                "expiration_month": {
+                                  "type": "integer",
+                                  "example": 9
+                                },
+                                "expiration_year": {
+                                  "type": "integer",
+                                  "example": 2030
+                                }
+                              }
+                            },
+                            "response": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string",
+                                  "example": "00"
+                                },
+                                "message": {
+                                  "type": "string",
+                                  "example": "Approved"
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     },


### PR DESCRIPTION
## What

Documents the new response-only field **`card_data.network_token.number`** (the DPAN) on **Get Enrolled Payment Method by ID (PCI)** — `GET /v1/customers/{customer_id}/payment-methods/{payment_method_id}`.

- **Field**: `number`, nested under `card_data.network_token`
- **Type**: `string` · optional · response-only
- **Gating**: PCI-only — same gate as `card_data.number` (the PAN), so it is documented on the PCI variant of the endpoint only
- **Description**: the DPAN, the full network token number provisioned by the network, read from the vault

## Notes

- `number` is the only **new** field in the contract. The rest of the `network_token` block (`network`, `status`, `par`, `network_token_id`, `token_data`, `response`) already existed in the public contract but was not yet documented on this page, so the whole block is added to the schema and the response example here.
- Only `openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json` is touched; the reference `.mdx` page renders from it.
- Pre-existing gap, out of scope for this PR: the non-PCI variant (`retrieve-enrolled-payment-method-by-id-api.json`) does not document `network_token` metadata at all.

Ticket: C2-17645

🤖 Generated with [Claude Code](https://claude.com/claude-code)