### PR TITLE
docs(reference): keep item_category enums on one line

### DIFF
--- a/reference/items-category-list.mdx
+++ b/reference/items-category-list.mdx
@@ -5,6 +5,8 @@ description: "Lists item category codes and descriptions used to classify produc
 
 On this page, you will find the items category information you need when using Yuno API endpoints. The table below provides codes for each item category available on the Yuno API and their descriptions. Use this page to understand better when to use each category.
 
+<div className="code-nowrap-table dense-table">
+
 | item\_category            | Description                                                                                                                                                                 |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ART`                       | Collectibles & Art.                                                                                                                                                         |
@@ -39,3 +41,5 @@ On this page, you will find the items category information you need when using Y
 | `TRAVELS`                   | Plane tickets, Hotel vouchers, Travel vouchers.                                                                                                                             |
 | `VIRTUAL_GOODS`            | E-books, Music Files, Software, Digital Images, PDF Files and any item which can be electronically stored in a file, Mobile Recharge, DTH Recharge and any Online Recharge. |
 | `OTHERS`                    | Other categories.                                                                                                                                                           |
+
+</div>


### PR DESCRIPTION
## Summary

On [/reference/items-category-list](https://docs.y.uno/reference/items-category-list), measured on production: the table fits (576px vs 608px) but three enum chips wrap mid-identifier (`BEAUTY&_PERSONAL_CARE`, `GROCERY_&_GOURMET_FOOD`, `MUSICAL_INSTRUMENTS`).

## Fix

Same as #597 (industry-category-list): wrapped the table in the standard `code-nowrap-table dense-table` opt-in wrappers. Two columns, no horizontal scroll risk.

## Verification

Measured against this PR's preview after deploy — posted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CSS wrapper on a single MDX page; no runtime or API impact.
> 
> **Overview**
> Wraps the **Items Category** reference table in the standard `code-nowrap-table dense-table` container so long `item_category` enum values (e.g. `BEAUTY&_PERSONAL_CARE`, `GROCERY_&_GOURMET_FOOD`, `MUSICAL_INSTRUMENTS`) stay on one line instead of breaking mid-identifier in the docs UI.
> 
> No content or API changes—presentation-only, matching the fix already used on the industry category list page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f41249f235bc7cdab7506b1fcd50f50669f00b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->