### PR TITLE
chore: web sdk changelog 1.9.16

### DIFF
--- a/auth.md
+++ b/auth.md
@@ -15,10 +15,10 @@ Do not share `private-secret-key` in public places like GitHub or Bitbucket.
 
 ## Base URLs
 
-| Environment | Base URL |
-| --- | --- |
-| Sandbox | `https://api-sandbox.y.uno` |
-| Production | `https://api.y.uno` |
+| Environment | Base URL                    |
+| ----------- | --------------------------- |
+| Sandbox     | `https://api-sandbox.y.uno` |
+| Production  | `https://api.y.uno`         |
 
 Sandbox data is simulated and does not affect live accounting or metrics. See [API environments](/reference/getting-started/api-environments) for full details.
 
@@ -40,4 +40,4 @@ Both methods use the same API key credentials as the REST API, no separate OAuth
 
 ## Machine-readable docs
 
-Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](/llms.txt) for the full page index.
+Every Yuno Docs page is available as plain-text Markdown by appending `.md` to its URL, for both guides and API reference pages. See [llms.txt](https://docs.y.uno/llms.txt) for the full page index.

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,37 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.16",
+      "release_date": "2026-07-14",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.16",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Fixed Installments for Dual Cards in Credit-Only Mode",
+          "description": "Installment options now load correctly for Brazilian dual cards when credit_card_only_processing is enabled, ensuring payments are tokenized as credit with the proper installment selection.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Slim Form Support for Bank Transfer Fields",
+          "description": "Added slim form support to the bank transfer fields.",
+          "group": "APM",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17157",
+        "CORECM-18131",
+        "CORECM-18223"
+      ]
+    },
+    {
       "version": "1.9.15",
       "release_date": "2026-07-10",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,19 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.16
+*July 14, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Fixed Installments for Dual Cards in Credit-Only Mode**  
+  Installment options now load correctly for Brazilian dual cards when credit_card_only_processing is enabled, ensuring payments are tokenized as credit with the proper installment selection.
+
+**APM**
+
+- <ChangelogBadge type="fixed" /> **Slim Form Support for Bank Transfer Fields**  
+  Added slim form support to the bank transfer fields.
+
 ## v1.9.15
 *July 10, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.16`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.16

2 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or API changes in this repository.
> 
> **Overview**
> Adds **Web SDK v1.9.16** (July 14, 2026) to the published changelog by inserting a new release block at the top of `changelog/source/web.json` and mirroring it in `changelog/web.mdx`.
> 
> The new release documents two SDK changes: installment options loading correctly for Brazilian dual cards when `credit_card_only_processing` is enabled, and slim-form styling support for bank transfer fields. It also records consumed tickets `CORECM-17157`, `CORECM-18131`, and `CORECM-18223` plus the `npm install @yuno-payments/sdk-web@1.9.16` upgrade snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe06e98822dad0c1901f55c8805f9ee2c31fd3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->