### PR TITLE
docs(reference): keep response-code enums on one line

### DIFF
--- a/reference/getting-started/response-codes.mdx
+++ b/reference/getting-started/response-codes.mdx
@@ -25,6 +25,8 @@ Codes in the 2xx range usually indicate success. Codes in the 4xx range indicate
 
 See what codes are returned by Yuno's Rest API.
 
+<div className="code-nowrap-table">
+
 | HTTP Status Code          | Code                            | Description                                                                                                                                                                                        |
 | :------------------------ | :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 400 Bad Request           | `INVALID_REQUEST`               | Invalid request.                                                                                                                                                                                   |
@@ -74,3 +76,5 @@ See what codes are returned by Yuno's Rest API.
 | 405 Method not allowed    | `UNSUPPORTED_METHOD`            | Method not supported.                                                                                                                                                                              |
 | 500 Internal Server Error | `INTERNAL_ERROR`                | Internal error.                                                                                                                                                                                    |
 | 504 Gateway Timeout       | `REQUEST_TIMEOUT`               | Request Timeout.                                                                                                                                                                                   |
+
+</div>

--- a/style.css
+++ b/style.css
@@ -297,6 +297,13 @@ html.dark .status-secondary {
   min-width: 110px;
 }
 
+/* Enum/code tables — opt-in via .code-nowrap-table wrapper. Keeps code chips
+   on one line so the code column gets its full width and the prose columns
+   wrap instead (e.g. the response-codes table). */
+.code-nowrap-table td code {
+  white-space: nowrap;
+}
+
 
 /* === API Reference: shift code rail (cURL + response) toward the content === */
 /* Maple theme by default anchors the code panel to the right edge of the viewport,


### PR DESCRIPTION
## Summary

On [/reference/getting-started/response-codes](https://docs.y.uno/reference/getting-started/response-codes), the long Description texts squeeze the **Code** column, wrapping enum names like `PAYMENT_METHOD_STATUS_INVALID` mid-identifier.

## Fix

- New opt-in `.code-nowrap-table` wrapper class in `style.css` (3 lines): code chips inside the wrapped table don't wrap, so the auto table layout gives the Code column its full content width and the Description column wraps instead.
- Wrapped the response-codes table in `<div className="code-nowrap-table">`.

Follows the same opt-in wrapper convention as the existing `.payment-status-table` / `.mdx-card-tiles` classes, and is reusable for other enum tables in the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)