### PR TITLE
docs(pci-proxy): drop "and is returned to you" from the audit-trail bullet

### DIFF
--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -69,7 +69,7 @@ When you use the PCI Proxy together with Yuno's SDKs to collect cards, raw card 
 * **HTTPS only.** The proxy connects to destinations over TLS 1.2 or higher, on port 443 only. Destinations must be public DNS hostnames — IP addresses and internal networks are rejected.
 * **Credential isolation.** Your Yuno API credentials and all `yuno-*` headers are stripped before the request is forwarded. The destination only sees the headers you intend it to see.
 * **No storage, no logging.** The proxy holds card data in memory only for the lifetime of the request. Request and response bodies are excluded from logs and traces.
-* **Full audit trail.** Every invocation is recorded server-side (who, when, destination, outcome — never card data). Each response carries a unique `yuno-proxy-request-id` you can quote in support requests to reference that record.
+* **Full audit trail.** Every invocation produces an audit record (who, when, destination, outcome — never card data).
 
 ## Limits
 

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -69,7 +69,7 @@ When you use the PCI Proxy together with Yuno's SDKs to collect cards, raw card 
 * **HTTPS only.** The proxy connects to destinations over TLS 1.2 or higher, on port 443 only. Destinations must be public DNS hostnames — IP addresses and internal networks are rejected.
 * **Credential isolation.** Your Yuno API credentials and all `yuno-*` headers are stripped before the request is forwarded. The destination only sees the headers you intend it to see.
 * **No storage, no logging.** The proxy holds card data in memory only for the lifetime of the request. Request and response bodies are excluded from logs and traces.
-* **Full audit trail.** Every invocation produces an audit record (who, when, destination, outcome — never card data) and is returned to you with a unique `yuno-proxy-request-id`.
+* **Full audit trail.** Every invocation is recorded server-side (who, when, destination, outcome — never card data). Each response carries a unique `yuno-proxy-request-id` you can quote in support requests to reference that record.
 
 ## Limits
 


### PR DESCRIPTION
## What

The overview's "Full audit trail" bullet implied the **audit record** is returned to the caller:

> Every invocation produces an audit record (who, when, destination, outcome — never card data) **and is returned to you** with a unique `yuno-proxy-request-id`.

There is no endpoint to retrieve the audit/forward records (`pci-proxy-ms` routes are only forward + destinations CRUD); the record is produced server-side. Kept the original wording and just removed the misleading clause.

## Change
`overview.mdx`:
> **Full audit trail.** Every invocation produces an audit record (who, when, destination, outcome — never card data).

Ref: C2-17643

🤖 Generated with [Claude Code](https://claude.com/claude-code)