### PR TITLE
docs(C2-17637): document bank transfer mandate fields on payments and direct enrollment

### DIFF
--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -288,6 +288,42 @@
                               "reference": {
                                 "type": "string",
                                 "description": "Reference associated with the bank account. MIN 1 / MAX 255."
+                              },
+                              "bank_account_mask_number": {
+                                "type": "string",
+                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                              },
+                              "mandate": {
+                                "type": "object",
+                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Mandate identifier, as provided by the payment provider."
+                                  },
+                                  "info": {
+                                    "type": "string",
+                                    "description": "Free-text mandate information."
+                                  },
+                                  "received_status": {
+                                    "type": "string",
+                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                  },
+                                  "existing_status": {
+                                    "type": "string",
+                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                  }
+                                }
                               }
                             }
                           }
@@ -433,7 +469,16 @@
                           "bank_account": "000123456789",
                           "routing_number": "110000000",
                           "beneficiary_name": "John Doe",
-                          "account_type": "CHECKINGS"
+                          "account_type": "CHECKINGS",
+                          "bank_account_mask_number": "****6789",
+                          "mandate": {
+                            "id": "MND-123",
+                            "info": "free text mandate info",
+                            "received_status": "RECEIVED",
+                            "existing_status": "ACTIVE",
+                            "created_at": "2026-07-09T00:00:00Z",
+                            "updated_at": "2026-07-09T00:00:00Z"
+                          }
                         }
                       }
                     }

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -2068,6 +2068,42 @@
                                 "type": "string",
                                 "description": "Payment methods expiration date. \"yyyy-MM-dd HH:mm:ss.SSSz\". Only available when the provider associated to the payment supports it. Please feel free to reach out to your technical account manager for further questions.",
                                 "format": "date-time"
+                              },
+                              "bank_account_mask_number": {
+                                "type": "string",
+                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                              },
+                              "mandate": {
+                                "type": "object",
+                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Mandate identifier, as provided by the payment provider."
+                                  },
+                                  "info": {
+                                    "type": "string",
+                                    "description": "Free-text mandate information."
+                                  },
+                                  "received_status": {
+                                    "type": "string",
+                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                  },
+                                  "existing_status": {
+                                    "type": "string",
+                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                  }
+                                }
                               }
                             }
                           }

--- a/openapi/payments/cancel-or-refund-a-payment.json
+++ b/openapi/payments/cancel-or-refund-a-payment.json
@@ -448,6 +448,42 @@
                               "reference": {
                                 "type": "string",
                                 "description": "Reference code for the user (MAX 255; MIN 1)"
+                              },
+                              "bank_account_mask_number": {
+                                "type": "string",
+                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                              },
+                              "mandate": {
+                                "type": "object",
+                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Mandate identifier, as provided by the payment provider."
+                                  },
+                                  "info": {
+                                    "type": "string",
+                                    "description": "Free-text mandate information."
+                                  },
+                                  "received_status": {
+                                    "type": "string",
+                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                  },
+                                  "existing_status": {
+                                    "type": "string",
+                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                  }
+                                }
                               }
                             }
                           }

--- a/openapi/payments/cancel-or-refund-payment-with-transaction.json
+++ b/openapi/payments/cancel-or-refund-payment-with-transaction.json
@@ -458,6 +458,42 @@
                               "reference": {
                                 "type": "string",
                                 "description": "Reference code for the user (MAX 255; MIN 1)"
+                              },
+                              "bank_account_mask_number": {
+                                "type": "string",
+                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                              },
+                              "mandate": {
+                                "type": "object",
+                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Mandate identifier, as provided by the payment provider."
+                                  },
+                                  "info": {
+                                    "type": "string",
+                                    "description": "Free-text mandate information."
+                                  },
+                                  "received_status": {
+                                    "type": "string",
+                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                  },
+                                  "existing_status": {
+                                    "type": "string",
+                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                  }
+                                }
                               }
                             }
                           }

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -2767,6 +2767,42 @@
                                     "description": "This object is used to send additional information about recurrence."
                                   }
                                 }
+                              },
+                              "bank_account_mask_number": {
+                                "type": "string",
+                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                              },
+                              "mandate": {
+                                "type": "object",
+                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Mandate identifier, as provided by the payment provider."
+                                  },
+                                  "info": {
+                                    "type": "string",
+                                    "description": "Free-text mandate information."
+                                  },
+                                  "received_status": {
+                                    "type": "string",
+                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                  },
+                                  "existing_status": {
+                                    "type": "string",
+                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                  }
+                                }
                               }
                             }
                           },
@@ -3233,6 +3269,15 @@
                             "number": "646180142000000006",
                             "digit": "123456",
                             "type": "SAVINGS"
+                          },
+                          "bank_account_mask_number": "****6789",
+                          "mandate": {
+                            "id": "MND-123",
+                            "info": "free text mandate info",
+                            "received_status": "RECEIVED",
+                            "existing_status": "ACTIVE",
+                            "created_at": "2026-07-09T00:00:00Z",
+                            "updated_at": "2026-07-09T00:00:00Z"
                           }
                         }
                       }

--- a/openapi/payments/refund-payment.json
+++ b/openapi/payments/refund-payment.json
@@ -463,6 +463,42 @@
                               "reference": {
                                 "type": "string",
                                 "description": "Reference code for the user (MAX 255; MIN 1)"
+                              },
+                              "bank_account_mask_number": {
+                                "type": "string",
+                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                              },
+                              "mandate": {
+                                "type": "object",
+                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "description": "Mandate identifier, as provided by the payment provider."
+                                  },
+                                  "info": {
+                                    "type": "string",
+                                    "description": "Free-text mandate information."
+                                  },
+                                  "received_status": {
+                                    "type": "string",
+                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                  },
+                                  "existing_status": {
+                                    "type": "string",
+                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                  },
+                                  "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                  },
+                                  "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                  }
+                                }
                               }
                             }
                           }

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -3559,6 +3559,42 @@
                                         "redirect_url": {
                                           "type": "string",
                                           "example": "https://api-sandbox.bankofamerica.com/v1/payment_methods/redirect/bank_transfer?transferCode=52xB9jF695TdDvHK-approved"
+                                        },
+                                        "bank_account_mask_number": {
+                                          "type": "string",
+                                          "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                        },
+                                        "mandate": {
+                                          "type": "object",
+                                          "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string",
+                                              "description": "Mandate identifier, as provided by the payment provider."
+                                            },
+                                            "info": {
+                                              "type": "string",
+                                              "description": "Free-text mandate information."
+                                            },
+                                            "received_status": {
+                                              "type": "string",
+                                              "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                            },
+                                            "existing_status": {
+                                              "type": "string",
+                                              "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                            },
+                                            "created_at": {
+                                              "type": "string",
+                                              "format": "date-time",
+                                              "description": "Date and time when the mandate was created (ISO 8601)."
+                                            },
+                                            "updated_at": {
+                                              "type": "string",
+                                              "format": "date-time",
+                                              "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                            }
+                                          }
                                         }
                                       }
                                     }
@@ -3827,6 +3863,42 @@
                                               "redirect_url": {
                                                 "type": "string",
                                                 "example": "https://api-sandbox.bankofamerica.com/v1/payment_methods/redirect/bank_transfer?transferCode=52xB9jF695TdDvHK-approved"
+                                              },
+                                              "bank_account_mask_number": {
+                                                "type": "string",
+                                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                              },
+                                              "mandate": {
+                                                "type": "object",
+                                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string",
+                                                    "description": "Mandate identifier, as provided by the payment provider."
+                                                  },
+                                                  "info": {
+                                                    "type": "string",
+                                                    "description": "Free-text mandate information."
+                                                  },
+                                                  "received_status": {
+                                                    "type": "string",
+                                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                                  },
+                                                  "existing_status": {
+                                                    "type": "string",
+                                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                                  },
+                                                  "created_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                                  },
+                                                  "updated_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                                  }
+                                                }
                                               }
                                             }
                                           }
@@ -11728,6 +11800,42 @@
                                         "redirect_url": {
                                           "type": "string",
                                           "example": "https://checkout.sandbox.y.uno/payment?session=2cc7ac83-029d-4e13-8360-9b627bba8fc5"
+                                        },
+                                        "bank_account_mask_number": {
+                                          "type": "string",
+                                          "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                        },
+                                        "mandate": {
+                                          "type": "object",
+                                          "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string",
+                                              "description": "Mandate identifier, as provided by the payment provider."
+                                            },
+                                            "info": {
+                                              "type": "string",
+                                              "description": "Free-text mandate information."
+                                            },
+                                            "received_status": {
+                                              "type": "string",
+                                              "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                            },
+                                            "existing_status": {
+                                              "type": "string",
+                                              "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                            },
+                                            "created_at": {
+                                              "type": "string",
+                                              "format": "date-time",
+                                              "description": "Date and time when the mandate was created (ISO 8601)."
+                                            },
+                                            "updated_at": {
+                                              "type": "string",
+                                              "format": "date-time",
+                                              "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                            }
+                                          }
                                         }
                                       }
                                     }
@@ -11999,6 +12107,42 @@
                                               "redirect_url": {
                                                 "type": "string",
                                                 "example": "https://checkout.sandbox.y.uno/payment?session=2cc7ac83-029d-4e13-8360-9b627bba8fc5"
+                                              },
+                                              "bank_account_mask_number": {
+                                                "type": "string",
+                                                "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                              },
+                                              "mandate": {
+                                                "type": "object",
+                                                "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string",
+                                                    "description": "Mandate identifier, as provided by the payment provider."
+                                                  },
+                                                  "info": {
+                                                    "type": "string",
+                                                    "description": "Free-text mandate information."
+                                                  },
+                                                  "received_status": {
+                                                    "type": "string",
+                                                    "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                                  },
+                                                  "existing_status": {
+                                                    "type": "string",
+                                                    "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                                  },
+                                                  "created_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "description": "Date and time when the mandate was created (ISO 8601)."
+                                                  },
+                                                  "updated_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                                  }
+                                                }
                                               }
                                             }
                                           }

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -3226,6 +3226,42 @@
                                     "redirect_url": {
                                       "type": "string",
                                       "example": "https://api-sandbox.bankofamerica.com/v1/payment_methods/redirect/bank_transfer?transferCode=52xB9jF695TdDvHK-approved"
+                                    },
+                                    "bank_account_mask_number": {
+                                      "type": "string",
+                                      "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                    },
+                                    "mandate": {
+                                      "type": "object",
+                                      "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "description": "Mandate identifier, as provided by the payment provider."
+                                        },
+                                        "info": {
+                                          "type": "string",
+                                          "description": "Free-text mandate information."
+                                        },
+                                        "received_status": {
+                                          "type": "string",
+                                          "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                        },
+                                        "existing_status": {
+                                          "type": "string",
+                                          "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                        },
+                                        "created_at": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "description": "Date and time when the mandate was created (ISO 8601)."
+                                        },
+                                        "updated_at": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                        }
+                                      }
                                     }
                                   }
                                 }
@@ -3475,6 +3511,42 @@
                                           "redirect_url": {
                                             "type": "string",
                                             "example": "https://api-sandbox.bankofamerica.com/v1/payment_methods/redirect/bank_transfer?transferCode=52xB9jF695TdDvHK-approved"
+                                          },
+                                          "bank_account_mask_number": {
+                                            "type": "string",
+                                            "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                          },
+                                          "mandate": {
+                                            "type": "object",
+                                            "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string",
+                                                "description": "Mandate identifier, as provided by the payment provider."
+                                              },
+                                              "info": {
+                                                "type": "string",
+                                                "description": "Free-text mandate information."
+                                              },
+                                              "received_status": {
+                                                "type": "string",
+                                                "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                              },
+                                              "existing_status": {
+                                                "type": "string",
+                                                "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                              },
+                                              "created_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "description": "Date and time when the mandate was created (ISO 8601)."
+                                              },
+                                              "updated_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                              }
+                                            }
                                           }
                                         }
                                       }
@@ -10937,6 +11009,42 @@
                                     "redirect_url": {
                                       "type": "string",
                                       "example": "https://checkout.sandbox.y.uno/payment?session=2cc7ac83-029d-4e13-8360-9b627bba8fc5"
+                                    },
+                                    "bank_account_mask_number": {
+                                      "type": "string",
+                                      "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                    },
+                                    "mandate": {
+                                      "type": "object",
+                                      "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string",
+                                          "description": "Mandate identifier, as provided by the payment provider."
+                                        },
+                                        "info": {
+                                          "type": "string",
+                                          "description": "Free-text mandate information."
+                                        },
+                                        "received_status": {
+                                          "type": "string",
+                                          "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                        },
+                                        "existing_status": {
+                                          "type": "string",
+                                          "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                        },
+                                        "created_at": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "description": "Date and time when the mandate was created (ISO 8601)."
+                                        },
+                                        "updated_at": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                        }
+                                      }
                                     }
                                   }
                                 }
@@ -11189,6 +11297,42 @@
                                           "redirect_url": {
                                             "type": "string",
                                             "example": "https://checkout.sandbox.y.uno/payment?session=2cc7ac83-029d-4e13-8360-9b627bba8fc5"
+                                          },
+                                          "bank_account_mask_number": {
+                                            "type": "string",
+                                            "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                          },
+                                          "mandate": {
+                                            "type": "object",
+                                            "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string",
+                                                "description": "Mandate identifier, as provided by the payment provider."
+                                              },
+                                              "info": {
+                                                "type": "string",
+                                                "description": "Free-text mandate information."
+                                              },
+                                              "received_status": {
+                                                "type": "string",
+                                                "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                              },
+                                              "existing_status": {
+                                                "type": "string",
+                                                "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                              },
+                                              "created_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "description": "Date and time when the mandate was created (ISO 8601)."
+                                              },
+                                              "updated_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                              }
+                                            }
                                           }
                                         }
                                       }

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -3293,6 +3293,42 @@
                                       "redirect_url": {
                                         "type": "string",
                                         "example": "https://api-sandbox.wompi.co/v1/payment_methods/redirect/bank_transfer?transferCode=52xB9jF695TdDvHK-approved"
+                                      },
+                                      "bank_account_mask_number": {
+                                        "type": "string",
+                                        "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                      },
+                                      "mandate": {
+                                        "type": "object",
+                                        "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string",
+                                            "description": "Mandate identifier, as provided by the payment provider."
+                                          },
+                                          "info": {
+                                            "type": "string",
+                                            "description": "Free-text mandate information."
+                                          },
+                                          "received_status": {
+                                            "type": "string",
+                                            "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                          },
+                                          "existing_status": {
+                                            "type": "string",
+                                            "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                          },
+                                          "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Date and time when the mandate was created (ISO 8601)."
+                                          },
+                                          "updated_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                          }
+                                        }
                                       }
                                     }
                                   }
@@ -3548,6 +3584,42 @@
                                             "redirect_url": {
                                               "type": "string",
                                               "example": "https://api-sandbox.wompi.co/v1/payment_methods/redirect/bank_transfer?transferCode=52xB9jF695TdDvHK-approved"
+                                            },
+                                            "bank_account_mask_number": {
+                                              "type": "string",
+                                              "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                            },
+                                            "mandate": {
+                                              "type": "object",
+                                              "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string",
+                                                  "description": "Mandate identifier, as provided by the payment provider."
+                                                },
+                                                "info": {
+                                                  "type": "string",
+                                                  "description": "Free-text mandate information."
+                                                },
+                                                "received_status": {
+                                                  "type": "string",
+                                                  "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                                },
+                                                "existing_status": {
+                                                  "type": "string",
+                                                  "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                                },
+                                                "created_at": {
+                                                  "type": "string",
+                                                  "format": "date-time",
+                                                  "description": "Date and time when the mandate was created (ISO 8601)."
+                                                },
+                                                "updated_at": {
+                                                  "type": "string",
+                                                  "format": "date-time",
+                                                  "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                                }
+                                              }
                                             }
                                           }
                                         }
@@ -10615,6 +10687,42 @@
                                       "redirect_url": {
                                         "type": "string",
                                         "example": "https://checkout.sandbox.y.uno/payment?session=2cc7ac83-029d-4e13-8360-9b627bba8fc5"
+                                      },
+                                      "bank_account_mask_number": {
+                                        "type": "string",
+                                        "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                      },
+                                      "mandate": {
+                                        "type": "object",
+                                        "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string",
+                                            "description": "Mandate identifier, as provided by the payment provider."
+                                          },
+                                          "info": {
+                                            "type": "string",
+                                            "description": "Free-text mandate information."
+                                          },
+                                          "received_status": {
+                                            "type": "string",
+                                            "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                          },
+                                          "existing_status": {
+                                            "type": "string",
+                                            "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                          },
+                                          "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Date and time when the mandate was created (ISO 8601)."
+                                          },
+                                          "updated_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                          }
+                                        }
                                       }
                                     }
                                   }
@@ -10860,6 +10968,42 @@
                                             "redirect_url": {
                                               "type": "string",
                                               "example": "https://checkout.sandbox.y.uno/payment?session=2cc7ac83-029d-4e13-8360-9b627bba8fc5"
+                                            },
+                                            "bank_account_mask_number": {
+                                              "type": "string",
+                                              "description": "Masked bank account number associated with the bank transfer (for example, ****6789). This is account data, not mandate data."
+                                            },
+                                            "mandate": {
+                                              "type": "object",
+                                              "description": "Direct debit mandate details, for bank transfer methods that operate with mandates (for example, ACH, SEPA, BACS, PAD).",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string",
+                                                  "description": "Mandate identifier, as provided by the payment provider."
+                                                },
+                                                "info": {
+                                                  "type": "string",
+                                                  "description": "Free-text mandate information."
+                                                },
+                                                "received_status": {
+                                                  "type": "string",
+                                                  "description": "Provider status indicating whether the mandate was received. Forwarded as provided by the payment provider."
+                                                },
+                                                "existing_status": {
+                                                  "type": "string",
+                                                  "description": "Provider status of the existing mandate. Forwarded as provided by the payment provider."
+                                                },
+                                                "created_at": {
+                                                  "type": "string",
+                                                  "format": "date-time",
+                                                  "description": "Date and time when the mandate was created (ISO 8601)."
+                                                },
+                                                "updated_at": {
+                                                  "type": "string",
+                                                  "format": "date-time",
+                                                  "description": "Date and time when the mandate was last updated (ISO 8601)."
+                                                }
+                                              }
                                             }
                                           }
                                         }


### PR DESCRIPTION
## What
Add `bank_account_mask_number` and the nested `mandate` object (`id`, `info`, `received_status`, `existing_status`, `created_at`, `updated_at`) to every `bank_transfer` schema in the payments and direct-workflow enrollment OpenAPI specs, plus the bank transfer request examples.

## Notes
- Mandate statuses are provider pass-through strings (not a Yuno enum).
- Covers: direct B2B enrollment, create/authorize payment requests, refund/cancel-or-refund (shared request schema), and the payment retrieve responses (18 schema nodes + 2 examples).
- `payouts/` specs excluded (different domain, not part of C2-17637).