### PR TITLE
docs(theme): slate surface for accordions in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,6 +80,15 @@ html.dark code:not(pre code) {
   border-color: #334155;
 }
 
+/* Accordions — the theme paints them with its neutral near-black background
+   token (#0B0C0E), which reads as a black box against the blue-cast slate
+   page background. Raise them one step into the slate family instead, like
+   the homepage cards. Dark mode only; light keeps the theme default. */
+html.dark details.accordion {
+  background: #0f172a !important;
+  border-color: #334155 !important;
+}
+
 /* Copy chip — inline code chip with one-click copy (snippets/CopyChip.jsx) */
 .copy-chip {
   display: inline-flex;


### PR DESCRIPTION
## Summary

In dark mode, accordions (e.g. the status tables on [/reference/payments/status-and-response-codes/transaction](https://docs.y.uno/reference/payments/status-and-response-codes/transaction)) render with the theme's neutral near-black background token (**#0B0C0E**, measured via computed styles) — they read as black boxes floating on the blue-cast slate page background (`#0B1120` from `docs.json`).

## Fix

Global rule in `style.css`, dark mode only: `details.accordion` gets the slate-900 surface (`#0F172A`, one step above the page) with a slate-700 border (`#334155`) — the same surface/border relationship already used by the homepage cards and inline code chips. Light mode untouched.

## Verification

Computed-style check against this PR's preview in dark mode posted below after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic dark-mode styling only; no logic, auth, or data changes.
> 
> **Overview**
> **Dark mode accordions** (`details.accordion`) no longer use the theme’s near-black fill (**#0B0C0E**), which looked like floating black boxes on the slate page background.
> 
> A global rule in `style.css` sets accordion background to slate-900 (**#0f172a**) and border to slate-700 (**#334155**), aligned with other dark surfaces (e.g. inline code). **Light mode is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c239c42f5e19bcb95fe830e2dc7b0bd6f325de39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->