### PR TITLE
docs(navigation): replace "(Beta)" suffix with Mintlify tag badges

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -354,7 +354,8 @@
             ]
           },
           {
-            "group": "Checkout Builder (Beta)",
+            "group": "Checkout Builder",
+            "tag": "Beta",
             "pages": [
               "reference/checkout-builder/overview",
               {
@@ -387,7 +388,8 @@
             ]
           },
           {
-            "group": "PCI Proxy (Beta)",
+            "group": "PCI Proxy",
+            "tag": "Beta",
             "pages": [
               "reference/pci-proxy/destination-status",
               "reference/pci-proxy/invoke-forward-proxy",


### PR DESCRIPTION
## Summary
- Replace the plain-text `(Beta)` suffix in the sidebar group names **PCI Proxy** and **Checkout Builder** with Mintlify's native group-level `tag` property.
- The sidebar now renders a styled `Beta` badge next to the group name instead of parenthetical text.

## Changes
- `docs.json`: `"group": "PCI Proxy (Beta)"` → `"group": "PCI Proxy"` + `"tag": "Beta"`
- `docs.json`: `"group": "Checkout Builder (Beta)"` → `"group": "Checkout Builder"` + `"tag": "Beta"`

## Notes
- The `tag` property is validated against the official Mintlify schema (`baseGroupSchema.properties.tag`).
- JSON validated with `python3 -m json.tool`; no remaining references to the old group names in any `.json`/`.mdx` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)