### PR TITLE
docs(C2-16596): document provider_data.raw_request in payments and operations

### DIFF
--- a/openapi/payments/cancel-or-refund-a-payment.json
+++ b/openapi/payments/cancel-or-refund-a-payment.json
@@ -521,6 +521,13 @@
                         "response_code": "SUCCEEDED",
                         "iso8583_response_code": "00",
                         "iso8583_response_message": "Approved or completed successfully",
+                        "raw_request": {
+                          "amount": {
+                            "currency": "BRL",
+                            "value": 2100
+                          },
+                          "reference": "34343434"
+                        },
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null

--- a/openapi/payments/cancel-or-refund-payment-with-transaction.json
+++ b/openapi/payments/cancel-or-refund-payment-with-transaction.json
@@ -528,6 +528,13 @@
                         "response_code": "SUCCEEDED",
                         "iso8583_response_code": "00",
                         "iso8583_response_message": "Approved or completed successfully",
+                        "raw_request": {
+                          "amount": {
+                            "currency": "BRL",
+                            "value": 2100
+                          },
+                          "reference": "34343434"
+                        },
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null

--- a/openapi/payments/cancel-payment.json
+++ b/openapi/payments/cancel-payment.json
@@ -111,6 +111,13 @@
                         "type": "boolean",
                         "description": "When true, includes the transactions history in the response"
                       },
+                      "raw_request": {
+                        "amount": {
+                          "currency": "BRL",
+                          "value": 2100
+                        },
+                        "reference": "34343434"
+                      },
                       "raw_response": {
                         "type": "boolean",
                         "description": "When true, includes the provider raw response in the output"

--- a/openapi/payments/capture-authorization.json
+++ b/openapi/payments/capture-authorization.json
@@ -818,6 +818,13 @@
                         "response_code": "",
                         "iso8583_response_code": "00",
                         "iso8583_response_message": "Approved or completed successfully",
+                        "raw_request": {
+                          "amount": {
+                            "currency": "BRL",
+                            "value": 2100
+                          },
+                          "reference": "34343434"
+                        },
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -4263,6 +4263,13 @@
                         "status_detail": "",
                         "response_message": null,
                         "response_code": null,
+                        "raw_request": {
+                          "amount": {
+                            "currency": "BRL",
+                            "value": 2100
+                          },
+                          "reference": "34343434"
+                        },
                         "raw_response": {
                           "amount": {
                             "currency": "BRL",

--- a/openapi/payments/refund-payment.json
+++ b/openapi/payments/refund-payment.json
@@ -692,6 +692,13 @@
                           "status_detail": "",
                           "response_message": null,
                           "response_code": "SUCCEEDED",
+                          "raw_request": {
+                            "amount": {
+                              "currency": "BRL",
+                              "value": 2100
+                            },
+                            "reference": "34343434"
+                          },
                           "raw_response": {
                             "message": "provider response"
                           },

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -204,6 +204,13 @@
                             "response_message": "",
                             "iso8583_response_code": "00",
                             "iso8583_response_message": "Approved or completed successfully",
+                            "raw_request": {
+                              "amount": {
+                                "currency": "BRL",
+                                "value": 2100
+                              },
+                              "reference": "34343434"
+                            },
                             "raw_response": {
                               "data": {
                                 "amount_in_cents": 5200000,

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -5094,6 +5094,12 @@ This object represents the payment created after generating the checkout session
               Example: JSON
             </ParamField>
 
+            <ParamField body="raw_request" type="object">
+              The raw request payload that Yuno sent to the payment provider, exposed alongside `raw_response`. It is returned for payments and for the capture, cancel, and refund operations. Only present for organizations enabled for this feature; otherwise it is omitted.
+
+              Example: JSON
+            </ParamField>
+
           </Expandable>
         </ParamField>
 


### PR DESCRIPTION
Documents the new `provider_data.raw_request` field — the raw request payload Yuno sends to the payment provider, exposed alongside `raw_response`.

**Payments**
- `reference/payments/the-payment-object.mdx` — new `raw_request` ParamField next to `raw_response`.
- `openapi/payments/create-payment.json`, `retrieve-payment-by-id.json` — example added.

**Operations**
- `openapi/payments/capture-authorization.json`, `cancel-payment.json`, `refund-payment.json`, `cancel-or-refund-a-payment.json`, `cancel-or-refund-payment-with-transaction.json` — example added.

Notes: the field is returned only for organizations enabled for the feature (omitted otherwise), and is intentionally **not** documented on webhooks (it is exposed only via the payment API / GET payment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI example updates only; no runtime or API behavior changes in this diff.
> 
> **Overview**
> Documents **`provider_data.raw_request`**, the outbound payload Yuno sends to the payment provider, as a companion to existing **`raw_response`** documentation.
> 
> **`reference/payments/the-payment-object.mdx`** adds a `raw_request` field description: it appears on payment GET/create responses and on capture, cancel, and refund operation responses, only for orgs with the feature enabled (otherwise omitted). Webhooks are intentionally out of scope.
> 
> **OpenAPI payment specs** embed the same sample `raw_request` object under `provider_data` in response examples for create, retrieve, capture, refund, and cancel-or-refund flows. Note: **`cancel-payment.json`** also adds a `raw_request` entry under **`response_additional_data`** alongside the boolean `raw_response` flag—worth verifying that matches the real request API vs. a misplaced response example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a7d39b288c9f11d7e5538fd74ebfe16187a0c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->