### PR TITLE
docs: agent-readiness — page descriptions, description lint, auth.md

### DIFF
--- a/.github/workflows/description-lint.yml
+++ b/.github/workflows/description-lint.yml
@@ -1,0 +1,25 @@
+name: Description lint
+
+# Ensures every docs.json navigation page has a `description:` frontmatter field,
+# so Mintlify's auto-generated llms.txt stays agent-readable (one summary per entry).
+
+on:
+  pull_request:
+    paths:
+      - "**/*.mdx"
+      - "docs.json"
+      - "scripts/check-descriptions.cjs"
+      - ".github/workflows/description-lint.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check-descriptions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check page descriptions
+        run: node scripts/check-descriptions.cjs

--- a/auth.md
+++ b/auth.md
@@ -1,0 +1,43 @@
+# Authentication for AI agents
+
+How to authenticate programmatic and agent-driven requests against the Yuno API and MCP server.
+
+## REST API
+
+The Yuno API uses API key authentication. Every request requires two headers:
+
+- `public-api-key`
+- `private-secret-key`
+
+Find both in the [Yuno Dashboard](https://dashboard.y.uno/developers), under Developers credentials. Sandbox and Production use different key pairs; the keys shown in the Dashboard depend on which environment (Test Mode or Live Mode) is selected.
+
+Do not share `private-secret-key` in public places like GitHub or Bitbucket.
+
+## Base URLs
+
+| Environment | Base URL |
+| --- | --- |
+| Sandbox | `https://api-sandbox.y.uno` |
+| Production | `https://api.y.uno` |
+
+Sandbox data is simulated and does not affect live accounting or metrics. See [API environments](/reference/getting-started/api-environments) for full details.
+
+## Idempotency
+
+Send an `X-Idempotency-Key` header (UUID) on requests that support it to safely retry after a connection issue without duplicating the operation. Yuno stores the key and the transaction outcome for 24 hours. A repeated key within that window returns the original response instead of creating a new transaction.
+
+See [Authentication](/reference/getting-started/authentication#idempotency) for retry and error-handling behavior.
+
+## Model Context Protocol (MCP)
+
+Yuno exposes its API as MCP tools for AI agents. Two ways to connect:
+
+**Local (CLI-launched)**: run `npx @yuno-payments/yuno-mcp@latest` and set `YUNO_PUBLIC_API_KEY`, `YUNO_PRIVATE_SECRET_KEY`, and `YUNO_ACCOUNT_CODE` as environment variables. See [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp).
+
+**Remote (hosted endpoint)**: connect over HTTP transport to `https://mcp.prod.y.uno/mcp`, passing `public-api-key`, `private-secret-key`, and `account-code` as request headers. Adds IP binding, rate limiting (15 requests/minute/session), and session TTLs (30 min idle, 6 hours absolute). See [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server).
+
+Both methods use the same API key credentials as the REST API, no separate OAuth flow.
+
+## Machine-readable docs
+
+Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](/llms.txt) for the full page index.

--- a/docs/additional-services/card-account-updater.mdx
+++ b/docs/additional-services/card-account-updater.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Card Account Updater"
+description: "Automatically refreshes expired or replaced card details on stored payment methods to prevent failed charges"
 ---
 
 Card Account Updater (CAU) is a feature available at Yuno to maintain the integrity of stored credit or debit cards, preventing issues caused by expired or outdated card details. When customers provide their card information for recurring billing or subscription services, Card Account Updater ensures that their stored card data remains current. With Yuno’s Card Account Updater, no additional development effort is required to ensure your card details will be updated seamlessly in the background.

--- a/docs/additional-services/currency-conversion.mdx
+++ b/docs/additional-services/currency-conversion.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Currency Conversion"
+description: "Settles payments by converting between merchant and cardholder currencies using configurable exchange rate providers"
 ---
 
 ## Introduction

--- a/docs/additional-services/qr-and-instant-pay.mdx
+++ b/docs/additional-services/qr-and-instant-pay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "QR code & Instant Payment"
+description: "Combines a Pix QR code payment with subscription enrollment to enable automated recurring charges"
 ---
 
 In the **QR Code & Instant Payment** journey, Yuno presents a single QR code that both charges the customer immediately and enrolls them for all future recurring payments in one seamless step. When the customer scans the QR, their banking app processes the first installment and simultaneously captures their consent for subsequent automated charges, removing the need for any additional approvals or manual input.

--- a/docs/additional-services/upi-autopay.mdx
+++ b/docs/additional-services/upi-autopay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "UPI Autopay"
+description: "Configures UPI recurring debits with pre-debit notifications, mandates, and NPCI compliant retry scheduling"
 ---
 
 This guide covers Yuno's support for UPI Autopay recurring payments with Pre-Debit Notification (PDN).

--- a/docs/ai-capabilities/aida-ai-agent.mdx
+++ b/docs/ai-capabilities/aida-ai-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Aida AI Agent"
+description: "Retrieves payment, payout, subscription, and webhook details through a conversational AI agent across Slack, email, and Dashboard"
 ---
 
 ## Introduction

--- a/docs/ai-capabilities/aida-ai-dashboard.mdx
+++ b/docs/ai-capabilities/aida-ai-dashboard.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Aida AI in the Dashboard"
+description: "Provides contextual AI assistance for payments, insights, and routing directly within the Yuno Dashboard"
 ---
 
 Aida AI is integrated throughout the Yuno Dashboard, providing contextual assistance and AI-powered features directly within different dashboard sections. Aida AI helps you get instant answers, generate insights, and streamline your workflow without leaving the dashboard.

--- a/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx
+++ b/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Building AI Integrations with Yuno's LLMs and MCP"
+description: "Exposes Yuno API endpoints as MCP tools and machine readable docs for LLM powered integrations"
 ---
 
 Yuno offers tools to help you build AI-aware and merchant-friendly payment experiences. Our machine-ready documentation makes it easier for large language models (LLMs) to understand Yuno’s APIs and documentation, while our Model Context Protocol (MCP) provides a seamless way to integrate Yuno's capabilities into your product.

--- a/docs/ai-capabilities/remote-yuno-mcp-server.mdx
+++ b/docs/ai-capabilities/remote-yuno-mcp-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Remote Yuno MCP Server"
+description: "Provides a hosted MCP endpoint with API key auth, IP binding, rate limits, and session TTLs"
 ---
 
 The Remote Yuno MCP Server implements the Model Context Protocol (MCP) to provide secure, remote access to Yuno services. It acts as a hardened proxy so AI agents and automation clients can call Yuno APIs over MCP with enterprise‑grade security and session controls.

--- a/docs/basic-concepts/3ds-1.mdx
+++ b/docs/basic-concepts/3ds-1.mdx
@@ -1,5 +1,6 @@
 ---
 title: "3DS"
+description: "Explains 3D Secure and 3DS2 authentication flows, standalone mode, and integration options in Yuno."
 ---
 
 ## What is 3D Secure

--- a/docs/basic-concepts/customers.mdx
+++ b/docs/basic-concepts/customers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Customers"
+description: "Defines the customer object in Yuno and how it stores payment methods and personal data."
 ---
 
 The term **customer** refers to an individual who is part of a merchant's payment network in Yuno, with the ability to make payments and store payment methods. This term is closely related to phrases used in the banking and payment sectors, such as **cardholder** and **account holder**. Each customer has associated information, which is used to process payments using different payment methods and processors.

--- a/docs/basic-concepts/fraud.mdx
+++ b/docs/basic-concepts/fraud.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fraud prevention"
+description: "Configure pre and post authorization fraud screening with external providers through Yuno's payment routing."
 ---
 
 Yuno integrates with external fraud detection services to help prevent fraud in your payment process. You can configure both **pre-authorization** and **post-authorization** fraud screening through your preferred **fraud detection provider**.

--- a/docs/basic-concepts/index.mdx
+++ b/docs/basic-concepts/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: "Introduces Yuno's core concepts: sessions, payments, transactions, tokens, payment methods, fraud, and 3DS."
 ---
 
 To understand how Yuno operates, you need to grasp some fundamental concepts about its architecture. This guide covers the essential elements required for integration:

--- a/docs/basic-concepts/payment-methods.mdx
+++ b/docs/basic-concepts/payment-methods.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment methods"
+description: "Explains payment methods versus processors and how enrollment and synchronous flows differ in Yuno."
 ---
 
 Yuno offers a wide range of connections with various processors and payment methods, continuously expanding each month. This page explains the available payment methods, their capabilities, and how they are organized within Yuno's platform.

--- a/docs/basic-concepts/payments-1.mdx
+++ b/docs/basic-concepts/payments-1.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payments"
+description: "Describes the payment object, its status lifecycle, and how transactions relate to a payment."
 ---
 
 ## What is a payment?

--- a/docs/basic-concepts/sessions.mdx
+++ b/docs/basic-concepts/sessions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sessions"
+description: "Explains customer sessions and checkout sessions and when to create each one in Yuno."
 ---
 
 With Yuno, you can create sessions to initiate payments or register payment methods for future purchases. There are two types of sessions: **customer sessions** and **checkout sessions**. These sessions ensure the correct information is collected for each scenario.

--- a/docs/basic-concepts/tokens.mdx
+++ b/docs/basic-concepts/tokens.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Tokens"
+description: "Compares one-time, vaulted, and network tokens and how Yuno's tokenization reduces PCI scope."
 ---
 
 Yuno provides a fully managed, PCI DSS Level 1 tokenization service. When a customer provides their payment details, Yuno replaces the sensitive data with a token — a non-sensitive string that represents the original credentials. Your systems only ever store and transmit tokens, never raw card data.

--- a/docs/basic-concepts/transactions.mdx
+++ b/docs/basic-concepts/transactions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transactions"
+description: "Explains primary and secondary transaction types and their statuses within a Yuno payment."
 ---
 
 ## What is a transaction?

--- a/docs/basic-concepts/webhooks-1.mdx
+++ b/docs/basic-concepts/webhooks-1.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Webhooks"
+description: "Explains how Yuno webhooks notify your system of payment and event status changes."
 ---
 
 Webhooks allow apps to receive real-time updates whenever an event occurs, eliminating the need for constant requests. They provide a passive way to transfer data between systems using an HTTP POST request. Once you configure Yuno webhooks, your system will receive event notifications whenever an activity or function occurs within the Yuno flow.

--- a/docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx
+++ b/docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "3DS Configuration and Testing"
+description: "Configure 3D Secure routing and test frictionless and challenge flows with sandbox test cards."
 ---
 
 Use this step-by-step guide to configure and test 3D Secure in Yuno. You’ll set up a 3DS-enabled connection and provider credentials, add 3DS to your routing, enable Card in Checkout Builder, and validate payments using either the Yuno Testing Gateway, the Yuno SDK, or the API. Scheme-specific test cards, OTP codes, and troubleshooting notes are included to verify frictionless and challenge scenarios.

--- a/docs/direct-integration-use-cases/build-reports.mdx
+++ b/docs/direct-integration-use-cases/build-reports.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Build Reports"
+description: "Walks through requesting, checking, and downloading payment, transaction, and settlement reports via the API."
 ---
 
 Yuno reports provides a practical way to acquire information regarding different stages of payments. You can effortlessly request and download various reports associated with your Yuno operations. Yuno provides four types of reports:

--- a/docs/direct-integration-use-cases/cancel-payments.mdx
+++ b/docs/direct-integration-use-cases/cancel-payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cancel Payments"
+description: "Shows how to manually cancel a pending payment using the Cancel Payment endpoint."
 ---
 
 In this guide, you will find step-by-step instructions on manually canceling a previously created payment on Yuno.

--- a/docs/direct-integration-use-cases/capture-payments.mdx
+++ b/docs/direct-integration-use-cases/capture-payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Capture Payments"
+description: "Shows how to manually capture a pending authorization using the Capture Payment endpoint."
 ---
 
 In this guide, you will find step-by-step instructions on manually capturing a previously created payment on Yuno.

--- a/docs/direct-integration-use-cases/create-payment-basic.mdx
+++ b/docs/direct-integration-use-cases/create-payment-basic.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create Payments"
+description: "Walks through creating a customer and a basic payment using Yuno's Create Payment endpoint."
 ---
 
 On this page, you will find a walk-through guide on creating a payment and the necessary information to accomplish such a task.

--- a/docs/direct-integration-use-cases/direct-flow.mdx
+++ b/docs/direct-integration-use-cases/direct-flow.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Direct Flow Integration"
+description: "Explains server-to-server Direct Flow integration for PCI-compliant merchants using DIRECT and REDIRECT workflows."
 ---
 
 ## How it works

--- a/docs/direct-integration-use-cases/refund-payments.mdx
+++ b/docs/direct-integration-use-cases/refund-payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Refund Payments"
+description: "Shows how to fully or partially refund a captured payment using the Refund Payment endpoint."
 ---
 
 The payment refund process is the procedure by which you will reimburse a customer for a previous payment. In this guide, you will find instructions on refunding a previously created payment on Yuno.

--- a/docs/direct-integration-use-cases/set-up-payment-connection.mdx
+++ b/docs/direct-integration-use-cases/set-up-payment-connection.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Set Up Payment Connection"
+description: "Walks through configuring a payment connection, routing, checkout builder, and API credentials in Yuno."
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
+++ b/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Yuno Testing Gateway"
+description: "Configure and test card payments in sandbox using Yuno's Test Payment Gateway and test cards."
 ---
 
 To test Card payments in general, Yuno provides the **Yuno Test Payment Gateway**. It works as a connection, however, it is available **only** in the sandbox environment.

--- a/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
+++ b/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment flow"
+description: "Walks through the customer, checkout session, payment detail, and payment creation steps in a Yuno transaction"
 ---
 
 While Yuno provides diverse payment options, the basic payment process always follows the same sequence. This guide provides a step-by-step breakdown of the process and key elements involved, clarifying how payments flow when utilizing Yuno's SDKs or API.

--- a/docs/how-yuno-works/step-1-set-up-your-account.mdx
+++ b/docs/how-yuno-works/step-1-set-up-your-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Set Up Your Account"
+description: "Guides creating a Yuno account, configuring a connection, routing, and enabling a payment method in the Dashboard"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/how-yuno-works/step-2-your-first-payment.mdx
+++ b/docs/how-yuno-works/step-2-your-first-payment.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Create Your First Payment With SDK"
+description: "Walks through installing the Yuno SDK sample project and submitting a test card payment in sandbox"
 ---
 
 This guide shows you how to create your first payment using the Yuno SDK. You'll learn how to:

--- a/docs/payment-features/3ds-standalone.mdx
+++ b/docs/payment-features/3ds-standalone.mdx
@@ -1,5 +1,6 @@
 ---
 title: "3DS Standalone"
+description: "Run 3D Secure authentication only, with no payment provider or authorization involved, via routing configuration"
 ---
 
 3DS Standalone runs only the 3D Secure authentication step — no payment provider is involved and no authorization happens. The response returns the authentication result (ECI + CAVV cryptogram and related data), which the merchant uses to decide what to do next (for example, forward it to their acquirer).

--- a/docs/payment-features/Cancel-and-capture-flow.mdx
+++ b/docs/payment-features/Cancel-and-capture-flow.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cancel and Capture Flow"
+description: "Configure real-time, manual, or delayed capture and cancel settings for authorized card payments"
 ---
 
 When integrating with Yuno, you have multiple options for implementing capture and cancel operations. This guide outlines all available approaches and explains how to interact with our APIs for each scenario.

--- a/docs/payment-features/account-funding-transactions-afts.mdx
+++ b/docs/payment-features/account-funding-transactions-afts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account Funding Transactions (AFTs)"
+description: "Load funds into wallets or transfer between accounts using account funding transactions through the Payments API"
 ---
 
 ## Introduction

--- a/docs/payment-features/enrollment/enroll-cards-with-payment-link.mdx
+++ b/docs/payment-features/enrollment/enroll-cards-with-payment-link.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Enroll Cards with Payment Links"
+description: "Generate a payment link so customers can update an expired or declined card and re-enroll automatically"
 ---
 
 Yuno provides merchants with the ability to manage overdue or declined payments using secure payment links. When a credit card expires or is reported as stolen or lost, you can generate a payment link to share with customers via email or text message, allowing them to easily update their payment information.

--- a/docs/payment-features/enrollment/enroll-payment-methods.mdx
+++ b/docs/payment-features/enrollment/enroll-payment-methods.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Enroll Payment Methods"
+description: "Store a customer's payment method in Yuno's vault to enable recurring charges and retries across providers"
 ---
 
 Enrollment allows you to securely store a customer's payment method in Yuno's vault for future use. When you enroll a payment method, Yuno generates a `vaulted_token` that references the payment details without exposing sensitive information. This enables recurring payments, subscriptions, and retries across providers while maintaining PCI compliance.

--- a/docs/payment-features/installments/index.mdx
+++ b/docs/payment-features/installments/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Installments"
+description: "Offer card payments in installments through merchant-defined or provider-defined plans for flexible checkout"
 ---
 
 In this section, you'll discover how Yuno supports payments in installments, offering you and your customers the flexibility to make large purchases more affordable. Explore the benefits of this feature and understand the difference between "Merchant" and "Provider" installments for a tailored payment solution.

--- a/docs/payment-features/installments/merchant-installments.mdx
+++ b/docs/payment-features/installments/merchant-installments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Merchant Installments"
+description: "Configure installment options yourself when your commercial agreements with payment processors already define the available plans"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/payment-features/installments/provider-installments.mdx
+++ b/docs/payment-features/installments/provider-installments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Provider Installments"
+description: "Let Yuno consult the payment provider for available installment plans when no merchant agreement exists"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/payment-features/network-token-authentication.mdx
+++ b/docs/payment-features/network-token-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Token Authentication"
+description: "Authenticate card-on-file payments with network passkeys to raise approval rates and shift fraud liability to the issuer"
 ---
 
 Network Token Authentication (NTA) is Yuno's unified solution for authenticating card payments through **Network Token Passkeys** — the passkey-backed authentication experiences offered by the card networks on top of their tokenization services. It consolidates every network's passkey integration under a single Yuno product, providing merchants with a consistent flow, configuration point, and shopper experience regardless of the underlying network.

--- a/docs/payment-features/payment-amount-details.mdx
+++ b/docs/payment-features/payment-amount-details.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Details"
+description: "Break down a payment's total into fee, shipping, tips, taxes, and discount components for transparency"
 ---
 
 Our API offers flexibility in structuring payment amounts, accommodating various factors that may contribute to the total transaction sum. Whether it's base charges, taxes, fees, or tips, our system is designed to handle diverse components seamlessly. You can easily integrate and manage payments with different elements contributing to the overall amount

--- a/docs/payment-features/sca-exemptions.mdx
+++ b/docs/payment-features/sca-exemptions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SCA Exemptions"
+description: "Request PSD2 exemptions from Strong Customer Authentication for eligible low-risk or recurring card transactions"
 ---
 
 # Understanding SCA Exemptions

--- a/docs/payment-features/split-payments-marketplace.mdx
+++ b/docs/payment-features/split-payments-marketplace.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Split Payments Marketplace"
+description: "Onboard recipients and split a marketplace payment among multiple sellers, fees, and commissions"
 ---
 
 This feature allows **merchants to split payments among multiple recipients**, which is particularly useful for marketplace models where transactions need to be divided among different sellers or stakeholders. Merchants can specify how the payment is split, including the amounts, recipients, and any applicable fees.

--- a/docs/payment-features/stored-credentials.mdx
+++ b/docs/payment-features/stored-credentials.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Stored Credentials"
+description: "Store and reuse card details for customer-initiated or merchant-initiated transactions while complying with scheme rules"
 ---
 
 Depending on how and when a payment is processed, it can originate from either customer-initiated transactions (CIT) or merchant-initiated transactions (MIT).

--- a/docs/payment-features/subscriptions/index.mdx
+++ b/docs/payment-features/subscriptions/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Subscriptions"
+description: "Automate recurring billing by letting Yuno's engine create, pause, resume, and cancel subscriptions on schedule"
 ---
 
 Subscriptions are essential components of a business model that enable your company to offer its products or services to customers on a recurring basis. Yuno's subscription service allows you to easily manage recurring payments, automate subscription billing, and provide seamless subscription experiences for your users. Whether running a SaaS application, a content platform, or an e-commerce store, Yuno's service can help you handle subscription-related tasks efficiently.

--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Smart Retries"
+description: "Recover declined recurring card charges by retrying them on an optimized, customizable schedule"
 ---
 
 Yuno's Smart Retries help recover declined recurring credit card payments by retrying them on an optimized schedule. By retrying at the right moments, Smart Retries increase the likelihood of payment success, ensuring a consistent revenue stream and reducing involuntary subscriber churn.

--- a/docs/payment-features/transaction-retries.mdx
+++ b/docs/payment-features/transaction-retries.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transaction Retries"
+description: "Automatically retry failed capture or refund transactions up to seven times over a 96-hour window"
 ---
 
 Yuno provides merchants with the ability to retry capture and refund transactions that have encountered errors or been declined by the provider. This feature aims to enhance transaction success rates and improve the user experience. By setting the `simplified_mode` field to `true` in [capture](/reference/capture-authorization) and [refund](/reference/refund-payment) requests, Yuno will automatically retry failed transactions up to seven times within a 96-hour period. The system handles the following scenarios during the retry process:

--- a/docs/payouts-and-disputes/chargeback-management.mdx
+++ b/docs/payouts-and-disputes/chargeback-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chargeback Management"
+description: "Explains chargeback and dispute states, evidence submission, and predispute deflection handling across providers"
 ---
 
 Yuno offers a unified and automated solution for handling disputes, allowing you to manage chargebacks across all providers from a single dashboard. Our platform helps you automate workflows, recover revenue, and stay audit-ready, all without the back and forth.

--- a/docs/payouts-and-disputes/payouts.mdx
+++ b/docs/payouts-and-disputes/payouts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payouts"
+description: "Sends secure payouts to beneficiaries via bank, card, or wallet withdrawal methods across multiple providers"
 ---
 
 Yuno Payouts is an API solution designed to streamline the process of sending secure payouts to various beneficiaries, such as users, merchants, providers, and customers. With Yuno Payouts, you can efficiently distribute funds to multiple recipients while ensuring their security and taking complete control of your payout operations.

--- a/docs/payouts-and-disputes/reason-codes.mdx
+++ b/docs/payouts-and-disputes/reason-codes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Chargeback Response Codes"
+description: "Lists chargeback response codes and their meanings by category across card networks"
 ---
 
 A chargeback reason code is a short alphanumeric code assigned by the issuing bank to explain why a customer disputed a transaction. These codes help merchants understand the issue and respond accordingly. While merchants can challenge chargebacks by providing evidence, the reason code might change if new information arises during the dispute process. Major card networks like Visa, Mastercard, American Express, Discover, and Diners each have their own set of reason codes.

--- a/docs/sdks/additional-platforms/flutter.mdx
+++ b/docs/sdks/additional-platforms/flutter.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: true
 metadata:
   robots: index
+description: "Integrate Yuno's Flutter SDK for payment and enrollment flows, including styling, customization, and troubleshooting"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/card-enrollment/android-enrollment.mdx
+++ b/docs/sdks/card-enrollment/android-enrollment.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Enroll payment methods on Android using full-checkout with pre-built UI and ProGuard configuration"
 ---
 
 The Android SDK makes it easy to implement enrollment flows for saving payment methods to a customer account.

--- a/docs/sdks/card-enrollment/ios-enrollment.mdx
+++ b/docs/sdks/card-enrollment/ios-enrollment.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Enroll payment methods on iOS using full-checkout with the enrollment delegate and result handling"
 ---
 
 The iOS SDK makes it easy to implement enrollment flows for saving payment methods to a customer account.

--- a/docs/sdks/card-enrollment/web-enrollment.mdx
+++ b/docs/sdks/card-enrollment/web-enrollment.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Enroll payment methods on Web using full-checkout, mounting the enrollment form and handling callbacks"
 ---
 The Web SDK makes it easy to implement enrollment flows for saving payment methods to a customer account.
 

--- a/docs/sdks/customization/android.mdx
+++ b/docs/sdks/customization/android.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Customize Android SDK fonts, buttons, colors, and text styles to match your brand"
 ---
 
 Modify Yuno Android SDK styles (colors, text, buttons) to align payment forms and checkout with your brand. Element structure stays uniform. For all Android SDK parameters and config options, see [Android SDK Common Reference](/docs/sdks/resources/references/android).

--- a/docs/sdks/customization/ios.mdx
+++ b/docs/sdks/customization/ios.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Customize iOS SDK appearance, including fonts, colors, and button styles, to match your brand"
 ---
 
 Modify Yuno iOS SDK styles (font, button, color) by setting appearance fields. Use these to match your app brand and improve consistency. For all iOS SDK parameters and config options, see [iOS SDK Common Reference](/docs/sdks/resources/references/ios).

--- a/docs/sdks/customization/secure-fields/enrollment-secure-fields.mdx
+++ b/docs/sdks/customization/secure-fields/enrollment-secure-fields.mdx
@@ -9,6 +9,7 @@ metadata:
   robots: index
 next:
   description: ''
+description: "Implement secure-fields enrollment on Web, mounting card fields and generating a vaulted token"
 ---
 Implement Yuno's secure-fields enrollment in your application by following these steps.
 

--- a/docs/sdks/customization/secure-fields/index.mdx
+++ b/docs/sdks/customization/secure-fields/index.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Compare secure-fields enrollment and payment integrations for PCI-compliant custom checkout UIs on Web"
 ---
 
 Yuno's secure-fields provide a way to securely collect sensitive payment information while maintaining PCI compliance. This approach allows you to build custom user interfaces while keeping sensitive data secure. For SDK setup, see [Quickstart guide](/docs/sdks/overview/quickstart). For integration comparison, see [Choose the right integration for you](/docs/sdks/overview/choose-integration).

--- a/docs/sdks/customization/secure-fields/payment-secure-fields.mdx
+++ b/docs/sdks/customization/secure-fields/payment-secure-fields.mdx
@@ -9,6 +9,7 @@ metadata:
   robots: index
 next:
   description: ''
+description: "Implement secure-fields checkout on Web, generating a one-time token and handling 3DS challenges"
 ---
 Implement Yuno's secure-fields checkout in your application by following these steps.
 

--- a/docs/sdks/full-checkout/android-payments.mdx
+++ b/docs/sdks/full-checkout/android-payments.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Integrate full-checkout payment flows on Android, from checkout session creation through payment status handling"
 ---
 
 

--- a/docs/sdks/full-checkout/ios-payments.mdx
+++ b/docs/sdks/full-checkout/ios-payments.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Integrate full-checkout payment flows on iOS, from checkout session creation through payment result handling"
 ---
 The iOS SDK makes it easy to integrate payment flows into your iOS app.
 

--- a/docs/sdks/full-checkout/web-payments.mdx
+++ b/docs/sdks/full-checkout/web-payments.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Integrate full-checkout payment flows on Web, from SDK initialization through payment retry handling"
 ---
 The Web SDK makes it easy to integrate payment flows into your web and browser-based experiences.
 

--- a/docs/sdks/headless-web/enrollment.mdx
+++ b/docs/sdks/headless-web/enrollment.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Headless SDK (Enrollment Web) into
     your web application, including customer session and vaulted token generation.
   robots: index
+description: "Enroll payment methods using the Headless SDK on Web, generating a vaulted token for card data"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/headless-web/payment.mdx
+++ b/docs/sdks/headless-web/payment.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Headless SDK (Payment Web) into
     your web application, including token generation and 3DS handling.
   robots: index
+description: "Create payments using the Headless SDK on Web, generating one-time tokens and handling 3DS actions"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/lite-android/checkout.mdx
+++ b/docs/sdks/lite-android/checkout.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Lite SDK (Payment Android) into
     your mobile application for a streamlined checkout experience.
   robots: index
+description: "Integrate the Lite SDK on Android for a streamlined card payment checkout experience"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/lite-android/enrollment.mdx
+++ b/docs/sdks/lite-android/enrollment.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Lite SDK (Enrollment Android) into
     your mobile application.
   robots: index
+description: "Enroll payment methods using the Lite SDK on Android with a lightweight enrollment flow"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/lite-ios/checkout.mdx
+++ b/docs/sdks/lite-ios/checkout.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Lite SDK (Payment iOS) into your
     mobile application for a streamlined checkout experience.
   robots: index
+description: "Integrate the Lite SDK on iOS for a streamlined card payment checkout experience"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/lite-ios/enrollment.mdx
+++ b/docs/sdks/lite-ios/enrollment.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Lite SDK (Enrollment iOS) into your
     mobile application.
   robots: index
+description: "Enroll payment methods using the Lite SDK on iOS with the enrollment delegate flow"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/lite-web/enrollment.mdx
+++ b/docs/sdks/lite-web/enrollment.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Lite SDK (Enrollment Web) into
     your web application for a customized enrollment experience.
   robots: index
+description: "Enroll payment methods using the Lite SDK on Web with a customizable enrollment form"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/lite-web/payment.mdx
+++ b/docs/sdks/lite-web/payment.mdx
@@ -9,6 +9,7 @@ metadata:
     Step-by-step guide on integrating Yuno's Lite SDK (Payment Web) into
     your web application, offering more control over payment method display.
   robots: index
+description: "Integrate the Lite SDK on Web for payment method display with full checkout control"
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 

--- a/docs/sdks/overview/choose-integration.mdx
+++ b/docs/sdks/overview/choose-integration.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Compare Seamless SDK, Lite SDK, and secure-fields integration types to pick the right fit"
 ---
 Within each platform's SDK, Yuno offers various **integration methods** allowing varying degrees of control over the UI and user experience.
 

--- a/docs/sdks/overview/quickstart.mdx
+++ b/docs/sdks/overview/quickstart.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Implement Yuno's full payment flow on Web, iOS, and Android with pre-built checkout UI"
 ---
 
 Welcome to the Yuno SDKs quickstart guide. This guide shows you how to easily implement our full payment flow, Yuno's most straightforward solution with pre-built UI and automatic payment method display.

--- a/docs/sdks/overview/understanding-flows.mdx
+++ b/docs/sdks/overview/understanding-flows.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Understand payment, enrollment, vaulted token, and Headless SDK flows with diagrams and step sequences"
 ---
 
 In Yuno SDKs, **payment flows** and **enrollment flows** are separate. Payment is the process of completing a transaction; enrollment is the process of saving a payment method (e.g. a card) to a customer account for future use. This page explains both flows at a high level with diagrams and step sequences. Use the Quickstart guide and platform flow pages for implementation details.

--- a/docs/sdks/resources/country-coverage.mdx
+++ b/docs/sdks/resources/country-coverage.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Reference supported countries and their codes for Yuno SDK payment and enrollment flows"
 ---
 
 Yuno is dedicated to expanding its coverage of solutions worldwide. Use the buttons to check the countries by region supported by Yuno's SDKs. If you require access to a Yuno SDK in a country that is not yet supported, reach out to our commercial team.

--- a/docs/sdks/resources/languages-supported.mdx
+++ b/docs/sdks/resources/languages-supported.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Reference locale codes for setting the display language across Yuno SDK checkout forms"
 ---
 Use these locale codes with Yuno SDKs to specify your desired display language. If you omit the  `language` parameter, the SDK defaults to the browser language when available.
 

--- a/docs/sdks/resources/references/android.mdx
+++ b/docs/sdks/resources/references/android.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Reference all Android SDK parameters, YunoConfig options, and the keepLoader public methods"
 ---
 
 Parameters, customizations, and advanced features for all Android SDK flows. Setup: [Payment flows (Android)](/docs/sdks/full-checkout/android-payments), [Enrollment flows (Android)](/docs/sdks/card-enrollment/android-enrollment), [integration modes](/docs/sdks/overview/choose-integration).

--- a/docs/sdks/resources/references/ios.mdx
+++ b/docs/sdks/resources/references/ios.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Reference all iOS SDK parameters, YunoConfig options, and enrollment delegate configuration"
 ---
 Parameters, customizations, and advanced features for all Yuno iOS SDK flows. For integration setup, see [Payment flows (iOS)](/docs/sdks/full-checkout/ios-payments), [Enrollment flows (iOS)](/docs/sdks/card-enrollment/ios-enrollment), and [integration modes](/docs/sdks/overview/choose-integration).
 

--- a/docs/sdks/resources/references/web.mdx
+++ b/docs/sdks/resources/references/web.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Reference all Web SDK parameters, SRI integration, payment retry, and enrollment options"
 ---
 Parameters, customizations, and advanced features for all Web SDK flows. See [Quickstart guide](/docs/sdks/overview/quickstart) and [Choose the Right Integration for You](/docs/sdks/overview/choose-integration) for introductory information.
 

--- a/docs/sdks/resources/release-notes/android.mdx
+++ b/docs/sdks/resources/release-notes/android.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Review version-by-version changes, new features, and fixes for the Android SDK"
 ---
 
 The Android SDK release notes offer a comprehensive overview of the updates, improvements, and fixes introduced in each version of the Android SDK.

--- a/docs/sdks/resources/release-notes/flutter-sdk.mdx
+++ b/docs/sdks/resources/release-notes/flutter-sdk.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Review version-by-version changes and fixes for the Flutter SDK"
 ---
 
 The Flutter SDK release notes offer a comprehensive overview of the updates, improvements, and fixes introduced in each version of the Flutter SDK.

--- a/docs/sdks/resources/release-notes/ios.mdx
+++ b/docs/sdks/resources/release-notes/ios.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Review version-by-version changes, new features, and fixes for the iOS SDK"
 ---
 
 The iOS SDK release notes provide a comprehensive overview of the updates, improvements, and fixes introduced in each version of the iOS SDK.

--- a/docs/sdks/resources/release-notes/web.mdx
+++ b/docs/sdks/resources/release-notes/web.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Find links to the Web SDK changelog and version history for release notes"
 ---
 
 Release notes and changelog for the Yuno Web SDK.

--- a/docs/sdks/resources/swift-6-concurrency.mdx
+++ b/docs/sdks/resources/swift-6-concurrency.mdx
@@ -4,6 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
+description: "Handle Swift 6 concurrency requirements when implementing Yuno's payment and enrollment delegate protocols"
 ---
 
 Swift 6 introduces stricter concurrency requirements that affect how you implement the SDK delegate protocols (e.g., `YunoPaymentDelegate`, `YunoEnrollmentDelegate`). This section explains the challenges and provides solutions for different implementation scenarios.

--- a/docs/security-and-compliance/3d-secure.mdx
+++ b/docs/security-and-compliance/3d-secure.mdx
@@ -1,5 +1,6 @@
 ---
 title: "3D Secure"
+description: "Explains 3D Secure 2 authentication flows, configuration requirements, and integration options for card payments."
 ---
 
 ## What is 3D Secure?

--- a/docs/security-and-compliance/card-verification.mdx
+++ b/docs/security-and-compliance/card-verification.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Card Verification"
+description: "Verify a customer's card is valid at enrollment or payment without charging the customer."
 ---
 
 Yuno lets you verify if the customer's credit card is real and is working. Our Credit Card Verification API is designed to empower your applications with a robust mechanism for validating credit card transactions, ensuring a seamless and secure payment experience for your users. This operation does not create any charges for your client.

--- a/docs/security-and-compliance/co-badged-cards-compliance.mdx
+++ b/docs/security-and-compliance/co-badged-cards-compliance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Co-badged Cards Compliance"
+description: "Explains EU network selection requirements for co-badged cards and Yuno's SDK compliance support."
 ---
 
 Co-badged cards are payment cards that support multiple payment networks (e.g., a card that supports both Cartes Bancaires and Visa). To comply with [EU IFR Regulation 2015/751 Article 8](https://eur-lex.europa.eu/eli/reg/2015/751/oj), merchants must allow customers to choose which network to use when processing payments with co-badged cards.

--- a/docs/security-and-compliance/data-migration-processes/exporting-tokens-from-yuno.mdx
+++ b/docs/security-and-compliance/data-migration-processes/exporting-tokens-from-yuno.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Exporting Tokens from Yuno"
+description: "Explains the requirements and secure process for exporting tokenized card data from Yuno's vault."
 ---
 
 Yuno offers a secure and PCI DSS-compliant process to export tokens from our vault to your systems, or a third-party provider. This guide explains the requirements, encryption protocols, data format, and delivery method to ensure safe and compliant migration of sensitive card data.

--- a/docs/security-and-compliance/data-migration-processes/network-token-migration-process.mdx
+++ b/docs/security-and-compliance/data-migration-processes/network-token-migration-process.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Token Migration Process"
+description: "Explains the steps and requirements for migrating network tokens from a provider into Yuno's vault."
 ---
 
 Network Token migration is the process of transferring `network_tokens` from an existing provider to Yuno's secure vault. During this process, a new token is generated for each `network_token`, ensuring seamless continuity and security for payment processing. The `network_token` migration process consists of three main steps:

--- a/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
+++ b/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Token Migration Process"
+description: "Explains the steps, data format, and security requirements for migrating tokenized cards into Yuno."
 ---
 
 Token migration is the process of transferring card numbers from an existing provider to Yuno's secure vault. During this process, a new token is generated for each card, ensuring seamless continuity and security for payment processing. The token migration process consists of three main steps:

--- a/docs/security-and-compliance/data-migration-processes/via-api.mdx
+++ b/docs/security-and-compliance/data-migration-processes/via-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Via API"
+description: "Walks through migrating customers and enrolling payment methods via the Yuno API endpoints."
 ---
 
 This guide provides a step-by-step process for migrating tokens using the Yuno API endpoints. By following the steps outlined, you will compile a list of customers with their enrolled payment methods.

--- a/docs/security-and-compliance/fingerprint.mdx
+++ b/docs/security-and-compliance/fingerprint.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Card Fingerprint"
+description: "Use card fingerprints to detect and deduplicate repeated card enrollments without storing card data."
 ---
 
 Card fingerprints are a cryptographic hash of the card's PAN that uniquely identifies a specific payment card. Yuno returns this value as `fingerprint` on the [Payment Method object](/reference/the-payment-method-object-api). When the same card is enrolled multiple times by the same customer, Yuno creates separate enrollments with distinct `vaulted_token` values, and the fingerprint helps you detect duplicates.

--- a/docs/security-and-compliance/network-tokens.mdx
+++ b/docs/security-and-compliance/network-tokens.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Network Tokens"
+description: "Explains network tokens, their lifecycle statuses, and how to integrate them for card payments."
 ---
 
 Network tokens represent a significant advancement in the payment processing industry, acting as digital surrogates for sensitive payment card details, including credit card numbers. Issued by payment networks such as Visa, Mastercard, and American Express, these tokens are at the forefront of enhancing transaction security within our evolving digital landscape.

--- a/docs/security-and-compliance/pci-compliance.mdx
+++ b/docs/security-and-compliance/pci-compliance.mdx
@@ -1,5 +1,6 @@
 ---
 title: "PCI Compliance"
+description: "Explains how Yuno's tokenization reduces PCI DSS scope for merchants using its SDKs."
 ---
 
 The Payment Card Industry Data Security Standard (PCI DSS) requires any business that stores, processes, or transmits cardholder data to meet a defined set of security controls. Non-compliance can result in fines from card brands and increased liability in the event of a breach.

--- a/docs/using-yuno/dashboard-overview/checkout-builder.mdx
+++ b/docs/using-yuno/dashboard-overview/checkout-builder.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Checkout Builder"
+description: "Configure payment method display conditions, required fields, and checkout styling with a no-code builder"
 ---
 
 The Checkout Builder is a no-code tool designed to customize your checkout experience. It includes two main modules:

--- a/docs/using-yuno/dashboard-overview/connections.mdx
+++ b/docs/using-yuno/dashboard-overview/connections.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Connections"
+description: "Add, edit, and manage provider connections for payment methods, processors, and anti-fraud solutions"
 ---
 
 The Connections section within the dashboard enables you to integrate and manage various providers, including payment methods, payment processors, and anti-fraud solutions. The ability to connect with providers from around the world using Yuno greatly reduces integration times and brings additional functionalities to your customers, increasing conveniency and revenue.

--- a/docs/using-yuno/dashboard-overview/insights.mdx
+++ b/docs/using-yuno/dashboard-overview/insights.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Insights"
+description: "Analyze payment performance, conversion rates, and fraud metrics with customizable charts and exports"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/using-yuno/dashboard-overview/monitors.mdx
+++ b/docs/using-yuno/dashboard-overview/monitors.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Monitors"
+description: "Detect approval rate drops and automatically redirect traffic to fallback providers to protect conversion"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/using-yuno/dashboard-overview/payment-links.mdx
+++ b/docs/using-yuno/dashboard-overview/payment-links.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Links"
+description: "Create no-code payment links with custom amounts, expiration dates, and advanced checkout options"
 ---
 
 The dashboard's payment links section allows you to create URLs to simplify your payment collection effortlessly. Let's see how Yuno's payment links solution brings both simplicity and advanced features.

--- a/docs/using-yuno/dashboard-overview/payments.mdx
+++ b/docs/using-yuno/dashboard-overview/payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payments"
+description: "Review payments, transactions, fraud screenings, and payouts, plus batch refunds and scheduled exports"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/using-yuno/dashboard-overview/reconciliations.mdx
+++ b/docs/using-yuno/dashboard-overview/reconciliations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reconciliations"
+description: "Compare transactions against provider settlements to resolve discrepancies and confirm accurate payouts"
 ---
 
 Reconciliation is a process that compares your transactions with settlement documents from payment providers to:

--- a/docs/using-yuno/dashboard-overview/risk-conditions.mdx
+++ b/docs/using-yuno/dashboard-overview/risk-conditions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Risk Conditions"
+description: "Create fraud prevention rules, blocklists, and allowlists to control which transactions get screened"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/using-yuno/dashboard-overview/routing.mdx
+++ b/docs/using-yuno/dashboard-overview/routing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Routing"
+description: "Configure dynamic and Smart Routing rules to direct payments across providers and boost approval rates"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/using-yuno/dashboard-overview/your-payment-operative-system.mdx
+++ b/docs/using-yuno/dashboard-overview/your-payment-operative-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Home"
+description: "Overview of the Yuno Dashboard's layout and core capabilities for managing payment operations"
 ---
 
 The Yuno dashboard provides a centralized, intuitive interface for managing and configuring your Yuno accounts. The dashboard features a clean, user-friendly layout with key functionalities readily accessible, guaranteeing an effortless and quick experience. Some of the dashboard's functionalities include:

--- a/docs/using-yuno/environments.mdx
+++ b/docs/using-yuno/environments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Environments"
+description: "Understand Test Mode and Live Mode in the Dashboard and how to switch between them"
 ---
 
 This guide explains how **Test Mode** and **Live Mode** work in the Yuno dashboard and how to switch between them. For API base URLs and credentials per environment, see the [API Environments](/reference/api-environments) reference.

--- a/docs/using-yuno/settings/account-management.mdx
+++ b/docs/using-yuno/settings/account-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account Management"
+description: "Create, edit, and review organizational accounts to manage access and segment your business"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/using-yuno/settings/audit-logs.mdx
+++ b/docs/using-yuno/settings/audit-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Audit logs"
+description: "Track team member and API activity across the Dashboard for security and compliance"
 ---
 
 The **Audit logs** section provides transparency, security, and regulatory compliance by logging and tracking all team members' activities within the dashboard. Using the audit logs, you can stay informed about the actions happening inside your organization.

--- a/docs/using-yuno/settings/developers-credentials.mdx
+++ b/docs/using-yuno/settings/developers-credentials.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Developers (Credentials)"
+description: "Manage organization and account keys, customized API keys, allowed IPs, and webhooks"
 ---
 
 The **Developers** section in the Yuno dashboard provides secure authentication credentials (also known as keys) for integrating Yuno's services. Yuno maintains separate keys for Test and Live environments, ensuring robust security and smooth operations.

--- a/docs/using-yuno/settings/security.mdx
+++ b/docs/using-yuno/settings/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Security"
+description: "Manage password policies, two-factor authentication, SSO, and login methods for your organization"
 ---
 
 The dashboard's **Security** section acts as your digital defense hub. From here, you can leverage multiple features to protect your organization and customer data, creating a strong shield against security threats and ensuring your most valuable information stays secure. To access this section, select **Security** after clicking your profile image.

--- a/docs/using-yuno/settings/single-sign-on-sso/index.mdx
+++ b/docs/using-yuno/settings/single-sign-on-sso/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Single Sign-On (SSO)"
+description: "Set up SAML 2.0 SSO through domain verification and a hosted configuration portal"
 ---
 
 **Single Sign-On (SSO)** lets your team log in to the Yuno dashboard using your company's existing identity provider (IdP), instead of creating separate credentials for Yuno. SSO centralizes authentication, simplifies onboarding and offboarding, and ensures that only authorized users from your organization can access the dashboard.

--- a/docs/using-yuno/settings/single-sign-on-sso/microsoft-entra-id-sso-guide.mdx
+++ b/docs/using-yuno/settings/single-sign-on-sso/microsoft-entra-id-sso-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Microsoft Entra ID SSO Guide"
+description: "Connect the Dashboard to Microsoft Entra ID for SSO using SAML 2.0 configuration"
 ---
 
 This guide explains how to connect Yuno to Microsoft Entra ID (formerly Azure Active Directory) using SAML 2.0.

--- a/docs/using-yuno/settings/single-sign-on-sso/okta-sso-guide.mdx
+++ b/docs/using-yuno/settings/single-sign-on-sso/okta-sso-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Okta SSO Guide"
+description: "Connect the Dashboard to Okta for SSO using SAML 2.0 application configuration"
 ---
 
 This guide explains how to connect Yuno to Okta using SAML 2.0.

--- a/docs/using-yuno/settings/teams-and-roles.mdx
+++ b/docs/using-yuno/settings/teams-and-roles.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Teams and Roles"
+description: "Create teams, assign default or custom roles, and manage member permissions across accounts"
 ---
 
 import { Video } from "/snippets/Video.jsx";

--- a/docs/wallets/apple-pay.mdx
+++ b/docs/wallets/apple-pay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Apple Pay"
+description: "Introduces Apple Pay integration options with Yuno through the SDK or Direct API."
 ---
 
 Apple Pay is a cutting-edge mobile payment solution designed exclusively for iOS devices. With its proprietary technologies, Apple Pay offers a seamless, end-to-end payment experience that differentiates it from traditional payment methods. Before integrating with Yuno, it's crucial to grasp the workflow of this innovative system.

--- a/docs/wallets/apple-pay/apple-pay-direct-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-direct-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Direct Integration"
+description: "Integrate Apple Pay directly with Yuno's API for one-time and recurring CIT/MIT payments."
 ---
 
 This guide describes how to integrate Apple Pay directly with Yuno's API. Direct integration offers full control over the payment flow and is ideal for merchants who need custom implementations or have existing payment systems.

--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SDK Integration"
+description: "Integrate Apple Pay one-time and recurring payments using Yuno's SDK and checkout sessions."
 ---
 
 This guide provides a comprehensive process to integrate Apple Pay with Yuno SDK for both one-time and recurring payments. The SDK simplifies Apple Pay integration by handling payment token management and providing built-in security.

--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prerequisites (Apple Pay)"
+description: "Walks through Apple Pay certificate setup, domain registration, and Yuno dashboard connection configuration."
 ---
 
 Use this guide to prepare and configure Apple Pay with Yuno.

--- a/docs/wallets/click-to-pay.mdx
+++ b/docs/wallets/click-to-pay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Click to Pay"
+description: "Integrate Click to Pay as a standalone method or embedded in the card flow."
 ---
 
 Click to Pay is an online payment solution designed to streamline and secure online transactions. It's based on the EMVCo secure payment standard, a global consortium comprising major card companies like Visa, MasterCard, American Express, and Discover.

--- a/docs/wallets/google-pay.mdx
+++ b/docs/wallets/google-pay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Google Pay™"
+description: "Compares Google Pay integration options and authorization methods for card and PIX payments."
 ---
 
 Google Pay™ is a digital wallet that lets customers pay using credit and debit cards stored in their Google account or on their Android device. Instead of sharing card details with the merchant, Google Pay generates a secure token that represents the payment information, protecting customer data throughout the transaction.

--- a/docs/wallets/google-pay/google-pay-direct-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-direct-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Direct Integration"
+description: "Integrate Google Pay directly with Yuno's API by passing the encrypted payment token."
 ---
 
 With Direct integration, you integrate with the Google Pay™ API on your frontend, obtain the encrypted payment token from Google, and pass it to Yuno's API for processing. This gives you full control over the Google Pay user experience.

--- a/docs/wallets/google-pay/google-pay-sdk-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-sdk-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SDK Integration"
+description: "Integrate Google Pay one-time and recurring payments using Yuno's SDK and checkout sessions."
 ---
 
 This guide covers how to integrate Google Pay™ with Yuno using the SDK. With this approach, Yuno's SDK manages the complete Google Pay experience: displaying the Google Pay button, presenting the payment sheet, and handling the payment token. You don't need to integrate directly with the Google Pay API.

--- a/docs/wallets/google-pay/google-pay-with-pix.mdx
+++ b/docs/wallets/google-pay/google-pay-with-pix.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Google Pay with PIX"
+description: "Explains how Google Pay presents PIX as an asynchronous payment option in Brazil."
 ---
 
 In Brazil, Yuno supports Google Pay™ as an interface for PIX payments. Customers select Google Pay at checkout, and the payment is processed through PIX, Brazil's instant payment system. This combines the convenience of Google Pay's stored payment methods with PIX's real-time settlement.

--- a/docs/wallets/google-pay/integration-via-provider-google-pay.mdx
+++ b/docs/wallets/google-pay/integration-via-provider-google-pay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Integration Via Provider"
+description: "Integrate Google Pay through a payment provider that manages token decryption and processing."
 ---
 
 With provider integration, Google Pay™ is handled entirely by your payment provider (e.g., Adyen, Cielo). Yuno routes the transaction to the provider, which manages the Google Pay token decryption and processing. Card data does not pass through Yuno in this flow.

--- a/docs/wallets/index.mdx
+++ b/docs/wallets/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wallets Overview"
+description: "Lists the wallet connections available on Yuno, including Apple Pay, Google Pay, and Click to Pay."
 ---
 
 Here you find the complete list of Wallets' connections available on Yuno. Wallets let your customers use the stored cards they have with different providers. Select the desired wallet to access more information.

--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Configure Webhooks"
+description: "Sets up webhook endpoints, authentication, and trigger events from the Yuno Dashboard Developers tab"
 ---
 
 ## Setup

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Webhooks Overview"
+description: "Summarizes webhook delivery, retry schedule, and event types across payments, subscriptions, payouts, and banking connectivity"
 ---
 
 ## What is a webhook

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Object and Examples"
+description: "Documents webhook payload attributes with example JSON for payments, chargebacks, enrollments, payouts, and subscriptions"
 ---
 
 # Webhook attributes

--- a/docs/webhooks/verify-webhook-signatures-hmac.mdx
+++ b/docs/webhooks/verify-webhook-signatures-hmac.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Verify Webhook Signatures (HMAC)"
+description: "Verifies webhook authenticity by validating the HMAC SHA256 signature sent in the request header"
 ---
 
 Learn how to verify webhook signatures using HMAC to ensure webhooks from Yuno are authentic and haven't been tampered with during transmission.

--- a/reference/ai-caller/declined-payment-calls.mdx
+++ b/reference/ai-caller/declined-payment-calls.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Declined Payment Calls"
 openapi: "/openapi/ai-caller/declined-payment-calls.json POST /smart-support/external/payments/recover"
+description: "Initiates bulk AI calls and WhatsApp messages to recover customers with declined payments"
 ---
 
 This endpoint allows you to initiate large-scale processing of calls and WhatsApp messages related to declined payments. To use the endpoint, you have to provide an object containing detailed information about the declined payment.

--- a/reference/ai-caller/initiate-recovery-outreach-for-abandoned-user-flows.mdx
+++ b/reference/ai-caller/initiate-recovery-outreach-for-abandoned-user-flows.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Initiate Recovery Outreach for Abandoned User Flows"
 openapi: "/openapi/ai-caller/initiate-recovery-outreach-for-abandoned-user-flows.json POST /smart-support/external/payments"
+description: "Notifies Yuno's recovery agent to contact a customer who abandoned checkout before completing payment"
 ---
 
 This endpoint allows merchants to notify Yuno's Recovery Agent when a user abandons their purchase flow, such as during product selection or after initiating checkout, before completing a payment. The submitted data enables Yuno to follow up with the user via call or WhatsApp to encourage completion of the transaction.

--- a/reference/airline-information.mdx
+++ b/reference/airline-information.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Airline Information"
+description: "Lists standard passenger type, fare class, and loyalty tier values for airline related payment fields"
 ---
 
 On this page, you will find airline information you may need when using Yuno API endpoints. It covers passenger types, fare class codes, and loyalty tiers. Use this page to understand and have access to standard values for each information category.

--- a/reference/banking-connectivity/accounts/close-account-banking.mdx
+++ b/reference/banking-connectivity/accounts/close-account-banking.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Close Account"
 openapi: "/openapi/banking-connectivity/accounts/close-account-banking.json DELETE /banking/accounts/{account_id}"
+description: "Close a bank account for an onboarded entity through Banking Connectivity"
 ---
 
 Close a Banking Connectivity account. The account must have a zero balance before it can be closed.

--- a/reference/banking-connectivity/accounts/create-account-banking.mdx
+++ b/reference/banking-connectivity/accounts/create-account-banking.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Account"
 openapi: "/openapi/banking-connectivity/accounts/create-account-banking.json POST /banking/accounts"
+description: "Create a bank account for an entity whose onboarding status has succeeded"
 ---
 
 Create a bank account for an onboarded entity. The onboarding referenced by `onboarding_id` must have `status: SUCCEEDED`.

--- a/reference/banking-connectivity/accounts/get-account-details-banking.mdx
+++ b/reference/banking-connectivity/accounts/get-account-details-banking.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Account Details"
 openapi: "/openapi/banking-connectivity/accounts/get-account-details-banking.json GET /banking/accounts/{account_id}"
+description: "Retrieve the details and region-specific identifiers of a bank account"
 ---
 
 Retrieve the details of an existing Banking Connectivity account, including balance information, banking identifiers, and supported payment rails.

--- a/reference/banking-connectivity/accounts/update-account-banking.mdx
+++ b/reference/banking-connectivity/accounts/update-account-banking.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Account"
 openapi: "/openapi/banking-connectivity/accounts/update-account-banking.json PATCH /banking/accounts/{account_id}"
+description: "Update the details of an existing bank account under Banking Connectivity"
 ---
 
 Update an existing Banking Connectivity account. Only include the fields you want to change.

--- a/reference/banking-connectivity/entities-banking-connectivity/create-entity.mdx
+++ b/reference/banking-connectivity/entities-banking-connectivity/create-entity.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Entity (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entities-banking-connectivity/create-entity.json POST /banking/entities"
+description: "Create an individual or business entity for banking connectivity onboarding"
 ---
 
 Create a Yuno entity representing an individual or organization. Set `national_entity` to `INDIVIDUAL` or `ENTITY` and provide the corresponding `entity_detail` sub-object. See [Entity types](/reference/banking-connectivity#entity-types) for details.

--- a/reference/banking-connectivity/entities-banking-connectivity/get-entity-details.mdx
+++ b/reference/banking-connectivity/entities-banking-connectivity/get-entity-details.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Entity Details (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entities-banking-connectivity/get-entity-details.json GET /banking/entities/{entity_id}"
+description: "Retrieve the details of an existing individual or business entity"
 ---
 
 Retrieve the details of an existing entity. Sensitive fields are masked in the response.

--- a/reference/banking-connectivity/entities-banking-connectivity/update-entity.mdx
+++ b/reference/banking-connectivity/entities-banking-connectivity/update-entity.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Entity (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entities-banking-connectivity/update-entity.json PATCH /banking/entities/{entity_id}"
+description: "Update the details of an existing individual or business entity"
 ---
 
 Update an existing entity's information. Only include the fields you want to change. The `national_entity` type cannot be changed after creation.

--- a/reference/banking-connectivity/entity-onboarding-banking-connectivity/cancel-entity-onboarding.mdx
+++ b/reference/banking-connectivity/entity-onboarding-banking-connectivity/cancel-entity-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel Entity Onboarding (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entity-onboarding-banking-connectivity/cancel-entity-onboarding.json POST /banking/entities/{entity_id}/onboardings/{onboarding_id}/cancel"
+description: "Cancel an in-progress entity onboarding with a banking connectivity provider"
 ---
 
 Cancel a pending onboarding. Only onboardings that have not reached a terminal status can be cancelled. See [Onboarding statuses](/reference/banking-connectivity#onboarding-statuses) for which statuses are terminal.

--- a/reference/banking-connectivity/entity-onboarding-banking-connectivity/create-entity-onboarding.mdx
+++ b/reference/banking-connectivity/entity-onboarding-banking-connectivity/create-entity-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Entity Onboarding (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entity-onboarding-banking-connectivity/create-entity-onboarding.json POST /banking/entities/{entity_id}/onboardings"
+description: "Onboard an existing entity with a banking connectivity provider using KYC or KYB documentation"
 ---
 
 Onboard an existing [Entity](/reference/create-entity) with a Banking Connectivity provider.

--- a/reference/banking-connectivity/entity-onboarding-banking-connectivity/get-entity-onboarding-status.mdx
+++ b/reference/banking-connectivity/entity-onboarding-banking-connectivity/get-entity-onboarding-status.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Entity Onboarding Status (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entity-onboarding-banking-connectivity/get-entity-onboarding-status.json GET /banking/entities/{entity_id}/onboardings/{onboarding_id}"
+description: "Retrieve the current status of an entity's onboarding with the provider"
 ---
 
 Retrieve the current status of an entity onboarding. See [Onboarding statuses](/reference/banking-connectivity#onboarding-statuses) for the full status lifecycle.

--- a/reference/banking-connectivity/entity-onboarding-banking-connectivity/update-entity-onboarding.mdx
+++ b/reference/banking-connectivity/entity-onboarding-banking-connectivity/update-entity-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Entity Onboarding"
 openapi: "openapi/banking-connectivity/entity-transfers-banking-connectivity/update-entity-onboarding.json PATCH /banking/entities/{entity_id}/onboardings/{onboarding_id}"
+description: "Update the documentation or details of an existing entity onboarding"
 ---
 
 Update an existing onboarding with new compliance declarations, risk assessment results, or additional documentation. Typically used when the onboarding is in `PENDING_ADDITIONAL_DOCUMENTATION` status.

--- a/reference/banking-connectivity/entity-transfers-banking-connectivity/cancel-entity-transfer.mdx
+++ b/reference/banking-connectivity/entity-transfers-banking-connectivity/cancel-entity-transfer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel Entity Transfer (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entity-transfers-banking-connectivity/cancel-entity-transfer.json POST /banking/accounts/{account_id}/transfers/{transfer_id}/cancel"
+description: "Cancel a pending outgoing transfer before it reaches the payment network"
 ---
 
 Cancel a pending transfer. Only transfers in `PENDING` status can be cancelled. Transfers that have moved to `PROCESSING` or later statuses cannot be cancelled.

--- a/reference/banking-connectivity/entity-transfers-banking-connectivity/get-entity-transfer-status.mdx
+++ b/reference/banking-connectivity/entity-transfers-banking-connectivity/get-entity-transfer-status.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Entity Transfer Status (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entity-transfers-banking-connectivity/get-entity-transfer-status.json GET /banking/accounts/{account_id}/transfers/{transfer_id}"
+description: "Retrieve the current status of a bank transfer initiated through an account"
 ---
 
 Retrieve the current status and details of a transfer. See [Transfer statuses](/reference/banking-connectivity#transfer-statuses) for the full status lifecycle.

--- a/reference/banking-connectivity/entity-transfers-banking-connectivity/initiate-entity-transfer.mdx
+++ b/reference/banking-connectivity/entity-transfers-banking-connectivity/initiate-entity-transfer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Initiate Entity Transfer (Banking Connectivity)"
 openapi: "/openapi/banking-connectivity/entity-transfers-banking-connectivity/initiate-entity-transfer.json POST /banking/transfers"
+description: "Initiate an outgoing or internal book transfer from a banking connectivity account"
 ---
 
 Initiate an outgoing transfer from a Banking Connectivity account. For external transfers, provide the `destination_account` details. For internal (book) transfers between accounts on the same provider, set `destination_account_id` to the target account.

--- a/reference/banking-connectivity/index.mdx
+++ b/reference/banking-connectivity/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Banking Connectivity"
+description: "Unified API to create bank accounts, run transfers, and onboard entities across multiple banking providers"
 ---
 
 Yuno Banking Connectivity provides a unified API to create bank accounts, process transfers, and manage entity onboarding across multiple banking providers. A single integration gives you access to providers across the US, UK, Australia, and EU.

--- a/reference/banking-connectivity/webhooks/webhook-notifications-banking.mdx
+++ b/reference/banking-connectivity/webhooks/webhook-notifications-banking.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Webhook Notifications"
 openapi: "/openapi/banking-connectivity/webhooks/webhook-notifications-banking.json POST /banking/transfers"
+description: "Receive incoming transfer notifications with sender, amount, rail, and status details"
 ---
 
 Yuno sends incoming transfer notifications to your endpoint at `{merchant_base_URL}/v1/banking/transfers`. Your endpoint must return a `200 OK` response with `{"received": true}`.

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Fetch Checkout Configuration"
 openapi: "/openapi/checkout-builder/fetch-checkout-configuration.json GET /v1/checkouts/{checkout_code}"
+description: "Retrieves the configuration of a checkout session by its checkout code"
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/fetch-styling-settings.mdx
+++ b/reference/checkout-builder/fetch-styling-settings.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Fetch Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/fetch-styling-settings.json GET /v1/checkouts/builder/settings"
+description: "Retrieves the styling and SDK settings configured for the checkout builder"
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/get-country-data.mdx
+++ b/reference/checkout-builder/get-country-data.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Country Data"
 openapi: "/openapi/checkout-builder/get-country-data.json GET /v1/checkouts/country-data"
+description: "Retrieves supported country data available for checkout builder configuration"
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/get-required-fields.mdx
+++ b/reference/checkout-builder/get-required-fields.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Required Fields"
 openapi: "/openapi/checkout-builder/get-required-fields.json GET /v1/checkouts/payment-methods/{payment_method_type}/required-fields"
+description: "Retrieves the required fields for a given payment method type in the checkout builder"
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/publish-checkout-configuration.mdx
+++ b/reference/checkout-builder/publish-checkout-configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Publish Checkout Configuration"
 openapi: "/openapi/checkout-builder/publish-checkout-configuration.json PATCH /v1/checkouts/{checkout_code}/publish"
+description: "Publishes a draft checkout configuration by its checkout code to make it live"
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-builder/update-styling-settings.mdx
+++ b/reference/checkout-builder/update-styling-settings.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Styling & SDK Settings"
 openapi: "/openapi/checkout-builder/update-styling-settings.json PATCH /v1/checkouts/builder/settings"
+description: "Updates checkout builder styling and SDK configuration settings for the merchant's payment experience"
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>

--- a/reference/checkout-sessions/create-checkout-session.mdx
+++ b/reference/checkout-sessions/create-checkout-session.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Checkout Session"
 openapi: "/openapi/checkout-sessions/create-checkout-session.json POST /checkout/sessions"
+description: "Creates a checkout session tied to a customer, used to initialize a payment through the SDK"
 ---
 
 This request creates a checkout session using the unique identifier generated when the `customer` resource was created.

--- a/reference/checkout-sessions/create-one-time-use-token-sdk-checkout.mdx
+++ b/reference/checkout-sessions/create-one-time-use-token-sdk-checkout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create One Time Use Token (SDK Checkout)"
 openapi: "/openapi/checkout-sessions/create-one-time-use-token-sdk-checkout.json POST /checkout/sessions/{checkout_session}/token"
+description: "Generates a one time volatile token for secure payment processing within an active checkout session"
 ---
 
 Creates a one-time volatile token for secure payment processing within a checkout session.

--- a/reference/checkout-sessions/create-one-time-use-token.mdx
+++ b/reference/checkout-sessions/create-one-time-use-token.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create One Time Use Token (Direct)"
 openapi: "/openapi/checkout-sessions/create-one-time-use-token.json POST /tokens"
+description: "Generates a one time use card token directly for PCI compliant merchants under the DIRECT workflow"
 ---
 
 <Warning>

--- a/reference/checkout-sessions/retrieve-checkout-session.mdx
+++ b/reference/checkout-sessions/retrieve-checkout-session.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Checkout Session"
 openapi: "/openapi/checkout-sessions/retrieve-checkout-session.json GET /checkout/sessions/{id}"
+description: "Retrieves the details of a checkout session using its unique identifier"
 ---
 
 This request retrieves a checkout session using its unique identifier.

--- a/reference/checkout-sessions/retrieve-payment-methods-for-checkout.mdx
+++ b/reference/checkout-sessions/retrieve-payment-methods-for-checkout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payment Methods for Checkout"
 openapi: "/openapi/checkout-sessions/retrieve-payment-methods-for-checkout.json GET /checkout/sessions/{checkout_session}/payment-methods"
+description: "Retrieves the available payment methods associated with an existing checkout session"
 ---
 
 This request retrieves a checkout session using the unique identifier that was generated when the session was first created.

--- a/reference/checkout-sessions/the-checkout-session-object.mdx
+++ b/reference/checkout-sessions/the-checkout-session-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Checkout Session Object"
+description: "Describes the checkout session object and its attributes, including amount, country, and installments"
 ---
 
 

--- a/reference/checkout-sessions/update-checkout-session.mdx
+++ b/reference/checkout-sessions/update-checkout-session.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Checkout Session"
 openapi: "/openapi/checkout-sessions/update-checkout-session.json PATCH /checkout/sessions/{checkout_session}"
+description: "Updates fields on an existing checkout session, modifying only the values you send"
 ---
 
 Update an existing checkout session with this endpoint. Only fields you send will be updated.

--- a/reference/communications-campaigns/create-campaign.mdx
+++ b/reference/communications-campaigns/create-campaign.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Campaign"
 openapi: "/openapi/communications-campaigns/create-campaign.json POST /campaigns"
+description: "Creates a new communications campaign for declined payment recovery, defaulting to INACTIVE status."
 ---
 
 Creates a new campaign. If no `status` is provided, campaigns default to `INACTIVE`.

--- a/reference/communications-campaigns/create-rules.mdx
+++ b/reference/communications-campaigns/create-rules.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Rules"
 openapi: "/openapi/communications-campaigns/create-rules.json POST /campaigns/{campaign_id}/rules"
+description: "Creates one or more targeting rules that determine which declined payments trigger a campaign."
 ---
 
 Creates one or more rules for a campaign. All active rules must pass for a payment to trigger the campaign (AND logic).

--- a/reference/communications-campaigns/get-campaign.mdx
+++ b/reference/communications-campaigns/get-campaign.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Campaign"
 openapi: "/openapi/communications-campaigns/get-campaign.json GET /campaigns/{campaign_id}"
+description: "Retrieves a single communications campaign by ID, including its attached rules."
 ---
 
 Retrieves a single campaign by ID, including its rules.

--- a/reference/communications-campaigns/get-rule.mdx
+++ b/reference/communications-campaigns/get-rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Rule"
 openapi: "/openapi/communications-campaigns/get-rule.json GET /campaigns/{campaign_id}/rules/{rule_id}"
+description: "Retrieves a specific targeting rule attached to a communications campaign."
 ---
 
 Retrieves a specific rule from a campaign.

--- a/reference/communications-campaigns/index.mdx
+++ b/reference/communications-campaigns/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Communications Campaigns"
+description: "Explains the Campaigns API for automating declined payment recovery communications via WhatsApp or phone."
 ---
 
 Learn how to integrate with the Yuno Campaigns API to automate personalized communications for declined payment recovery.

--- a/reference/communications-campaigns/list-campaigns.mdx
+++ b/reference/communications-campaigns/list-campaigns.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Campaigns"
 openapi: "/openapi/communications-campaigns/list-campaigns.json GET /campaigns"
+description: "Lists communications campaigns with optional filtering and pagination."
 ---
 
 Lists campaigns with optional filtering and pagination.

--- a/reference/communications-campaigns/update-campaign-status.mdx
+++ b/reference/communications-campaigns/update-campaign-status.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Campaign Status"
 openapi: "/openapi/communications-campaigns/update-campaign-status.json PATCH /campaigns/{campaign_id}"
+description: "Updates a campaign's status to pause, resume, complete, or cancel it."
 ---
 
 Updates the status of a campaign. Use this to pause, resume, complete, or cancel a campaign.

--- a/reference/communications-campaigns/update-rule-status.mdx
+++ b/reference/communications-campaigns/update-rule-status.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Rule Status"
 openapi: "/openapi/communications-campaigns/update-rule-status.json PATCH /campaigns/{campaign_id}/rules/{rule_id}/status"
+description: "Updates a campaign rule's status to activate or deactivate it without deleting it."
 ---
 
 Updates a rule's type, values, conditional, or metadata key.

--- a/reference/communications-campaigns/update-rule.mdx
+++ b/reference/communications-campaigns/update-rule.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Rule"
 openapi: "/openapi/communications-campaigns/update-rule.json PATCH /campaigns/{campaign_id}/rules/{rule_id}"
+description: "Updates a campaign rule's type, values, conditional operator, or metadata key."
 ---
 
 Updates a rule's type, values, conditional, or metadata key.

--- a/reference/conversion-rate/currency-conversion.mdx
+++ b/reference/conversion-rate/currency-conversion.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Currency Conversion"
+description: "Explains how Yuno's currency conversion service settles payments across merchant and customer currencies"
 ---
 
 Yuno's currency conversion service allows you to settle payments in both your currency and your customer's. Currency conversion is the process of converting one currency into another. It involves using exchange rates to determine the equivalent amount in the target currency.

--- a/reference/conversion-rate/get-conversion-rate.mdx
+++ b/reference/conversion-rate/get-conversion-rate.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Conversion Rate"
 openapi: "/openapi/conversion-rate/get-conversion-rate.json POST /currency-conversion"
+description: "Retrieves the currency conversion rate for a given transaction using an external provider"
 ---
 
 This page will help you get started with Currency conversions.

--- a/reference/country-reference.mdx
+++ b/reference/country-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Country Reference"
+description: "Lists ISO country, currency, document type, and phone codes used across Yuno API endpoints"
 ---
 
 On this page, you will find the country's information you need when using Yuno API endpoints. The below table provides standard codes for the country's identification, currencies, document types used in each country, and phone codes. Use this page to understand and have access to standard values for each piece of information. Use the buttons below to go directly to the desired country list region.

--- a/reference/customer-sessions-enrollment/create-customer-session.mdx
+++ b/reference/customer-sessions-enrollment/create-customer-session.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Customer Session"
 openapi: "/openapi/customer-sessions-enrollment/create-customer-session.json POST /customers/sessions"
+description: "Creates a customer session for enrolling and managing saved payment methods for future use"
 ---
 
 Creates a customer session for enrolling and managing payment methods. Use this to save cards, wallets, and other payment methods for future use. Requires a `customer_id` from [Create Customer](/reference/create-customer) .

--- a/reference/customer-sessions-enrollment/enrollment-workflow.mdx
+++ b/reference/customer-sessions-enrollment/enrollment-workflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Enrollment Status"
+description: "Lists the possible statuses a payment method can have during the enrollment process"
 ---
 
 Yuno gives customers the possibility to enroll a payment method to use it for future purchases and have a seamless payment experience. That payment method enrollment can be used either in our [Full](/docs/sdks/overview/understanding-flows) or [Lite](/docs/sdks/overview/quickstart) payment implementation and could have one of the following statuses.

--- a/reference/customer-sessions-enrollment/the-customer-session-object.mdx
+++ b/reference/customer-sessions-enrollment/the-customer-session-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Customer Session Object"
+description: "Describes the customer session object and its attributes used for payment method enrollment"
 ---
 
 

--- a/reference/customers/create-customer.mdx
+++ b/reference/customers/create-customer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Customer"
 openapi: "/openapi/customers/create-customer.json POST /customers"
+description: "Creates a customer resource with personal, billing, and shipping details for checkout initialization"
 ---
 
 This request creates a customer resource. You need to provide several parameters of the customer in the request body, including the unique identifier of the customer in the external merchant, personal information, as well as billing and shipping addresses.

--- a/reference/customers/delete-customer.mdx
+++ b/reference/customers/delete-customer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Customer"
 openapi: "/openapi/customers/delete-customer.json DELETE /customers/{customer_id}"
+description: "Deletes or anonymizes a customer and triggers deletion with the associated payment providers"
 ---
 
 You can delete a customer via this API request. In addition to deleting or anonymizing the customer within Yuno, this request will also trigger the deletion process with the payment providers the customer has interacted with.

--- a/reference/customers/retrieve-customer-by-external-id.mdx
+++ b/reference/customers/retrieve-customer-by-external-id.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Customer by External ID"
 openapi: "/openapi/customers/retrieve-customer-by-external-id.json GET /customers"
+description: "Retrieves customer details using the merchant assigned external customer identifier"
 ---
 
 This request enables you to retrieve details of customers based on their `merchant_customer_id`, which needs to be provided in the request path.

--- a/reference/customers/retrieve-customer.mdx
+++ b/reference/customers/retrieve-customer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Customer"
 openapi: "/openapi/customers/retrieve-customer.json GET /customers/{customer_id}"
+description: "Retrieves customer details using the customer's unique Yuno identifier"
 ---
 
 This request enables you to retrieve details of customers based on their `id`, which needs to be provided in the request path.

--- a/reference/customers/the-customer-object.mdx
+++ b/reference/customers/the-customer-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Customer Object"
+description: "Describes the customer object and its attributes, including contact, address, and document data"
 ---
 
 

--- a/reference/customers/update-customer.mdx
+++ b/reference/customers/update-customer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Customer"
 openapi: "/openapi/customers/update-customer.json PATCH /customers/{id}"
+description: "Updates fields on an existing customer, modifying only the values included in the request"
 ---
 
 You can update a customer created earlier with the `POST/customers` API request. The only required field for the request is the customer `id`. Other supported request fields are equal to the ones on the customer creation process.

--- a/reference/eci-indicators-list.mdx
+++ b/reference/eci-indicators-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ECI Indicators List"
+description: "Lists ECI response codes returned by card networks during 3D Secure authentication attempts"
 ---
 
 import { HTMLBlock } from "/snippets/HTMLBlock.jsx";

--- a/reference/getting-started/api-environments.mdx
+++ b/reference/getting-started/api-environments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Environments"
+description: "Explains the sandbox and production API base URLs and their credentials and timeout behavior"
 ---
 
 import { CopyChip } from '/snippets/CopyChip.jsx';

--- a/reference/getting-started/api-reference-overview.mdx
+++ b/reference/getting-started/api-reference-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "API Overview"
+description: "Introduces the Yuno REST API structure and links to authentication, SDKs, webhooks, and reference sections"
 ---
 
 The Yuno API has been implemented around RESTful. Our API uses standard HTTP protocols where JSON payloads are returned in response to the HTTP requests. All operations can be performed via GET, POST and PATCH requests.

--- a/reference/getting-started/api-updates.mdx
+++ b/reference/getting-started/api-updates.mdx
@@ -1,5 +1,6 @@
 ---
 title: "API Updates"
+description: "Explains how Yuno versions and rolls out backward compatible API changes and updates"
 ---
 
 Stay up to date with Yuno API changes and updates.

--- a/reference/getting-started/authentication.mdx
+++ b/reference/getting-started/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Authentication"
+description: "Explains API key headers and idempotency keys used to authenticate and secure Yuno API requests"
 ---
 
 The Yuno API uses the ApiKey security schema to authenticate HTTP requests. API keys are alphanumeric credentials that grant access to specific API features.

--- a/reference/getting-started/postman-collections.mdx
+++ b/reference/getting-started/postman-collections.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Postman Collections"
+description: "Walks through importing and configuring the Yuno Postman collection to test sandbox endpoints"
 ---
 
 Postman is an API platform to help developers design and test APIs. Postman is an alternative to run Yuno API requests using Readme.io. You can download Postman [here](https://www.postman.com/downloads/) for Linux, Windows, or Mac or use it through your web browser.

--- a/reference/getting-started/response-codes.mdx
+++ b/reference/getting-started/response-codes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HTTP Response Codes"
+description: "Lists HTTP status codes and error codes returned by the Yuno API with their meanings"
 ---
 
 import { HTMLBlock } from "/snippets/HTMLBlock.jsx";

--- a/reference/industry-category-list.mdx
+++ b/reference/industry-category-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Industry Category"
+description: "Lists industry category codes and descriptions used when configuring merchant accounts via the API"
 ---
 
 On this page, you will find the industry category information you need when using Yuno API endpoints. The table below provides codes for each industry category available on the Yuno API and their descriptions. Use this page to understand better when to use each category.

--- a/reference/installments/apm-installments.mdx
+++ b/reference/installments/apm-installments.mdx
@@ -1,6 +1,7 @@
 ---
 title: "APM Installments"
 openapi: "/openapi/installments/apm-installments.json POST /apm-installments"
+description: "Retrieves available installment plans for alternative payment methods like NuPay before payment"
 ---
 
 The `apm-installments` endpoint allows you to retrieve available installment plans for specific Alternative Payment Methods (APMs). This is particularly useful for integrations like NuPay, where you may want to present installment options to the customer before finalizing the payment.

--- a/reference/installments/create-installments-plan.mdx
+++ b/reference/installments/create-installments-plan.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Installments Plan"
 openapi: "/openapi/installments/create-installments-plan.json POST /installments-plans"
+description: "Creates an installment plan defining amount range, card BIN, currency, and availability rules"
 ---
 
 Yuno allows you to create installment plans to offer to your customers. These plans can be used based on factors such as the amount to pay, currency, and card used, as described below:

--- a/reference/installments/delete-installments-plan-by-id.mdx
+++ b/reference/installments/delete-installments-plan-by-id.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Installments Plan"
 openapi: "/openapi/installments/delete-installments-plan-by-id.json DELETE /installments-plans/{installment_code}"
+description: "Permanently deletes a specific installment plan by its installment code"
 ---
 
 The **Delete Installments Plan by ID** endpoint allows you to delete a specific installment plan from the system. This operation permanently removes the plan and makes it unavailable for future transactions.

--- a/reference/installments/get-installments-plan-by-account.mdx
+++ b/reference/installments/get-installments-plan-by-account.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Installments Plans"
 openapi: "/openapi/installments/get-installments-plan-by-account.json GET /installments-plans"
+description: "Retrieves the list of installment plans configured for a specific account"
 ---
 
 The **Get Installments Plan** API lets you retrieve a list of installment plans associated with a specific account. This endpoint helps view all available plans linked to an account, including their installment options, limits, and availability periods.

--- a/reference/installments/get-installments-plan.mdx
+++ b/reference/installments/get-installments-plan.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Installments Plan by ID"
 openapi: "/openapi/installments/get-installments-plan.json GET /installments-plans/{installment_code}"
+description: "Retrieves the configuration details of a specific installment plan by its code"
 ---
 
 The **Get Installments Plan** API lets you retrieve detailed information about an existing installment plan. This includes the plan’s installment options, billing frequency, amount limits, and other relevant details.

--- a/reference/installments/update-plan.mdx
+++ b/reference/installments/update-plan.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Plan"
 openapi: "/openapi/installments/update-plan.json PATCH /installments-plans/{installment_code}"
+description: "Updates an existing installment plan's status, installment details, or payment method"
 ---
 
 The **Update Plan** API allows you to modify an existing plan, enabling you to update attributes such as the plan's status, installment details, and the payment method associated with the plan.

--- a/reference/items-category-list.mdx
+++ b/reference/items-category-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Items Category"
+description: "Lists item category codes and descriptions used to classify products in order payloads"
 ---
 
 On this page, you will find the items category information you need when using Yuno API endpoints. The table below provides codes for each item category available on the Yuno API and their descriptions. Use this page to understand better when to use each category.

--- a/reference/organizations/authenticate-whitelabel-user.mdx
+++ b/reference/organizations/authenticate-whitelabel-user.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Authenticate Whitelabel User"
 openapi: "/openapi/organizations/authenticate-whitelabel-user.json POST /organizations/authenticate"
+description: "Authenticates a whitelabel user and returns a JWT embed token for subsequent requests"
 ---
 
 Authenticates a whitelabel user and returns a JWT embed token. This token can be used for subsequent authenticated requests on behalf of the whitelabel user.

--- a/reference/organizations/create-account-group.mdx
+++ b/reference/organizations/create-account-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Account Group"
 openapi: "/openapi/organizations/create-account-group.json POST /organizations/account-groups"
+description: "Creates a new account group to organize merchants or business units within an organization"
 ---
 
 Creates a new group (sub-organization) within your organization. Account groups can be used to organize different merchants or business units under a single parent entity.

--- a/reference/organizations/create-account.mdx
+++ b/reference/organizations/create-account.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Account"
 openapi: "/openapi/organizations/create-account.json POST /organizations/account-groups/{account_group_id}/accounts"
+description: "Creates a new merchant account under a specific account group in the organization"
 ---
 
 Creates a new account under a specific account group. Each account represents a distinct merchant environment or business unit within the group.

--- a/reference/organizations/create-role.mdx
+++ b/reference/organizations/create-role.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Role"
 openapi: "/openapi/organizations/create-role.json POST /organizations/roles"
+description: "Creates a custom role with a defined set of permissions for the organization"
 ---
 
 Create a custom role for the organization.

--- a/reference/organizations/create-user.mdx
+++ b/reference/organizations/create-user.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Create User"
 openapi: "/openapi/organizations/create-user.json POST /organizations/users"
+description: "Creates a new user within the authenticated organization"
 ---

--- a/reference/organizations/delete-account-group.mdx
+++ b/reference/organizations/delete-account-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Account Group"
 openapi: "/openapi/organizations/delete-account-group.json DELETE /organizations/account-groups/{account_group_id}"
+description: "Deletes an account group and reassigns its accounts to a default organization group"
 ---
 
 Deletes an account group. All accounts previously belonging to the deleted group are automatically reassigned to a default organization group.

--- a/reference/organizations/delete-account.mdx
+++ b/reference/organizations/delete-account.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Account"
 openapi: "/openapi/organizations/delete-account.json DELETE /organizations/accounts/{account_id}"
+description: "Disables a specific merchant account within the organization"
 ---
 
 Disables a specific account within your organization.

--- a/reference/organizations/delete-role.mdx
+++ b/reference/organizations/delete-role.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Role"
 openapi: "/openapi/organizations/delete-role.json DELETE /organizations/roles/{role_id}"
+description: "Deletes a custom role and reassigns its users to the ReadOnly role"
 ---
 
 Delete a custom role. Users assigned to the deleted role will be automatically reassigned to the ReadOnly role.

--- a/reference/organizations/delete-user-account-group-permission.mdx
+++ b/reference/organizations/delete-user-account-group-permission.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete User Account Group Permission"
 openapi: "/openapi/organizations/delete-user-account-group-permission.json DELETE /organizations/users/{user_id}/account-group-permissions/{account_group_id}"
+description: "Removes a specific account group permission assigned to a user"
 ---
 
 Removes a specific account group permission from a user.

--- a/reference/organizations/delete-user-account-permission.mdx
+++ b/reference/organizations/delete-user-account-permission.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete User Account Permission"
 openapi: "/openapi/organizations/delete-user-account-permission.json DELETE /organizations/users/{user_id}/account-permissions/{account_id}"
+description: "Removes a specific account permission assigned to a user"
 ---
 
 Removes a specific account permission from a user.

--- a/reference/organizations/delete-user.mdx
+++ b/reference/organizations/delete-user.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete User"
 openapi: "/openapi/organizations/delete-user.json DELETE /organizations/users/{user_id}"
+description: "Deletes a user and all associated organization, account, and role records"
 ---
 
 Deletes a user and removes all their associated records, including organization links, account links, and role assignments.

--- a/reference/organizations/list-account-groups.mdx
+++ b/reference/organizations/list-account-groups.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Account Groups"
 openapi: "/openapi/organizations/list-account-groups.json GET /organizations/account-groups"
+description: "Lists all account groups belonging to the authenticated organization"
 ---
 
 Lists all account groups for the authenticated organization. Use this endpoint to retrieve a summary of all sub-organizations under your parent entity.

--- a/reference/organizations/list-accounts-of-group.mdx
+++ b/reference/organizations/list-accounts-of-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Accounts of Group"
 openapi: "/openapi/organizations/list-accounts-of-group.json GET /organizations/account-groups/{account_group_id}/accounts"
+description: "Retrieves all accounts associated with a specific account group"
 ---
 
 Retrieves all accounts associated with a specific account group.

--- a/reference/organizations/list-accounts.mdx
+++ b/reference/organizations/list-accounts.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Accounts"
 openapi: "/openapi/organizations/list-accounts.json GET /organizations/accounts"
+description: "Lists all merchant accounts belonging to the authenticated organization"
 ---
 
 Lists all accounts belonging to the authenticated organization. Use this endpoint to see all sub-entities across all your account groups.

--- a/reference/organizations/list-permissions-catalog.mdx
+++ b/reference/organizations/list-permissions-catalog.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Permissions Catalog"
 openapi: "/openapi/organizations/list-permissions-catalog.json GET /organizations/permissions-catalog"
+description: "Retrieves the catalog of permission sections available for custom roles"
 ---
 
 Slim permissions catalog including sections and specific permissions.

--- a/reference/organizations/list-roles.mdx
+++ b/reference/organizations/list-roles.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Roles"
 openapi: "/openapi/organizations/list-roles.json GET /organizations/roles"
+description: "Lists Yuno default roles and organization custom roles"
 ---
 
 List Yuno default and organization custom roles.

--- a/reference/organizations/list-users.mdx
+++ b/reference/organizations/list-users.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Users"
 openapi: "/openapi/organizations/list-users.json GET /organizations/users"
+description: "Lists organization users, optionally filtered by account group or account"
 ---
 
 Lists all users belonging to the authenticated organization. You can optionally filter the results by account group or account ID.

--- a/reference/organizations/replace-user-account-group-permissions.mdx
+++ b/reference/organizations/replace-user-account-group-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Replace User Account Group Permissions"
 openapi: "/openapi/organizations/replace-user-account-group-permissions.json PUT /organizations/users/{user_id}/account-group-permissions"
+description: "Replaces all account group permission assignments for a user"
 ---
 
 Replaces all account group permission assignments for a user. Full replacement.

--- a/reference/organizations/replace-user-account-permissions.mdx
+++ b/reference/organizations/replace-user-account-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Replace User Account Permissions"
 openapi: "/openapi/organizations/replace-user-account-permissions.json PUT /organizations/users/{user_id}/account-permissions"
+description: "Replaces all account permission assignments for a user with a new set"
 ---
 
 Replaces all account permission assignments for a user. This is a full replacement — any existing account permissions not included in the request will be removed.

--- a/reference/organizations/retrieve-account-group.mdx
+++ b/reference/organizations/retrieve-account-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Account Group"
 openapi: "/openapi/organizations/retrieve-account-group.json GET /organizations/account-groups/{account_group_id}"
+description: "Retrieves a specific account group by its unique identifier"
 ---
 
 Gets a specific account group by its unique identifier (UUID).

--- a/reference/organizations/retrieve-account.mdx
+++ b/reference/organizations/retrieve-account.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Account"
 openapi: "/openapi/organizations/retrieve-account.json GET /organizations/accounts/{account_id}"
+description: "Retrieves the details of a specific merchant account by its unique identifier"
 ---
 
 Retrieves the details of a specific account using its unique identifier (UUID).

--- a/reference/organizations/retrieve-user-account-group-permissions.mdx
+++ b/reference/organizations/retrieve-user-account-group-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve User Account Group Permissions"
 openapi: "/openapi/organizations/retrieve-user-account-group-permissions.json GET /organizations/users/{user_id}/account-group-permissions"
+description: "Returns all account group permission assignments for a specific user"
 ---
 
 Returns all account group permission assignments for a user.

--- a/reference/organizations/retrieve-user-account-permissions.mdx
+++ b/reference/organizations/retrieve-user-account-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve User Account Permissions"
 openapi: "/openapi/organizations/retrieve-user-account-permissions.json GET /organizations/users/{user_id}/account-permissions"
+description: "Returns all account permission assignments for a user, including role details"
 ---
 
 Returns all account permission assignments for a user, including the account name and role details.

--- a/reference/organizations/retrieve-user.mdx
+++ b/reference/organizations/retrieve-user.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve User"
 openapi: "/openapi/organizations/retrieve-user.json GET /organizations/users/{user_id}"
+description: "Retrieves the details of a specific user by their unique identifier"
 ---
 
 Retrieves the details of a specific user using their unique identifier (UUID).

--- a/reference/organizations/update-account-group.mdx
+++ b/reference/organizations/update-account-group.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Account Group"
 openapi: "/openapi/organizations/update-account-group.json PATCH /organizations/account-groups/{account_group_id}"
+description: "Updates the name or merchant ID of an existing account group"
 ---
 
 Updates the details of an existing account group, such as its name or merchant ID.

--- a/reference/organizations/update-account.mdx
+++ b/reference/organizations/update-account.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Account"
 openapi: "/openapi/organizations/update-account.json PATCH /organizations/accounts/{account_id}"
+description: "Updates the name or other details of an existing merchant account"
 ---
 
 Updates the name or other details of an existing account.

--- a/reference/organizations/update-role.mdx
+++ b/reference/organizations/update-role.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Role"
 openapi: "/openapi/organizations/update-role.json PATCH /organizations/roles/{role_id}"
+description: "Partially updates a custom role's permissions without changing its role type"
 ---
 
 Partial update of a custom role. Note that `role_type` is immutable.

--- a/reference/organizations/update-user-account-group-permissions.mdx
+++ b/reference/organizations/update-user-account-group-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update User Account Group Permissions"
 openapi: "/openapi/organizations/update-user-account-group-permissions.json PATCH /organizations/users/{user_id}/account-group-permissions"
+description: "Adds or updates account group permissions for a user without removing existing ones"
 ---
 
 Partially updates account group permissions. Adds or updates without removing existing ones.

--- a/reference/organizations/update-user-account-permissions.mdx
+++ b/reference/organizations/update-user-account-permissions.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update User Account Permissions"
 openapi: "/openapi/organizations/update-user-account-permissions.json PATCH /organizations/users/{user_id}/account-permissions"
+description: "Adds or updates account permissions for a user without removing existing ones"
 ---
 
 Partially updates account permissions. Adds or updates the specified entries without removing existing ones.

--- a/reference/organizations/update-user.mdx
+++ b/reference/organizations/update-user.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update User"
 openapi: "/openapi/organizations/update-user.json PATCH /organizations/users/{user_id}"
+description: "Updates the first or last name of an existing user"
 ---
 
 Updates the first or last name of an existing user.

--- a/reference/payment-links/cancel-payment-link.mdx
+++ b/reference/payment-links/cancel-payment-link.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Cancel Payment Link"
 openapi: "/openapi/payment-links/cancel-payment-link.json POST /payment-links/{code}/cancel"
+description: "Cancels an active payment link, preventing further use for collecting payment"
 ---

--- a/reference/payment-links/create-payment-link.mdx
+++ b/reference/payment-links/create-payment-link.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Create Payment Link"
 openapi: "/openapi/payment-links/create-payment-link.json POST /payment-links"
+description: "Creates a shareable payment link for collecting a payment from a customer"
 ---

--- a/reference/payment-links/retrieve-payment-link.mdx
+++ b/reference/payment-links/retrieve-payment-link.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Retrieve Payment Link"
 openapi: "/openapi/payment-links/retrieve-payment-link.json GET /payment-links/{code}"
+description: "Retrieves the details and current status of a specific payment link by code"
 ---

--- a/reference/payment-links/status-payment-links.mdx
+++ b/reference/payment-links/status-payment-links.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Link Status"
+description: "Describes the possible statuses of a payment link and how they transition"
 ---
 
 Yuno's payment links solution enables businesses to accept payments effortlessly and offer subscriptions without additional websites or applications. These versatile links can be shared across various platforms, including social media, emails, and websites. Supporting diverse payment methods like credit and debit cards, Apple Pay, and Google Pay, payment links provide a secure and rapid way to collect payments.

--- a/reference/payment-links/the-payment-link-object.mdx
+++ b/reference/payment-links/the-payment-link-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Payment Link Object"
+description: "Describes the attributes returned in a payment link object, including customer and amount data"
 ---
 
 

--- a/reference/payment-methods-checkout/enroll-payment-method-checkout.mdx
+++ b/reference/payment-methods-checkout/enroll-payment-method-checkout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enroll Payment Method"
 openapi: "/openapi/payment-methods-checkout/enroll-payment-method-checkout.json POST /customers/sessions/{customer_session}/payment-methods"
+description: "Enrolls a customer's selected payment method for future use during checkout"
 ---
 
 This request enrolls a payment method for a customer. With the information provided by Yuno after the customer selects the payment method to enroll, you will be able to save it for future purchases in the payment method object created.

--- a/reference/payment-methods-checkout/retrieve-payment-method-by-id-checkout.mdx
+++ b/reference/payment-methods-checkout/retrieve-payment-method-by-id-checkout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payment Method by ID"
 openapi: "/openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json GET /payment-methods/{payment_method_id}"
+description: "Retrieves details of a specific enrolled payment method by its ID"
 ---
 
 Retrieve information about a payment method based on its `payment_method_id`, which needs to be provided in the request path.

--- a/reference/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.mdx
+++ b/reference/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payment Methods to Enroll"
 openapi: "/openapi/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.json GET /checkout/customers/sessions/{customer_session}/payment-methods"
+description: "Retrieves the payment methods available for a customer to enroll during checkout"
 ---
 
 Get the list of payment methods the user has available for enrollment.

--- a/reference/payment-methods-checkout/the-payment-method-object-checkout.mdx
+++ b/reference/payment-methods-checkout/the-payment-method-object-checkout.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Payment Method Object"
+description: "Describes the attributes returned in a payment method object, including provider and enrollment data"
 ---
 
 

--- a/reference/payment-methods-checkout/unenroll-payment-method-checkout.mdx
+++ b/reference/payment-methods-checkout/unenroll-payment-method-checkout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Unenroll Payment Method"
 openapi: "/openapi/payment-methods-checkout/unenroll-payment-method-checkout.json POST /customers/payment-methods/{payment_method_id}/unenroll"
+description: "Unenrolls a previously saved payment method, marking it inactive for future transactions"
 ---
 
 Unenroll a previously saved payment method for a customer.

--- a/reference/payment-methods-direct-workflow/enroll-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/enroll-payment-method-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enroll Payment Method"
 openapi: "/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json POST /customers/{customer_id}/payment-methods"
+description: "Enrolls a customer's payment method and returns a vaulted token for future use"
 ---
 
 This request enrolls a payment method for a customer. With the information provided by Yuno after the customer selects the payment method to enroll, you will be able to save that information for future purchases using the payment method object created.

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Enrolled Payment Method by ID"
 openapi: "/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json GET /customers/{customer_id}/payment-methods/{payment_method_id}"
+description: "Retrieves a specific payment method a customer has enrolled, by its vaulted token"
 ---
 
 Retrieve a specific payment method that a user has enrolled in.

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Enrolled Payment Method by ID PCI Data"
 openapi: "/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json GET /customers/{customer_id}/payment-methods/{payment_method_id}"
+description: "Retrieves an enrolled payment method including the full card number, PCI merchants only"
 ---
 
 Retrieve a specific payment method that a user has enrolled in, including the full card number in the response.

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Enrolled Payment Methods"
 openapi: "/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.json GET /customers/{customer_id}/payment-methods"
+description: "Retrieves the list of payment methods a customer has enrolled"
 ---
 
 Get the list of payment methods the user has enrolled.

--- a/reference/payment-methods-direct-workflow/the-payment-method-object-api.mdx
+++ b/reference/payment-methods-direct-workflow/the-payment-method-object-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Payment Method Object"
+description: "Describes the payment method object's attributes for back to back payment integrations"
 ---
 
 

--- a/reference/payment-methods-direct-workflow/unenroll-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/unenroll-payment-method-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Unenroll Payment Method"
 openapi: "/openapi/payment-methods-direct-workflow/unenroll-payment-method-api.json POST /customers/{customer_id}/payment-methods/{payment_method_id}/unenroll"
+description: "Unenrolls a customer's saved payment method and sets its status to UNENROLLED"
 ---
 
 Unenroll a saved payment method for the user. Once you've done the POST to the unenrollment endpoint, the payment method status will be changed to UNENROLLED.

--- a/reference/payment-type-list.mdx
+++ b/reference/payment-type-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Type"
+description: "Lists all payment methods, providers, and categories supported by the Yuno API"
 ---
 
 This reference lists all payment methods supported by Yuno's API, organized by category and provider. Use the `payment_method_type`, `category`, and `provider` values when creating payments or enrolling payment methods.

--- a/reference/payments/authorize-payment.mdx
+++ b/reference/payments/authorize-payment.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Authorize Payment"
 openapi: "/openapi/payments/authorize-payment.json POST /payments"
+description: "Authorizes a payment amount on a card without charging the customer immediately."
 ---
 
 This request allows you to authorize a payment after you created a checkout session. It just authorizes the amount on the `credit_card` (the client is not charged). If you want to make an authorization for a payment, you will need to send the `capture` as "false" within the card object, which is located inside the `payment_method` object.

--- a/reference/payments/cancel-or-refund-a-payment.mdx
+++ b/reference/payments/cancel-or-refund-a-payment.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel or Refund a Payment"
 openapi: "/openapi/payments/cancel-or-refund-a-payment.json POST /payments/{payment_id}/cancel-or-refund"
+description: "Cancels or refunds an existing payment automatically based on its current transaction status."
 ---
 
 <Warning>

--- a/reference/payments/cancel-or-refund-payment-with-transaction.mdx
+++ b/reference/payments/cancel-or-refund-payment-with-transaction.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel or Refund a Payment with Transaction"
 openapi: "/openapi/payments/cancel-or-refund-payment-with-transaction.json POST /payments/{payment_id}/transactions/{transaction_id}/cancel-or-refund"
+description: "Cancels or refunds a payment based on the status of a specific transaction ID."
 ---
 
 <Warning>

--- a/reference/payments/cancel-payment.mdx
+++ b/reference/payments/cancel-payment.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel Payment"
 openapi: "/openapi/payments/cancel-payment.json POST /payments/{payment_id}/transactions/{transaction_id}/cancel"
+description: "Cancels a pending payment before it completes, updating its status to cancelled."
 ---
 
 A payment with a **PENDING** status due to an **AUTHORIZE** transaction status can be canceled before it is completed if the payment is no longer required. Sending a cancel request will update the payment status to **CANCELLED**.

--- a/reference/payments/capture-authorization.mdx
+++ b/reference/payments/capture-authorization.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Capture Authorization"
 openapi: "/openapi/payments/capture-authorization.json POST /payments/{payment_id}/transactions/{transaction_id}/capture"
+description: "Captures a previously authorized payment, partially or in full depending on the provider."
 ---
 
 <Warning>

--- a/reference/payments/disputes.mdx
+++ b/reference/payments/disputes.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Dispute a Chargeback"
 openapi: "/openapi/payments/disputes.json POST /payments/{payment_id}/transactions/{transaction_id}/dispute"
+description: "Submits chargeback dispute evidence for Yuno to forward to the issuer for processing."
 ---
 
 This request enables clients to [submit dispute documentation for chargeback management](/docs/chargeback-management), allowing Yuno to forward these documents to the appropriate issuers for processing.

--- a/reference/payments/manage-payments.mdx
+++ b/reference/payments/manage-payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payments"
+description: "Overview of the Payments API, covering endpoints, status handling, and integration workflows."
 ---
 
 

--- a/reference/payments/notify-fulfillments.mdx
+++ b/reference/payments/notify-fulfillments.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Notify Fulfillment"
 openapi: "/openapi/payments/notify-fulfillments.json POST /payments/{payment_id}/fulfillments"
+description: "Adds fulfillments to an order to notify fraud prevention providers after payment."
 ---
 
 This endpoint allows you to add multiple fulfillments to an order to notify fraud prevention providers. Any fulfillments provided will be appended to the ones that already exist.

--- a/reference/payments/payment-examples/bank-transfer.mdx
+++ b/reference/payments/payment-examples/bank-transfer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bank Transfer"
+description: "Request and response examples for creating bank transfer payments across supported providers."
 ---
 
 This page presents examples of requests and responses for creating Bank Transfer payments using the [Create Payment](/reference/create-payment) endpoint.

--- a/reference/payments/payment-examples/bnpl.mdx
+++ b/reference/payments/payment-examples/bnpl.mdx
@@ -1,5 +1,6 @@
 ---
 title: "BNPL"
+description: "Request and response examples for creating buy now pay later payments via redirect."
 ---
 
 This page presents examples of requests and responses for creating BNPL payments using the [Create Payment](/reference/create-payment) endpoint with the REDIRECT workflow for back-to-back integrations.

--- a/reference/payments/payment-examples/cards.mdx
+++ b/reference/payments/payment-examples/cards.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cards"
+description: "Request and response examples for creating card payments and authorizations across common scenarios."
 ---
 
 

--- a/reference/payments/payment-examples/index.mdx
+++ b/reference/payments/payment-examples/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Examples"
+description: "Explains payment method scenarios requiring extra customer information within the SDK checkout workflow."
 ---
 
 When using [Yuno's SDK](/docs/sdks/full-checkout/web-payments), we take care of every particular scenario any payment method could have. Once the customer selects the payment method and chooses to pay, if there is any extra information needed to process the payment (besides the one that you shared with us in the integration), we will display a form asking the customer for that particular information needed. A few examples of these scenarios could be:

--- a/reference/payments/payment-examples/payment-link.mdx
+++ b/reference/payments/payment-examples/payment-link.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Link"
+description: "Request and response examples for creating payments using payment link providers."
 ---
 
 

--- a/reference/payments/payment-examples/ticket.mdx
+++ b/reference/payments/payment-examples/ticket.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ticket"
+description: "Request and response examples for creating payments using ticket payment methods."
 ---
 
 

--- a/reference/payments/payment-examples/wallet.mdx
+++ b/reference/payments/payment-examples/wallet.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wallet"
+description: "Request and response examples for creating payments using wallet payment providers."
 ---
 
 

--- a/reference/payments/refund-payment.mdx
+++ b/reference/payments/refund-payment.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Refund Payment"
 openapi: "/openapi/payments/refund-payment.json POST /payments/{id}/transactions/{transaction_id}/refund"
+description: "Issues a partial or full refund for an existing payment transaction."
 ---
 
 <Warning>

--- a/reference/payments/retrieve-issuers.mdx
+++ b/reference/payments/retrieve-issuers.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Issuers"
 openapi: "/openapi/payments/retrieve-issuers.json GET /issuers"
+description: "Retrieves the list of issuers that support a specific payment method."
 ---
 
 This endpoint retrieves a list of all issuers that support the specific payment method. It allows you to filter issuers based on their compatibility with a particular payment method.

--- a/reference/payments/retrieve-payment-by-id-v2.mdx
+++ b/reference/payments/retrieve-payment-by-id-v2.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payment by ID"
 openapi: "/openapi/payments/retrieve-payment-by-id-v2.json GET /payments/{payment_id}"
+description: "Retrieves payment details using the payment ID provided in the request path."
 ---
 
 This request enables you to retrieve details of payments based on their `id`,  which needs to be provided in the request path.

--- a/reference/payments/retrieve-payment-by-id.mdx
+++ b/reference/payments/retrieve-payment-by-id.mdx
@@ -2,6 +2,7 @@
 title: "Retrieve Payment by ID"
 openapi: "/openapi/payments/retrieve-payment-by-id.json GET /payments/{payment_id}"
 hidden: true
+description: "Retrieves payment details using the payment ID provided in the request path."
 ---
 
 This request enables you to retrieve details of payments based on their `id`,  which needs to be provided in the request path.

--- a/reference/payments/retrieve-payment-by-merchant-order-id.mdx
+++ b/reference/payments/retrieve-payment-by-merchant-order-id.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payment by Merchant Order ID"
 openapi: "/openapi/payments/retrieve-payment-by-merchant-order-id.json GET /payments"
+description: "Retrieves payment details using the merchant order ID provided in the request."
 ---
 
 This request enables you to retrieve details of payments based on their `merchant_order_id`,  which needs to be provided in the request path.

--- a/reference/payments/status-and-response-codes/merchant-advice-codes-mac.mdx
+++ b/reference/payments/status-and-response-codes/merchant-advice-codes-mac.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Merchant Advice Codes (MAC)"
+description: "Maps normalized merchant advice codes to network equivalents to guide retry decisions."
 ---
 
 When a transaction is declined, Merchant Advice Codes (MACs) provide clear guidance on whether and when a retry is appropriate. To support transparency and informed decision-making, Yuno’s public APIs include both normalized and raw response codes. By understanding MACs, merchants can quickly identify the reason for a decline and determine the best actions to take, such as updating routing or customer information before attempting a retry.

--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment Status and Response Codes"
+description: "Lists payment statuses, substatuses, and their corresponding transaction states and descriptions."
 ---
 
 import { HTMLBlock } from "/snippets/HTMLBlock.jsx";

--- a/reference/payments/status-and-response-codes/transaction.mdx
+++ b/reference/payments/status-and-response-codes/transaction.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transaction Status and Response Codes"
+description: "Lists transaction types, response codes, and their descriptions for processed transactions."
 ---
 
 

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Payment Object"
+description: "Reference for the payment object fields returned after creating a checkout session."
 ---
 
 

--- a/reference/payments/update-dispute.mdx
+++ b/reference/payments/update-dispute.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update a Chargeback Dispute"
 openapi: "/openapi/payments/update-dispute.json PATCH /payments/{payment_id}/transactions/{transaction_id}/dispute"
+description: "Updates an existing chargeback dispute with additional evidence or status information."
 ---
 
 This endpoint allows you to add additional evidence to an existing dispute after it has been submitted. Use this endpoint when you need to provide supplementary documentation to support your dispute case.

--- a/reference/payouts/create-payout.mdx
+++ b/reference/payouts/create-payout.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Payout"
 openapi: "/openapi/payouts/create-payout.json POST /payouts"
+description: "Creates a payout to transfer funds from your account to a recipient"
 ---
 
 This request allows you to create a payout to transfer funds from your account to another account or recipient.

--- a/reference/payouts/payout-workflow.mdx
+++ b/reference/payouts/payout-workflow.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payout Status"
+description: "Explains the payout state machine and the status and response codes it can return"
 ---
 
 This page provides an overview of the payout process on Yuno, along with a detailed workflow and corresponding status information. Each status represents a specific stage in the payout process, from creation to completion or cancellation. You can always refer to the [transaction details](/reference/transaction) for more details about the order and the payment interactions.

--- a/reference/payouts/retrieve-payout-by-id.mdx
+++ b/reference/payouts/retrieve-payout-by-id.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payout by ID"
 openapi: "/openapi/payouts/retrieve-payout-by-id.json GET /payouts/{payout_id}"
+description: "Retrieves the details of a payout using its unique ID"
 ---
 
 This request enables you to retrieve details of a payout based on their `id`, which needs to be provided in the request path.

--- a/reference/payouts/retrieve-payout-by-merchant-reference.mdx
+++ b/reference/payouts/retrieve-payout-by-merchant-reference.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve Payout by Merchant Reference"
 openapi: "/openapi/payouts/retrieve-payout-by-merchant-reference.json GET /payouts"
+description: "Retrieves the details of a payout using its merchant reference"
 ---
 
 This request enables you to retrieve details of a payout based on the  `merchant_reference`, which needs to be provided as a query param.

--- a/reference/payouts/the-payout-object.mdx
+++ b/reference/payouts/the-payout-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Payout Object"
+description: "Describes the payout object's attributes, including beneficiary, withdrawal method, and transactions"
 ---
 
 

--- a/reference/pci-proxy/destination-status.mdx
+++ b/reference/pci-proxy/destination-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Destination Status"
+description: "Explains the enabled, disabled, and removed states of a PCI Proxy allowlist destination"
 ---
 
 Every host on your PCI Proxy [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) has a status that controls whether the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) may send card data to it. A destination is created in the `ENABLED` state and can be toggled without losing its configuration or audit history. Only `ENABLED` destinations are reachable — a request to a `DISABLED` (or removed) host is rejected with `403 DESTINATION_NOT_ALLOWED`.

--- a/reference/purposes-list.mdx
+++ b/reference/purposes-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Purposes List"
+description: "Lists the enum values used to identify the reason for a payout"
 ---
 
 On this page, you will find the purposes list available on the Yuno system. The purpose information is used to identify the reason for the payout. The below table provides all ENUM accepted for the payout purpose.

--- a/reference/recipients-for-marketplace/block-recipient.mdx
+++ b/reference/recipients-for-marketplace/block-recipient.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Block Onboarding"
 openapi: "/openapi/recipients-for-marketplace/block-recipient.json POST /recipients/{recipient_id}/onboardings/{onboarding_id}/block"
+description: "Block a recipient's onboarding to temporarily prevent payouts for compliance or risk review"
 ---
 
 Blocks a recipient. This prevents the recipient from receiving payments until unblocked.

--- a/reference/recipients-for-marketplace/cancel-recipient.mdx
+++ b/reference/recipients-for-marketplace/cancel-recipient.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel Onboarding"
 openapi: "/openapi/recipients-for-marketplace/cancel-recipient.json POST /recipients/{recipient_id}/onboardings/{onboarding_id}/cancel"
+description: "Cancel a recipient's onboarding before it completes with a provider"
 ---
 
 Cancels a recipient. This action can be undone by unblocking the recipient.

--- a/reference/recipients-for-marketplace/continue-onboarding.mdx
+++ b/reference/recipients-for-marketplace/continue-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Continue Onboarding"
 openapi: "/openapi/recipients-for-marketplace/continue-onboarding.json POST /recipients/{recipient_id}/onboardings/{onboarding_id}/continue"
+description: "Resume a recipient's onboarding after providing additional required data or documentation"
 ---
 
 Continues the onboarding process for a recipient. This endpoint is used for two-step onboarding flows to execute the KYC step after account creation.

--- a/reference/recipients-for-marketplace/create-onboarding.mdx
+++ b/reference/recipients-for-marketplace/create-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Onboarding"
 openapi: "/openapi/recipients-for-marketplace/create-onboarding.json POST /recipients/{recipient_id}/onboardings"
+description: "Start a new onboarding to register a recipient with a payment provider for split payouts"
 ---
 
 Creates an onboarding for a recipient.

--- a/reference/recipients-for-marketplace/create-recipient-1.mdx
+++ b/reference/recipients-for-marketplace/create-recipient-1.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Recipient"
 openapi: "/openapi/recipients-for-marketplace/create-recipient-1.json POST /recipients"
+description: "Create a recipient to receive funds from split payments in a marketplace"
 ---
 
 Creates  a new recipient for split payment scenarios. This endpoint allows merchants to define recipients that can receive portions of payments in marketplace or split payment models.

--- a/reference/recipients-for-marketplace/delete-recipient.mdx
+++ b/reference/recipients-for-marketplace/delete-recipient.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Recipient"
 openapi: "/openapi/recipients-for-marketplace/delete-recipient.json DELETE /recipients/{recipient_id}"
+description: "Permanently delete a recipient and its associated onboarding records"
 ---
 
 Deletes a recipient. This action cannot be undone.

--- a/reference/recipients-for-marketplace/get-onboarding.mdx
+++ b/reference/recipients-for-marketplace/get-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Onboarding"
 openapi: "/openapi/recipients-for-marketplace/get-onboarding.json GET /recipients/{recipient_id}/onboardings/{onboarding_id}"
+description: "Retrieve the current status and details of a specific recipient onboarding"
 ---
 
 Retrieves detailed information about a specific onboarding for a recipient.

--- a/reference/recipients-for-marketplace/get-recipient.mdx
+++ b/reference/recipients-for-marketplace/get-recipient.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Recipient"
 openapi: "/openapi/recipients-for-marketplace/get-recipient.json GET /recipients/{recipient_id}"
+description: "Retrieve the details of a specific recipient by its unique identifier"
 ---
 
 Retrieves detailed information about a specific recipient.

--- a/reference/recipients-for-marketplace/get-transfers/get-transfer-by-id.mdx
+++ b/reference/recipients-for-marketplace/get-transfers/get-transfer-by-id.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Transfer by ID"
 openapi: "/openapi/recipients-for-marketplace/get-transfers/get-transfer-by-id.json GET /transfers/{transfer_id}"
+description: "Retrieve the details and status of a specific transfer by its identifier"
 ---
 
 Retrieve a single transfer using its `transfer_id`.

--- a/reference/recipients-for-marketplace/get-transfers/index.mdx
+++ b/reference/recipients-for-marketplace/get-transfers/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Get Transfers"
+description: "Explain common use cases and error codes for tracking recipient and onboarding transfers"
 ---
 
 ## Use cases

--- a/reference/recipients-for-marketplace/get-transfers/list-onboarding-transfers.mdx
+++ b/reference/recipients-for-marketplace/get-transfers/list-onboarding-transfers.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Onboarding Transfers"
 openapi: "/openapi/recipients-for-marketplace/get-transfers/list-onboarding-transfers.json GET /onboardings/{onboarding_id}/transfers"
+description: "Retrieve the transfer history associated with a specific onboarding"
 ---
 
 View all transfers associated with a specific onboarding. Useful to track the complete transfer chain, including reversals.

--- a/reference/recipients-for-marketplace/get-transfers/list-recipient-transfers.mdx
+++ b/reference/recipients-for-marketplace/get-transfers/list-recipient-transfers.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Recipient Transfers"
 openapi: "/openapi/recipients-for-marketplace/get-transfers/list-recipient-transfers.json GET /recipients/{recipient_id}/transfers"
+description: "Retrieve the transfer history associated with a specific recipient"
 ---
 
 List all recipient transfers using the `recipient_id`.

--- a/reference/recipients-for-marketplace/list-recipients.mdx
+++ b/reference/recipients-for-marketplace/list-recipients.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List Recipients"
 openapi: "/openapi/recipients-for-marketplace/list-recipients.json GET /recipients"
+description: "Retrieve a list of recipients registered in the marketplace"
 ---
 
 Retrieves a list of recipients for the authenticated account. Supports pagination and filtering.

--- a/reference/recipients-for-marketplace/onboarding-statuses-and-response-codes.mdx
+++ b/reference/recipients-for-marketplace/onboarding-statuses-and-response-codes.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Onboarding Statuses"
+description: "Reference the possible onboarding statuses and the actions required for each one"
 ---
 
 Onboarding tracks the lifecycle of recipient (submerchant) registration with providers for split payments. Use the onboarding `status` to understand where a recipient is in the process and whether any action is required.

--- a/reference/recipients-for-marketplace/request-a-transfer.mdx
+++ b/reference/recipients-for-marketplace/request-a-transfer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Request a Transfer"
 openapi: "/openapi/recipients-for-marketplace/request-a-transfer.json POST /payments/{payment_id}/transactions/{transaction_id}/split-marketplace/transfer-reversal"
+description: "Reverse a split transfer between recipients for a specific payment transaction"
 ---
 
 Enables marketplaces using Yuno Split Payments to request a transfer based on an existing payment. Request a transfer for a specified amount to one of the recipients participating in the split.

--- a/reference/recipients-for-marketplace/reverse-onboarding.mdx
+++ b/reference/recipients-for-marketplace/reverse-onboarding.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Reverse Transfer Onboarding"
 openapi: "/openapi/recipients-for-marketplace/reverse-onboarding.json POST /recipients/onboardings/reverse-transfer/{transfer_id}"
+description: "Reverse a completed onboarding transfer back to its original recipient"
 ---

--- a/reference/recipients-for-marketplace/the-recipient-object.mdx
+++ b/reference/recipients-for-marketplace/the-recipient-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Recipient Object"
+description: "Reference the recipient object's attributes, including onboardings, bank details, and documentation"
 ---
 
 

--- a/reference/recipients-for-marketplace/transfer-onboarding.mdx
+++ b/reference/recipients-for-marketplace/transfer-onboarding.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Transfer Onboarding"
 openapi: "/openapi/recipients-for-marketplace/transfer-onboarding.json POST /recipients/{recipient_id}/onboardings/{onboarding_id}/transfer"
+description: "Transfer a recipient's onboarding and its associated provider connection to another recipient"
 ---

--- a/reference/recipients-for-marketplace/unblock-recipient.mdx
+++ b/reference/recipients-for-marketplace/unblock-recipient.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Unblock Onboarding"
 openapi: "/openapi/recipients-for-marketplace/unblock-recipient.json POST /recipients/{recipient_id}/onboardings/{onboarding_id}/unblock"
+description: "Unblock a previously blocked recipient onboarding to resume payouts"
 ---
 
 Unblocks a recipient. This allows the recipient to receive payments again.

--- a/reference/recipients-for-marketplace/update-onboarding.mdx
+++ b/reference/recipients-for-marketplace/update-onboarding.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Onboarding"
 openapi: "/openapi/recipients-for-marketplace/update-onboarding.json PATCH /recipients/{recipient_id}/onboardings/{onboarding_id}"
+description: "Update the data or documentation of an existing recipient onboarding"
 ---
 
 Updates an existing onboarding for a recipient. Only specified fields will be updated.

--- a/reference/recipients-for-marketplace/update-recipient-1.mdx
+++ b/reference/recipients-for-marketplace/update-recipient-1.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Recipient"
 openapi: "/openapi/recipients-for-marketplace/update-recipient-1.json PATCH /recipients/{recipient_id}"
+description: "Update the details of an existing recipient"
 ---
 
 Updates an existing recipient. Only specified fields will be updated.

--- a/reference/reference-lists.mdx
+++ b/reference/reference-lists.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reference"
+description: "Indexes all reference lists for enums, payment methods, countries, and other Yuno API data"
 ---
 
 Discover a comprehensive collection of essential data the Yuno API utilizes on this page. Effortlessly access the following categories through the provided links:

--- a/reference/reports/create-a-report.mdx
+++ b/reference/reports/create-a-report.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create a Report"
 openapi: "/openapi/reports/create-a-report.json POST /reports"
+description: "Requests generation of a payment, transaction, or settlement report and returns its ID and status."
 ---
 
 This endpoint allows you to request the generation of specific report types. The response from this endpoint provides an object containing:

--- a/reference/reports/download-a-report.mdx
+++ b/reference/reports/download-a-report.mdx
@@ -2,6 +2,7 @@
 title: "Download a Report"
 openapi: "/openapi/reports/download-a-report.json GET /reports/{report_id}/download
 "
+description: "Retrieves the download link for a generated report using its report ID."
 ---
 
 <Warning>

--- a/reference/reports/list-all-reports.mdx
+++ b/reference/reports/list-all-reports.mdx
@@ -1,6 +1,7 @@
 ---
 title: "List All Reports"
 openapi: "/openapi/reports/list-all-reports.json GET /reports/list"
+description: "Lists all generated reports sorted by creation date, most recent first."
 ---
 
 This request can be used to list all reports. The list of objects is sorted in descending order by creation date, with the most recently created object appearing first.

--- a/reference/reports/report-status.mdx
+++ b/reference/reports/report-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Report Status"
+description: "Explains the report lifecycle statuses from generation through download or expiration."
 ---
 
 ## Workflow

--- a/reference/reports/reports-fields.mdx
+++ b/reference/reports/reports-fields.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Reports Fields"
+description: "Documents every field available across Yuno's payment, transaction, and reconciliation report types."
 ---
 
 In this section, you can find all report types and related fields available when generating your reports. Take into account the description of the fields, where you can find the origin of the data and its availability.

--- a/reference/reports/retrieve-a-report.mdx
+++ b/reference/reports/retrieve-a-report.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retrieve a Report"
 openapi: "/openapi/reports/retrieve-a-report.json GET /reports/{report_id}"
+description: "Retrieves the details of a specific report using its report ID."
 ---
 
 This request enables you to retrieve details of a report based on their `id`, which needs to be provided in the request path.

--- a/reference/reports/the-reports-object.mdx
+++ b/reference/reports/the-reports-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Reports Object"
+description: "Documents the reports object's attributes, including type, date range, and status fields."
 ---
 
 

--- a/reference/sellers/create-seller.mdx
+++ b/reference/sellers/create-seller.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Seller"
 openapi: "/openapi/sellers/sellers-api.json POST /sellers"
+description: "Creates a franchise seller mapping tied to a merchant account"
 ---
 
 Creates a new franchise seller mapping. A seller is created under a specific `account_code`, but is available organization-wide.

--- a/reference/sellers/delete-seller.mdx
+++ b/reference/sellers/delete-seller.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Delete Seller"
 openapi: "/openapi/sellers/sellers-api.json DELETE /sellers/{merchant_seller_id}"
+description: "Soft deletes a franchise seller mapping and its associated payment method data"
 ---
 
 Soft-deletes a franchise seller mapping and all associated payment method data.

--- a/reference/sellers/get-seller.mdx
+++ b/reference/sellers/get-seller.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Seller"
 openapi: "/openapi/sellers/sellers-api.json GET /sellers/{merchant_seller_id}"
+description: "Retrieves a franchise seller mapping by the merchant's seller identifier"
 ---
 
 Retrieves a franchise seller mapping by the merchant's own identifier (`merchant_seller_id`).

--- a/reference/sellers/update-seller.mdx
+++ b/reference/sellers/update-seller.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Seller"
 openapi: "/openapi/sellers/sellers-api.json PUT /sellers/{merchant_seller_id}"
+description: "Fully replaces a seller's details and payment method configurations"
 ---
 
 Fully replaces the seller details and payment method configurations for a given seller.

--- a/reference/shipping-reference.mdx
+++ b/reference/shipping-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Shipping Reference"
+description: "Lists supported shipping types and carriers for Yuno API integrations"
 ---
 
 On this page, you will find shipping information you may need when using Yuno API endpoints. It covers types and carriers. Use this page to understand and have access to standard values for each information category.

--- a/reference/subscriptions/cancel-subscription.mdx
+++ b/reference/subscriptions/cancel-subscription.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cancel Subscription"
 openapi: "/openapi/subscriptions/cancel-subscription.json POST /subscriptions/{subscription_id}/cancel"
+description: "Cancels a subscription permanently, changing its status to CANCELED with no reversal."
 ---
 
 Calling this endpoint will cancel a subscription, changing its `status` to CANCELED. This change cannot be reverted back, being a final point for the respective subscription.

--- a/reference/subscriptions/create-subscription.mdx
+++ b/reference/subscriptions/create-subscription.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Subscription"
 openapi: "/openapi/subscriptions/create-subscription.json POST /subscriptions"
+description: "Creates a recurring subscription plan with billing cycles, trial periods, and stored payment credentials."
 ---
 
 <Warning>

--- a/reference/subscriptions/pause-subscription.mdx
+++ b/reference/subscriptions/pause-subscription.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Pause Subscription"
 openapi: "/openapi/subscriptions/pause-subscription.json POST /subscriptions/{subscription_id}/pause"
+description: "Pauses an active subscription, allowing it to later resume or be canceled."
 ---
 
 Calling this endpoint will change the subscription `status` to PAUSED. This status can be changed to ACTIVE or CANCELED.

--- a/reference/subscriptions/resume-subscription.mdx
+++ b/reference/subscriptions/resume-subscription.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Resume Subscription"
 openapi: "/openapi/subscriptions/resume-subscription.json POST /subscriptions/{subscription_id}/resume"
+description: "Reactivates a paused subscription, changing its status back to ACTIVE."
 ---
 
 Calling this endpoint will reactivate a subscription. It will change a subscription with PAUSED `status` to ACTIVE once again.

--- a/reference/subscriptions/retrieve-subscription.mdx
+++ b/reference/subscriptions/retrieve-subscription.mdx
@@ -1,4 +1,5 @@
 ---
 title: "Retrieve Subscription"
 openapi: "/openapi/subscriptions/retrieve-subscription.json GET /subscriptions/{subscription_id}"
+description: "Retrieves the details of a specific subscription by its ID."
 ---

--- a/reference/subscriptions/retry-subscription.mdx
+++ b/reference/subscriptions/retry-subscription.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Retry Subscription"
 openapi: "/openapi/subscriptions/retry-subscription.json POST /subscriptions/{id}/retry"
+description: "Manually retries a subscription's most recent declined payment for the current billing cycle."
 ---
 
 Use this endpoint to manually retry the most recent failed payment of a subscription. This is useful when a customer updates their payment method or resolves a payment issue (e.g., insufficient funds, expired card) mid-billing cycle, since subscription updates only take effect starting from the next billing cycle. Calling this endpoint forces a new charge attempt for the current cycle using the latest subscription configuration.

--- a/reference/subscriptions/status-subscriptions.mdx
+++ b/reference/subscriptions/status-subscriptions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Subscription Status"
+description: "Explains the subscription lifecycle statuses: active, paused, completed, canceled, and error."
 ---
 
 With Yuno, managing subscriptions becomes seamless – no additional websites or applications are required. Our intuitive subscription management system enables you to create, pause, resume, and cancel subscriptions.

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The Subscription Object"
+description: "Documents the subscription object's attributes, including billing cycles, frequency, and payment method."
 ---
 
 ## Attributes

--- a/reference/subscriptions/update-subscription.mdx
+++ b/reference/subscriptions/update-subscription.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Update Subscription"
 openapi: "/openapi/subscriptions/update-subscription.json PATCH /subscriptions/{id}"
+description: "Updates a subscription's fields, including retroactively adding stored credential usage data."
 ---
 
 <Warning>

--- a/reference/transaction-category-list.mdx
+++ b/reference/transaction-category-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transaction Category"
+description: "Lists the transaction categories Yuno uses to group payment methods"
 ---
 
 Yuno organizes the available payment methods into distinct transaction categories. On this page, you will find all transaction categories used on the Yuno API and their descriptions. Note that every payment method is associated with one of these transaction categories.

--- a/reference/transfers/create-standalone-transfer.mdx
+++ b/reference/transfers/create-standalone-transfer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Create Standalone Transfer"
 openapi: "/openapi/transfers/create-standalone-transfer.json POST /split-marketplace/transfers"
+description: "Creates a forward transfer distributing organization balance funds to recipients"
 ---
 
 Create a forward transfer to distribute funds from your organization balance to your recipients independently of a payment.

--- a/reference/transfers/get-standalone-transfer.mdx
+++ b/reference/transfers/get-standalone-transfer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Get Standalone Transfer"
 openapi: "/openapi/transfers/get-standalone-transfer.json GET /split-marketplace/transfers/{transfer_id}"
+description: "Retrieves the status, provider information, and metadata for a standalone transfer"
 ---
 
 Retrieve the current status, provider information, and metadata for a specific transfer using its unique ID.

--- a/reference/transfers/reverse-standalone-transfer.mdx
+++ b/reference/transfers/reverse-standalone-transfer.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Reverse Standalone Transfer"
 openapi: "/openapi/transfers/reverse-standalone-transfer.json POST /split-marketplace/transfers/{transfer_id}/reverse"
+description: "Fully or partially reverses a succeeded standalone forward transfer"
 ---
 
 Reverse a specific standalone transfer. This endpoint allows you to fully or partially reverse a SUCCEEDED forward transfer.

--- a/scripts/check-descriptions.cjs
+++ b/scripts/check-descriptions.cjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Fail if any docs.json navigation page lacks a `description:` frontmatter field.
+ *
+ * Mintlify builds each line of the auto-generated llms.txt from a page's
+ * `description`. Missing descriptions produce bare, low-signal index entries
+ * that are hard for AI agents and RAG tools to navigate. This check keeps every
+ * navigable page self-describing.
+ *
+ * Usage: node scripts/check-descriptions.cjs
+ * Exit 0 when every nav page has a non-empty description, 1 otherwise.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const repo = path.resolve(__dirname, "..");
+
+function navSlugs(node, out) {
+  if (Array.isArray(node)) {
+    for (const item of node) navSlugs(item, out);
+  } else if (node && typeof node === "object") {
+    for (const value of Object.values(node)) navSlugs(value, out);
+  } else if (typeof node === "string" && node.includes("/") && !node.startsWith("http")) {
+    out.push(node);
+  }
+}
+
+function hasDescription(file) {
+  const text = fs.readFileSync(file, "utf8");
+  const fm = text.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+  return Boolean(fm && /^description:\s*\S/m.test(fm[1]));
+}
+
+const docs = JSON.parse(fs.readFileSync(path.join(repo, "docs.json"), "utf8"));
+const slugs = [];
+navSlugs(docs.navigation || {}, slugs);
+const unique = [...new Set(slugs)];
+
+const missing = [];
+for (const slug of unique) {
+  const rel = slug === "index" ? "index.mdx" : `${slug}.mdx`;
+  const file = path.join(repo, rel);
+  if (!fs.existsSync(file)) missing.push(`${rel} (file not found)`);
+  else if (!hasDescription(file)) missing.push(rel);
+}
+
+if (missing.length) {
+  console.error(`❌ ${missing.length} of ${unique.length} nav pages lack a description:`);
+  for (const rel of missing) console.error(`   - ${rel}`);
+  console.error("\nAdd a `description:` field to each page's frontmatter.");
+  process.exit(1);
+}
+
+console.log(`✅ All ${unique.length} nav pages have a description.`);


### PR DESCRIPTION
Make docs.y.uno maximally usable by AI agents and RAG tools.

1. Most nav pages lacked a `description:` frontmatter, so `llms.txt` emitted title-only
   entries with no real context per page.
2. `/auth.md` was missing, so agents had no single place to find auth requirements.

## What this PR does

**1. Page descriptions** → every `docs.json` nav page gets a `description:` frontmatter line.
Sentence case, ~8-18 words, Yuno terminology (checkout session, payment method, provider,
Dashboard, sandbox, merchant; no `account_code`).

**2. CI description lint** (`scripts/check-descriptions.cjs` +
`.github/workflows/description-lint.yml`) — fails the build if any nav page is missing a
description, so this doesn't regress.

**3. `auth.md`** — agent authentication discovery file, served by Mintlify at
`https://docs.y.uno/auth.md`. Covers REST API key headers, sandbox/production base URLs,
idempotency, and how to authenticate against the local and remote MCP server.

## Notes

- Only `.mdx` frontmatter changed + 1 new file (`auth.md`). No unrelated content/body edits.