### PR TITLE
docs(reference): fit all transaction tables without horizontal scroll

### DIFF
--- a/reference/payments/status-and-response-codes/transaction.mdx
+++ b/reference/payments/status-and-response-codes/transaction.mdx
@@ -12,6 +12,8 @@ Each payment has one or more associated transactions. The following documentatio
 
 ## Types of transactions
 
+<div className="code-nowrap-table dense-table">
+
 | Type              | Description                                                          |
 | :---------------- | :------------------------------------------------------------------- |
 | `PURCHASE`        | A direct purchase transaction.                                       |
@@ -26,6 +28,8 @@ Each payment has one or more associated transactions. The following documentatio
 | `SPLIT_TRANSFER_REVERSAL` | A transfer reversal linked to a specific payment transaction. |
 | `SPLIT_TRANSFER`  | A standalone forward transfer within a Marketplace.                  |
 | `SPLIT_TRANSFER_REVERSE` | A standalone reverse transfer within a Marketplace.           |
+
+</div>
 
 ## Transaction codes
 
@@ -50,7 +54,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>SUCCEEDED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -67,7 +71,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>WON</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -82,7 +86,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>CREATED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -99,7 +103,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>PENDING</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -122,7 +126,7 @@ With every transaction, you´ll receive a `response_code` detailing more info ab
 
 <Accordion title={<><code>DECLINED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -204,6 +208,8 @@ Please refer to [Merchant Advice Codes (MAC)](#merchant-advice-codes-mac) for mo
 
 Merchant Advice Codes provide guidance from issuers/providers about retry behavior and policy. When present on a decline, use the MAC to determine whether to retry and the recommended timing.
 
+<div className="code-nowrap-table dense-table">
+
 | merchant_advice_code | Description | Provider MAC code |
 | --- | --- | --- |
 | `UPDATE_INFORMATION` | Updated/additional information needed | 01 – Updated account information available |
@@ -222,6 +228,8 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 | `NO_RETRY_SECURITY` | No retry security | 42 – Sanction score exceeded |
 | `MULTIPLE_USE_CARD` | Multiple‑use virtual card | 43 – Multiple‑use virtual card |
 
+</div>
+
 </Accordion>
 
 ### Rejected status
@@ -229,7 +237,7 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>REJECTED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -249,7 +257,7 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>ERROR</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -274,7 +282,7 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>EXPIRED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -289,7 +297,7 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>LOST</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -307,7 +315,7 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 <Accordion title={<><code>PREVENTED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
 | response_code | Description | Hard/Soft decline | ISO 8583 code |
 | --- | --- | --- | --- |
@@ -330,34 +338,34 @@ For more details, please refer to the [reason codes page](/docs/reason-codes) in
 
 <Accordion title={<><code>CREATED</code> status details</>}>
 
-<div className="code-nowrap-table">
+<div className="code-nowrap-table dense-table">
 
-| response_code | response_message | Category | Description |
-| --- | --- | --- | --- |
-| `EMV_LIABILITY_SHIFT_COUNTERFEIT` | EMV Liability Shift Counterfeit Fraud | Fraud | The cardholder is claiming that they did not authorize or participate in a transaction that you processed. |
-| `EMV_LIABILITY_SHIFT_NOT_COUNTERFEIT` | EMV Liability Shift Non-Counterfeit Fraud | Fraud | The cardholder is claiming that they did not authorize or participate in a transaction that you processed. |
-| `CARD_PRESENT_FRAUD` | Other Fraud – Card-Present Environment | Fraud | The cardholder is claiming that they did not authorize or participate in a key-entered or unattended transaction conducted in a card-present environment. |
-| `NON_CARD_PRESENT_FRAUD` | Other Fraud – Card-Absent Environment | Fraud | The cardholder did not authorize or participate in a transaction conducted in a card-not-present environment, such as internet, mail-order, phone-order, and others. |
-| `SCHEME_MONITORING_PROGRAM` | Other Fraud - Scheme Monitoring Program | Fraud | Scheme Fraud Monitoring program |
-| `NO_AUTHORIZATION` | No Authorization | Authorization | Correct and valid authorization was not obtained by the merchant. |
-| `DECLINED_AUTHORIZATION` | Declined Authorization | Authorization | Authorization request received a Decline response and the merchant completed the transaction. |
-| `LATE_PRESENTMENT` | Late Presentment | Processing Errors | The transaction was not sent to Visa within the timeframe required. |
-| `INCORRECT_TRANSACTION_CODE` | Incorrect Transaction Code | Processing Errors | The cardholder is claiming that the converted amount of charge on an international transaction is incorrect. |
-| `INCORRECT_CURRENCY` | Incorrect Currency | Processing Errors | The merchant made one or more errors related to the transaction currency |
-| `INCORRECT_ACCOUNT_NUMBER` | Incorrect Account Number | Processing Errors | The account number in the authorization does not match the account number used in the transaction. |
-| `INCORRECT_AMOUNT` | Incorrect Amount | Processing Errors | The cardholder is claiming that the amount they agreed to pay differs from the amount charged. |
-| `DUPLICATE_PROCESSING` | Duplicate Processing/Paid by Other Means | Processing Errors | A single transaction was processed two or more times. |
-| `INVALID_DATA` | Invalid Data | Processing Errors | The authorization was obtained using invalid or incorrect data. |
-| `PRODUCT_OR_SERVICE_NOT_RECEIVED` | Merchandise/Services Not Received | Customer Disputes | The cardholder is claiming that merchandise or services that they ordered were not received. |
-| `CANCELED_RECURRING_TRANSACTION` | Cancelled Recurring Transaction | Customer Disputes | A recurring transaction was processed after it was cancelled. |
-| `PRODUCT_OR_SERVICE_ISSUE` | Not as Described or Defective Merchandise/Services | Customer Disputes | The cardholder is claiming the goods were not as described. |
-| `COUNTERFEIT_MERCHANDISE` | Counterfeit Merchandise | Customer Disputes | The merchandise was identified as counterfeit. |
-| `MISREPRESENTATION` | Misrepresentation | Customer Disputes | The cardholder’s bank received a notice from the cardholder is claiming misrepresented terms of sale. |
-| `CREDIT_NOT_PROCESSED` | Credit Not Processed | Customer Disputes | The cardholder’s bank received a notice from the cardholder claiming that they received authorization, credit or voided transaction receipt that has not been processed. |
-| `PRODUCT_OR_SERVICE_CANCELED` | Cancelled Merchandise/Services | Customer Disputes | The cardholder’s bank received a notice from the cardholder stating that they returned merchandise or cancelled services, but the credit has not appeared on the cardholder’s Visa statement. |
-| `ORIGINAL_TRANSACTION_NOT_ACCEPTED` | Original Credit Transaction Not Accepted | Customer Disputes | The original credit was not accepted. |
-| `CASH_TRANSACTION_VALUE` | Non-Receipt of Cash or Load Transaction Value | Customer Disputes | Cardholder did not receive the full cash withdrawal at an ATM. |
-| `CUSTOMER_AGREEMENT` | Proof of customer transaction or agreement required. | Customer Disputes | The issuer asks the merchant for a copy of the receipt signed by the cardholder or any other documentation that verifies the customers agreement for the purchase. Usually to verify a card-present transaction the cardholder disputes or doesn’t recognize. |
+| response_code | Category | Description |
+| --- | --- | --- |
+| `EMV_LIABILITY_SHIFT_COUNTERFEIT`<br />EMV Liability Shift Counterfeit Fraud | Fraud | The cardholder is claiming that they did not authorize or participate in a transaction that you processed. |
+| `EMV_LIABILITY_SHIFT_NOT_COUNTERFEIT`<br />EMV Liability Shift Non-Counterfeit Fraud | Fraud | The cardholder is claiming that they did not authorize or participate in a transaction that you processed. |
+| `CARD_PRESENT_FRAUD`<br />Other Fraud – Card-Present Environment | Fraud | The cardholder is claiming that they did not authorize or participate in a key-entered or unattended transaction conducted in a card-present environment. |
+| `NON_CARD_PRESENT_FRAUD`<br />Other Fraud – Card-Absent Environment | Fraud | The cardholder did not authorize or participate in a transaction conducted in a card-not-present environment, such as internet, mail-order, phone-order, and others. |
+| `SCHEME_MONITORING_PROGRAM`<br />Other Fraud - Scheme Monitoring Program | Fraud | Scheme Fraud Monitoring program |
+| `NO_AUTHORIZATION`<br />No Authorization | Authorization | Correct and valid authorization was not obtained by the merchant. |
+| `DECLINED_AUTHORIZATION`<br />Declined Authorization | Authorization | Authorization request received a Decline response and the merchant completed the transaction. |
+| `LATE_PRESENTMENT`<br />Late Presentment | Processing Errors | The transaction was not sent to Visa within the timeframe required. |
+| `INCORRECT_TRANSACTION_CODE`<br />Incorrect Transaction Code | Processing Errors | The cardholder is claiming that the converted amount of charge on an international transaction is incorrect. |
+| `INCORRECT_CURRENCY`<br />Incorrect Currency | Processing Errors | The merchant made one or more errors related to the transaction currency |
+| `INCORRECT_ACCOUNT_NUMBER`<br />Incorrect Account Number | Processing Errors | The account number in the authorization does not match the account number used in the transaction. |
+| `INCORRECT_AMOUNT`<br />Incorrect Amount | Processing Errors | The cardholder is claiming that the amount they agreed to pay differs from the amount charged. |
+| `DUPLICATE_PROCESSING`<br />Duplicate Processing/Paid by Other Means | Processing Errors | A single transaction was processed two or more times. |
+| `INVALID_DATA`<br />Invalid Data | Processing Errors | The authorization was obtained using invalid or incorrect data. |
+| `PRODUCT_OR_SERVICE_NOT_RECEIVED`<br />Merchandise/Services Not Received | Customer Disputes | The cardholder is claiming that merchandise or services that they ordered were not received. |
+| `CANCELED_RECURRING_TRANSACTION`<br />Cancelled Recurring Transaction | Customer Disputes | A recurring transaction was processed after it was cancelled. |
+| `PRODUCT_OR_SERVICE_ISSUE`<br />Not as Described or Defective Merchandise/Services | Customer Disputes | The cardholder is claiming the goods were not as described. |
+| `COUNTERFEIT_MERCHANDISE`<br />Counterfeit Merchandise | Customer Disputes | The merchandise was identified as counterfeit. |
+| `MISREPRESENTATION`<br />Misrepresentation | Customer Disputes | The cardholder’s bank received a notice from the cardholder is claiming misrepresented terms of sale. |
+| `CREDIT_NOT_PROCESSED`<br />Credit Not Processed | Customer Disputes | The cardholder’s bank received a notice from the cardholder claiming that they received authorization, credit or voided transaction receipt that has not been processed. |
+| `PRODUCT_OR_SERVICE_CANCELED`<br />Cancelled Merchandise/Services | Customer Disputes | The cardholder’s bank received a notice from the cardholder stating that they returned merchandise or cancelled services, but the credit has not appeared on the cardholder’s Visa statement. |
+| `ORIGINAL_TRANSACTION_NOT_ACCEPTED`<br />Original Credit Transaction Not Accepted | Customer Disputes | The original credit was not accepted. |
+| `CASH_TRANSACTION_VALUE`<br />Non-Receipt of Cash or Load Transaction Value | Customer Disputes | Cardholder did not receive the full cash withdrawal at an ATM. |
+| `CUSTOMER_AGREEMENT`<br />Proof of customer transaction or agreement required. | Customer Disputes | The issuer asks the merchant for a copy of the receipt signed by the cardholder or any other documentation that verifies the customers agreement for the purchase. Usually to verify a card-present transaction the cardholder disputes or doesn’t recognize. |
 
 </div>
 

--- a/style.css
+++ b/style.css
@@ -314,10 +314,15 @@ html.dark .status-secondary {
 
 /* Dense tables — opt-in via .dense-table wrapper. The theme forces
    min-width: 150px on every td, so a 5-column table can never fit the
-   ~600px content column. Let cells shrink to their content instead
-   (e.g. the MACs list). */
+   ~600px content column. Let cells shrink to their content instead,
+   and shave the chip font a point so long nowrap enums leave room for
+   the prose columns (e.g. the MACs list, transaction code tables). */
 .dense-table td {
   min-width: 0 !important;
+}
+
+.dense-table td code {
+  font-size: 12px;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -325,6 +325,22 @@ html.dark .status-secondary {
   font-size: 12px;
 }
 
+.dense-table td,
+.dense-table th {
+  padding-left: 6px !important;
+  padding-right: 6px !important;
+}
+
+.dense-table td:first-child,
+.dense-table th:first-child {
+  padding-left: 0 !important;
+}
+
+.dense-table td:last-child,
+.dense-table th:last-child {
+  padding-right: 0 !important;
+}
+
 
 /* === API Reference: shift code rail (cURL + response) toward the content === */
 /* Maple theme by default anchors the code panel to the right edge of the viewport,


### PR DESCRIPTION
## Summary

On [/reference/payments/status-and-response-codes/transaction](https://docs.y.uno/reference/payments/status-and-response-codes/transaction), measured on production with headless Chromium (accordions expanded):

- The 11 accordion tables overflowed their **558px** container by **42–204px** — the theme's `td { min-width: 150px }` sets impossible floors (worst: declined 755px, chargebacks 762px).
- The two tables #586 didn't wrap (**Types of transactions**, **Merchant Advice Codes**) fit but wrapped enum chips mid-identifier (`SPLIT_TRANSFER_REVERSAL`, `REQUIREMENTS_NOT_FULFILLED`).

## Fix

1. `dense-table` added to the 11 existing wrappers (lifts the td min-width, per #592).
2. Types and MAC tables wrapped in `code-nowrap-table dense-table`.
3. Chargebacks table: `response_message` merged beneath the code chip (4 → 3 columns) — its 35-char enums can't fit 4 columns otherwise.
4. `.dense-table` chips shaved to 12px and horizontal cell gutters to 6px — the declined table (36-char enums) needed both to clear the narrower 518px container at the 1280px viewport.

## Verification (headless Chromium against this PR's preview)

All **13 tables** on the page, accordions expanded, at **1440 / 1280 / 1080 / 768px** viewports:

- Horizontal overflow: **0px on every table at every viewport** (tightest: declined, 513px vs 518px container at 1280px).
- Enum chips rendering on more than one line (`getClientRects()`): **none**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)