### PR TITLE
docs(C2-17068): add Level 2 / Level 3 order fields to payments docs

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -161,6 +161,8 @@ The next JSON object presents an example of a data structure related to a paymen
                     "shipping_amount": 0,
                     "fee_amount": null,
                     "tip_amount": null,
+                    "duty_amount": null,
+                    "date": null,
                     "items": [
                         {
                             "id": "item123",
@@ -171,7 +173,11 @@ The next JSON object presents an example of a data structure related to a paymen
                             "brand": null,
                             "sku_code": null,
                             "manufacture_part_number": null,
-                            "image_url": null
+                            "image_url": null,
+                            "unit_of_measure": null,
+                            "commodity_code": null,
+                            "total_amount": null,
+                            "gross_net_indicator": null
                         }
                     ],
                     "taxes": []
@@ -448,6 +454,8 @@ The next JSON object presents an example of a data structure related to a paymen
          "order":{
             "shipping_amount":0.0,
             "fee_amount":0.0,
+            "duty_amount":0.0,
+            "date":"2026-06-12",
             "items":[
                {
                   "id":"123AD",
@@ -458,7 +466,11 @@ The next JSON object presents an example of a data structure related to a paymen
                   "brand":"XYZ",
                   "sku_code":"8765432109",
                   "manufacture_part_number":"XYZ123456",
-                  "image_url":null
+                  "image_url":null,
+                  "unit_of_measure":"EA",
+                  "commodity_code":"31161501",
+                  "total_amount":2000.0,
+                  "gross_net_indicator":"NET"
                }
             ]
          },
@@ -682,6 +694,8 @@ The next JSON object presents an example of a data structure related to a paymen
                "shipping_amount":0.0,
                "fee_amount":0.0,
                "tip_amount":null,
+               "duty_amount":null,
+               "date":null,
                "items":[
                   {
                      "id":"26609",
@@ -692,7 +706,11 @@ The next JSON object presents an example of a data structure related to a paymen
                      "brand":null,
                      "sku_code":"26609",
                      "manufacture_part_number":null,
-                     "image_url":null
+                     "image_url":null,
+                     "unit_of_measure":null,
+                     "commodity_code":null,
+                     "total_amount":null,
+                     "gross_net_indicator":null
                   }
                ],
                "taxes":[
@@ -1173,6 +1191,8 @@ The next JSON object presents an example of a data structure related to a paymen
          "order":{
             "shipping_amount":0.0,
             "fee_amount":0.0,
+            "duty_amount":0.0,
+            "date":"2026-06-12",
             "items":[
                {
                   "id":"123AD",
@@ -1183,7 +1203,11 @@ The next JSON object presents an example of a data structure related to a paymen
                   "brand":"XYZ",
                   "sku_code":"8765432109",
                   "manufacture_part_number":"XYZ123456",
-                  "image_url":null
+                  "image_url":null,
+                  "unit_of_measure":"EA",
+                  "commodity_code":"31161501",
+                  "total_amount":2000.0,
+                  "gross_net_indicator":"NET"
                }
             ]
          },
@@ -2165,6 +2189,8 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
         "shipping_amount": 10.35,
         "fee_amount": 40.5,
         "tip_amount": null,
+        "duty_amount": null,
+        "date": "2026-06-12",
         "items": [
           {
             "id": "123AD",
@@ -2175,7 +2201,11 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
             "brand": "XYZ",
             "sku_code": "8765432109",
             "manufacture_part_number": "XYZ123456",
-            "image_url": null
+            "image_url": null,
+            "unit_of_measure": "EA",
+            "commodity_code": "31161501",
+            "total_amount": 60,
+            "gross_net_indicator": "NET"
           }
         ],
         "taxes": [],

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -88,6 +88,16 @@
                             "type": "string",
                             "description": "The tip amount of the order (multiple of 0.0001). This field is for informational purposes, the tip amount is already included in the final transaction amount and is not added separately."
                           },
+                          "duty_amount": {
+                            "type": "number",
+                            "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                            "format": "float"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                          },
                           "taxes": {
                             "type": "array",
                             "description": "The taxes of the order. This struct is for informational purposes, the taxes amount is already included in the final transaction amount and is not added separately.",
@@ -202,6 +212,27 @@
                                 "manufacture_part_number": {
                                   "type": "string",
                                   "description": "The manufacture part number of the item."
+                                },
+                                "unit_of_measure": {
+                                  "type": "string",
+                                  "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                },
+                                "commodity_code": {
+                                  "type": "string",
+                                  "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "gross_net_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether the item line amount is gross or net.",
+                                  "enum": [
+                                    "GROSS",
+                                    "NET"
+                                  ]
                                 }
                               },
                               "required": [
@@ -711,6 +742,19 @@
                                 "unit_amount": {
                                   "type": "number",
                                   "description": "The unit amount of the discount (multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "discount_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether a discount was applied to the line.",
+                                  "enum": [
+                                    "Y",
+                                    "N"
+                                  ]
+                                },
+                                "discount_rate": {
+                                  "type": "number",
+                                  "description": "The discount rate applied to the line (multiple of 0.0001).",
                                   "format": "float"
                                 }
                               },
@@ -9742,9 +9786,40 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
+                                },
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                 }
                               }
                             },

--- a/openapi/payments/capture-authorization.json
+++ b/openapi/payments/capture-authorization.json
@@ -192,6 +192,27 @@
                                 "manufacture_part_number": {
                                   "type": "string",
                                   "description": "The manufacture part number of the item"
+                                },
+                                "unit_of_measure": {
+                                  "type": "string",
+                                  "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                },
+                                "commodity_code": {
+                                  "type": "string",
+                                  "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "gross_net_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether the item line amount is gross or net.",
+                                  "enum": [
+                                    "GROSS",
+                                    "NET"
+                                  ]
                                 }
                               },
                               "required": [
@@ -202,6 +223,16 @@
                               ],
                               "type": "object"
                             }
+                          },
+                          "duty_amount": {
+                            "type": "number",
+                            "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                            "format": "float"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                           }
                         }
                       },

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -210,6 +210,16 @@
                             "type": "string",
                             "description": "The tip amount of the order (multiple of 0.0001). This field is for informational purposes, the tip amount is already included in the final transaction amount and is not added separately."
                           },
+                          "duty_amount": {
+                            "type": "number",
+                            "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                            "format": "float"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                          },
                           "taxes": {
                             "type": "array",
                             "description": "The taxes of the order. This struct is for informational purposes, the taxes amount is already included in the final transaction amount and is not added separately.",
@@ -334,6 +344,27 @@
                                   "description": "URL of the product image. Complements the existing url field, which points to the product page (MAX 512; MIN 3).",
                                   "minLength": 3,
                                   "maxLength": 512
+                                },
+                                "unit_of_measure": {
+                                  "type": "string",
+                                  "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                },
+                                "commodity_code": {
+                                  "type": "string",
+                                  "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "gross_net_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether the item line amount is gross or net.",
+                                  "enum": [
+                                    "GROSS",
+                                    "NET"
+                                  ]
                                 }
                               },
                               "required": [
@@ -867,6 +898,19 @@
                                 "unit_amount": {
                                   "type": "number",
                                   "description": "The unit amount of the discount (multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "discount_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether a discount was applied to the line.",
+                                  "enum": [
+                                    "Y",
+                                    "N"
+                                  ]
+                                },
+                                "discount_rate": {
+                                  "type": "number",
+                                  "description": "The discount rate applied to the line (multiple of 0.0001).",
                                   "format": "float"
                                 }
                               },
@@ -3593,10 +3637,16 @@
                             "name": "Skirt",
                             "quantity": 1,
                             "sku_code": "8765432109",
-                            "unit_amount": 5000
+                            "unit_amount": 5000,
+                            "unit_of_measure": "EA",
+                            "commodity_code": "31161501",
+                            "total_amount": 5000,
+                            "gross_net_indicator": "NET"
                           }
                         ],
-                        "shipping_amount": 0
+                        "shipping_amount": 0,
+                        "date": "2026-06-12",
+                        "duty_amount": 0
                       }
                     },
                     "customer_payer": {
@@ -6842,14 +6892,20 @@
                               "brand": "XYZ",
                               "sku_code": "8765432109",
                               "manufacture_part_number": "XYZ123456",
-                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg",
+                              "unit_of_measure": "EA",
+                              "commodity_code": "31161501",
+                              "total_amount": 5000,
+                              "gross_net_indicator": "NET"
                             }
                           ],
                           "account_funding": null,
                           "tickets": null,
                           "fulfillment": null,
                           "discounts": null,
-                          "sales_channel": null
+                          "sales_channel": null,
+                          "date": "2026-06-12",
+                          "duty_amount": 0
                         },
                         "seller_details": null
                       },
@@ -11225,6 +11281,16 @@
                                   "default": 0
                                 },
                                 "tip_amount": {},
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -11267,6 +11333,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
@@ -15559,6 +15646,16 @@
                                   "default": 0
                                 },
                                 "tip_amount": {},
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -15601,6 +15698,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
@@ -23069,6 +23187,16 @@
                                   "example": 50,
                                   "default": 0
                                 },
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -23111,6 +23239,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
@@ -25757,6 +25906,16 @@
                                 "fee_amount": {},
                                 "shipping_amount": {},
                                 "tip_amount": {},
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -25799,6 +25958,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -7537,9 +7537,40 @@
                                           "manufacture_part_number": {
                                             "type": "string",
                                             "example": "XYZ123456"
+                                          },
+                                          "unit_of_measure": {
+                                            "type": "string",
+                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                          },
+                                          "commodity_code": {
+                                            "type": "string",
+                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                          },
+                                          "total_amount": {
+                                            "type": "number",
+                                            "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                            "format": "float"
+                                          },
+                                          "gross_net_indicator": {
+                                            "type": "string",
+                                            "description": "Indicates whether the item line amount is gross or net.",
+                                            "enum": [
+                                              "GROSS",
+                                              "NET"
+                                            ]
                                           }
                                         }
                                       }
+                                    },
+                                    "duty_amount": {
+                                      "type": "number",
+                                      "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                      "format": "float"
+                                    },
+                                    "date": {
+                                      "type": "string",
+                                      "format": "date",
+                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                     }
                                   }
                                 },
@@ -14049,9 +14080,40 @@
                                             "type": "object",
                                             "example": null,
                                             "nullable": true
+                                          },
+                                          "unit_of_measure": {
+                                            "type": "string",
+                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                          },
+                                          "commodity_code": {
+                                            "type": "string",
+                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                          },
+                                          "total_amount": {
+                                            "type": "number",
+                                            "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                            "format": "float"
+                                          },
+                                          "gross_net_indicator": {
+                                            "type": "string",
+                                            "description": "Indicates whether the item line amount is gross or net.",
+                                            "enum": [
+                                              "GROSS",
+                                              "NET"
+                                            ]
                                           }
                                         }
                                       }
+                                    },
+                                    "duty_amount": {
+                                      "type": "number",
+                                      "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                      "format": "float"
+                                    },
+                                    "date": {
+                                      "type": "string",
+                                      "format": "date",
+                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                     }
                                   }
                                 },

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -6972,9 +6972,40 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
+                                },
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                 }
                               }
                             },

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -6685,9 +6685,40 @@
                                         "manufacture_part_number": {
                                           "type": "string",
                                           "example": "XYZ123456"
+                                        },
+                                        "unit_of_measure": {
+                                          "type": "string",
+                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        },
+                                        "commodity_code": {
+                                          "type": "string",
+                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        },
+                                        "total_amount": {
+                                          "type": "number",
+                                          "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                          "format": "float"
+                                        },
+                                        "gross_net_indicator": {
+                                          "type": "string",
+                                          "description": "Indicates whether the item line amount is gross or net.",
+                                          "enum": [
+                                            "GROSS",
+                                            "NET"
+                                          ]
                                         }
                                       }
                                     }
+                                  },
+                                  "duty_amount": {
+                                    "type": "number",
+                                    "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                    "format": "float"
+                                  },
+                                  "date": {
+                                    "type": "string",
+                                    "format": "date",
+                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                   }
                                 }
                               },
@@ -12519,9 +12550,40 @@
                                         "category": {},
                                         "brand": {},
                                         "sku_code": {},
-                                        "manufacture_part_number": {}
+                                        "manufacture_part_number": {},
+                                        "unit_of_measure": {
+                                          "type": "string",
+                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        },
+                                        "commodity_code": {
+                                          "type": "string",
+                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        },
+                                        "total_amount": {
+                                          "type": "number",
+                                          "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                          "format": "float"
+                                        },
+                                        "gross_net_indicator": {
+                                          "type": "string",
+                                          "description": "Indicates whether the item line amount is gross or net.",
+                                          "enum": [
+                                            "GROSS",
+                                            "NET"
+                                          ]
+                                        }
                                       }
                                     }
+                                  },
+                                  "duty_amount": {
+                                    "type": "number",
+                                    "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                    "format": "float"
+                                  },
+                                  "date": {
+                                    "type": "string",
+                                    "format": "date",
+                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                   }
                                 }
                               },

--- a/reference/payments/payment-examples/cards.mdx
+++ b/reference/payments/payment-examples/cards.mdx
@@ -735,6 +735,8 @@ curl --request POST \
             "fee_amount": 5,
             "shipping_amount": 5.76,
             "tip_amount": null,
+            "duty_amount": null,
+            "date": "2026-06-12",
             "items": [
                 {
                     "id": "SKU-98765",
@@ -744,7 +746,11 @@ curl --request POST \
                     "category": "Apparel",
                     "brand": "Fashionista",
                     "sku_code": "SKT-DNM-BLK-28",
-                    "manufacture_part_number": "FASH-SKIRT-001"
+                    "manufacture_part_number": "FASH-SKIRT-001",
+                    "unit_of_measure": "EA",
+                    "commodity_code": "31161501",
+                    "total_amount": 49.99,
+                    "gross_net_indicator": "NET"
                 }
             ],
             "account_funding": null,
@@ -1357,6 +1363,8 @@ curl --request POST \
     "additional_data": {
         "order": {
             "fee_amount": 0,
+            "date": "2026-06-12",
+            "duty_amount": 0,
             "items": [
                 {
                     "brand": "XYZ",
@@ -1366,7 +1374,11 @@ curl --request POST \
                     "name": "Skirt",
                     "quantity": 1,
                     "sku_code": "8765432109",
-                    "unit_amount": 49.99
+                    "unit_amount": 49.99,
+                    "unit_of_measure": "EA",
+                    "commodity_code": "31161501",
+                    "total_amount": 49.99,
+                    "gross_net_indicator": "NET"
                 }
             ],
             "shipping_amount": 0
@@ -1561,6 +1573,8 @@ curl --request POST \
             "fee_amount": 0,
             "shipping_amount": 0,
             "tip_amount": null,
+            "duty_amount": 0,
+            "date": "2026-06-12",
             "items": [
                 {
                     "id": "123AD",
@@ -1570,7 +1584,11 @@ curl --request POST \
                     "category": "Clothes",
                     "brand": "XYZ",
                     "sku_code": "8765432109",
-                    "manufacture_part_number": "XYZ123456"
+                    "manufacture_part_number": "XYZ123456",
+                    "unit_of_measure": "EA",
+                    "commodity_code": "31161501",
+                    "total_amount": 49.99,
+                    "gross_net_indicator": "NET"
                 }
             ],
             "account_funding": null,

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -2107,6 +2107,18 @@ This object represents the payment created after generating the checkout session
           Example: 215.10
         </ParamField>
 
+        <ParamField body="duty_amount" type="float">
+          The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.
+
+          Example: 35.50
+        </ParamField>
+
+        <ParamField body="date" type="string">
+          The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.
+
+          Example: 2026-06-12
+        </ParamField>
+
         <ParamField body="sales_channel" type="string">
           Sales channel id of the payment. (MIN:3 y MAX:255)
 
@@ -2198,6 +2210,30 @@ This object represents the payment created after generating the checkout session
               Example: 345621234
             </ParamField>
 
+            <ParamField body="unit_of_measure" type="string">
+              The unit of measure of the item, using UN/ECE Recommendation 20 codes (MAX 12; MIN 1). Required to qualify for Level 3 processing.
+
+              Example: EA
+            </ParamField>
+
+            <ParamField body="commodity_code" type="string">
+              The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the `category` field. Required to qualify for Level 3 processing.
+
+              Example: 31161501
+            </ParamField>
+
+            <ParamField body="total_amount" type="float">
+              The total amount of the item line (`quantity` x `unit_amount`; multiple of 0.0001).
+
+              Example: 550
+            </ParamField>
+
+            <ParamField body="gross_net_indicator" type="string">
+              Indicates whether the item line amount is gross or net.
+
+              Possible values: `GROSS`, `NET`
+            </ParamField>
+
           </Expandable>
         </ParamField>
 
@@ -2222,6 +2258,18 @@ This object represents the payment created after generating the checkout session
               The amount of the discount (multiple of 0.0001).
 
               Example: 100
+            </ParamField>
+
+            <ParamField body="discount_indicator" type="string">
+              Indicates whether a discount was applied to the line.
+
+              Possible values: `Y`, `N`
+            </ParamField>
+
+            <ParamField body="discount_rate" type="float">
+              The discount rate applied to the line (multiple of 0.0001).
+
+              Example: 0.05
             </ParamField>
 
           </Expandable>


### PR DESCRIPTION
## [C2-17068] Add Level 2 / Level 3 order fields to the payments documentation

### Description
Documents the new optional `additional_data.order` fields introduced in [public-api #1952](https://github.com/yuno-payments/public-api/pull/1952) for Level 2 / Level 3 card data qualification (Visa CEDP / Mastercard):

| Object | Field | Notes |
|---|---|---|
| `order` | `date` | Order date `YYYY-MM-DD`, mapped to the scheme `orderDate` |
| `order` | `duty_amount` | Import/customs duty, multiple of 0.0001, informational (already included in the final amount) |
| `order.items[]` | `unit_of_measure` | UN/ECE Rec 20 code (`EA`, `KGM`, `MTR`…), MAX 12 |
| `order.items[]` | `commodity_code` | UNSPSC/NIGP code, MAX 12 (not the `category` enum) |
| `order.items[]` | `total_amount` | Line total (`quantity` × `unit_amount`) |
| `order.items[]` | `gross_net_indicator` | `GROSS` / `NET` |
| `order.discounts[]` | `discount_indicator` | `Y` / `N` |
| `order.discounts[]` | `discount_rate` | Multiple of 0.0001 |

### Endpoints / pages changed
- **OpenAPI specs** (request/response schemas + flagship example): `POST /payments` (create), `POST /payments` (authorize), `POST /payments/{id}/capture`, `GET /payments/{id}`, `GET /v2/payments/{id}`, `GET /payments?merchant_order_id=`
- **`reference/payments/the-payment-object.mdx`**: new `ParamField` entries under `order`, `items` and `discounts` (hand-maintained page, not rendered from OpenAPI)
- **`reference/payments/payment-examples/cards.mdx`**: card examples updated with the new fields
- **`docs/webhooks/object-and-examples.mdx`**: webhook payload examples updated (fields are also delivered in notifications)

### Example request (`POST /v1/payments`)
```json
{
  "amount": { "currency": "USD", "value": 1180.00 },
  "merchant_order_id": "PO-4471",
  "additional_data": {
    "order": {
      "date": "2026-06-12",
      "duty_amount": 0.00,
      "items": [
        {
          "id": "SKU-100",
          "name": "Industrial bolt M8",
          "quantity": 500,
          "unit_amount": 2.00,
          "unit_of_measure": "EA",
          "commodity_code": "31161501",
          "total_amount": 1000.00,
          "gross_net_indicator": "NET"
        }
      ],
      "taxes": [
        { "type": "VAT", "tax_base": 1000.00, "value": 160.00, "percentage": 16.0 }
      ],
      "discounts": [
        { "id": "LINE-DISC-1", "name": "Volume discount", "unit_amount": 5.00, "discount_indicator": "Y", "discount_rate": 0.05 }
      ]
    }
  }
}
```
The same fields are returned in the create/capture responses, `GET /payments/{id}` and webhook notifications. All fields are optional — omitting them keeps current behavior (no breaking change). Per-line taxes/discounts are **not** new fields: `taxes[i]`/`discounts[i]` map positionally to `items[i]`.

Scope: payments endpoints + webhooks only, matching the ticket. `payment-links` and `subscriptions` also share the `additional_data` model and can be documented in a follow-up PR (same as was done for `payer_risk_data`).

### What type of PR is this?
- [x] Documentation Update

### Related Tickets & Documents
- [C2-17068](https://yunopayments.atlassian.net/browse/C2-17068)
- Implementation PR: yuno-payments/public-api#1952

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[C2-17068]: https://yunopayments.atlassian.net/browse/C2-17068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[C2-17068]: https://yunopayments.atlassian.net/browse/C2-17068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ