### PR TITLE
Add List Routings endpoint documentation (GET /v1/routing)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -635,6 +635,7 @@
                   "reference/organizations/routing/routing-resource-shape",
                   "reference/organizations/routing/routing-conditions",
                   "reference/organizations/routing/create-routing",
+                  "reference/organizations/routing/list-routings",
                   "reference/organizations/routing/retrieve-routing",
                   "reference/organizations/routing/update-routing"
                 ]

--- a/openapi/organizations/routing/create-routing.json
+++ b/openapi/organizations/routing/create-routing.json
@@ -14,7 +14,7 @@
       "post": {
         "summary": "Create a Routing",
         "operationId": "create-routing",
-        "description": "Creates a routing for one (account_code, payment_method) pair.",
+        "description": "Creates a routing for one (account_id, payment_method) pair.",
         "parameters": [
           { "name": "X-Idempotency-Key", "in": "header", "required": true, "schema": { "type": "string", "format": "uuid" } }
         ],
@@ -61,7 +61,7 @@
                   "type": "object",
                   "properties": {
                     "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
-                    "account_code": { "type": "string", "example": "acc-uuid" },
+                    "account_id": { "type": "string", "example": "acc-uuid" },
                     "payment_method": { "type": "string", "example": "CARD" },
                     "name": { "type": "string", "example": "Card routing" },
                     "default_route": { 

--- a/openapi/organizations/routing/list-routings.json
+++ b/openapi/organizations/routing/list-routings.json
@@ -30,7 +30,7 @@
                     "type": "object",
                     "properties": {
                       "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
-                      "account_code": { "type": "string", "example": "acc-uuid" },
+                      "account_id": { "type": "string", "example": "acc-uuid" },
                       "payment_method": { "type": "string", "example": "CARD" },
                       "name": { "type": "string", "example": "Card routing — Stripe primary, Adyen fallback" },
                       "default_route": {

--- a/openapi/organizations/routing/list-routings.json
+++ b/openapi/organizations/routing/list-routings.json
@@ -1,0 +1,91 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Routing API - List", "version": "1.0.0" },
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/routing": {
+      "get": {
+        "summary": "List Routings",
+        "operationId": "list-routings",
+        "description": "Lists all routings of an account, optionally filtered by payment method. Each item has the same shape as Retrieve a Routing.",
+        "parameters": [
+          { "name": "account_id", "in": "query", "required": true, "schema": { "type": "string", "format": "uuid" }, "description": "Account to list routings for. Must belong to the organization of your API credentials." },
+          { "name": "payment_method", "in": "query", "required": false, "schema": { "type": "string", "example": "CARD" }, "description": "Filter by payment method (e.g., CARD, PIX)." }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
+                      "account_code": { "type": "string", "example": "acc-uuid" },
+                      "payment_method": { "type": "string", "example": "CARD" },
+                      "name": { "type": "string", "example": "Card routing — Stripe primary, Adyen fallback" },
+                      "default_route": {
+                        "type": "object",
+                        "properties": {
+                          "steps": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "index": { "type": "integer", "example": 1 },
+                                "provider_id": { "type": "string", "example": "STRIPE" },
+                                "connection_id": { "type": "string", "example": "f1a3c4d5-..." }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "condition_sets": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "sort_number": { "type": "integer", "example": 1 },
+                            "name": { "type": "string", "example": "High Value US" },
+                            "conditions": { "type": "array", "items": { "type": "object" } },
+                            "route": { "type": "object" }
+                          }
+                        }
+                      },
+                      "created_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" },
+                      "updated_at": { "type": "string", "format": "date-time", "example": "2026-05-12T14:30:00Z" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "invalid_request" },
+                    "code": { "type": "string", "example": "ROUTING_VALIDATION_FAILED" },
+                    "message": { "type": "string", "example": "account_id is required." }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/routing/list-routings.json
+++ b/openapi/organizations/routing/list-routings.json
@@ -21,7 +21,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "The routings configured on the account, or an empty array if it has none.",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi/organizations/routing/retrieve-routing.json
+++ b/openapi/organizations/routing/retrieve-routing.json
@@ -27,7 +27,7 @@
                   "type": "object",
                   "properties": {
                     "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
-                    "account_code": { "type": "string", "example": "acc-uuid" },
+                    "account_id": { "type": "string", "example": "acc-uuid" },
                     "payment_method": { "type": "string", "example": "CARD" },
                     "name": { "type": "string", "example": "Card routing — Stripe primary, Adyen fallback" },
                     "default_route": { 

--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -28,7 +28,7 @@
                   "type": "object",
                   "properties": {
                     "id": { "type": "string", "example": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f" },
-                    "account_code": { "type": "string", "example": "acc-uuid" },
+                    "account_id": { "type": "string", "example": "acc-uuid" },
                     "payment_method": { "type": "string", "example": "CARD" },
                     "name": { "type": "string", "example": "Updated Card routing v2" },
                     "default_route": { 

--- a/reference/organizations/routing/create-routing.mdx
+++ b/reference/organizations/routing/create-routing.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Create a Routing"
-description: "Creates a routing for one (account_code, payment_method) pair. Always live on success."
+description: "Creates a routing for one (account_id, payment_method) pair. Always live on success."
 openapi: "/openapi/organizations/routing/create-routing.json POST /routing"
 ---
 
-Creates a routing for one `(account_code, payment_method)` pair. Each routing references **connections** by their `connection_id`. Make sure your connections are created and `ACTIVE` for the requested `payment_method` *before* you call routing.
+Creates a routing for one `(account_id, payment_method)` pair. Each routing references **connections** by their `connection_id`. Make sure your connections are created and `ACTIVE` for the requested `payment_method` *before* you call routing.
 
 ### Body
 
@@ -77,8 +77,8 @@ Creates a routing for one `(account_code, payment_method)` pair. Each routing re
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
-<ResponseField name="account_code" type="string">
-  Unique code for the account.
+<ResponseField name="account_id" type="string">
+  Unique identifier for the account.
 </ResponseField>
 <ResponseField name="payment_method" type="enum">
   The payment method this routing applies to (e.g., `CARD`).
@@ -155,7 +155,7 @@ curl -X POST 'https://api.y.uno/v1/routing' \
 ```json 201 Created
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
-  "account_code": "acc-uuid",
+  "account_id": "acc-uuid",
   "payment_method": "CARD",
   "name": "Card routing — Stripe primary, Adyen fallback",
   "default_route": {

--- a/reference/organizations/routing/list-routings.mdx
+++ b/reference/organizations/routing/list-routings.mdx
@@ -4,7 +4,7 @@ description: "Lists all routings of an account, optionally filtered by payment m
 openapi: "/openapi/organizations/routing/list-routings.json GET /routing"
 ---
 
-Lists the routings configured on an account. Each item in the response has the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing).
+Lists the routings configured on an account. Each item in the response has the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing), and reflects the routing's current live configuration — routings that only exist as dashboard drafts are not included.
 
 Pass `payment_method` to list only the routings for that payment method, and omit it to list all of them.
 

--- a/reference/organizations/routing/list-routings.mdx
+++ b/reference/organizations/routing/list-routings.mdx
@@ -4,7 +4,7 @@ description: "Lists all routings of an account, optionally filtered by payment m
 openapi: "/openapi/organizations/routing/list-routings.json GET /routing"
 ---
 
-Lists the routings configured on an account. Each item in the response has the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing), and reflects the routing's current live configuration — routings that only exist as dashboard drafts are not included.
+Lists the routings configured on an account. Each item returns the routing's current live configuration, with the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing).
 
 Pass `payment_method` to list only the routings for that payment method, and omit it to list all of them.
 

--- a/reference/organizations/routing/list-routings.mdx
+++ b/reference/organizations/routing/list-routings.mdx
@@ -4,7 +4,9 @@ description: "Lists all routings of an account, optionally filtered by payment m
 openapi: "/openapi/organizations/routing/list-routings.json GET /routing"
 ---
 
-Lists all routings of an account. Each item in the response has the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing). Returns an empty array if the account has no routings.
+Lists the routings configured on an account. Each item in the response has the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing).
+
+Pass `payment_method` to list only the routings for that payment method, and omit it to list all of them.
 
 ### Query Parameters
 
@@ -17,7 +19,7 @@ Lists all routings of an account. Each item in the response has the same shape a
 
 ### Response
 
-Array of routing objects:
+The routings configured on the account, or an empty array if it has none. Each routing contains:
 
 <ResponseField name="id" type="string">
   Unique identifier for the routing.

--- a/reference/organizations/routing/list-routings.mdx
+++ b/reference/organizations/routing/list-routings.mdx
@@ -45,6 +45,9 @@ The routings configured on the account, or an empty array if it has none. Each r
 <ResponseField name="updated_at" type="string">
   ISO 8601 timestamp.
 </ResponseField>
+<ResponseField name="warnings" type="string[]">
+  Optional list of non-blocking orchestration warnings (e.g., `MONITOR_REDISTRIBUTION_DEFERRED`).
+</ResponseField>
 
 <CodeGroup>
 ```bash cURL

--- a/reference/organizations/routing/list-routings.mdx
+++ b/reference/organizations/routing/list-routings.mdx
@@ -22,8 +22,8 @@ Array of routing objects:
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
-<ResponseField name="account_code" type="string">
-  Unique code for the account.
+<ResponseField name="account_id" type="string">
+  Unique identifier for the account.
 </ResponseField>
 <ResponseField name="payment_method" type="enum">
   The payment method this routing applies to (e.g., `CARD`).
@@ -55,7 +55,7 @@ curl -X GET 'https://api.y.uno/v1/routing?account_id=7825fc5e-e50a-4248-9ae8-5d3
 [
   {
     "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
-    "account_code": "acc-uuid",
+    "account_id": "acc-uuid",
     "payment_method": "CARD",
     "name": "Card routing — Stripe primary, Adyen fallback",
     "default_route": {

--- a/reference/organizations/routing/list-routings.mdx
+++ b/reference/organizations/routing/list-routings.mdx
@@ -1,0 +1,99 @@
+---
+title: "List Routings"
+description: "Lists all routings of an account, optionally filtered by payment method."
+openapi: "/openapi/organizations/routing/list-routings.json GET /routing"
+---
+
+Lists all routings of an account. Each item in the response has the same shape as [Retrieve a Routing](/reference/organizations/routing/retrieve-routing). Returns an empty array if the account has no routings.
+
+### Query Parameters
+
+<ParamField query="account_id" type="string" required>
+  The account to list routings for. Must belong to the organization your API credentials are scoped to.
+</ParamField>
+<ParamField query="payment_method" type="enum">
+  Optional filter by payment method (e.g., `CARD`, `PIX`). Same values as the `payment_method` field in routing responses.
+</ParamField>
+
+### Response
+
+Array of routing objects:
+
+<ResponseField name="id" type="string">
+  Unique identifier for the routing.
+</ResponseField>
+<ResponseField name="account_code" type="string">
+  Unique code for the account.
+</ResponseField>
+<ResponseField name="payment_method" type="enum">
+  The payment method this routing applies to (e.g., `CARD`).
+</ResponseField>
+<ResponseField name="name" type="string">
+  Label for the routing.
+</ResponseField>
+<ResponseField name="default_route" type="object">
+  The default routing logic.
+</ResponseField>
+<ResponseField name="condition_sets" type="object[]">
+  Optional conditional logic.
+</ResponseField>
+<ResponseField name="created_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+<ResponseField name="updated_at" type="string">
+  ISO 8601 timestamp.
+</ResponseField>
+
+<CodeGroup>
+```bash cURL
+curl -X GET 'https://api.y.uno/v1/routing?account_id=7825fc5e-e50a-4248-9ae8-5d3786afb0be&payment_method=CARD' \
+  -H 'public-api-key: <YOUR_PUBLIC_KEY>' \
+  -H 'private-secret-key: <YOUR_SECRET_KEY>'
+```
+
+```json 200 OK
+[
+  {
+    "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
+    "account_code": "acc-uuid",
+    "payment_method": "CARD",
+    "name": "Card routing — Stripe primary, Adyen fallback",
+    "default_route": {
+      "steps": [
+        {
+          "index": 1,
+          "provider_id": "STRIPE",
+          "connection_id": "f1a3c4d5-7b8e-4a2c-9d1e-3f4a5b6c7d8e",
+          "output": [
+            { "status": "DECLINE_GROUP", "next": 2 },
+            { "status": "TIMEOUT",        "next": 2 }
+          ]
+        },
+        { "index": 2, "provider_id": "ADYEN", "connection_id": "b2c4d5e6-..." }
+      ]
+    },
+    "created_at": "2026-05-12T14:30:00Z",
+    "updated_at": "2026-05-12T14:30:00Z"
+  }
+]
+```
+
+```json 400 Bad Request
+{
+  "type": "invalid_request",
+  "code": "ROUTING_VALIDATION_FAILED",
+  "message": "account_id is required."
+}
+```
+</CodeGroup>
+
+### Errors
+
+<div className="code-nowrap-table dense-table">
+
+| HTTP | `code` | When |
+|---|---|---|
+| `400` | `ROUTING_VALIDATION_FAILED` | Missing `account_id` query parameter. |
+| `403` | `INSUFFICIENT_SCOPE` | API key missing `routing:read`, or `account_id` belongs to a different organization. |
+
+</div>

--- a/reference/organizations/routing/retrieve-routing.mdx
+++ b/reference/organizations/routing/retrieve-routing.mdx
@@ -17,8 +17,8 @@ Returns the routing's current live configuration.
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
-<ResponseField name="account_code" type="string">
-  Unique code for the account.
+<ResponseField name="account_id" type="string">
+  Unique identifier for the account.
 </ResponseField>
 <ResponseField name="payment_method" type="enum">
   The payment method this routing applies to (e.g., `CARD`).
@@ -52,7 +52,7 @@ curl -X GET 'https://api.y.uno/v1/routing/r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f
 ```json 200 OK
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
-  "account_code": "acc-uuid",
+  "account_id": "acc-uuid",
   "payment_method": "CARD",
   "name": "Card routing — Stripe primary, Adyen fallback",
   "default_route": {

--- a/reference/organizations/routing/routing-resource-shape.mdx
+++ b/reference/organizations/routing/routing-resource-shape.mdx
@@ -10,7 +10,7 @@ A routing tells Yuno, for one `payment_method` on one account, which connection 
 ```json
 {
   "id": "r_8f2c1d3e-…",
-  "account_code": "acc-uuid",
+  "account_id": "acc-uuid",
   "payment_method": "CARD",
   "name": "Card routing",
   "default_route": {
@@ -48,7 +48,7 @@ A routing tells Yuno, for one `payment_method` on one account, which connection 
 | Field | Type | Notes |
 |---|---|---|
 | `id` | UUID | Server-assigned. The same value is referenced as `routing_id` in URL paths. |
-| `account_code` | string | Inferred from your API key. Not supplied in request bodies. |
+| `account_id` | string | Inferred from your API key. Not supplied in request bodies. |
 | `payment_method` | enum | E.g., `CARD`, `PIX`, `WALLET`. Immutable per routing — to route a different method, create a new routing. |
 | `name` | string | Free-form label. |
 | `default_route` | object | The route used when no `condition_sets[]` matches. **Required.** |

--- a/reference/organizations/routing/update-routing.mdx
+++ b/reference/organizations/routing/update-routing.mdx
@@ -6,7 +6,7 @@ openapi: "/openapi/organizations/routing/update-routing.json PATCH /routing/{rou
 
 Replaces the routing's full configuration. The body has the same shape as [Create a Routing](/reference/organizations/routing/create-routing) — the new `default_route` and `condition_sets[]` entirely supersede the previous live state. **There is no field-level merge.**
 
-`account_code` and `payment_method` are sticky to the `routing_id` — they're set at creation and cannot be changed by `PATCH`.
+`account_id` and `payment_method` are sticky to the `routing_id` — they're set at creation and cannot be changed by `PATCH`.
 
 ### Path Parameters
 
@@ -77,8 +77,8 @@ Replaces the routing's full configuration. The body has the same shape as [Creat
 <ResponseField name="id" type="string">
   Unique identifier for the routing.
 </ResponseField>
-<ResponseField name="account_code" type="string">
-  Unique code for the account.
+<ResponseField name="account_id" type="string">
+  Unique identifier for the account.
 </ResponseField>
 <ResponseField name="payment_method" type="enum">
   The payment method this routing applies to (e.g., `CARD`).
@@ -148,7 +148,7 @@ curl -X PATCH 'https://api.y.uno/v1/routing/r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e
 ```json 200 OK — Updated
 {
   "id": "r_8f2c1d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f",
-  "account_code": "acc-uuid",
+  "account_id": "acc-uuid",
   "payment_method": "CARD",
   "name": "Card routing v2 — adds BR installments rule",
   "default_route": {


### PR DESCRIPTION
## What

Adds public documentation for the new **List Routings** endpoint:

`GET /v1/routing?account_id={uuid}&payment_method={type}`

- `account_id` (query, **required**) — must belong to the organization of the API credentials.
- `payment_method` (query, optional) — filter, e.g. `CARD`.
- Response: array of routing objects, same shape as [Retrieve a Routing](https://docs.y.uno/reference/organizations/routing/retrieve-routing). Empty array if none.
- 400 `ROUTING_VALIDATION_FAILED` when `account_id` is missing.

## Files

- `reference/organizations/routing/list-routings.mdx` — new page (mirrors retrieve-routing conventions).
- `openapi/organizations/routing/list-routings.json` — OpenAPI spec for the interactive playground.
- `docs.json` — nav entry under Routing, between Create and Retrieve.

## Related

Backend implementation: C2-17752 (public-api + routing-ms).

⚠️ Note: docs auto-deploy on merge — hold merging until the endpoint is live in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; merge timing matters only because docs auto-deploy before the backend endpoint may be live in production.
> 
> **Overview**
> Documents **GET `/v1/routing`** so integrators can list routings for an account, with required `account_id` and optional `payment_method`, returning an array matching the retrieve-routing shape (including empty list and `400` when `account_id` is missing). Adds `list-routings.mdx`, `list-routings.json`, and a **Routing** nav entry between Create and Retrieve.
> 
> Aligns routing reference and OpenAPI with **`account_id`** instead of **`account_code`** on create, retrieve, and update responses and in the resource-shape docs, so the public contract matches the API field name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ce3b74156c54586aa205122e492459be8a8cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->