### PR TITLE
docs(C2-17639): add Reassign Payment Method to Another Customer API reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -391,7 +391,8 @@
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api",
-              "reference/payment-methods-direct-workflow/unenroll-payment-method-api"
+              "reference/payment-methods-direct-workflow/unenroll-payment-method-api",
+              "reference/payment-methods-direct-workflow/reassign-payment-method-api"
             ]
           },
           {

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -170,7 +170,9 @@
             "type": "string",
             "description": "Machine-readable error code.",
             "enum": [
+              "INVALID_PARAMETERS",
               "BAD_REQUEST",
+              "CUSTOMER_NOT_FOUND",
               "PAYMENT_METHOD_NOT_REASSIGNABLE"
             ]
           },
@@ -190,7 +192,7 @@
             "type": "string",
             "description": "Machine-readable error code.",
             "enum": [
-              "NOT_FOUND"
+              "PAYMENT_METHOD_NOT_FOUND"
             ]
           },
           "messages": {
@@ -326,11 +328,35 @@
                   "$ref": "#/components/schemas/BadRequestError"
                 },
                 "examples": {
-                  "Target customer does not exist": {
+                  "Missing customer_id": {
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The field 'customer_id' is required."
+                      ]
+                    }
+                  },
+                  "Invalid customer_id": {
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The field 'customer_id' must be a valid uuid v4."
+                      ]
+                    }
+                  },
+                  "Malformed request body": {
                     "value": {
                       "code": "BAD_REQUEST",
                       "messages": [
-                        "target customer does not exist"
+                        "Bad request"
+                      ]
+                    }
+                  },
+                  "Target customer does not exist": {
+                    "value": {
+                      "code": "CUSTOMER_NOT_FOUND",
+                      "messages": [
+                        "Customer not found."
                       ]
                     }
                   },
@@ -356,9 +382,9 @@
                 "examples": {
                   "Payment method not found": {
                     "value": {
-                      "code": "NOT_FOUND",
+                      "code": "PAYMENT_METHOD_NOT_FOUND",
                       "messages": [
-                        "payment_method not found"
+                        "Payment method not found."
                       ]
                     }
                   }

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -321,7 +321,7 @@
             }
           },
           "400": {
-            "description": "The request is invalid, or the target customer does not exist.",
+            "description": "The request is invalid, the target customer does not exist, or the payment method is not a card.",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -33,7 +33,7 @@
         "properties": {
           "customer_id": {
             "type": "string",
-            "description": "The unique identifier of the customer the payment method is reassigned to (UUID, 36 chars). The payment method can be reassigned only while its current customer has no data; otherwise the request returns `409 CONFLICT`."
+            "description": "The unique identifier of the customer the payment method is reassigned to (UUID). The payment method can be reassigned only while its current customer has no data; otherwise the request returns `409 CONFLICT`."
           }
         }
       },
@@ -239,7 +239,7 @@
           {
             "name": "payment_method_id",
             "in": "path",
-            "description": "The unique identifier of the `payment_method`. This is the `vaulted_token` received when enrolling a payment method with [Enroll Payment Method](/reference/enroll-payment-method-api) (UUID, 36 chars).",
+            "description": "The unique identifier of the `payment_method`. This is the `vaulted_token` received when enrolling a payment method with [Enroll Payment Method](/reference/enroll-payment-method-api) (UUID).",
             "schema": {
               "type": "string"
             },
@@ -248,7 +248,7 @@
           {
             "name": "X-account-code",
             "in": "header",
-            "description": "The unique identifier of your account (UUID, 36 chars).",
+            "description": "The unique identifier of your account (UUID).",
             "schema": {
               "type": "string",
               "x-default": "<Your X-account-code>"

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -62,7 +62,6 @@
           },
           "country": {
             "type": "string",
-            "description": "The country of the payment method, in ISO 3166-1 alpha-2 format.",
             "example": "US"
           },
           "parent_type": {},
@@ -76,7 +75,6 @@
           },
           "vaulted_token": {
             "type": "string",
-            "description": "The unique identifier of the payment method (the same value passed as `payment_method_id`).",
             "example": "b0000000-0000-4000-8000-000000000002"
           },
           "callback_url": {},
@@ -84,12 +82,10 @@
           "redirect_url": {},
           "created_at": {
             "type": "string",
-            "description": "The date and time when the payment method was created, in ISO 8601 format.",
             "example": "2024-06-04T12:47:46.992602Z"
           },
           "updated_at": {
             "type": "string",
-            "description": "The date and time when the payment method was last updated, in ISO 8601 format.",
             "example": "2024-06-04T12:47:46.992603Z"
           },
           "card_data": {
@@ -252,20 +248,10 @@
           {
             "name": "X-account-code",
             "in": "header",
-            "description": "The unique identifier of the account that owns the payment method (UUID, 36 chars).",
+            "description": "The unique identifier of your account (UUID, 36 chars).",
             "schema": {
               "type": "string",
               "x-default": "<Your X-account-code>"
-            },
-            "required": true
-          },
-          {
-            "name": "X-idempotency-key",
-            "in": "header",
-            "description": "A unique key that makes the request safe to retry. Use the UUID format.",
-            "schema": {
-              "type": "string",
-              "x-default": "<Your X-idempotency-key>"
             },
             "required": true
           }

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -33,7 +33,7 @@
         "properties": {
           "customer_id": {
             "type": "string",
-            "description": "The unique identifier of the customer the payment method is reassigned to. The customer must already exist and belong to the same organization as the caller (UUID, 36 chars)."
+            "description": "The unique identifier of the customer the payment method is reassigned to (UUID, 36 chars). The payment method can be reassigned only while its current customer has no data; otherwise the request returns `409 CONFLICT`."
           }
         }
       },
@@ -233,7 +233,7 @@
     "/payment-methods/{payment_method_id}": {
       "patch": {
         "summary": "Reassign a Payment Method to Another Customer",
-        "description": "Reassigns an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. The target customer must exist and belong to the same organization. The reassignment fails when the payment method is already assigned to a customer that has data. Returns the payment method in the same shape as the Enroll Payment Method response, with the new owner in the `customer_id` field.",
+        "description": "Reassigns an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. The reassignment fails when the payment method is already assigned to a customer that has data. Returns the payment method in the same shape as the Enroll Payment Method response, with the new owner in the `customer_id` field.",
         "operationId": "reassign-payment-method-api",
         "parameters": [
           {

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -1,0 +1,348 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "customer-api",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    },
+    "schemas": {
+      "ReassignPaymentMethodInput": {
+        "type": "object",
+        "required": [
+          "customer_id"
+        ],
+        "properties": {
+          "customer_id": {
+            "type": "string",
+            "description": "The unique identifier of the customer the payment method is reassigned to. The customer must already exist and belong to the same organization as the caller (UUID, 36 chars)."
+          }
+        }
+      },
+      "PaymentMethod": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the payment method (its `vaulted_token`).",
+            "example": "2fd6bf11-2129-4061-9c2a-34e196f89753"
+          },
+          "account_id": {
+            "type": "string",
+            "description": "The unique identifier of the account that owns the payment method.",
+            "example": "493e9374-510a-4201-9e09-de669d75f256"
+          },
+          "customer_id": {
+            "type": "string",
+            "description": "The unique identifier of the customer the payment method now belongs to. Returned by the reassignment response so you can confirm the new owner.",
+            "example": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the payment method.",
+            "example": "VISA ****1111"
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the payment method.",
+            "example": "VISA ****1111"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the payment method.",
+            "example": "CARD"
+          },
+          "category": {
+            "type": "string",
+            "description": "The category of the payment method.",
+            "example": "CARD"
+          },
+          "country": {
+            "type": "string",
+            "description": "The country of the payment method, in ISO 3166-1 alpha-2 format.",
+            "example": "US"
+          },
+          "status": {
+            "type": "string",
+            "description": "The status of the payment method.",
+            "example": "ENROLLED"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "The date and time when the payment method was created, in ISO 8601 format.",
+            "example": "2024-06-04T12:47:46.992602Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "The date and time when the payment method was last updated, in ISO 8601 format.",
+            "example": "2024-06-04T12:47:46.992603Z"
+          },
+          "enrollment": {
+            "type": "object",
+            "properties": {
+              "session": {
+                "type": "string",
+                "description": "The enrollment session identifier.",
+                "example": ""
+              },
+              "sdk_required_action": {
+                "type": "boolean",
+                "description": "Whether the SDK requires an additional action to complete enrollment.",
+                "example": false
+              }
+            }
+          },
+          "provider": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The identifier of the provider that holds the payment method.",
+                "example": "YUNO"
+              },
+              "type": {
+                "type": "string",
+                "description": "The type of the provider.",
+                "example": "YUNO"
+              },
+              "token": {
+                "type": "string",
+                "description": "The provider token for the payment method.",
+                "example": "a0000000-0000-4000-8000-000000000002"
+              }
+            }
+          }
+        }
+      },
+      "BadRequestError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code.",
+            "enum": [
+              "BAD_REQUEST"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "description": "Human-readable description of the error.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PaymentMethodNotFoundError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code.",
+            "enum": [
+              "NOT_FOUND"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "description": "Human-readable description of the error.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PaymentMethodConflictError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code.",
+            "enum": [
+              "CONFLICT"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "description": "Human-readable description of the error.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/payment-methods/{payment_method_id}": {
+      "patch": {
+        "summary": "Reassign a Payment Method to Another Customer",
+        "description": "Reassigns an enrolled payment method to a different customer of the same account. The target customer must exist and belong to the same organization. The reassignment fails when the payment method is already assigned to a customer that has data. Returns the updated payment method, with the new owner in the `customer_id` field.",
+        "operationId": "reassign-payment-method-api",
+        "parameters": [
+          {
+            "name": "payment_method_id",
+            "in": "path",
+            "description": "The unique identifier of the `payment_method`. This is the `vaulted_token` received when enrolling a payment method with [Enroll Payment Method](/reference/enroll-payment-method-api) (UUID, 36 chars).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "X-account-code",
+            "in": "header",
+            "description": "The unique identifier of the account that owns the payment method (UUID, 36 chars).",
+            "schema": {
+              "type": "string",
+              "x-default": "<Your X-account-code>"
+            },
+            "required": true
+          },
+          {
+            "name": "X-idempotency-key",
+            "in": "header",
+            "description": "A unique key that makes the request safe to retry. Use the UUID format.",
+            "schema": {
+              "type": "string",
+              "x-default": "<Your X-idempotency-key>"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReassignPaymentMethodInput"
+              },
+              "example": {
+                "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The reassigned payment method, including the new owner in the `customer_id` field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethod"
+                },
+                "example": {
+                  "id": "2fd6bf11-2129-4061-9c2a-34e196f89753",
+                  "account_id": "493e9374-510a-4201-9e09-de669d75f256",
+                  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001",
+                  "name": "VISA ****1111",
+                  "description": "VISA ****1111",
+                  "type": "CARD",
+                  "category": "CARD",
+                  "country": "US",
+                  "status": "ENROLLED",
+                  "created_at": "2024-06-04T12:47:46.992602Z",
+                  "updated_at": "2024-06-04T12:47:46.992603Z",
+                  "enrollment": {
+                    "session": "",
+                    "sdk_required_action": false
+                  },
+                  "provider": {
+                    "id": "YUNO",
+                    "type": "YUNO",
+                    "token": "a0000000-0000-4000-8000-000000000002"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request is invalid, or the target customer does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                },
+                "examples": {
+                  "Target customer does not exist": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": [
+                        "target customer does not exist"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The payment method does not exist for this account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodNotFoundError"
+                },
+                "examples": {
+                  "Payment method not found": {
+                    "value": {
+                      "code": "NOT_FOUND",
+                      "messages": [
+                        "payment_method not found"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The payment method is already assigned to a customer that has data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodConflictError"
+                },
+                "examples": {
+                  "Already assigned to a customer with data": {
+                    "value": {
+                      "code": "CONFLICT",
+                      "messages": [
+                        "payment_method is already assigned to a customer with data"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  }
+}

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -155,12 +155,12 @@
           "last_successfully_used": {},
           "last_successfully_used_at": {},
           "preferred": {},
-          "verify": {},
           "customer_id": {
             "type": "string",
             "description": "The unique identifier of the customer the payment method now belongs to. Returned by the reassignment response so you can confirm the new owner.",
             "example": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
-          }
+          },
+          "verify": {}
         }
       },
       "BadRequestError": {
@@ -314,8 +314,8 @@
                   "last_successfully_used": null,
                   "last_successfully_used_at": null,
                   "preferred": null,
-                  "verify": null,
-                  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
+                  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001",
+                  "verify": null
                 }
               }
             }

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -40,39 +40,24 @@
       "PaymentMethod": {
         "type": "object",
         "properties": {
-          "id": {
+          "idempotency_key": {
             "type": "string",
-            "description": "The unique identifier of the payment method (its `vaulted_token`).",
-            "example": "2fd6bf11-2129-4061-9c2a-34e196f89753"
-          },
-          "account_id": {
-            "type": "string",
-            "description": "The unique identifier of the account that owns the payment method.",
-            "example": "493e9374-510a-4201-9e09-de669d75f256"
-          },
-          "customer_id": {
-            "type": "string",
-            "description": "The unique identifier of the customer the payment method now belongs to. Returned by the reassignment response so you can confirm the new owner.",
-            "example": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
+            "example": "a0000000-0000-4000-8000-000000000010"
           },
           "name": {
             "type": "string",
-            "description": "The display name of the payment method.",
             "example": "VISA ****1111"
           },
           "description": {
             "type": "string",
-            "description": "The description of the payment method.",
             "example": "VISA ****1111"
           },
           "type": {
             "type": "string",
-            "description": "The type of the payment method.",
             "example": "CARD"
           },
           "category": {
             "type": "string",
-            "description": "The category of the payment method.",
             "example": "CARD"
           },
           "country": {
@@ -80,11 +65,23 @@
             "description": "The country of the payment method, in ISO 3166-1 alpha-2 format.",
             "example": "US"
           },
+          "parent_type": {},
           "status": {
             "type": "string",
-            "description": "The status of the payment method.",
             "example": "ENROLLED"
           },
+          "sub_status": {
+            "type": "string",
+            "example": "ENROLLED"
+          },
+          "vaulted_token": {
+            "type": "string",
+            "description": "The unique identifier of the payment method (the same value passed as `payment_method_id`).",
+            "example": "b0000000-0000-4000-8000-000000000002"
+          },
+          "callback_url": {},
+          "action": {},
+          "redirect_url": {},
           "created_at": {
             "type": "string",
             "description": "The date and time when the payment method was created, in ISO 8601 format.",
@@ -95,40 +92,78 @@
             "description": "The date and time when the payment method was last updated, in ISO 8601 format.",
             "example": "2024-06-04T12:47:46.992603Z"
           },
-          "enrollment": {
+          "card_data": {
             "type": "object",
             "properties": {
-              "session": {
+              "iin": {
                 "type": "string",
-                "description": "The enrollment session identifier.",
-                "example": ""
+                "example": "41111111"
               },
-              "sdk_required_action": {
-                "type": "boolean",
-                "description": "Whether the SDK requires an additional action to complete enrollment.",
-                "example": false
-              }
-            }
-          },
-          "provider": {
-            "type": "object",
-            "properties": {
-              "id": {
+              "lfd": {
                 "type": "string",
-                "description": "The identifier of the provider that holds the payment method.",
-                "example": "YUNO"
+                "example": "1111"
+              },
+              "holder_name": {
+                "type": "string",
+                "description": "Cardholder's full name as returned by the payment provider.",
+                "example": "JOHN DOE"
+              },
+              "expiration_month": {
+                "type": "integer",
+                "example": 3,
+                "default": 0
+              },
+              "expiration_year": {
+                "type": "integer",
+                "example": 26,
+                "default": 0
+              },
+              "number_length": {
+                "type": "integer",
+                "example": 16,
+                "default": 0
+              },
+              "security_code_length": {
+                "type": "integer",
+                "example": 3,
+                "default": 0
+              },
+              "brand": {
+                "type": "string",
+                "example": "VISA"
+              },
+              "issuer": {
+                "type": "string",
+                "example": "JPMORGAN CHASE BANK N A"
+              },
+              "issuer_code": {},
+              "country_code": {
+                "type": "string",
+                "description": "ISO 3166-1 alpha-2 country code of the card's issuing country.",
+                "example": "US"
+              },
+              "category": {
+                "type": "string",
+                "example": "CREDIT"
               },
               "type": {
                 "type": "string",
-                "description": "The type of the provider.",
-                "example": "YUNO"
+                "example": "CREDIT"
               },
-              "token": {
+              "fingerprint": {
                 "type": "string",
-                "description": "The provider token for the payment method.",
-                "example": "a0000000-0000-4000-8000-000000000002"
+                "example": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
               }
             }
+          },
+          "last_successfully_used": {},
+          "last_successfully_used_at": {},
+          "preferred": {},
+          "verify": {},
+          "customer_id": {
+            "type": "string",
+            "description": "The unique identifier of the customer the payment method now belongs to. Returned by the reassignment response so you can confirm the new owner.",
+            "example": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
           }
         }
       },
@@ -139,7 +174,8 @@
             "type": "string",
             "description": "Machine-readable error code.",
             "enum": [
-              "BAD_REQUEST"
+              "BAD_REQUEST",
+              "PAYMENT_METHOD_NOT_REASSIGNABLE"
             ]
           },
           "messages": {
@@ -201,7 +237,7 @@
     "/payment-methods/{payment_method_id}": {
       "patch": {
         "summary": "Reassign a Payment Method to Another Customer",
-        "description": "Reassigns an enrolled payment method to a different customer of the same account. The target customer must exist and belong to the same organization. The reassignment fails when the payment method is already assigned to a customer that has data. Returns the updated payment method, with the new owner in the `customer_id` field.",
+        "description": "Reassigns an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. The target customer must exist and belong to the same organization. The reassignment fails when the payment method is already assigned to a customer that has data. Returns the payment method in the same shape as the Enroll Payment Method response, with the new owner in the `customer_id` field.",
         "operationId": "reassign-payment-method-api",
         "parameters": [
           {
@@ -256,26 +292,42 @@
                   "$ref": "#/components/schemas/PaymentMethod"
                 },
                 "example": {
-                  "id": "2fd6bf11-2129-4061-9c2a-34e196f89753",
-                  "account_id": "493e9374-510a-4201-9e09-de669d75f256",
-                  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001",
+                  "idempotency_key": "a0000000-0000-4000-8000-000000000010",
                   "name": "VISA ****1111",
                   "description": "VISA ****1111",
                   "type": "CARD",
                   "category": "CARD",
                   "country": "US",
+                  "parent_type": null,
                   "status": "ENROLLED",
+                  "sub_status": "ENROLLED",
+                  "vaulted_token": "b0000000-0000-4000-8000-000000000002",
+                  "callback_url": null,
+                  "action": null,
+                  "redirect_url": null,
                   "created_at": "2024-06-04T12:47:46.992602Z",
                   "updated_at": "2024-06-04T12:47:46.992603Z",
-                  "enrollment": {
-                    "session": "",
-                    "sdk_required_action": false
+                  "card_data": {
+                    "iin": "41111111",
+                    "lfd": "1111",
+                    "holder_name": "JOHN DOE",
+                    "expiration_month": 3,
+                    "expiration_year": 26,
+                    "number_length": 16,
+                    "security_code_length": 3,
+                    "brand": "VISA",
+                    "issuer": "JPMORGAN CHASE BANK N A",
+                    "issuer_code": null,
+                    "country_code": "US",
+                    "category": "CREDIT",
+                    "type": "CREDIT",
+                    "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
                   },
-                  "provider": {
-                    "id": "YUNO",
-                    "type": "YUNO",
-                    "token": "a0000000-0000-4000-8000-000000000002"
-                  }
+                  "last_successfully_used": null,
+                  "last_successfully_used_at": null,
+                  "preferred": null,
+                  "verify": null,
+                  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
                 }
               }
             }
@@ -293,6 +345,14 @@
                       "code": "BAD_REQUEST",
                       "messages": [
                         "target customer does not exist"
+                      ]
+                    }
+                  },
+                  "Payment method is not a card": {
+                    "value": {
+                      "code": "PAYMENT_METHOD_NOT_REASSIGNABLE",
+                      "messages": [
+                        "Only card payment methods can be reassigned."
                       ]
                     }
                   }

--- a/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
@@ -1,0 +1,18 @@
+---
+title: "Reassign a Payment Method to Another Customer"
+openapi: "/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json PATCH /payment-methods/{payment_method_id}"
+description: "Reassigns an enrolled payment method to a different customer of the same account"
+keywords: ["payment methods", "customers", "vaulted token", "reassign"]
+---
+
+Reassign an enrolled payment method to a different customer of the same account. Send the `customer_id` of the target customer, who must already exist and belong to the same organization. The payment method is resolved within the account you pass in the `X-account-code` header. The response returns the updated payment method, with the new owner in the `customer_id` field.
+
+<Note>
+To reassign the payment method, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.
+</Note>
+
+A payment method that is already assigned to a customer that has data cannot be reassigned, and the request is rejected with `409 CONFLICT`.
+
+<Warning>
+After a payment method is reassigned, the merchant is responsible for updating the customer identifier wherever the payment method was already used. This includes any subscription created with it, the merchant's own mapping between a user and the `vaulted_token`, and any stored pair of customer and payment method. Yuno reassigns the payment method to the new customer, but it does not update those references on the merchant side.
+</Warning>

--- a/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
@@ -5,7 +5,7 @@ description: "Reassigns an enrolled payment method to a different customer of th
 keywords: ["payment methods", "customers", "vaulted token", "reassign"]
 ---
 
-Reassign an enrolled payment method to a different customer of the same account. Send the `customer_id` of the target customer, who must already exist and belong to the same organization. The payment method is resolved within the account you pass in the `X-account-code` header. The response returns the updated payment method, with the new owner in the `customer_id` field.
+Reassign an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. Send the `customer_id` of the target customer, who must already exist and belong to the same organization. The payment method is resolved within the account you pass in the `X-account-code` header. The response returns the payment method in the same shape as the [Enroll Payment Method](/reference/enroll-payment-method-api) response, with the new owner in the `customer_id` field.
 
 <Note>
 To reassign the payment method, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.

--- a/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
@@ -5,7 +5,7 @@ description: "Reassigns an enrolled payment method to a different customer of th
 keywords: ["payment methods", "customers", "vaulted token", "reassign"]
 ---
 
-Reassign an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. Send the `customer_id` of the target customer, who must already exist and belong to the same organization. Send your account in the `X-account-code` header. The response returns the payment method in the same shape as the [Enroll Payment Method](/reference/enroll-payment-method-api) response, with the new owner in the `customer_id` field.
+Reassign an enrolled payment method to a different customer of the same account. Send the `customer_id` of the target customer in the request body. Only card payment methods can be reassigned. The response returns the payment method in the same shape as the [Enroll Payment Method](/reference/enroll-payment-method-api) response, with the new owner in the `customer_id` field.
 
 <Note>
 To reassign the payment method, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.

--- a/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/reassign-payment-method-api.mdx
@@ -5,7 +5,7 @@ description: "Reassigns an enrolled payment method to a different customer of th
 keywords: ["payment methods", "customers", "vaulted token", "reassign"]
 ---
 
-Reassign an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. Send the `customer_id` of the target customer, who must already exist and belong to the same organization. The payment method is resolved within the account you pass in the `X-account-code` header. The response returns the payment method in the same shape as the [Enroll Payment Method](/reference/enroll-payment-method-api) response, with the new owner in the `customer_id` field.
+Reassign an enrolled payment method to a different customer of the same account. Only card payment methods can be reassigned. Send the `customer_id` of the target customer, who must already exist and belong to the same organization. Send your account in the `X-account-code` header. The response returns the payment method in the same shape as the [Enroll Payment Method](/reference/enroll-payment-method-api) response, with the new owner in the `customer_id` field.
 
 <Note>
 To reassign the payment method, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.


### PR DESCRIPTION
Documents the new public endpoint that reassigns an enrolled payment method to a different customer.

Ticket: C2-17639

### What this adds

- New API reference page `Reassign a Payment Method to Another Customer` under Payment Methods (direct workflow).
- New OpenAPI spec `openapi/payment-methods-direct-workflow/reassign-payment-method-api.json`.
- One navigation entry in `docs.json`.

### Endpoint

`PATCH /v1/payment-methods/{payment_method_id}`

Reassigns an enrolled payment method to another customer of the same account. The payment method is resolved within the account passed in `X-account-code`. The target customer must already exist and belong to the same organization as the caller.

### Fields

- Request body: `customer_id` (required, UUID) - the customer the payment method is reassigned to.
- Response 200: the updated payment method (same shape the GET payment method by id returns), now including a new `customer_id` field with the new owner, so the caller can confirm the reassignment.
- Errors: `400 BAD_REQUEST` (invalid body or target customer does not exist), `404 NOT_FOUND` (payment method does not exist for this account), `409 CONFLICT` (payment method is already assigned to a customer that has data).

### Example

Request

```
PATCH /v1/payment-methods/2fd6bf11-2129-4061-9c2a-34e196f89753
X-account-code: <Your X-account-code>
X-idempotency-key: <Your X-idempotency-key>
private-secret-key: <Your private-secret-key>
Content-Type: application/json

{
  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001"
}
```

Response 200

```
{
  "id": "2fd6bf11-2129-4061-9c2a-34e196f89753",
  "account_id": "493e9374-510a-4201-9e09-de669d75f256",
  "customer_id": "b3f2c1a0-1234-4a5b-9c8d-000000000001",
  "name": "VISA ****1111",
  "type": "CARD",
  "category": "CARD",
  "status": "ENROLLED",
  "created_at": "2024-06-04T12:47:46.992602Z",
  "updated_at": "2024-06-04T12:47:46.992603Z"
}
```

### Open question: where should this live in the navigation?

Every existing endpoint in the `payment-methods-direct-workflow` group is customer-scoped (`/customers/{customer_id}/payment-methods/...`). This new endpoint is top-level (`/payment-methods/{payment_method_id}`) and scoped by the `X-account-code` header instead. For now the page is placed in that same group so the preview renders, but the placement is open: keep it in `payment-methods-direct-workflow`, or give it a different home. Happy to move it wherever you prefer.

### Notes

- This is a draft for copy review. Please review the descriptions and the `Warning` note before it is merged.
- Merging to `main` auto-publishes to docs.y.uno, so it stays as a draft until the copy is approved.
