### PR TITLE
docs(yuno): refresh Postman collection page (content, dark/light images, useful resources)

### DIFF
--- a/files/postman/Yuno_Production.postman_environment.json
+++ b/files/postman/Yuno_Production.postman_environment.json
@@ -1,0 +1,39 @@
+{
+	"id": "3f8a1d92-6c4e-4b07-a5d8-91b2c7e0f446",
+	"name": "Yuno Production",
+	"values": [
+		{
+			"key": "base_url",
+			"value": "https://api.y.uno/v1",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "public_api_key",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "private_secret_key",
+			"value": "",
+			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "account_id",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "org_code",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2026-07-15T12:00:00.000Z",
+	"_postman_exported_using": "Postman/11.0.0"
+}

--- a/reference/getting-started/postman-collections.mdx
+++ b/reference/getting-started/postman-collections.mdx
@@ -95,3 +95,9 @@ After selecting the environment and defining the variable values, you can start 
 
 In the Yuno Collection, various parameters are considered as variables. These values can be defined in the environment or upon receiving a response from the server. Postman variables aid in testing different endpoints in a sequence as the values received fill in the body parameters for the subsequent request.
 </Note>
+
+## Useful resources
+
+- [Yuno Postman collection](https://documenter.getpostman.com/view/25083296/2sBXikpXDZ?utm_source=slack&utm_medium=link_preview&utm_campaign=other&utm_content=link&utm_term=other#173ba2dd-1dbb-466c-934c-19a4308d9d80)
+- [`Yuno_Sandbox.postman_environment.json`](/files/postman/Yuno_Sandbox.postman_environment.json)
+- [`Yuno_Production.postman_environment.json`](/files/postman/Yuno_Production.postman_environment.json)


### PR DESCRIPTION
## Summary

Follow-up to the Postman Collection page refresh (already merged). Adds a new "Useful resources" section to `reference/getting-started/postman-collections.mdx`, requested by Ilya Ryabukhin during review.

### Status
**READY FOR REVIEW**

### What changed
- **New "Useful resources" section added**: links to the Yuno Postman collection plus both `Yuno_Sandbox.postman_environment.json` and `Yuno_Production.postman_environment.json`, so Collection and Environment are findable in one place instead of scattered through the steps.
- `Yuno_Production.postman_environment.json` added to `files/postman/` (previously only the Sandbox file existed there).
