### PR TITLE
docs(pci-proxy): align docs with implementation, add PRODUCT_NOT_ENABLED gating + Destination Status page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -389,6 +389,7 @@
           {
             "group": "PCI Proxy (Beta)",
             "pages": [
+              "reference/pci-proxy/destination-status",
               "reference/pci-proxy/invoke-forward-proxy",
               "reference/pci-proxy/register-destination",
               "reference/pci-proxy/list-destinations",

--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -45,8 +45,9 @@ curl -X POST "https://api.y.uno/v1/pci-proxy/destinations" \
 ```
 
 Returns `201` with the created entry, which starts in the `ENABLED` state. A hostname that is
-already registered returns `409`; a value that is not a bare public hostname (a URL, a host with
-a port or path, an IP address, or a wildcard) returns `422 INVALID_HOSTNAME`.
+already registered returns `409 DESTINATION_EXISTS`; a value that is not a bare public hostname
+(a URL, a host with a port or path, an IP address, or a wildcard) returns `422 INVALID_HOSTNAME`;
+an `account_id` that is not a valid account for your organization returns `400 INVALID_ACCOUNT_ID`.
 
 `account_id` is optional. Left `null` (the default), the destination is allowed for **every
 account** in your organization. Set it to a specific account id to scope the destination to

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -93,7 +93,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     ```json
     {
       "code": "EXPRESSION_RESOLUTION_FAILED",
-      "messages": ["vaulted_token 1a2b3c4d-... could not be resolved"]
+      "messages": ["a vaulted_token expression could not be resolved"]
     }
     ```
 
@@ -106,7 +106,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
     | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |
-    | `502` | `RESPONSE_BLOCKED` | The destination's response contained card data and your account is configured to reject (rather than redact) such responses |
+    | `502` | `RESPONSE_BLOCKED` | The destination's response contained card data and Yuno is configured service-wide to reject such responses instead of redacting them (redaction is the default) |
     | `504` | `DESTINATION_TIMEOUT` | The destination did not respond within the timeout |
     | `500` | `PROXY_ERROR` | An unexpected error inside the proxy |
 
@@ -198,7 +198,7 @@ yuno-proxy-response-redactions: 1
 { "status": "approved", "card": { "number": "XXXXXXXXXXXX1111" } }
 ```
 
-A non-zero `yuno-proxy-response-redactions` is a signal that your destination is returning card data you should not receive. Depending on your account configuration, the proxy may instead **reject** any response containing card data with `502 RESPONSE_BLOCKED`.
+A non-zero `yuno-proxy-response-redactions` is a signal that your destination is returning card data you should not receive. Redaction is the default behavior. Yuno can optionally be configured — as a service-wide setting, not per account — to instead **reject** any response containing card data with `502 RESPONSE_BLOCKED`.
 
 ## Authenticating to the destination
 

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -77,7 +77,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
   </Step>
 
   <Step title="Read the response">
-    The destination's status code, headers, and body are returned to you unchanged, except that any card number the destination echoes back is redacted first (see [Card data in responses](#card-data-in-responses) below). The proxy adds diagnostic headers:
+    The destination's status code, headers, and body are returned to you unchanged, except that any card number the destination echoes back is redacted first (see [Card data in responses](#card-data-in-responses) below). Redirects are **not** followed: a `3xx` from the destination is returned to you as-is, so you decide whether to follow it. The proxy adds diagnostic headers:
 
     | Header | Meaning |
     |---|---|
@@ -105,7 +105,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
-    | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |
+    | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection, its response exceeded the 10 MB limit, or it returned a compressed / unsupported `Content-Encoding` |
     | `502` | `RESPONSE_BLOCKED` | The destination's response contained card data and Yuno is configured service-wide to reject such responses instead of redacting them (redaction is the default) |
     | `504` | `DESTINATION_TIMEOUT` | The destination did not respond within the timeout |
     | `500` | `PROXY_ERROR` | An unexpected error inside the proxy |

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -103,6 +103,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-destination-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
     | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your organization, or a referenced field is unavailable |
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
+    | `403` | `PRODUCT_NOT_ENABLED` | The PCI Proxy is not activated for your organization. This gate applies in **production** only — contact your Key Account Manager (KAM) to activate it. The sandbox is open for testing |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
     | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -105,7 +105,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |
     | `429` | `TOO_MANY_REQUESTS` | Rate limit exceeded |
-    | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection, its response exceeded the 10 MB limit, or it returned a compressed / unsupported `Content-Encoding` |
+    | `502` | `DESTINATION_UNREACHABLE` | The destination could not be reached or closed the connection |
     | `502` | `RESPONSE_BLOCKED` | The destination's response contained card data and Yuno is configured service-wide to reject such responses instead of redacting them (redaction is the default) |
     | `504` | `DESTINATION_TIMEOUT` | The destination did not respond within the timeout |
     | `500` | `PROXY_ERROR` | An unexpected error inside the proxy |

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -35,7 +35,7 @@ The proxy is a pass-through: Yuno does not store your request or the destination
 
 If a destination echoes a full card number back in its response, returning it to you would put your systems back in PCI scope. To prevent that, the proxy scans each response for card numbers — the one it just injected, plus any other valid card number.
 
-By default the proxy **redacts** them, leaving only the last four digits, and reports how many in the `yuno-proxy-response-redactions` response header; a non-zero value is a sign your destination is returning card data you should not receive. Depending on your account's configuration, the proxy may instead **reject** any response that contains card data with `502 RESPONSE_BLOCKED` rather than redacting it.
+By default the proxy **redacts** them, leaving only the last four digits, and reports how many in the `yuno-proxy-response-redactions` response header; a non-zero value is a sign your destination is returning card data you should not receive. Redaction is the default behavior. Yuno can optionally be configured — as a service-wide setting, not per account — to instead **reject** any response that contains card data with `502 RESPONSE_BLOCKED`.
 
 ## Card data you can reference
 

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -177,7 +177,7 @@
             }
           },
           "403": {
-            "description": "The destination is not allowed.",
+            "description": "The destination is not allowed, or the PCI Proxy is not activated for your organization (production only).",
             "content": {
               "application/json": {
                 "schema": {
@@ -189,6 +189,14 @@
                       "code": "DESTINATION_NOT_ALLOWED",
                       "messages": [
                         "destination host is not registered on your allowlist"
+                      ]
+                    }
+                  },
+                  "Product not enabled": {
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "The PCI Proxy is enabled per organization. Contact your Key Account Manager (KAM) to activate it."
                       ]
                     }
                   }
@@ -336,6 +344,7 @@
               "INVALID_REQUEST",
               "EXPRESSION_RESOLUTION_FAILED",
               "DESTINATION_NOT_ALLOWED",
+              "PRODUCT_NOT_ENABLED",
               "REQUEST_TOO_LARGE",
               "TOO_MANY_REQUESTS",
               "DESTINATION_UNREACHABLE",

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -168,7 +168,7 @@
                     "value": {
                       "code": "EXPRESSION_RESOLUTION_FAILED",
                       "messages": [
-                        "vaulted_token 1a2b3c4d-5678-90ab-cdef-111213141516 could not be resolved"
+                        "a vaulted_token expression could not be resolved"
                       ]
                     }
                   }
@@ -237,7 +237,7 @@
             }
           },
           "502": {
-            "description": "The destination could not be reached, or (when the account is configured to block) its response contained card data.",
+            "description": "The destination could not be reached, or (when Yuno is configured service-wide to block rather than redact) its response contained card data.",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -121,7 +121,7 @@
             }
           },
           "400": {
-            "description": "The request body could not be parsed, or the `account_id` is not a valid account for your organization.",
+            "description": "The request body could not be parsed.",
             "content": {
               "application/json": {
                 "schema": {
@@ -133,14 +133,6 @@
                       "code": "INVALID_REQUEST",
                       "messages": [
                         "invalid body"
-                      ]
-                    }
-                  },
-                  "Invalid account id": {
-                    "value": {
-                      "code": "INVALID_ACCOUNT_ID",
-                      "messages": [
-                        "account_id is not a valid account"
                       ]
                     }
                   }
@@ -172,7 +164,7 @@
             }
           },
           "422": {
-            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard).",
+            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard), or the `account_id` is not a valid account you can use.",
             "content": {
               "application/json": {
                 "schema": {
@@ -184,6 +176,14 @@
                       "code": "INVALID_HOSTNAME",
                       "messages": [
                         "hostname must be a bare public FQDN with no scheme, port, path, or wildcard"
+                      ]
+                    }
+                  },
+                  "Invalid account id": {
+                    "value": {
+                      "code": "INVALID_ACCOUNT_ID",
+                      "messages": [
+                        "account_id is not a valid account"
                       ]
                     }
                   }

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -121,7 +121,7 @@
             }
           },
           "400": {
-            "description": "The request body could not be parsed.",
+            "description": "The request body could not be parsed, or the `account_id` is not a valid account for your organization.",
             "content": {
               "application/json": {
                 "schema": {
@@ -133,6 +133,14 @@
                       "code": "INVALID_REQUEST",
                       "messages": [
                         "invalid body"
+                      ]
+                    }
+                  },
+                  "Invalid account id": {
+                    "value": {
+                      "code": "INVALID_ACCOUNT_ID",
+                      "messages": [
+                        "account_id is not a valid account"
                       ]
                     }
                   }
@@ -164,7 +172,7 @@
             }
           },
           "422": {
-            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard), or the `account_id` is not a valid account you can use.",
+            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard).",
             "content": {
               "application/json": {
                 "schema": {
@@ -176,14 +184,6 @@
                       "code": "INVALID_HOSTNAME",
                       "messages": [
                         "hostname must be a bare public FQDN with no scheme, port, path, or wildcard"
-                      ]
-                    }
-                  },
-                  "Invalid account id": {
-                    "value": {
-                      "code": "INVALID_ACCOUNT_ID",
-                      "messages": [
-                        "account_id is not a valid account"
                       ]
                     }
                   }

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -121,7 +121,7 @@
             }
           },
           "400": {
-            "description": "The request body could not be parsed.",
+            "description": "The request body could not be parsed, or the `account_id` is not a valid account for your organization.",
             "content": {
               "application/json": {
                 "schema": {
@@ -133,6 +133,14 @@
                       "code": "INVALID_REQUEST",
                       "messages": [
                         "invalid body"
+                      ]
+                    }
+                  },
+                  "Invalid account id": {
+                    "value": {
+                      "code": "INVALID_ACCOUNT_ID",
+                      "messages": [
+                        "account_id is not a valid account"
                       ]
                     }
                   }
@@ -164,7 +172,7 @@
             }
           },
           "422": {
-            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard), or the `account_id` is not a UUID or does not match the `yuno-account-id` you are scoped to.",
+            "description": "The hostname is not a bare public hostname (a URL, a host with a scheme, port, or path, an IP address, or a wildcard).",
             "content": {
               "application/json": {
                 "schema": {
@@ -176,14 +184,6 @@
                       "code": "INVALID_HOSTNAME",
                       "messages": [
                         "hostname must be a bare public FQDN with no scheme, port, path, or wildcard"
-                      ]
-                    }
-                  },
-                  "Invalid account code": {
-                    "value": {
-                      "code": "INVALID_ACCOUNT_CODE",
-                      "messages": [
-                        "account_id must match your yuno-account-id"
                       ]
                     }
                   }
@@ -537,7 +537,7 @@
               "AuthenticationFail",
               "INVALID_REQUEST",
               "INVALID_HOSTNAME",
-              "INVALID_ACCOUNT_CODE",
+              "INVALID_ACCOUNT_ID",
               "DESTINATION_EXISTS",
               "NOT_FOUND",
               "INTERNAL_ERROR"

--- a/reference/pci-proxy/destination-status.mdx
+++ b/reference/pci-proxy/destination-status.mdx
@@ -12,9 +12,10 @@ stateDiagram-v2
   [*] --> ENABLED: Register
   ENABLED --> DISABLED: Disable
   DISABLED --> ENABLED: Enable
-  ENABLED --> [*]: Remove
   DISABLED --> [*]: Remove
 ```
+
+A destination can be **removed** from either state — enabled or disabled. Removal is permanent; the record leaves the allowlist, though the deletion stays in the append-only audit log.
 
 ## Destination status
 

--- a/reference/pci-proxy/destination-status.mdx
+++ b/reference/pci-proxy/destination-status.mdx
@@ -8,11 +8,12 @@ Every host on your PCI Proxy [destination allowlist](/docs/security-and-complian
 
 ```mermaid
 stateDiagram-v2
-  [*] --> ENABLED: Register Destination
-  ENABLED --> DISABLED: Disable Destination
-  DISABLED --> ENABLED: Enable Destination
-  ENABLED --> [*]: Remove Destination
-  DISABLED --> [*]: Remove Destination
+  direction LR
+  [*] --> ENABLED: Register
+  ENABLED --> DISABLED: Disable
+  DISABLED --> ENABLED: Enable
+  ENABLED --> [*]: Remove
+  DISABLED --> [*]: Remove
 ```
 
 ## Destination status

--- a/reference/pci-proxy/destination-status.mdx
+++ b/reference/pci-proxy/destination-status.mdx
@@ -1,0 +1,24 @@
+---
+title: "Destination Status"
+---
+
+Every host on your PCI Proxy [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) has a status that controls whether the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) may send card data to it. A destination is created in the `ENABLED` state and can be toggled without losing its configuration or audit history. Only `ENABLED` destinations are reachable — a request to a `DISABLED` (or removed) host is rejected with `403 DESTINATION_NOT_ALLOWED`.
+
+## Workflow
+
+```mermaid
+stateDiagram-v2
+  [*] --> ENABLED: Register Destination
+  ENABLED --> DISABLED: Disable Destination
+  DISABLED --> ENABLED: Enable Destination
+  ENABLED --> [*]: Remove Destination
+  DISABLED --> [*]: Remove Destination
+```
+
+## Destination status
+
+| Status     | Description                                                                                                   |
+| :--------- | :----------------------------------------------------------------------------------------------------------- |
+| `ENABLED`  | The destination is active. The forward proxy may send card data to this host. A destination starts here on registration. |
+| `DISABLED` | The destination is suspended. Its record and audit history are kept, but the forward proxy will not use it until it is re-enabled. Requests to it return `403 DESTINATION_NOT_ALLOWED`. |
+| _(removed)_ | The destination has been deleted from the allowlist. It is no longer returned by List and requests to it are rejected. The deletion remains in the append-only audit log. |

--- a/reference/pci-proxy/invoke-forward-proxy.mdx
+++ b/reference/pci-proxy/invoke-forward-proxy.mdx
@@ -10,7 +10,7 @@ Forwards your request to the destination in the `yuno-proxy-destination-url` hea
 <Note>
 **Beta**
 
-The PCI Proxy is in beta and is enabled per organization. Contact your Key Account Manager (KAM) to activate it.
+The PCI Proxy is in beta and is enabled per organization. In production, requests return `403 PRODUCT_NOT_ENABLED` until your organization is activated — contact your Key Account Manager (KAM). The sandbox is open for testing.
 </Note>
 
 <Warning>

--- a/reference/pci-proxy/invoke-forward-proxy.mdx
+++ b/reference/pci-proxy/invoke-forward-proxy.mdx
@@ -10,7 +10,7 @@ Forwards your request to the destination in the `yuno-proxy-destination-url` hea
 <Note>
 **Beta**
 
-The PCI Proxy is in beta and is enabled per account. Contact your Key Account Manager (KAM) to activate it.
+The PCI Proxy is in beta and is enabled per organization. Contact your Key Account Manager (KAM) to activate it.
 </Note>
 
 <Warning>


### PR DESCRIPTION
## What

Reconciles the PCI Proxy merchant docs (guides + OpenAPI + reference) with the `pci-proxy-ms` / `public-api` implementation, and adds a state-machine reference page. Ref: C2-17643.

## Changes

**Errors & behavior**
- `RESPONSE_BLOCKED` is a service-wide setting (`BLOCK_RESPONSE_CARD_DATA`), not per-account; default is **redaction**. (guides + forward OpenAPI)
- `EXPRESSION_RESOLUTION_FAILED` example uses the static message the service actually returns.
- Register errors now match the code: `409 DESTINATION_EXISTS` (duplicate hostname), `422 INVALID_HOSTNAME` (hostname only), `400 INVALID_ACCOUNT_ID` (invalid account, validated in public-api). (allowlist guide + OpenAPI)
- Documented that `3xx` redirects are not followed (returned as-is).
- `429 TOO_MANY_REQUESTS` kept — enforced at the WAF layer.

**Product gating**
- Beta is enabled **per organization** (not per account).
- New `403 PRODUCT_NOT_ENABLED`: in production the proxy must be activated for the org (contact KAM); the sandbox is open for testing. Added to the forward error table, OpenAPI (example + enum), and the Beta note. _(to be implemented in code)_

**Docs structure**
- New **Destination Status** reference page: `ENABLED ⇄ DISABLED → removed` state machine, placed first in the "PCI Proxy (Beta)" reference group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)