### PR TITLE
docs(reference): keep transaction response_code enums on one line

### DIFF
--- a/reference/payments/status-and-response-codes/transaction.mdx
+++ b/reference/payments/status-and-response-codes/transaction.mdx
@@ -50,11 +50,15 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>SUCCEEDED</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `SUCCEEDED` | Transaction successful | N/A | 0,8,10,11,16,32 |
 | `FRAUD_VERIFIED` | Transaction verified by fraud provider | N/A | - |
 | `SUCCEEDED_THREE_D_SECURE` | 3DS validation successful | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -63,9 +67,13 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>WON</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `REVIEW_WON` | Acquirer rejected the chargeback | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -74,11 +82,15 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>CREATED</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `ACTION_REQUIRED` | Payment created but requires additional user action. This occurs in 3D Secure authentication flows, payment method redirections, Headless SDK flows requiring continuePayment, or async payment methods with additional steps. Check the `redirect_url` or `sdk_action_required` field for next steps. | N/A | - |
 | `SUCCEEDED` | Transaction created successfully | N/A | - |
 | `RECEIVED` | Transaction received | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -87,6 +99,8 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>PENDING</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `CHALLENGE_REQUIRED` | Transaction waiting for the challenge completion | N/A | - |
@@ -94,6 +108,8 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 | `PENDING_FRAUD_REVIEW` | Transaction is being analyzed by fraud provider | N/A | - |
 | `PENDING_PROVIDER_CONFIRMATION` | Transaction waiting confirmation | N/A | - |
 | `PENDING_REVIEW` | Transaction waiting fraud review confirmation | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -105,6 +121,8 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 
 <Accordion title={<><code>DECLINED</code> status details</>}>
+
+<div className="code-nowrap-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -168,6 +186,8 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 | `UNKNOWN_ERROR` | Unknown error | SOFT | - |
 | `USER_RESTRICTION` | Transaction not permitted for cardholder | HARD | 57 |
 
+</div>
+
 </Accordion>
 
 ### Merchant Advice Codes (MAC)
@@ -209,6 +229,8 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>REJECTED</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `COUNTRY_NOT_SUPPORTED` | - | HARD | - |
@@ -218,12 +240,16 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 | `INTERNAL_ERROR` | - | HARD | - |
 | `MISSING_PARAMETERS` | - | HARD | - |
 
+</div>
+
 </Accordion>
 
 ### Error status
 
 
 <Accordion title={<><code>ERROR</code> status details</>}>
+
+<div className="code-nowrap-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -239,6 +265,8 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 | `PROVIDER_INVALID_RESPONSE` | Invalid response | HARD | 20 |
 | `PROVIDER_INVALID_API_VERSION` | Invalid API version | HARD | - |
 
+</div>
+
 </Accordion>
 
 ### Expired status
@@ -246,9 +274,13 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>EXPIRED</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `EXPIRED_BY_PROVIDER` | - | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -257,12 +289,16 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>LOST</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `CLOSED` | - | N/A | - |
 | `EXPIRED` | - | N/A | - |
 | `PARTIALLY_CHARGEBACKED` | - | N/A | - |
 | `REVIEW_LOST` | The Chargeback dispute was lost | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -271,9 +307,13 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>PREVENTED</code> status details</>}>
 
+<div className="code-nowrap-table">
+
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
 | `PREVENTED` | Predispute deflected by provider/network. No evidence required. Terminal. | N/A | - |
+
+</div>
 
 </Accordion>
 
@@ -289,6 +329,8 @@ For more details, please refer to the [reason codes page](/docs/reason-codes) in
 
 
 <Accordion title={<><code>CREATED</code> status details</>}>
+
+<div className="code-nowrap-table">
 
 | response_code | response_message | Category | Description |
 | --- | --- | --- | --- |
@@ -316,5 +358,7 @@ For more details, please refer to the [reason codes page](/docs/reason-codes) in
 | `ORIGINAL_TRANSACTION_NOT_ACCEPTED` | Original Credit Transaction Not Accepted | Customer Disputes | The original credit was not accepted. |
 | `CASH_TRANSACTION_VALUE` | Non-Receipt of Cash or Load Transaction Value | Customer Disputes | Cardholder did not receive the full cash withdrawal at an ATM. |
 | `CUSTOMER_AGREEMENT` | Proof of customer transaction or agreement required. | Customer Disputes | The issuer asks the merchant for a copy of the receipt signed by the cardholder or any other documentation that verifies the customers agreement for the purchase. Usually to verify a card-present transaction the cardholder disputes or doesn’t recognize. |
+
+</div>
 
 </Accordion>


### PR DESCRIPTION
## Summary

On [/reference/payments/status-and-response-codes/transaction](https://docs.y.uno/reference/payments/status-and-response-codes/transaction), the `response_code` columns wrapped long enum names mid-identifier (e.g. `PENDING_PROVIDER_CONFIRMATION`, `EMV_LIABILITY_SHIFT_NOT_COUNTERFEIT`) because the Description columns squeeze them.

## Fix

Wrapped all **11** `response_code` tables (the 10 status accordions plus the chargeback-specific one) in the `.code-nowrap-table` opt-in wrapper that #584 introduced for the HTTP response codes page. Code chips stay on one line, so the auto table layout gives the enum column its full width and the prose columns wrap instead.

Purely additive diff: 11 wrapper opens + 11 closes + blank lines (MDX flow separation). No CSS changes needed — the class already exists in `style.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX markup; no API, runtime, or CSS changes.
> 
> **Overview**
> Fixes **broken line wraps** in `response_code` cells on the transaction status reference page by wrapping **11** markdown tables (10 status accordions + chargeback-specific codes) in `<div className="code-nowrap-table">`.
> 
> Long enum names like `PENDING_PROVIDER_CONFIRMATION` and chargeback codes no longer split mid-identifier; **code chips stay on one line** and description columns wrap instead. Reuses the existing opt-in CSS from the HTTP response codes page—**no new styles** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2881a41c46ba6ff18edb4795f5e1cca4ab1839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->