### PR TITLE
docs(pci-proxy): clarify the CVV can be sent directly in the body

### DIFF
--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -55,9 +55,9 @@ These expressions resolve a vaulted token to the stored **card** data — the PA
 </Note>
 
 <Note>
-**Security code (CVV) is not supported**
+**No `vaulted_token` expression for the security code (CVV)**
 
-Card networks do not allow the security code to be stored after a payment is authorized, so a stored payment method has no CVV to inject. The proxy does not support a `security_code` field.
+Card networks do not allow the security code to be stored after a payment is authorized, so a stored payment method has no CVV to inject — there is no `{{vaulted_token.<TOKEN>.security_code}}` expression. If your destination requires the CVV and you have it, include it directly in the request body yourself; the proxy forwards it without storing it. Note that transmitting a raw security code keeps that request in your PCI scope.
 </Note>
 
 ## Your PCI scope


### PR DESCRIPTION
## What

The PCI Proxy overview note titled "Security code (CVV) is not supported" read as if the CVV couldn't be used at all. That's misleading: there is no `vaulted_token` expression for the security code (Yuno doesn't store it), but a merchant **can** include the CVV directly in the request body — the proxy forwards it without storing it.

## Change
`overview.mdx` — reworded the note to:
- Retitle it "No `vaulted_token` expression for the security code (CVV)".
- Explain that if you have the CVV, you send it directly in the body and the proxy forwards it.
- Keep the PCI-scope caveat (transmitting a raw CVV keeps that request in your PCI scope).

This aligns the overview with the existing "No CVV" note in the forward-proxy guide.

Ref: C2-17643

🤖 Generated with [Claude Code](https://claude.com/claude-code)