### PR TITLE
docs(pci-proxy): add 400 INVALID_ACCOUNT_ID to the forward endpoint errors

### DIFF
--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -102,6 +102,7 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     | `401` | `NOT_AUTHENTICATED` / `AuthenticationFail` | Missing or invalid API credentials |
     | `400` | `INVALID_REQUEST` | Missing or invalid `yuno-proxy-destination-url`, an expression or query string in the URL, an invalid `yuno-proxy-timeout`, or more than 20 distinct tokens in one request |
     | `400` | `EXPRESSION_RESOLUTION_FAILED` | A `vaulted_token` does not exist, does not belong to your organization, or a referenced field is unavailable |
+    | `400` | `INVALID_ACCOUNT_ID` | The `yuno-account-id` header is not a valid account for your organization |
     | `403` | `DESTINATION_NOT_ALLOWED` | The destination is not a public HTTPS hostname (IP addresses, non-443 ports, and internal networks are rejected), or the host is not on your [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) |
     | `403` | `PRODUCT_NOT_ENABLED` | The PCI Proxy is not activated for your organization. This gate applies in **production** only — contact your Key Account Manager (KAM) to activate it. The sandbox is open for testing |
     | `413` | `REQUEST_TOO_LARGE` | Request body over 1 MB |

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -171,6 +171,14 @@
                         "a vaulted_token expression could not be resolved"
                       ]
                     }
+                  },
+                  "Invalid account id": {
+                    "value": {
+                      "code": "INVALID_ACCOUNT_ID",
+                      "messages": [
+                        "account_id is not a valid account"
+                      ]
+                    }
                   }
                 }
               }
@@ -343,6 +351,7 @@
               "AuthenticationFail",
               "INVALID_REQUEST",
               "EXPRESSION_RESOLUTION_FAILED",
+              "INVALID_ACCOUNT_ID",
               "DESTINATION_NOT_ALLOWED",
               "PRODUCT_NOT_ENABLED",
               "REQUEST_TOO_LARGE",


### PR DESCRIPTION
## What

The forward endpoint accepts the optional `yuno-account-id` header, and `account_id` is validated in public-api (the same validation as the register endpoint, which already documents `400 INVALID_ACCOUNT_ID`). The forward "Handle errors" table was missing this case.

## Changes
- `forward-proxy.mdx` — added a `400 INVALID_ACCOUNT_ID` row to the Handle-errors table.
- `invoke-forward-proxy.json` — added an `INVALID_ACCOUNT_ID` example under the `400` response and the code to the `ProxyError` enum.

Ref: C2-17643

🤖 Generated with [Claude Code](https://claude.com/claude-code)