### PR TITLE
docs(auth): use absolute URL for the llms.txt link

### DIFF
--- a/auth.md
+++ b/auth.md
@@ -40,4 +40,4 @@ Both methods use the same API key credentials as the REST API, no separate OAuth
 
 ## Machine-readable docs
 
-Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](/llms.txt) for the full page index.
+Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](https://docs.y.uno/llms.txt) for the full page index.


### PR DESCRIPTION
## Summary

The **link-rot** check is failing on every PR since yesterday (e.g. [#586's run](https://github.com/yuno-payments/yuno-docs/pull/586/checks?check_run_id=87131529078)) with:

```
auth.md
  - llms.txt
Found 1 broken links
```

`auth.md` (added yesterday in the agent-readiness work, c6c25c82) links to `/llms.txt` with a relative URL. `/llms.txt` is auto-generated by Mintlify at serve time — it works on the live site (verified: `https://docs.y.uno/llms.txt` → 200) but is not a file in the repo, so the checker flags it as broken.

## Fix

One line: make the link absolute (`https://docs.y.uno/llms.txt`). This matches the file's other absolute links (dashboard.y.uno, mcp.prod.y.uno), which fits its purpose as an agent-discovery document read from arbitrary contexts, and unblocks the link-rot check for all open PRs once merged (they'll need a re-run/rebase to pick it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation link change with no runtime, auth, or API behavior impact.
> 
> **Overview**
> Fixes the **link-rot** CI failure on `auth.md` by changing the `llms.txt` reference from a repo-relative path (`/llms.txt`) to **`https://docs.y.uno/llms.txt`**.
> 
> Mintlify serves that index at deploy time, so it is not a tracked file and the checker treated the relative link as broken. The absolute URL matches how other external endpoints are linked in the same doc and still points agents at the live page index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c306c5a6388f2991b97460e165834b44450a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->