### PR TITLE
fix(docs.json): correct legacy headless SDK redirects for Android and iOS

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3352,11 +3352,11 @@
     },
     {
       "source": "/docs/headless-sdk-enrollment-android",
-      "destination": "/docs/sdks/card-enrollment/android-enrollment"
+      "destination": "/docs/sdks/headless-android/enrollment"
     },
     {
       "source": "/docs/headless-sdk-payment-android",
-      "destination": "/docs/sdks/full-checkout/android-payments"
+      "destination": "/docs/sdks/headless-android/checkout"
     },
     {
       "source": "/docs/haiti-connections",
@@ -3376,11 +3376,11 @@
     },
     {
       "source": "/docs/headless-sdk-enrollment-ios",
-      "destination": "/docs/sdks/card-enrollment/ios-enrollment"
+      "destination": "/docs/sdks/headless-ios/enrollment"
     },
     {
       "source": "/docs/headless-sdk-payment-ios",
-      "destination": "/docs/sdks/full-checkout/ios-payments"
+      "destination": "/docs/sdks/headless-ios/checkout"
     },
     {
       "source": "/docs/heard-island-and-mcdonald-islands",


### PR DESCRIPTION
## Summary
- Fixes 4 legacy redirects in `docs.json` that pointed to the wrong page (full-checkout / card-enrollment instead of the actual headless SDK pages):
  - `/docs/headless-sdk-enrollment-android` → now points to `/docs/sdks/headless-android/enrollment` (was `/docs/sdks/card-enrollment/android-enrollment`)
  - `/docs/headless-sdk-payment-android` → now points to `/docs/sdks/headless-android/checkout` (was `/docs/sdks/full-checkout/android-payments`)
  - `/docs/headless-sdk-enrollment-ios` → now points to `/docs/sdks/headless-ios/enrollment` (was `/docs/sdks/card-enrollment/ios-enrollment`)
  - `/docs/headless-sdk-payment-ios` → now points to `/docs/sdks/headless-ios/checkout` (was `/docs/sdks/full-checkout/ios-payments`)

## Context
Reported by Pedro Scarapicchia Junior (supporting merchant Turbi) as a missing Android headless enrollment doc. Investigation found the headless Android page already exists and is correctly published in the nav, the actual bug was this legacy redirect misrouting to the full-checkout page. Same bug found on the iOS enrollment/payment redirects, fixed in the same PR since it's the identical root cause. Web has no equivalent legacy redirects, unaffected.

## Files changed
- `docs.json` (4 redirect entries corrected, no nav structure changes, no new pages)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation redirect-only change with no runtime or API impact; slightly improves accuracy for merchants following old links.
> 
> **Overview**
> **Fixes four legacy URL redirects** in `docs.json` so old headless SDK paths land on the **Headless SDK** Android/iOS docs instead of **full-checkout** or **card-enrollment** pages.
> 
> Android: `/docs/headless-sdk-enrollment-android` and `/docs/headless-sdk-payment-android` now target `/docs/sdks/headless-android/enrollment` and `/docs/sdks/headless-android/checkout`. iOS enrollment and payment legacy URLs are updated the same way under `headless-ios`. No nav or new pages—redirect destinations only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5713e142901d4cb21eb1bde0fc70956155625df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->