### PR TITLE
C2-17641: document verify.metadata on Enroll Payment Method (direct B2B)

### DIFF
--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -340,6 +340,27 @@
                       "currency": {
                         "type": "string",
                         "description": "Currency of the card verification. For a full list of currency codes, see [Country reference](/reference/country-reference) (MAX 3; MIN 3; ISO 4217)."
+                      },
+                      "metadata": {
+                        "type": "array",
+                        "description": "Optional custom key–value tags for the verification (e.g., order_ref, invoice). They are attached to the internal verify payment created by the verification — available downstream exactly like payment `metadata` (payment data, provider gateway request, routing) — and stored with the enrolled payment method's verification settings. Up to 120 items.",
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "The metadata key (MAX 48. Value: MIN:1, MAX:48). **[Case Sensitive]**"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "The metadata key value (MAX 512. Value: MIN:1, MAX:512). **[Case Sensitive]**"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object"
+                        }
                       }
                     }
                   },
@@ -471,7 +492,13 @@
                     },
                     "verify": {
                       "vault_on_success": true,
-                      "currency": "USD"
+                      "currency": "USD",
+                      "metadata": [
+                        {
+                          "key": "order_ref",
+                          "value": "ABC-123"
+                        }
+                      ]
                     }
                   }
                 },
@@ -604,6 +631,12 @@
                             "refunded": 0,
                             "captured": 0
                           },
+                          "metadata": [
+                            {
+                              "key": "order_ref",
+                              "value": "ABC-123"
+                            }
+                          ],
                           "transactions": [
                             {
                               "id": "1e501f45-583b-4187-b42e-8c3e620d1ef5",
@@ -1073,6 +1106,23 @@
                                       "updated_at": {
                                         "type": "string",
                                         "example": "2023-09-04T16:37:56.348742Z"
+                                      }
+                                    }
+                                  }
+                                },
+                                "metadata": {
+                                  "type": "array",
+                                  "description": "The custom key–value tags sent in `verify.metadata`, echoed from the internal verify payment.",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "key": {
+                                        "type": "string",
+                                        "example": "order_ref"
+                                      },
+                                      "value": {
+                                        "type": "string",
+                                        "example": "ABC-123"
                                       }
                                     }
                                   }


### PR DESCRIPTION
## What

Documents the new `verify.metadata` capability on the [Enroll Payment Method](https://docs.y.uno/reference/payment-methods-direct-workflow/enroll-payment-method-api) API (`openapi/payment-methods-direct-workflow/enroll-payment-method-api.json`):

- **Request schema**: `verify.metadata` — array of `{key, value}` tags, same shape/limits as payment `metadata` (key ≤ 48 chars, value ≤ 512 chars, up to 120 items). Attached to the internal verify (zero-dollar) payment and stored with the payment method's verification settings.
- **Response schema + example**: the enrollment response's embedded `verify.payment` now echoes `metadata`, and it is also included in the ENROLLMENT webhook payloads.
- Request example "Card Enrollment With Verification" and response example "With Verify" updated to show the field.

## Why

C2-17641 ([Zuora] direct B2B enrollment) shipped `verify.metadata` end-to-end — request, persistence, verify payment, provider request, response echo, and both webhook bodies — validated on STG (evidence in C2-17642). The public docs are the last open acceptance criterion.

## Notes for review

- Copy needs Andrea's validation per docs workflow.
- Wording mirrors the `metadata` description in `openapi/payments/create-payment.json` for consistency.
- The link-rot CI failure is pre-existing (`auth.md` → `/llms.txt`, a Mintlify runtime file) — unrelated to this change; see PR comment.

Jira: C2-17641

🤖 Generated with [Claude Code](https://claude.com/claude-code)