### PR TITLE
docs(C2-16596): show raw_request as a provider_data attribute in payments + operations

### DIFF
--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -5610,6 +5610,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -5884,6 +5888,10 @@
                                 "response_code": {
                                   "type": "string",
                                   "example": ""
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -6577,6 +6585,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -7434,6 +7446,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -7871,6 +7887,10 @@
                                       "iso8583_response_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -8611,6 +8631,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -9256,6 +9280,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -9966,6 +9994,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -10531,6 +10563,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -11101,6 +11137,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -11667,6 +11707,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -12232,6 +12276,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",

--- a/openapi/payments/cancel-or-refund-a-payment.json
+++ b/openapi/payments/cancel-or-refund-a-payment.json
@@ -892,6 +892,10 @@
                               "type": "string",
                               "example": "Approved or completed successfully"
                             },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
@@ -1306,6 +1310,10 @@
                               "type": "string",
                               "example": "Approved or completed successfully"
                             },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
@@ -1719,6 +1727,10 @@
                             "iso8583_response_message": {
                               "type": "string",
                               "example": "Approved or completed successfully"
+                            },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                             },
                             "raw_response": {},
                             "third_party_transaction_id": {},

--- a/openapi/payments/cancel-or-refund-payment-with-transaction.json
+++ b/openapi/payments/cancel-or-refund-payment-with-transaction.json
@@ -899,6 +899,10 @@
                               "type": "string",
                               "example": "Approved or completed successfully"
                             },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
@@ -1307,6 +1311,10 @@
                               "type": "string",
                               "example": "Approved or completed successfully"
                             },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
@@ -1714,6 +1722,10 @@
                             "iso8583_response_message": {
                               "type": "string",
                               "example": "Approved or completed successfully"
+                            },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                             },
                             "raw_response": {},
                             "third_party_transaction_id": {},

--- a/openapi/payments/cancel-payment.json
+++ b/openapi/payments/cancel-payment.json
@@ -294,6 +294,10 @@
                           "type": "string",
                           "example": "SUCCEEDED"
                         },
+                        "raw_request": {
+                          "type": "object",
+                          "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                        },
                         "raw_response": {
                           "type": "object",
                           "properties": {

--- a/openapi/payments/capture-authorization.json
+++ b/openapi/payments/capture-authorization.json
@@ -1117,6 +1117,10 @@
                               "type": "string",
                               "example": "Approved or completed successfully"
                             },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
@@ -1299,6 +1303,10 @@
                             "iso8583_response_message": {
                               "type": "string",
                               "example": "Approved or completed successfully"
+                            },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                             },
                             "raw_response": {},
                             "third_party_transaction_id": {},
@@ -1671,6 +1679,10 @@
                             "iso8583_response_message": {
                               "type": "string",
                               "example": "Approved or completed successfully"
+                            },
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                             },
                             "raw_response": {},
                             "third_party_transaction_id": {},

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -11521,6 +11521,10 @@
                                 },
                                 "response_message": {},
                                 "response_code": {},
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -11812,6 +11816,10 @@
                                   },
                                   "response_message": {},
                                   "response_code": {},
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -12459,6 +12467,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -12735,6 +12747,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -12851,6 +12867,10 @@
                                       },
                                       "score": {
                                         "type": "string"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object"
@@ -13666,6 +13686,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -13942,6 +13966,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -14058,6 +14086,10 @@
                                       },
                                       "score": {
                                         "type": "string"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object"
@@ -14725,6 +14757,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -15001,6 +15037,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -15117,6 +15157,10 @@
                                       },
                                       "score": {
                                         "type": "string"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object"
@@ -15852,6 +15896,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -16127,6 +16175,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -16828,6 +16880,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -17103,6 +17159,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -17804,6 +17864,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -18079,6 +18143,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -18796,6 +18864,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -19087,6 +19159,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -19785,6 +19861,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -20060,6 +20140,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -20765,6 +20849,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -21040,6 +21128,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -21753,6 +21845,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -22032,6 +22128,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -22463,6 +22563,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -22611,6 +22715,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -23362,6 +23470,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -23637,6 +23749,10 @@
                                 "iso8583_response_message": {
                                   "type": "string",
                                   "example": "Approved or completed successfully"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -24308,6 +24424,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -24891,6 +25011,10 @@
                                   "type": "string",
                                   "example": "Approved or completed successfully"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -25169,6 +25293,10 @@
                                   "iso8583_response_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -26065,6 +26193,10 @@
                                 "response_code": {
                                   "type": "string",
                                   "example": "200"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",
@@ -27053,6 +27185,10 @@
                                   "response_code": {
                                     "type": "string",
                                     "example": "200"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",

--- a/openapi/payments/disputes.json
+++ b/openapi/payments/disputes.json
@@ -2203,6 +2203,10 @@
                             },
                             "response_message": {},
                             "response_code": {},
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {},

--- a/openapi/payments/refund-payment.json
+++ b/openapi/payments/refund-payment.json
@@ -1535,6 +1535,10 @@
                                   "type": "string",
                                   "example": "SUCCEEDED"
                                 },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                },
                                 "raw_response": {
                                   "type": "object",
                                   "properties": {
@@ -2178,6 +2182,10 @@
                                 "response_code": {
                                   "type": "string",
                                   "example": "SUCCEEDED"
+                                },
+                                "raw_request": {
+                                  "type": "object",
+                                  "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                 },
                                 "raw_response": {
                                   "type": "object",

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -3887,6 +3887,10 @@
                                         "type": "string",
                                         "example": "Approved or completed successfully"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -4697,6 +4701,10 @@
                                       "iso8583_response_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -5640,6 +5648,10 @@
                                         "type": "string",
                                         "example": "Do not honor"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -6176,6 +6188,10 @@
                                       "iso8583_response_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -6988,6 +7004,10 @@
                                         "type": "string",
                                         "example": "Approved or completed successfully"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -7781,6 +7801,10 @@
                                         "type": "string",
                                         "example": "Approved or completed successfully"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -8511,6 +8535,10 @@
                                         "type": "string",
                                         "example": "Approved or completed successfully"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -9240,6 +9268,10 @@
                                       "iso8583_response_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -9973,6 +10005,10 @@
                                       "iso8583_response_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -10718,6 +10754,10 @@
                                         "type": "string",
                                         "example": "Approved or completed successfully"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -11462,6 +11502,10 @@
                                         "type": "string",
                                         "example": "Approved or completed successfully"
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -12010,6 +12054,10 @@
                                       "iso8583_message": {
                                         "type": "string",
                                         "example": ""
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -12578,6 +12626,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                      },
                                       "raw_response": {
                                         "type": "object",
                                         "properties": {
@@ -13047,6 +13099,10 @@
                                       "iso8583_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -13531,6 +13587,10 @@
                                       "iso8583_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",
@@ -14292,6 +14352,10 @@
                                       "iso8583_message": {
                                         "type": "string",
                                         "example": "Approved or completed successfully"
+                                      },
+                                      "raw_request": {
+                                        "type": "object",
+                                        "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                       },
                                       "raw_response": {
                                         "type": "object",

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -3535,6 +3535,10 @@
                                     "type": "string",
                                     "example": "Approved or completed successfully"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -4294,6 +4298,10 @@
                                   "iso8583_response_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -5195,6 +5203,10 @@
                                     "type": "string",
                                     "example": "Do not honor"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -5689,6 +5701,10 @@
                                   "iso8583_response_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -6468,6 +6484,10 @@
                                     "type": "string",
                                     "example": "Approved or completed successfully"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -7223,6 +7243,10 @@
                                     "type": "string",
                                     "example": "Approved or completed successfully"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -7911,6 +7935,10 @@
                                     "type": "string",
                                     "example": "Approved or completed successfully"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -8598,6 +8626,10 @@
                                   "iso8583_response_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -9289,6 +9321,10 @@
                                   "iso8583_response_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -9992,6 +10028,10 @@
                                     "type": "string",
                                     "example": "Approved or completed successfully"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -10694,6 +10734,10 @@
                                     "type": "string",
                                     "example": "Approved or completed successfully"
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -11200,6 +11244,10 @@
                                   "iso8583_message": {
                                     "type": "string",
                                     "example": ""
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -11717,6 +11765,10 @@
                                     "type": "string",
                                     "example": ""
                                   },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                  },
                                   "raw_response": {
                                     "type": "object",
                                     "properties": {
@@ -12140,6 +12192,10 @@
                                   "iso8583_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",
@@ -12573,6 +12629,10 @@
                                   "iso8583_message": {
                                     "type": "string",
                                     "example": "Approved or completed successfully"
+                                  },
+                                  "raw_request": {
+                                    "type": "object",
+                                    "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                   },
                                   "raw_response": {
                                     "type": "object",

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -3608,6 +3608,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -4333,6 +4337,10 @@
                                     "iso8583_response_message": {
                                       "type": "string",
                                       "example": "Approved or completed successfully"
+                                    },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                     },
                                     "raw_response": {
                                       "type": "object",
@@ -5439,6 +5447,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -6190,6 +6202,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -6913,6 +6929,10 @@
                                     "iso8583_response_message": {
                                       "type": "string",
                                       "example": "Approved or completed successfully"
+                                    },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                     },
                                     "raw_response": {
                                       "type": "object",
@@ -7708,6 +7728,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -8368,6 +8392,10 @@
                                     "iso8583_response_message": {
                                       "type": "string",
                                       "example": "Approved or completed successfully"
+                                    },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                     },
                                     "raw_response": {
                                       "type": "object",
@@ -9032,6 +9060,10 @@
                                     "iso8583_response_message": {
                                       "type": "string",
                                       "example": "Approved or completed successfully"
+                                    },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                     },
                                     "raw_response": {
                                       "type": "object",
@@ -9708,6 +9740,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -10383,6 +10419,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -10876,6 +10916,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -11330,6 +11374,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -11781,6 +11829,10 @@
                                     "iso8583_message": {
                                       "type": "string",
                                       "example": "Approved or completed successfully"
+                                    },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                     },
                                     "raw_response": {
                                       "type": "object",
@@ -12241,6 +12293,10 @@
                                       "type": "string",
                                       "example": "Approved or completed successfully"
                                     },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                    },
                                     "raw_response": {
                                       "type": "object",
                                       "properties": {
@@ -12665,6 +12721,10 @@
                                     "iso8583_message": {
                                       "type": "string",
                                       "example": "Approved or completed successfully"
+                                    },
+                                    "raw_request": {
+                                      "type": "object",
+                                      "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
                                     },
                                     "raw_response": {
                                       "type": "object",

--- a/openapi/payments/update-dispute.json
+++ b/openapi/payments/update-dispute.json
@@ -2193,6 +2193,10 @@
                             },
                             "response_message": {},
                             "response_code": {},
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {},

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -5095,7 +5095,7 @@ This object represents the payment created after generating the checkout session
             </ParamField>
 
             <ParamField body="raw_request" type="object">
-              The raw request payload that Yuno sent to the payment provider, exposed alongside `raw_response`. It is returned for payments and for the capture, cancel, and refund operations. Only present for organizations enabled for this feature; otherwise it is omitted.
+              Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations.
 
               Example: JSON
             </ParamField>


### PR DESCRIPTION
Follow-up to #590. That PR added `raw_request` to response **examples** + the payment-object `ParamField`, but the **API Reference attributes** list renders from the OpenAPI response **schema** (`properties`), where `raw_response` is declared as a property and `raw_request` was not — so it didn't show up (screenshot: `transactions.provider_data` listed `raw_response` but not `raw_request`).

This declares `raw_request` as a `provider_data` schema property (type `object` + description) next to `raw_response` across every payment and operation response schema:
- create-payment (34), retrieve-payment-by-id (15), capture-authorization (3), cancel-payment (2), refund-payment (2), cancel-or-refund-a-payment (3), cancel-or-refund-payment-with-transaction (3).

Now it renders as `transactions.provider_data.raw_request` in the attributes list. All specs JSON-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI schema only; no API or runtime behavior changes in this diff.
> 
> **Overview**
> Documents **`transactions.provider_data.raw_request`** in the API Reference by adding it to OpenAPI response schemas wherever **`raw_response`** already appears, so the attributes list can render it (examples alone were insufficient).
> 
> Each addition is an **`object`** with the description: obfuscated provider outbound request, **only for allowlisted organizations**. Coverage spans create/authorize/retrieve/capture/cancel/refund/cancel-or-refund flows, disputes, and nested 3DS **`provider_data`** blocks.
> 
> The payment-object reference **`raw_request` `ParamField`** text is updated to match that OpenAPI wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7dd72d0af4a50dda50f95e69cc8de4053cc18b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->