### PR TITLE
docs(C2-17635): document connection_id on unreferenced refunds

### DIFF
--- a/reference/unreferenced-refunds/create-unreferenced-refund.mdx
+++ b/reference/unreferenced-refunds/create-unreferenced-refund.mdx
@@ -64,6 +64,10 @@ Pins the refund to a specific gateway, bypassing routing rules. Useful when the 
 <ParamField body="id" type="string" required>
 Provider identifier. Allowed values: `ADYEN`, `STRIPE`, `NUVEI`, `BRAINTREE`, `GOCARDLESS`, `ORBITAL`, `WORLDPAY`, `VANTIV`, `CARDCONNECT`, `FISERV_COMMERCEHUB`, `MONERIS`, `NMI`, `FIRSTDATA`, `WINDCAVE`, `SAFERPAY`, `JPM`, `PAYPAL_EXPRESS_CHECKOUT`, `MASTERCARD`, `CITI`, `WELLSFARGO`, `SAGEPAY`, `FATZEBRA`, `HELIX`, `24HF`, `MERCHANTE_SOLUTIONS`, `ANB`, `AUTHORIZE_NET`, `SPECTRUM`.
 </ParamField>
+
+<ParamField body="connection_id" type="string">
+Pins the refund to a specific PSP connection within the provider (UUID). Use it when the provider has more than one connection and the credit must target the exact one (for example, a billing migration). Must be sent together with `id`; a `connection_id` without `id` is rejected with `400`.
+</ParamField>
 </Expandable>
 </ParamField>
 
@@ -187,7 +191,8 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
     "currency": "USD"
   },
   "provider_data": {
-    "id": "STRIPE"
+    "id": "STRIPE",
+    "connection_id": "8821cf99-89a5-4ecb-aba9-149cb08624fa"
   },
   "payment_method": {
     "vaulted_token": "550e8400-e29b-41d4-a716-446655440000"


### PR DESCRIPTION
## What
Documents the new optional \`connection_id\` on \`provider_data\` for \`POST /v1/unreferenced-refunds\`, mirroring the public-api contract change in yuno-payments/public-api#1995 (ticket C2-17635).

## Changes
- Adds a \`connection_id\` \`<ParamField>\` inside \`provider_data\`, describing it as an optional UUID that pins the credit to a specific PSP connection within the provider, and noting it must be sent together with \`id\` (a \`connection_id\` without \`id\` is rejected with \`400\`).
- Shows \`connection_id\` in the request example alongside \`provider_data.id\`.

## Context
The contract lives in public-api PR #1995 (\`provider_data.{id, connection_id}\`, edge-validated as UUID, forwarded flat to unref-transaction-ms). This PR is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to the unreferenced refund reference page; no runtime or API behavior changes in this repo.
> 
> **Overview**
> Documents the optional **`connection_id`** field on **`provider_data`** for **`POST /v1/unreferenced-refunds`**, aligning the reference page with the public API contract (C2-17635).
> 
> The new **`connection_id`** param describes a UUID that pins the credit to a specific PSP connection when a provider has multiple connections (e.g. billing migration). It must be sent with **`provider_data.id`**; **`connection_id`** alone returns **`400`**. The JSON request example now includes **`connection_id`** next to **`id`: `STRIPE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5c953983efde4a92e03dc5b5959949667f0517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->