### PR TITLE
docs(reference): keep industry_category enums on one line

### DIFF
--- a/reference/industry-category-list.mdx
+++ b/reference/industry-category-list.mdx
@@ -5,6 +5,8 @@ description: "Lists industry category codes and descriptions used when configuri
 
 On this page, you will find the industry category information you need when using Yuno API endpoints. The table below provides codes for each industry category available on the Yuno API and their descriptions. Use this page to understand better when to use each category.
 
+<div className="code-nowrap-table dense-table">
+
 | industry\_category        | Description                                                                                                                                                                 |
 | :------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ADVERTISING`               | Advertising company and services.                                                                                                                                           |
@@ -46,4 +48,6 @@ On this page, you will find the industry category information you need when usin
 | `TRAVELS`                   | Plane tickets, Hotel vouchers, Travel vouchers.                                                                                                                             |
 | `VIDEO_GAMES`              | Video Games & Consoles.                                                                                                                                                     |
 | `VIRTUAL_GOODS`            | E-books, Music Files, Software, Digital Images, PDF Files and any item which can be electronically stored in a file, Mobile Recharge, DTH Recharge and any Online Recharge. |
+
+</div>
 


### PR DESCRIPTION
## Summary

On [/reference/industry-category-list](https://docs.y.uno/reference/industry-category-list), measured on production: the table fits (576px vs 608px container) but three enum chips wrap mid-identifier (`BEAUTY_&_PERSONAL_CARE`, `GROCERY_&_GOURMET_FOOD`, `INDUSTRIAL_&_SCIENTIFIC`).

## Fix

Wrapped the table in the standard `code-nowrap-table dense-table` opt-in wrappers (#584/#592). Two columns only, so the unwrapped chips (~190px) leave ample room for Description — no horizontal scroll risk.

## Verification

Measured against this PR's preview after deploy — posted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX markup change with no API or runtime impact.
> 
> **Overview**
> On **`reference/industry-category-list`**, the industry category reference table is wrapped in the standard **`code-nowrap-table dense-table`** container so long **`industry_category`** enum values (e.g. **`BEAUTY_&_PERSONAL_CARE`**) stay on one line instead of breaking mid-identifier in the docs UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb70d85f8c39dacb870182de2bb9ee025ba03efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->