### PR TITLE
docs(changelog): add v2026-07 API changelog entry for PCI Proxy

### DIFF
--- a/changelog/api.mdx
+++ b/changelog/api.mdx
@@ -10,30 +10,9 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 **Security**
 
-- <ChangelogBadge type="added" /> **PCI Proxy forward endpoint**  
-  A new PCI Proxy lets your servers call any third-party API with real card data through Yuno's PCI DSS Level 1 environment. Send your request to `/v1/pci-proxy/forward` with the destination in the `yuno-proxy-destination-url` header, referencing stored cards with expressions such as `{{vaulted_token.<TOKEN>.number}}`. Yuno resolves the expressions inside its secure environment and forwards the request, so raw card data never touches your infrastructure and your PCI scope does not change. Card numbers echoed back by the destination are redacted from the response by default.
-  *See also: [PCI Proxy overview](/docs/security-and-compliance/pci-proxy/overview) · [Invoke forward proxy reference](/reference/pci-proxy/invoke-forward-proxy)*
-
-<Accordion title="Card expressions in a proxied request body">
-
-```json
-{
-  "amount": 2500,
-  "currency": "USD",
-  "card": {
-    "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
-    "expiration_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
-    "expiration_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
-    "holder_name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
-  }
-}
-```
-
-</Accordion>
-
-- <ChangelogBadge type="added" /> **PCI Proxy destination allowlist**  
-  The proxy only forwards to hosts you have registered and enabled on your destination allowlist; a request to an unregistered host is rejected with `DESTINATION_NOT_ALLOWED`. New self-serve endpoints under `/v1/pci-proxy/destinations` let you register, list, enable, disable, and remove destinations, and changes take effect within minutes.
-  *See also: [Destination allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist) · [Register destination reference](/reference/pci-proxy/register-destination)*
+- <ChangelogBadge type="added" /> **PCI Proxy**  
+  You can now send stored card data to any third-party API through Yuno's PCI DSS Level 1 environment using the new `/v1/pci-proxy/forward` endpoint, without bringing your systems into PCI scope.
+  *See also: [PCI Proxy overview](/docs/security-and-compliance/pci-proxy/overview)*
 
 ## v2025-06
 *June 30, 2025*

--- a/changelog/api.mdx
+++ b/changelog/api.mdx
@@ -5,6 +5,36 @@ description: "Latest updates to the Yuno Payments API and platform features"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2026-07
+*July 11, 2026*
+
+**Security**
+
+- <ChangelogBadge type="added" /> **PCI Proxy forward endpoint**  
+  A new PCI Proxy lets your servers call any third-party API with real card data through Yuno's PCI DSS Level 1 environment. Send your request to `/v1/pci-proxy/forward` with the destination in the `yuno-proxy-destination-url` header, referencing stored cards with expressions such as `{{vaulted_token.<TOKEN>.number}}`. Yuno resolves the expressions inside its secure environment and forwards the request, so raw card data never touches your infrastructure and your PCI scope does not change. Card numbers echoed back by the destination are redacted from the response by default.
+  *See also: [PCI Proxy overview](/docs/security-and-compliance/pci-proxy/overview) · [Invoke forward proxy reference](/reference/pci-proxy/invoke-forward-proxy)*
+
+<Accordion title="Card expressions in a proxied request body">
+
+```json
+{
+  "amount": 2500,
+  "currency": "USD",
+  "card": {
+    "number": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}",
+    "expiration_month": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}",
+    "expiration_year": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}",
+    "holder_name": "{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}"
+  }
+}
+```
+
+</Accordion>
+
+- <ChangelogBadge type="added" /> **PCI Proxy destination allowlist**  
+  The proxy only forwards to hosts you have registered and enabled on your destination allowlist; a request to an unregistered host is rejected with `DESTINATION_NOT_ALLOWED`. New self-serve endpoints under `/v1/pci-proxy/destinations` let you register, list, enable, disable, and remove destinations, and changes take effect within minutes.
+  *See also: [Destination allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist) · [Register destination reference](/reference/pci-proxy/register-destination)*
+
 ## v2025-06
 *June 30, 2025*
 

--- a/changelog/source/api.json
+++ b/changelog/source/api.json
@@ -2,6 +2,52 @@
   "sdk": "api",
   "releases": [
     {
+      "version": "2026-07",
+      "release_date": "2026-07-11",
+      "upgrade": null,
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "PCI Proxy forward endpoint",
+          "description": "A new PCI Proxy lets your servers call any third-party API with real card data through Yuno's PCI DSS Level 1 environment. Send your request to `/v1/pci-proxy/forward` with the destination in the `yuno-proxy-destination-url` header, referencing stored cards with expressions such as `{{vaulted_token.<TOKEN>.number}}`. Yuno resolves the expressions inside its secure environment and forwards the request, so raw card data never touches your infrastructure and your PCI scope does not change. Card numbers echoed back by the destination are redacted from the response by default.",
+          "group": "Security",
+          "migration_guide": null,
+          "links": [
+            {
+              "label": "PCI Proxy overview",
+              "url": "/docs/security-and-compliance/pci-proxy/overview"
+            },
+            {
+              "label": "Invoke forward proxy reference",
+              "url": "/reference/pci-proxy/invoke-forward-proxy"
+            }
+          ],
+          "example": {
+            "title": "Card expressions in a proxied request body",
+            "language": "json",
+            "snippet": "{\n  \"amount\": 2500,\n  \"currency\": \"USD\",\n  \"card\": {\n    \"number\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}\",\n    \"expiration_month\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}\",\n    \"expiration_year\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}\",\n    \"holder_name\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}\"\n  }\n}"
+          }
+        },
+        {
+          "type": "ADDED",
+          "title": "PCI Proxy destination allowlist",
+          "description": "The proxy only forwards to hosts you have registered and enabled on your destination allowlist; a request to an unregistered host is rejected with `DESTINATION_NOT_ALLOWED`. New self-serve endpoints under `/v1/pci-proxy/destinations` let you register, list, enable, disable, and remove destinations, and changes take effect within minutes.",
+          "group": "Security",
+          "migration_guide": null,
+          "links": [
+            {
+              "label": "Destination allowlist guide",
+              "url": "/docs/security-and-compliance/pci-proxy/allowlist"
+            },
+            {
+              "label": "Register destination reference",
+              "url": "/reference/pci-proxy/register-destination"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "version": "2025-06",
       "release_date": "2025-06-30",
       "upgrade": null,

--- a/changelog/source/api.json
+++ b/changelog/source/api.json
@@ -8,40 +8,14 @@
       "entries": [
         {
           "type": "ADDED",
-          "title": "PCI Proxy forward endpoint",
-          "description": "A new PCI Proxy lets your servers call any third-party API with real card data through Yuno's PCI DSS Level 1 environment. Send your request to `/v1/pci-proxy/forward` with the destination in the `yuno-proxy-destination-url` header, referencing stored cards with expressions such as `{{vaulted_token.<TOKEN>.number}}`. Yuno resolves the expressions inside its secure environment and forwards the request, so raw card data never touches your infrastructure and your PCI scope does not change. Card numbers echoed back by the destination are redacted from the response by default.",
+          "title": "PCI Proxy",
+          "description": "You can now send stored card data to any third-party API through Yuno's PCI DSS Level 1 environment using the new `/v1/pci-proxy/forward` endpoint, without bringing your systems into PCI scope.",
           "group": "Security",
           "migration_guide": null,
           "links": [
             {
               "label": "PCI Proxy overview",
               "url": "/docs/security-and-compliance/pci-proxy/overview"
-            },
-            {
-              "label": "Invoke forward proxy reference",
-              "url": "/reference/pci-proxy/invoke-forward-proxy"
-            }
-          ],
-          "example": {
-            "title": "Card expressions in a proxied request body",
-            "language": "json",
-            "snippet": "{\n  \"amount\": 2500,\n  \"currency\": \"USD\",\n  \"card\": {\n    \"number\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.number}}\",\n    \"expiration_month\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_month}}\",\n    \"expiration_year\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.expiration_year}}\",\n    \"holder_name\": \"{{vaulted_token.1a2b3c4d-5678-90ab-cdef-111213141516.holder_name}}\"\n  }\n}"
-          }
-        },
-        {
-          "type": "ADDED",
-          "title": "PCI Proxy destination allowlist",
-          "description": "The proxy only forwards to hosts you have registered and enabled on your destination allowlist; a request to an unregistered host is rejected with `DESTINATION_NOT_ALLOWED`. New self-serve endpoints under `/v1/pci-proxy/destinations` let you register, list, enable, disable, and remove destinations, and changes take effect within minutes.",
-          "group": "Security",
-          "migration_guide": null,
-          "links": [
-            {
-              "label": "Destination allowlist guide",
-              "url": "/docs/security-and-compliance/pci-proxy/allowlist"
-            },
-            {
-              "label": "Register destination reference",
-              "url": "/reference/pci-proxy/register-destination"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Adds the new **PCI Proxy** feature to the [API changelog](https://docs.y.uno/changelog/api) as release `v2026-07`, under the **Security** group — a single concise announcement:

> **PCI Proxy** — You can now send stored card data to any third-party API through Yuno's PCI DSS Level 1 environment using the new `/v1/pci-proxy/forward` endpoint, without bringing your systems into PCI scope.
> *See also: [PCI Proxy overview](/docs/security-and-compliance/pci-proxy/overview)*

## How

Following the repo's changelog pipeline: the release was prepended to `changelog/source/api.json` and `changelog/api.mdx` was regenerated with `node scripts/generate_changelog.js changelog/source/api.json changelog/api.mdx` — the diff is purely additive. `scripts/fix_mdx_braces.js` reports no issues on the new content.

## Notes for reviewer

- `release_date` is set to **2026-07-11** (announcement date). Previous releases use end-of-month dates — happy to change it to `2026-07-31` if that convention should hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)