### PR TITLE
docs(reference): keep base URLs on one line in the environments table

### DIFF
--- a/reference/getting-started/api-environments.mdx
+++ b/reference/getting-started/api-environments.mdx
@@ -10,10 +10,10 @@ For how to switch between Test Mode and Live Mode in the Yuno dashboard, see [En
 
 ## Overview: Sandbox vs Production
 
-| Environment    | Purpose                                                     | Base URL                    |
-| -------------- | ----------------------------------------------------------- | --------------------------- |
-| **Sandbox**    | Testing and development. No live data or real transactions. | `https://api-sandbox.y.uno` |
-| **Production** | Live environment. Real transactions and accounting.         | `https://api.y.uno`         |
+| Environment    | Purpose                                                      | Base URL                                                             |
+| -------------- | ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| **Sandbox**    | Testing and development. No live data or real transactions. | <code className="whitespace-nowrap">https://api-sandbox.y.uno</code> |
+| **Production** | Live environment. Real transactions and accounting.         | <code className="whitespace-nowrap">https://api.y.uno</code>         |
 
 In the dashboard, Sandbox is referred to as **Test Mode** and Production as **Live Mode**. You use the same account for both; the dashboard toggle switches which environment you are using.
 

--- a/reference/getting-started/api-environments.mdx
+++ b/reference/getting-started/api-environments.mdx
@@ -2,6 +2,8 @@
 title: "Environments"
 ---
 
+import { CopyChip } from '/snippets/CopyChip.jsx';
+
 API base URLs and the two environments (Sandbox and Production) for calling the Yuno API.
 
 This page explains the API base URLs and the two environments you can use when calling the Yuno API: **Sandbox** and **Production**.
@@ -10,10 +12,10 @@ For how to switch between Test Mode and Live Mode in the Yuno dashboard, see [En
 
 ## Overview: Sandbox vs Production
 
-| Environment    | Purpose                                                      | Base URL                                                             |
-| -------------- | ------------------------------------------------------------ | -------------------------------------------------------------------- |
-| **Sandbox**    | Testing and development. No live data or real transactions. | <code className="whitespace-nowrap">https://api-sandbox.y.uno</code> |
-| **Production** | Live environment. Real transactions and accounting.         | <code className="whitespace-nowrap">https://api.y.uno</code>         |
+| Environment    | Purpose                                                      | Base URL                                       |
+| -------------- | ------------------------------------------------------------ | ---------------------------------------------- |
+| **Sandbox**    | Testing and development. No live data or real transactions. | <CopyChip value="https://api-sandbox.y.uno" /> |
+| **Production** | Live environment. Real transactions and accounting.         | <CopyChip value="https://api.y.uno" />         |
 
 In the dashboard, Sandbox is referred to as **Test Mode** and Production as **Live Mode**. You use the same account for both; the dashboard toggle switches which environment you are using.
 

--- a/snippets/CopyChip.jsx
+++ b/snippets/CopyChip.jsx
@@ -1,0 +1,54 @@
+export const CopyChip = ({ value }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="copy-chip"
+      onClick={copy}
+      title={copied ? 'Copied!' : 'Copy to clipboard'}
+      aria-label={`Copy ${value} to clipboard`}
+    >
+      <code>{value}</code>
+      {copied ? (
+        <svg
+          className="copy-chip__icon copy-chip__icon--copied"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          className="copy-chip__icon"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+};

--- a/style.css
+++ b/style.css
@@ -72,6 +72,42 @@ code:not(pre code) {
   font-size: 13px;
 }
 
+/* Copy chip — inline code chip with one-click copy (snippets/CopyChip.jsx) */
+.copy-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+.copy-chip code {
+  white-space: nowrap;
+}
+
+.copy-chip__icon {
+  flex: none;
+  color: #a1a1aa;
+  transition: color 0.15s;
+}
+
+.copy-chip:hover .copy-chip__icon {
+  color: #52525b;
+}
+
+html.dark .copy-chip:hover .copy-chip__icon {
+  color: #d4d4d8;
+}
+
+.copy-chip__icon--copied,
+.copy-chip:hover .copy-chip__icon--copied {
+  color: #16a34a;
+}
+
 /* CardGroup tiles — opt-in via .mdx-card-tiles wrapper */
 .mdx-card-tiles [class*="grid"]>*,
 .mdx-card-tiles [class*="grid"]>div>a {


### PR DESCRIPTION
## Summary

On [/reference/getting-started/api-environments](https://docs.y.uno/reference/getting-started/api-environments), the **Overview: Sandbox vs Production** table had two issues:

1. The Sandbox base URL wrapped mid-hostname (`https://api-` / `sandbox.y.uno`).
2. (introduced in the first iteration of this PR) a raw JSX `<code>` element let GFM autolink the URLs into clickable links.

## Fix

New `snippets/CopyChip.jsx` component + styles in `style.css`. Each Base URL cell now renders as a plain inline-code chip (no link) that:

- stays on **one line** (`white-space: nowrap`), so the auto table layout gives the Base URL column its full width and the **Purpose** column shrinks instead;
- **copies the URL to the clipboard on click**, showing a copy icon that flips to a green check for ~1.5s as confirmation.

The chip reuses the site's existing inline-code styling (`code:not(pre code)` in `style.css`), so it looks identical to the original backtick chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)