### PR TITLE
docs(payments): add L2/L3 order fields from C2-17068

### DIFF
--- a/auth.md
+++ b/auth.md
@@ -40,4 +40,4 @@ Both methods use the same API key credentials as the REST API, no separate OAuth
 
 ## Machine-readable docs
 
-Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](/llms.txt) for the full page index.
+Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](https://docs.y.uno/llms.txt) for the full page index.

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -161,6 +161,8 @@ The next JSON object presents an example of a data structure related to a paymen
                     "shipping_amount": 0,
                     "fee_amount": null,
                     "tip_amount": null,
+                    "duty_amount": null,
+                    "date": null,
                     "items": [
                         {
                             "id": "item123",
@@ -171,7 +173,11 @@ The next JSON object presents an example of a data structure related to a paymen
                             "brand": null,
                             "sku_code": null,
                             "manufacture_part_number": null,
-                            "image_url": null
+                            "image_url": null,
+                            "unit_of_measure": null,
+                            "commodity_code": null,
+                            "total_amount": null,
+                            "gross_net_indicator": null
                         }
                     ],
                     "taxes": []
@@ -448,6 +454,8 @@ The next JSON object presents an example of a data structure related to a paymen
          "order":{
             "shipping_amount":0.0,
             "fee_amount":0.0,
+            "duty_amount":0.0,
+            "date":"2026-06-12",
             "items":[
                {
                   "id":"123AD",
@@ -458,7 +466,11 @@ The next JSON object presents an example of a data structure related to a paymen
                   "brand":"XYZ",
                   "sku_code":"8765432109",
                   "manufacture_part_number":"XYZ123456",
-                  "image_url":null
+                  "image_url":null,
+                  "unit_of_measure":"EA",
+                  "commodity_code":"31161501",
+                  "total_amount":2000.0,
+                  "gross_net_indicator":"NET"
                }
             ]
          },
@@ -682,6 +694,8 @@ The next JSON object presents an example of a data structure related to a paymen
                "shipping_amount":0.0,
                "fee_amount":0.0,
                "tip_amount":null,
+               "duty_amount":null,
+               "date":null,
                "items":[
                   {
                      "id":"26609",
@@ -692,7 +706,11 @@ The next JSON object presents an example of a data structure related to a paymen
                      "brand":null,
                      "sku_code":"26609",
                      "manufacture_part_number":null,
-                     "image_url":null
+                     "image_url":null,
+                     "unit_of_measure":null,
+                     "commodity_code":null,
+                     "total_amount":null,
+                     "gross_net_indicator":null
                   }
                ],
                "taxes":[
@@ -1173,6 +1191,8 @@ The next JSON object presents an example of a data structure related to a paymen
          "order":{
             "shipping_amount":0.0,
             "fee_amount":0.0,
+            "duty_amount":0.0,
+            "date":"2026-06-12",
             "items":[
                {
                   "id":"123AD",
@@ -1183,7 +1203,11 @@ The next JSON object presents an example of a data structure related to a paymen
                   "brand":"XYZ",
                   "sku_code":"8765432109",
                   "manufacture_part_number":"XYZ123456",
-                  "image_url":null
+                  "image_url":null,
+                  "unit_of_measure":"EA",
+                  "commodity_code":"31161501",
+                  "total_amount":2000.0,
+                  "gross_net_indicator":"NET"
                }
             ]
          },
@@ -2165,6 +2189,8 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
         "shipping_amount": 10.35,
         "fee_amount": 40.5,
         "tip_amount": null,
+        "duty_amount": null,
+        "date": "2026-06-12",
         "items": [
           {
             "id": "123AD",
@@ -2175,7 +2201,11 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
             "brand": "XYZ",
             "sku_code": "8765432109",
             "manufacture_part_number": "XYZ123456",
-            "image_url": null
+            "image_url": null,
+            "unit_of_measure": "EA",
+            "commodity_code": "31161501",
+            "total_amount": 60,
+            "gross_net_indicator": "NET"
           }
         ],
         "taxes": [],

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -88,6 +88,16 @@
                             "type": "string",
                             "description": "The tip amount of the order (multiple of 0.0001). This field is for informational purposes, the tip amount is already included in the final transaction amount and is not added separately."
                           },
+                          "duty_amount": {
+                            "type": "number",
+                            "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                            "format": "float"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                          },
                           "taxes": {
                             "type": "array",
                             "description": "The taxes of the order. This struct is for informational purposes, the taxes amount is already included in the final transaction amount and is not added separately.",
@@ -202,6 +212,27 @@
                                 "manufacture_part_number": {
                                   "type": "string",
                                   "description": "The manufacture part number of the item."
+                                },
+                                "unit_of_measure": {
+                                  "type": "string",
+                                  "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                },
+                                "commodity_code": {
+                                  "type": "string",
+                                  "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "gross_net_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether the item line amount is gross or net.",
+                                  "enum": [
+                                    "GROSS",
+                                    "NET"
+                                  ]
                                 }
                               },
                               "required": [
@@ -711,6 +742,19 @@
                                 "unit_amount": {
                                   "type": "number",
                                   "description": "The unit amount of the discount (multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "discount_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether a discount was applied to the line.",
+                                  "enum": [
+                                    "Y",
+                                    "N"
+                                  ]
+                                },
+                                "discount_rate": {
+                                  "type": "number",
+                                  "description": "The discount rate applied to the line (multiple of 0.0001).",
                                   "format": "float"
                                 }
                               },
@@ -9742,9 +9786,40 @@
                                       "manufacture_part_number": {
                                         "type": "string",
                                         "example": "XYZ123456"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
+                                },
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                 }
                               }
                             },

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -9789,16 +9789,19 @@
                                       },
                                       "unit_of_measure": {
                                         "type": "string",
-                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "commodity_code": {
                                         "type": "string",
-                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "total_amount": {
                                         "type": "number",
                                         "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                        "format": "float"
+                                        "format": "float",
+                                        "nullable": true
                                       },
                                       "gross_net_indicator": {
                                         "type": "string",
@@ -9806,7 +9809,8 @@
                                         "enum": [
                                           "GROSS",
                                           "NET"
-                                        ]
+                                        ],
+                                        "nullable": true
                                       }
                                     }
                                   }
@@ -9814,12 +9818,14 @@
                                 "duty_amount": {
                                   "type": "number",
                                   "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                  "format": "float"
+                                  "format": "float",
+                                  "nullable": true
                                 },
                                 "date": {
                                   "type": "string",
                                   "format": "date",
-                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                  "nullable": true
                                 }
                               }
                             },

--- a/openapi/payments/capture-authorization.json
+++ b/openapi/payments/capture-authorization.json
@@ -192,6 +192,27 @@
                                 "manufacture_part_number": {
                                   "type": "string",
                                   "description": "The manufacture part number of the item"
+                                },
+                                "unit_of_measure": {
+                                  "type": "string",
+                                  "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                },
+                                "commodity_code": {
+                                  "type": "string",
+                                  "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "gross_net_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether the item line amount is gross or net.",
+                                  "enum": [
+                                    "GROSS",
+                                    "NET"
+                                  ]
                                 }
                               },
                               "required": [
@@ -202,6 +223,16 @@
                               ],
                               "type": "object"
                             }
+                          },
+                          "duty_amount": {
+                            "type": "number",
+                            "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                            "format": "float"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                           }
                         }
                       },

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -210,6 +210,16 @@
                             "type": "string",
                             "description": "The tip amount of the order (multiple of 0.0001). This field is for informational purposes, the tip amount is already included in the final transaction amount and is not added separately."
                           },
+                          "duty_amount": {
+                            "type": "number",
+                            "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                            "format": "float"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                          },
                           "taxes": {
                             "type": "array",
                             "description": "The taxes of the order. This struct is for informational purposes, the taxes amount is already included in the final transaction amount and is not added separately.",
@@ -334,6 +344,27 @@
                                   "description": "URL of the product image. Complements the existing url field, which points to the product page (MAX 512; MIN 3).",
                                   "minLength": 3,
                                   "maxLength": 512
+                                },
+                                "unit_of_measure": {
+                                  "type": "string",
+                                  "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                },
+                                "commodity_code": {
+                                  "type": "string",
+                                  "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                },
+                                "total_amount": {
+                                  "type": "number",
+                                  "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "gross_net_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether the item line amount is gross or net.",
+                                  "enum": [
+                                    "GROSS",
+                                    "NET"
+                                  ]
                                 }
                               },
                               "required": [
@@ -867,6 +898,19 @@
                                 "unit_amount": {
                                   "type": "number",
                                   "description": "The unit amount of the discount (multiple of 0.0001).",
+                                  "format": "float"
+                                },
+                                "discount_indicator": {
+                                  "type": "string",
+                                  "description": "Indicates whether a discount was applied to the line.",
+                                  "enum": [
+                                    "Y",
+                                    "N"
+                                  ]
+                                },
+                                "discount_rate": {
+                                  "type": "number",
+                                  "description": "The discount rate applied to the line (multiple of 0.0001).",
                                   "format": "float"
                                 }
                               },
@@ -3593,10 +3637,16 @@
                             "name": "Skirt",
                             "quantity": 1,
                             "sku_code": "8765432109",
-                            "unit_amount": 5000
+                            "unit_amount": 5000,
+                            "unit_of_measure": "EA",
+                            "commodity_code": "31161501",
+                            "total_amount": 5000,
+                            "gross_net_indicator": "NET"
                           }
                         ],
-                        "shipping_amount": 0
+                        "shipping_amount": 0,
+                        "date": "2026-06-12",
+                        "duty_amount": 0
                       }
                     },
                     "customer_payer": {
@@ -6842,14 +6892,20 @@
                               "brand": "XYZ",
                               "sku_code": "8765432109",
                               "manufacture_part_number": "XYZ123456",
-                              "image_url": "https://cdn.example.com/img/skirt-01.jpg"
+                              "image_url": "https://cdn.example.com/img/skirt-01.jpg",
+                              "unit_of_measure": "EA",
+                              "commodity_code": "31161501",
+                              "total_amount": 5000,
+                              "gross_net_indicator": "NET"
                             }
                           ],
                           "account_funding": null,
                           "tickets": null,
                           "fulfillment": null,
                           "discounts": null,
-                          "sales_channel": null
+                          "sales_channel": null,
+                          "date": "2026-06-12",
+                          "duty_amount": 0
                         },
                         "seller_details": null
                       },
@@ -11225,6 +11281,16 @@
                                   "default": 0
                                 },
                                 "tip_amount": {},
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -11267,6 +11333,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
@@ -15559,6 +15646,16 @@
                                   "default": 0
                                 },
                                 "tip_amount": {},
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -15601,6 +15698,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
@@ -23069,6 +23187,16 @@
                                   "example": 50,
                                   "default": 0
                                 },
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -23111,6 +23239,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
@@ -25757,6 +25906,16 @@
                                 "fee_amount": {},
                                 "shipping_amount": {},
                                 "tip_amount": {},
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                },
                                 "items": {
                                   "type": "array",
                                   "items": {
@@ -25799,6 +25958,27 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -11284,12 +11284,14 @@
                                 "duty_amount": {
                                   "type": "number",
                                   "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                  "format": "float"
+                                  "format": "float",
+                                  "nullable": true
                                 },
                                 "date": {
                                   "type": "string",
                                   "format": "date",
-                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                  "nullable": true
                                 },
                                 "items": {
                                   "type": "array",
@@ -11336,16 +11338,19 @@
                                       },
                                       "unit_of_measure": {
                                         "type": "string",
-                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "commodity_code": {
                                         "type": "string",
-                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "total_amount": {
                                         "type": "number",
                                         "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                        "format": "float"
+                                        "format": "float",
+                                        "nullable": true
                                       },
                                       "gross_net_indicator": {
                                         "type": "string",
@@ -11353,7 +11358,8 @@
                                         "enum": [
                                           "GROSS",
                                           "NET"
-                                        ]
+                                        ],
+                                        "nullable": true
                                       }
                                     }
                                   }
@@ -15649,12 +15655,14 @@
                                 "duty_amount": {
                                   "type": "number",
                                   "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                  "format": "float"
+                                  "format": "float",
+                                  "nullable": true
                                 },
                                 "date": {
                                   "type": "string",
                                   "format": "date",
-                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                  "nullable": true
                                 },
                                 "items": {
                                   "type": "array",
@@ -15701,16 +15709,19 @@
                                       },
                                       "unit_of_measure": {
                                         "type": "string",
-                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "commodity_code": {
                                         "type": "string",
-                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "total_amount": {
                                         "type": "number",
                                         "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                        "format": "float"
+                                        "format": "float",
+                                        "nullable": true
                                       },
                                       "gross_net_indicator": {
                                         "type": "string",
@@ -15718,7 +15729,8 @@
                                         "enum": [
                                           "GROSS",
                                           "NET"
-                                        ]
+                                        ],
+                                        "nullable": true
                                       }
                                     }
                                   }
@@ -23190,12 +23202,14 @@
                                 "duty_amount": {
                                   "type": "number",
                                   "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                  "format": "float"
+                                  "format": "float",
+                                  "nullable": true
                                 },
                                 "date": {
                                   "type": "string",
                                   "format": "date",
-                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                  "nullable": true
                                 },
                                 "items": {
                                   "type": "array",
@@ -23242,16 +23256,19 @@
                                       },
                                       "unit_of_measure": {
                                         "type": "string",
-                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "commodity_code": {
                                         "type": "string",
-                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "total_amount": {
                                         "type": "number",
                                         "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                        "format": "float"
+                                        "format": "float",
+                                        "nullable": true
                                       },
                                       "gross_net_indicator": {
                                         "type": "string",
@@ -23259,7 +23276,8 @@
                                         "enum": [
                                           "GROSS",
                                           "NET"
-                                        ]
+                                        ],
+                                        "nullable": true
                                       }
                                     }
                                   }
@@ -25909,12 +25927,14 @@
                                 "duty_amount": {
                                   "type": "number",
                                   "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                  "format": "float"
+                                  "format": "float",
+                                  "nullable": true
                                 },
                                 "date": {
                                   "type": "string",
                                   "format": "date",
-                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                  "nullable": true
                                 },
                                 "items": {
                                   "type": "array",
@@ -25961,16 +25981,19 @@
                                       },
                                       "unit_of_measure": {
                                         "type": "string",
-                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "commodity_code": {
                                         "type": "string",
-                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "total_amount": {
                                         "type": "number",
                                         "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                        "format": "float"
+                                        "format": "float",
+                                        "nullable": true
                                       },
                                       "gross_net_indicator": {
                                         "type": "string",
@@ -25978,7 +26001,8 @@
                                         "enum": [
                                           "GROSS",
                                           "NET"
-                                        ]
+                                        ],
+                                        "nullable": true
                                       }
                                     }
                                   }

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -7537,9 +7537,40 @@
                                           "manufacture_part_number": {
                                             "type": "string",
                                             "example": "XYZ123456"
+                                          },
+                                          "unit_of_measure": {
+                                            "type": "string",
+                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                          },
+                                          "commodity_code": {
+                                            "type": "string",
+                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                          },
+                                          "total_amount": {
+                                            "type": "number",
+                                            "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                            "format": "float"
+                                          },
+                                          "gross_net_indicator": {
+                                            "type": "string",
+                                            "description": "Indicates whether the item line amount is gross or net.",
+                                            "enum": [
+                                              "GROSS",
+                                              "NET"
+                                            ]
                                           }
                                         }
                                       }
+                                    },
+                                    "duty_amount": {
+                                      "type": "number",
+                                      "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                      "format": "float"
+                                    },
+                                    "date": {
+                                      "type": "string",
+                                      "format": "date",
+                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                     }
                                   }
                                 },
@@ -14049,9 +14080,40 @@
                                             "type": "object",
                                             "example": null,
                                             "nullable": true
+                                          },
+                                          "unit_of_measure": {
+                                            "type": "string",
+                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                          },
+                                          "commodity_code": {
+                                            "type": "string",
+                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                          },
+                                          "total_amount": {
+                                            "type": "number",
+                                            "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                            "format": "float"
+                                          },
+                                          "gross_net_indicator": {
+                                            "type": "string",
+                                            "description": "Indicates whether the item line amount is gross or net.",
+                                            "enum": [
+                                              "GROSS",
+                                              "NET"
+                                            ]
                                           }
                                         }
                                       }
+                                    },
+                                    "duty_amount": {
+                                      "type": "number",
+                                      "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                      "format": "float"
+                                    },
+                                    "date": {
+                                      "type": "string",
+                                      "format": "date",
+                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                     }
                                   }
                                 },

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -7540,16 +7540,19 @@
                                           },
                                           "unit_of_measure": {
                                             "type": "string",
-                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                            "nullable": true
                                           },
                                           "commodity_code": {
                                             "type": "string",
-                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                            "nullable": true
                                           },
                                           "total_amount": {
                                             "type": "number",
                                             "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                            "format": "float"
+                                            "format": "float",
+                                            "nullable": true
                                           },
                                           "gross_net_indicator": {
                                             "type": "string",
@@ -7557,7 +7560,8 @@
                                             "enum": [
                                               "GROSS",
                                               "NET"
-                                            ]
+                                            ],
+                                            "nullable": true
                                           }
                                         }
                                       }
@@ -7565,12 +7569,14 @@
                                     "duty_amount": {
                                       "type": "number",
                                       "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                      "format": "float"
+                                      "format": "float",
+                                      "nullable": true
                                     },
                                     "date": {
                                       "type": "string",
                                       "format": "date",
-                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                      "nullable": true
                                     }
                                   }
                                 },
@@ -14083,16 +14089,19 @@
                                           },
                                           "unit_of_measure": {
                                             "type": "string",
-                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                            "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                            "nullable": true
                                           },
                                           "commodity_code": {
                                             "type": "string",
-                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                            "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                            "nullable": true
                                           },
                                           "total_amount": {
                                             "type": "number",
                                             "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                            "format": "float"
+                                            "format": "float",
+                                            "nullable": true
                                           },
                                           "gross_net_indicator": {
                                             "type": "string",
@@ -14100,7 +14109,8 @@
                                             "enum": [
                                               "GROSS",
                                               "NET"
-                                            ]
+                                            ],
+                                            "nullable": true
                                           }
                                         }
                                       }
@@ -14108,12 +14118,14 @@
                                     "duty_amount": {
                                       "type": "number",
                                       "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                      "format": "float"
+                                      "format": "float",
+                                      "nullable": true
                                     },
                                     "date": {
                                       "type": "string",
                                       "format": "date",
-                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                      "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                      "nullable": true
                                     }
                                   }
                                 },

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -6972,9 +6972,40 @@
                                       "image_url": {
                                         "type": "string",
                                         "example": "https://cdn.example.com/img/skirt-01.jpg"
+                                      },
+                                      "unit_of_measure": {
+                                        "type": "string",
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                      },
+                                      "commodity_code": {
+                                        "type": "string",
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                      },
+                                      "total_amount": {
+                                        "type": "number",
+                                        "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                        "format": "float"
+                                      },
+                                      "gross_net_indicator": {
+                                        "type": "string",
+                                        "description": "Indicates whether the item line amount is gross or net.",
+                                        "enum": [
+                                          "GROSS",
+                                          "NET"
+                                        ]
                                       }
                                     }
                                   }
+                                },
+                                "duty_amount": {
+                                  "type": "number",
+                                  "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                  "format": "float"
+                                },
+                                "date": {
+                                  "type": "string",
+                                  "format": "date",
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                 }
                               }
                             },

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -6975,16 +6975,19 @@
                                       },
                                       "unit_of_measure": {
                                         "type": "string",
-                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "commodity_code": {
                                         "type": "string",
-                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                        "nullable": true
                                       },
                                       "total_amount": {
                                         "type": "number",
                                         "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                        "format": "float"
+                                        "format": "float",
+                                        "nullable": true
                                       },
                                       "gross_net_indicator": {
                                         "type": "string",
@@ -6992,7 +6995,8 @@
                                         "enum": [
                                           "GROSS",
                                           "NET"
-                                        ]
+                                        ],
+                                        "nullable": true
                                       }
                                     }
                                   }
@@ -7000,12 +7004,14 @@
                                 "duty_amount": {
                                   "type": "number",
                                   "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                  "format": "float"
+                                  "format": "float",
+                                  "nullable": true
                                 },
                                 "date": {
                                   "type": "string",
                                   "format": "date",
-                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                  "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                  "nullable": true
                                 }
                               }
                             },

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -6688,16 +6688,19 @@
                                         },
                                         "unit_of_measure": {
                                           "type": "string",
-                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                          "nullable": true
                                         },
                                         "commodity_code": {
                                           "type": "string",
-                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                          "nullable": true
                                         },
                                         "total_amount": {
                                           "type": "number",
                                           "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                          "format": "float"
+                                          "format": "float",
+                                          "nullable": true
                                         },
                                         "gross_net_indicator": {
                                           "type": "string",
@@ -6705,7 +6708,8 @@
                                           "enum": [
                                             "GROSS",
                                             "NET"
-                                          ]
+                                          ],
+                                          "nullable": true
                                         }
                                       }
                                     }
@@ -6713,12 +6717,14 @@
                                   "duty_amount": {
                                     "type": "number",
                                     "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                    "format": "float"
+                                    "format": "float",
+                                    "nullable": true
                                   },
                                   "date": {
                                     "type": "string",
                                     "format": "date",
-                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                    "nullable": true
                                   }
                                 }
                               },
@@ -12553,16 +12559,19 @@
                                         "manufacture_part_number": {},
                                         "unit_of_measure": {
                                           "type": "string",
-                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing.",
+                                          "nullable": true
                                         },
                                         "commodity_code": {
                                           "type": "string",
-                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing.",
+                                          "nullable": true
                                         },
                                         "total_amount": {
                                           "type": "number",
                                           "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
-                                          "format": "float"
+                                          "format": "float",
+                                          "nullable": true
                                         },
                                         "gross_net_indicator": {
                                           "type": "string",
@@ -12570,7 +12579,8 @@
                                           "enum": [
                                             "GROSS",
                                             "NET"
-                                          ]
+                                          ],
+                                          "nullable": true
                                         }
                                       }
                                     }
@@ -12578,12 +12588,14 @@
                                   "duty_amount": {
                                     "type": "number",
                                     "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
-                                    "format": "float"
+                                    "format": "float",
+                                    "nullable": true
                                   },
                                   "date": {
                                     "type": "string",
                                     "format": "date",
-                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
+                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.",
+                                    "nullable": true
                                   }
                                 }
                               },

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -6685,9 +6685,40 @@
                                         "manufacture_part_number": {
                                           "type": "string",
                                           "example": "XYZ123456"
+                                        },
+                                        "unit_of_measure": {
+                                          "type": "string",
+                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        },
+                                        "commodity_code": {
+                                          "type": "string",
+                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        },
+                                        "total_amount": {
+                                          "type": "number",
+                                          "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                          "format": "float"
+                                        },
+                                        "gross_net_indicator": {
+                                          "type": "string",
+                                          "description": "Indicates whether the item line amount is gross or net.",
+                                          "enum": [
+                                            "GROSS",
+                                            "NET"
+                                          ]
                                         }
                                       }
                                     }
+                                  },
+                                  "duty_amount": {
+                                    "type": "number",
+                                    "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                    "format": "float"
+                                  },
+                                  "date": {
+                                    "type": "string",
+                                    "format": "date",
+                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                   }
                                 }
                               },
@@ -12519,9 +12550,40 @@
                                         "category": {},
                                         "brand": {},
                                         "sku_code": {},
-                                        "manufacture_part_number": {}
+                                        "manufacture_part_number": {},
+                                        "unit_of_measure": {
+                                          "type": "string",
+                                          "description": "The unit of measure of the item, using UN/ECE Recommendation 20 codes, e.g., EA, KGM, MTR (MAX 12; MIN 1). Required to qualify for Level 3 processing."
+                                        },
+                                        "commodity_code": {
+                                          "type": "string",
+                                          "description": "The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the category field. Required to qualify for Level 3 processing."
+                                        },
+                                        "total_amount": {
+                                          "type": "number",
+                                          "description": "The total amount of the item line (quantity x unit_amount; multiple of 0.0001).",
+                                          "format": "float"
+                                        },
+                                        "gross_net_indicator": {
+                                          "type": "string",
+                                          "description": "Indicates whether the item line amount is gross or net.",
+                                          "enum": [
+                                            "GROSS",
+                                            "NET"
+                                          ]
+                                        }
                                       }
                                     }
+                                  },
+                                  "duty_amount": {
+                                    "type": "number",
+                                    "description": "The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.",
+                                    "format": "float"
+                                  },
+                                  "date": {
+                                    "type": "string",
+                                    "format": "date",
+                                    "description": "The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing."
                                   }
                                 }
                               },

--- a/reference/payments/payment-examples/cards.mdx
+++ b/reference/payments/payment-examples/cards.mdx
@@ -735,6 +735,8 @@ curl --request POST \
             "fee_amount": 5,
             "shipping_amount": 5.76,
             "tip_amount": null,
+            "duty_amount": null,
+            "date": "2026-06-12",
             "items": [
                 {
                     "id": "SKU-98765",
@@ -744,7 +746,11 @@ curl --request POST \
                     "category": "Apparel",
                     "brand": "Fashionista",
                     "sku_code": "SKT-DNM-BLK-28",
-                    "manufacture_part_number": "FASH-SKIRT-001"
+                    "manufacture_part_number": "FASH-SKIRT-001",
+                    "unit_of_measure": "EA",
+                    "commodity_code": "31161501",
+                    "total_amount": 49.99,
+                    "gross_net_indicator": "NET"
                 }
             ],
             "account_funding": null,
@@ -1357,6 +1363,8 @@ curl --request POST \
     "additional_data": {
         "order": {
             "fee_amount": 0,
+            "date": "2026-06-12",
+            "duty_amount": 0,
             "items": [
                 {
                     "brand": "XYZ",
@@ -1366,7 +1374,11 @@ curl --request POST \
                     "name": "Skirt",
                     "quantity": 1,
                     "sku_code": "8765432109",
-                    "unit_amount": 49.99
+                    "unit_amount": 49.99,
+                    "unit_of_measure": "EA",
+                    "commodity_code": "31161501",
+                    "total_amount": 49.99,
+                    "gross_net_indicator": "NET"
                 }
             ],
             "shipping_amount": 0
@@ -1561,6 +1573,8 @@ curl --request POST \
             "fee_amount": 0,
             "shipping_amount": 0,
             "tip_amount": null,
+            "duty_amount": 0,
+            "date": "2026-06-12",
             "items": [
                 {
                     "id": "123AD",
@@ -1570,7 +1584,11 @@ curl --request POST \
                     "category": "Clothes",
                     "brand": "XYZ",
                     "sku_code": "8765432109",
-                    "manufacture_part_number": "XYZ123456"
+                    "manufacture_part_number": "XYZ123456",
+                    "unit_of_measure": "EA",
+                    "commodity_code": "31161501",
+                    "total_amount": 49.99,
+                    "gross_net_indicator": "NET"
                 }
             ],
             "account_funding": null,

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -2107,6 +2107,18 @@ This object represents the payment created after generating the checkout session
           Example: 215.10
         </ParamField>
 
+        <ParamField body="duty_amount" type="float">
+          The import/customs duty amount of the order (multiple of 0.0001). This field is for informational purposes, the duty amount is already included in the final transaction amount and is not added separately.
+
+          Example: 35.50
+        </ParamField>
+
+        <ParamField body="date" type="string">
+          The date of the order in YYYY-MM-DD format. Mapped to the card scheme order date for Level 2 / Level 3 processing.
+
+          Example: 2026-06-12
+        </ParamField>
+
         <ParamField body="sales_channel" type="string">
           Sales channel id of the payment. (MIN:3 y MAX:255)
 
@@ -2198,6 +2210,30 @@ This object represents the payment created after generating the checkout session
               Example: 345621234
             </ParamField>
 
+            <ParamField body="unit_of_measure" type="string">
+              The unit of measure of the item, using UN/ECE Recommendation 20 codes (MAX 12; MIN 1). Required to qualify for Level 3 processing.
+
+              Example: EA
+            </ParamField>
+
+            <ParamField body="commodity_code" type="string">
+              The commodity code of the item, using UNSPSC or NIGP codes (MAX 12; MIN 1). Note this is a real commodity code, not the `category` field. Required to qualify for Level 3 processing.
+
+              Example: 31161501
+            </ParamField>
+
+            <ParamField body="total_amount" type="float">
+              The total amount of the item line (`quantity` x `unit_amount`; multiple of 0.0001).
+
+              Example: 550
+            </ParamField>
+
+            <ParamField body="gross_net_indicator" type="string">
+              Indicates whether the item line amount is gross or net.
+
+              Possible values: `GROSS`, `NET`
+            </ParamField>
+
           </Expandable>
         </ParamField>
 
@@ -2222,6 +2258,18 @@ This object represents the payment created after generating the checkout session
               The amount of the discount (multiple of 0.0001).
 
               Example: 100
+            </ParamField>
+
+            <ParamField body="discount_indicator" type="string">
+              Indicates whether a discount was applied to the line.
+
+              Possible values: `Y`, `N`
+            </ParamField>
+
+            <ParamField body="discount_rate" type="float">
+              The discount rate applied to the line (multiple of 0.0001).
+
+              Example: 0.05
             </ParamField>
 
           </Expandable>


### PR DESCRIPTION
Documents the new optional additional_data.order fields introduced in public-api PR #1952 (Level 2 / Level 3 card data):

- order.duty_amount, order.date
- items[].unit_of_measure, items[].commodity_code, items[].total_amount, items[].gross_net_indicator
- discounts[].discount_indicator, discounts[].discount_rate

Updated OpenAPI schemas and examples for create, authorize, capture and the three retrieve endpoints, the payment object reference, card payment examples, and webhook payload examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI/example updates only; no runtime or auth logic changes.
> 
> **Overview**
> Documents new optional **Level 2 / Level 3** card data on `additional_data.order` and related nested objects, aligned with public-api changes.
> 
> **Order-level:** `duty_amount` and `date` (YYYY-MM-DD, mapped to card-scheme order date).
> 
> **Line items:** `unit_of_measure`, `commodity_code`, `total_amount`, and `gross_net_indicator` (`GROSS` / `NET`).
> 
> **Discounts:** `discount_indicator` (`Y` / `N`) and `discount_rate`.
> 
> Updates span payment OpenAPI specs (create, authorize, capture, retrieve), the payment object reference, card payment examples, webhook JSON samples, and a small fix in `auth.md` pointing `llms.txt` to the absolute docs URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da002e38fb20b70c1aadcd5f2646b4e301bc2634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->