### PR TITLE
docs(pci-proxy): remove yuno-account-id header from allowlist endpoints (keep on forward)

### DIFF
--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -60,10 +60,10 @@ is your API key, so the object does not carry a user email.
 <Note>
 **Account-scoped API keys**
 
-If you call the allowlist endpoints with a `yuno-account-id` header (an account-scoped key), the
-new destination is automatically scoped to that account, and `List` and `Remove` only see and
-affect that account's entries plus the organization-wide ones. Org-level keys omit the header and
-manage all of the organization's destinations.
+If you call the allowlist endpoints with an account-scoped API key, the new destination is
+automatically scoped to that account, and `List` and `Remove` only see and affect that account's
+entries plus the organization-wide ones. Organization-level keys manage all of the organization's
+destinations.
 </Note>
 
 ## List your destinations

--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -57,15 +57,6 @@ The destination object returns `id`, `hostname`, `purpose`, `account_id`, `statu
 (`ENABLED` / `DISABLED`), `created_at`, and `updated_at`. When you call via the API the actor
 is your API key, so the object does not carry a user email.
 
-<Note>
-**Account-scoped API keys**
-
-If you call the allowlist endpoints with an account-scoped API key, the new destination is
-automatically scoped to that account, and `List` and `Remove` only see and affect that account's
-entries plus the organization-wide ones. Organization-level keys manage all of the organization's
-destinations.
-</Note>
-
 ## List your destinations
 
 ```sh

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -21,18 +21,6 @@
         "summary": "List Destinations",
         "description": "Returns the destinations registered on your account's allowlist. Only hosts on this list can be reached by the [forward proxy](/reference/pci-proxy/invoke-forward-proxy); a request to any other host is rejected with `403 DESTINATION_NOT_ALLOWED`.",
         "operationId": "listPciProxyDestinations",
-        "parameters": [
-          {
-            "name": "yuno-account-id",
-            "in": "header",
-            "required": false,
-            "description": "Optional account scope. When set, the response contains only that account's destinations plus the organization-wide ones. Omit it to list all of the organization's destinations.",
-            "schema": {
-              "type": "string",
-              "example": "acc_123"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "The destinations registered for your account.",
@@ -74,18 +62,6 @@
         "summary": "Register Destination",
         "description": "Adds a host to your account's allowlist so the forward proxy can send card data to it. Matching is on the exact hostname, case-insensitive; subdomains and wildcards are not implied. A newly registered host is usable within minutes.",
         "operationId": "registerPciProxyDestination",
-        "parameters": [
-          {
-            "name": "yuno-account-id",
-            "in": "header",
-            "required": false,
-            "description": "Optional account scope. When set, the new destination is scoped to that account and a differing `account_id` in the body is rejected. Omit it to register at the organization level (honoring the body `account_id`).",
-            "schema": {
-              "type": "string",
-              "example": "acc_123"
-            }
-          }
-        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -210,16 +186,6 @@
               "format": "uuid",
               "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
             }
-          },
-          {
-            "name": "yuno-account-id",
-            "in": "header",
-            "required": false,
-            "description": "Optional account scope. When set, only that account's own destinations can be removed (organization-wide entries and other accounts' entries are not visible).",
-            "schema": {
-              "type": "string",
-              "example": "acc_123"
-            }
           }
         ],
         "responses": {
@@ -288,16 +254,6 @@
               "format": "uuid",
               "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
             }
-          },
-          {
-            "name": "yuno-account-id",
-            "in": "header",
-            "required": false,
-            "description": "Optional account scope. When set, only that account's own destinations can be changed.",
-            "schema": {
-              "type": "string",
-              "example": "acc_123"
-            }
           }
         ],
         "responses": {
@@ -338,16 +294,6 @@
               "type": "string",
               "format": "uuid",
               "example": "d7e8f9a0-1234-4b5c-8d6e-7f8091a2b3c4"
-            }
-          },
-          {
-            "name": "yuno-account-id",
-            "in": "header",
-            "required": false,
-            "description": "Optional account scope. When set, only that account's own destinations can be changed.",
-            "schema": {
-              "type": "string",
-              "example": "acc_123"
             }
           }
         ],
@@ -473,7 +419,7 @@
             "type": "string",
             "format": "uuid",
             "nullable": true,
-            "description": "Optional. Restrict this destination to a single account (a UUID). Omit (or send `null`) to allow the host for the whole organization. If you send a `yuno-account-id` header, this must match it or be omitted.",
+            "description": "Optional. Restrict this destination to a single account (a UUID). Omit (or send `null`) to allow the host for the whole organization.",
             "example": null
           }
         }


### PR DESCRIPTION
## What

The `yuno-account-id` header was documented on every PCI Proxy endpoint, but it only applies to the **forward** endpoint — there it narrows which allowlisted destinations are permitted for that request. On the allowlist endpoints, a destination is scoped to an account with **`account_id` in the request body** at registration, not with a header or an API key.

## Changes
- Removed the `yuno-account-id` header parameter from all 5 destinations operations in `manage-destinations.json`.
- Dropped the header reference from the `DestinationInput.account_id` description (scoping is via the body field).
- Removed the incorrect "Account-scoped API keys" note from the allowlist guide — there is no account-scoped API key; scoping is `account_id` in the body, already explained above it.
- **Kept** `yuno-account-id` on the forward endpoint (guide + OpenAPI), unchanged.

Ref: C2-17643

🤖 Generated with [Claude Code](https://claude.com/claude-code)