### PR TITLE
docs(yuno-sdk): fix Android install pin and API names against the 3.0.0-alpha binary

### DIFF
--- a/docs/yuno-sdk/controllers/on-status.mdx
+++ b/docs/yuno-sdk/controllers/on-status.mdx
@@ -41,7 +41,7 @@ func onStatus(status: SdkPayments.TransactionStatus)
   <Tab title="Android">
 
 ```kotlin
-fun onStatus(status: PaymentStatus)
+fun onStatus(status: TransactionStatus)
 ```
 
   </Tab>

--- a/docs/yuno-sdk/features/handle-deeplinks.mdx
+++ b/docs/yuno-sdk/features/handle-deeplinks.mdx
@@ -1,15 +1,12 @@
 ---
 hidden: true
 title: "Handle deeplinks"
-description: "Forward incoming URLs to the iOS SDK so it can resume a transaction after returning from an external app or page."
+description: "Forward incoming URLs to the SDK so it can resume a transaction after returning from an external app or page."
 ---
 
-When a transaction redirects the user to an external destination. Another app, a wallet, a bank flow, or a hosted page. The user eventually returns to your app or site. The iOS SDK exposes `handleDeeplink(url)` so you can forward that incoming URL and let the SDK resume the transaction.
+When a transaction redirects the user to an external destination. Another app, a wallet, a bank flow, or a hosted page. The user eventually returns to your app or site. The iOS and Android SDKs expose `handleDeeplink` so you can forward that incoming URL and let the SDK resume the transaction.
 
-`handleDeeplink` is exclusive to iOS. The Android and Web SDKs do not expose it:
-
-- **Android.** The Android SDK has no deeplink entry point and won't add one. Your app receives the incoming intent and is responsible for handling it: decide whether the deeplink belongs to a Yuno flow, and re-invoke the SDK on your side if you need to resume the transaction.
-- **Web.** Browsers receive the return URL natively and the SDK resumes the flow through its own session state.
+The Web SDK does not need it: browsers receive the return URL natively and the SDK resumes the flow through its own session state.
 
 ## Behavior
 
@@ -19,7 +16,12 @@ The method returns a boolean indicating whether the transaction could be continu
 
 ## Where to call it
 
-Call `handleDeeplink` from wherever your app receives an incoming URL. Use `AppDelegate` if you use UIKit, or the SwiftUI lifecycle if your app is SwiftUI-based.
+Call `handleDeeplink` from wherever your app receives an incoming URL.
+
+<Tabs>
+  <Tab title="iOS">
+
+Use `AppDelegate` if you use UIKit, or the SwiftUI lifecycle if your app is SwiftUI-based.
 
 **UIKit (`AppDelegate`)**
 
@@ -53,10 +55,52 @@ struct MyApp: App {
 }
 ```
 
+  </Tab>
+  <Tab title="Android">
+
+`handleDeeplink` is a method of `Transaction`. Forward the URI from the Activity that receives the deeplink intent — cover both the cold start (`onCreate`) and the warm return (`onNewIntent`). A session carried in the URL takes precedence over the one in `TransactionConfig`; the config session is the fallback when the URL only carries a token.
+
+```kotlin
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        intent?.data?.let(::forwardDeeplink)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        intent.data?.let(::forwardDeeplink)
+    }
+
+    private fun forwardDeeplink(uri: Uri) {
+        val handled = Transaction(
+            TransactionConfig(
+                countryCode = "US",
+                checkoutSession = "session-from-backend",
+                controller = controller,
+            ),
+        ).handleDeeplink(uri)
+        if (!handled) {
+            // Handle other URLs here.
+        }
+    }
+}
+```
+
+  </Tab>
+</Tabs>
+
 ## Signature
 
 ```swift
+// iOS
 func handleDeeplink(_ url: URL) -> Bool
+```
+
+```kotlin
+// Android — method of Transaction
+fun handleDeeplink(uri: Uri): Boolean
 ```
 
 ## Related

--- a/docs/yuno-sdk/features/payment-methods-list.mdx
+++ b/docs/yuno-sdk/features/payment-methods-list.mdx
@@ -72,7 +72,8 @@ if let selectedPayment {
 var selectedPayment: PaymentMethodSelected? = null
 
 val views = transaction.getPaymentMethodsViews(
-    types = listOf(PaymentMethodType.GOOGLE_PAY, PaymentMethodType.PAYMENT_METHOD_LIST),
+    host = this,
+    types = listOf(PaymentMethodType.GooglePay(), PaymentMethodType.PaymentMethodList),
     controller = this
 )
 

--- a/docs/yuno-sdk/features/payment-methods-list.mdx
+++ b/docs/yuno-sdk/features/payment-methods-list.mdx
@@ -99,6 +99,10 @@ selectedPayment?.let { transaction.start(paymentSelected = it) }
 
 If a requested type does not apply to the current platform or configuration, the corresponding entry in the returned map is `null`.
 
+<Note>
+On Android, `PaymentMethodType` is a sealed interface rather than a set of string constants: `GOOGLE_PAY` corresponds to `PaymentMethodType.GooglePay(...)` — which also carries the button customization (`cta`, `theme`, `cornerRadius`) — and `PAYMENT_METHOD_LIST` corresponds to `PaymentMethodType.PaymentMethodList`. `APPLE_PAY` does not exist on Android.
+</Note>
+
 ### Wallet buttons
 
 `APPLE_PAY` and `GOOGLE_PAY` return the platform's native wallet buttons. You style them through the standard view modifiers of each platform (size, padding, corner radius, etc.). The SDK only adds a loader on top while the payment flow is initializing.

--- a/docs/yuno-sdk/get-started.mdx
+++ b/docs/yuno-sdk/get-started.mdx
@@ -64,7 +64,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.yuno.payments:android-sdk:3.0.0'
+    implementation 'com.yuno.payments:android-sdk:3.0.0-alpha'
 }
 ````
 
@@ -103,12 +103,12 @@ Place this in your `AppDelegate` or `App` struct, depending on your app's entry 
   <Tab title="Android">
 
 ````kotlin
-import com.yuno.payments.Yuno
+import com.yuno.payments.sdk.api.SdkPayments
 
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        SDKPayment.initialize(this, apiKey = "your-public-api-key")
+        SdkPayments.initialize(this, apiKey = "your-public-api-key")
     }
 }
 ````
@@ -193,16 +193,15 @@ final class Checkout: SdkPayments.TransactionController {
 On Android, controllers are provided through a `TransactionController` object passed in the config.
 
 ````kotlin
-import com.yuno.payments.Yuno
-import com.yuno.payments.Transaction
-import com.yuno.payments.TransactionConfig
-import com.yuno.payments.TransactionController
-import com.yuno.payments.PaymentMethodSelected
-import com.yuno.payments.PaymentStatus
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class CheckoutActivity : ComponentActivity(), TransactionController {
 
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         println("Final status: ${status.value}")
     }
 

--- a/docs/yuno-sdk/migration/android/enrollment/headless.mdx
+++ b/docs/yuno-sdk/migration/android/enrollment/headless.mdx
@@ -11,7 +11,7 @@ In the unified API, headless enrollment is no longer a separate client. It's the
 | Before | After |
 |---|---|
 | `Yuno.apiClientEnroll(...).continueEnrollment(data, context)` | `Transaction(config).start(paymentSelected = <with transactionData>)` |
-| `EnrollmentCollectedData` / `EnrollmentMethod` / `CardData` / `Detail` | `PaymentMethodSelected` + `TransactionData` + `CardTransactionData` |
+| `EnrollmentCollectedData` / `EnrollmentMethod` / `CardData` / `Detail` | `PaymentMethodSelected` + `TransactionData` + `CardData` |
 | Result map with `vaultedToken` | `onStatus(status)` (token retrieved from your backend) |
 
 ## Side-by-side
@@ -31,7 +31,7 @@ class EnrollmentActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        Yuno.initialize(applicationContext, apiKey = "your-public-api-key")
     }
 
     suspend fun enroll() {
@@ -65,28 +65,28 @@ class EnrollmentActivity : ComponentActivity() {
 ```
 
 ```kotlin After. Unified Transaction
-import com.yuno.sdk.Yuno
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
-import com.yuno.sdk.TransactionData
-import com.yuno.sdk.CardTransactionData
+import com.yuno.payments.sdk.api.SdkPayments
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
+import com.yuno.payments.sdk.api.models.TransactionData
+import com.yuno.payments.sdk.api.models.CardData
 
 class EnrollmentActivity : ComponentActivity(), TransactionController {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        SdkPayments.initialize(applicationContext, apiKey = "your-public-api-key")
     }
 
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         // On a successful status, retrieve the vaulted token from your
         // backend's "list customer payment methods" endpoint.
     }
 
-    fun enroll(card: CardTransactionData) {
+    fun enroll(card: CardData) {
         val paymentSelected = PaymentMethodSelected(
             paymentMethodType = "CARD",
             transactionData = TransactionData(card = card),
@@ -117,21 +117,21 @@ class EnrollmentActivity : ComponentActivity(), TransactionController {
 | `Yuno.apiClientEnroll(customerSession, countryCode, context)` | `Transaction(config)` | The transaction object replaces the headless client. |
 | `EnrollmentCollectedData.customerSession` | `TransactionConfig.customerSession` | Moves to config. |
 | `EnrollmentMethod.type` | `PaymentMethodSelected.paymentMethodType` | Moves to the parent object. |
-| `EnrollmentMethod.card` (`CardData.detail`) | `TransactionData.card` (`CardTransactionData`) | Flat (no `detail` wrapper), namespaced under `transactionData`. |
+| `EnrollmentMethod.card` (`CardData.detail`) | `TransactionData.card` (`CardData`) | Flat (no `detail` wrapper), namespaced under `transactionData`. |
 | `continueEnrollment(data, context)` returning `Map<String, Any?>` | `start(paymentSelected)` + `onStatus(status)` | The SDK reports completion through `onStatus`. |
 
 ## Behavior changes
 
 - **No `vaultedToken` on the client.** Fetch it from your backend after success.
-- **`onOneTimeToken` is not invoked** during enrollment.
+- **`createPayment` is not invoked** during enrollment.
 - **`vaultedToken` on `PaymentMethodSelected` is ignored.** Enrollment exists to produce a vaulted token; there's nothing linked yet to reference.
-- **No `Context` argument on each call.** `SDKPayment.initialize` keeps the application context.
+- **No `Context` argument on each call.** `SdkPayments.initialize` keeps the application context.
 
 ## Checklist
 
 - [ ] Replace `Yuno.apiClientEnroll(...)` with `Transaction(config)`.
 - [ ] Move `customerSession` and `countryCode` into `TransactionConfig`.
-- [ ] Replace `EnrollmentCollectedData` / `EnrollmentMethod` / `CardData` / `Detail` with `PaymentMethodSelected` + `TransactionData` + `CardTransactionData`.
+- [ ] Replace `EnrollmentCollectedData` / `EnrollmentMethod` / `CardData` / `Detail` with `PaymentMethodSelected` + `TransactionData` + `CardData`.
 - [ ] Replace `continueEnrollment(data, context)` with `start(paymentSelected)` passing the data via `transactionData`.
 - [ ] Implement `onStatus(status)` to react to the final outcome.
 - [ ] Move the `vaultedToken` retrieval to your backend.

--- a/docs/yuno-sdk/migration/android/enrollment/lite.mdx
+++ b/docs/yuno-sdk/migration/android/enrollment/lite.mdx
@@ -9,7 +9,7 @@ description: "Migrate Android Lite enrollment (Activity.startEnrollment) to the 
 | Before | After |
 |---|---|
 | `Activity.initEnrollment(callback)` + `Activity.startEnrollment(...)` | `Transaction(config).start(paymentSelected = PaymentMethodSelected(...))` |
-| Lambda `callbackEnrollmentState: (String?) -> Unit` | `TransactionController.onStatus(status: PaymentStatus)` |
+| Lambda `callbackEnrollmentState: (String?) -> Unit` | `TransactionController.onStatus(status: TransactionStatus)` |
 
 ## Side-by-side
 
@@ -25,7 +25,7 @@ class EnrollmentActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        Yuno.initialize(applicationContext, apiKey = "your-public-api-key")
 
         initEnrollment { state ->
             // state: "SUCCEEDED" / "REJECT" / "FAIL" / "PROCESSING" / "INTERNAL_ERROR" / "CANCELED"
@@ -43,21 +43,21 @@ class EnrollmentActivity : ComponentActivity() {
 ```
 
 ```kotlin After. Unified Transaction
-import com.yuno.sdk.Yuno
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
+import com.yuno.payments.sdk.api.SdkPayments
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class EnrollmentActivity : ComponentActivity(), TransactionController {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        SdkPayments.initialize(applicationContext, apiKey = "your-public-api-key")
     }
 
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         // status.value comes from the backend. See /reference/status.
     }
 
@@ -67,7 +67,7 @@ class EnrollmentActivity : ComponentActivity(), TransactionController {
             countryCode = "CO",
             language = "en",
             controller = this,
-            showPaymentStatusScreen = true,
+            showStatusScreen = true,
         )
 
         Transaction(config = config)
@@ -91,15 +91,15 @@ class EnrollmentActivity : ComponentActivity(), TransactionController {
 
 - **You pick the method.** As in the legacy SDK, the merchant decides which method to enroll and passes it to `start(paymentSelected)` via `paymentMethodType`. The SDK does not render a list of enrollable methods.
 - **`paymentSelected` is always non-null.** Pass a `PaymentMethodSelected` with the `paymentMethodType`.
-- **`onOneTimeToken` is not invoked** during enrollment.
-- **No `Context` argument on each call.** `SDKPayment.initialize` keeps the application context.
+- **`createPayment` is not invoked** during enrollment.
+- **No `Context` argument on each call.** `SdkPayments.initialize` keeps the application context.
 
 ## Checklist
 
 - [ ] Remove `initEnrollment { ... }` and the `callbackEnrollmentState` lambda. Implement `TransactionController` instead.
 - [ ] Move `customerSession`, `countryCode`, `language` into `TransactionConfig`.
 - [ ] Replace `startEnrollment(...)` with `Transaction(config).start(paymentSelected = PaymentMethodSelected(...))`.
-- [ ] Set `showPaymentStatusScreen = true` in `TransactionConfig` if you relied on the SDK showing the result screen.
+- [ ] Set `showStatusScreen = true` in `TransactionConfig` if you relied on the SDK showing the result screen.
 - [ ] Re-run your sandbox enrollment test suite, including 3DS scenarios.
 
 ## Related

--- a/docs/yuno-sdk/migration/android/enrollment/render.mdx
+++ b/docs/yuno-sdk/migration/android/enrollment/render.mdx
@@ -4,7 +4,7 @@ title: "Render enrollment"
 description: "Migrate Android Render enrollment (Activity.startEnrollmentRender) to the unified Transaction API."
 ---
 
-Render enrollment let you embed the SDK's enrollment form inside your own layout. You got a `YunoEnrollmentFragmentController` and a `YunoEnrollmentRenderController.showView(fragment, needSubmit)` callback. The `needSubmit` flag told you whether the form required a submit button at all.
+Render enrollment let you embed the SDK's enrollment form inside your own layout. You got a `YunoEnrollmentFragmentController` and a `YunoEnrollmentRenderListener.showView(fragment, needSubmit)` callback. The `needSubmit` flag told you whether the form required a submit button at all.
 
 In the unified API the same pattern is expressed by overriding [`showView`](/docs/yuno-sdk/controllers/show-view): the SDK delivers the fragment together with a `TransactionProcess` you call `onSubmit()` on. As with Lite enrollment, you pass a `PaymentMethodSelected` carrying the method type — `start(paymentSelected)` never accepts null.
 
@@ -12,7 +12,7 @@ In the unified API the same pattern is expressed by overriding [`showView`](/doc
 |---|---|
 | `Activity.startEnrollmentRender(..., controller)` | `Transaction(config).start(paymentSelected = PaymentMethodSelected(...))` + override `showView` |
 | `YunoEnrollmentFragmentController.submitForm()` | `process.onSubmit()` |
-| `YunoEnrollmentRenderController.showView(fragment, needSubmit)` | `TransactionController.showView(view, process, step)` |
+| `YunoEnrollmentRenderListener.showView(fragment, needSubmit)` | `TransactionController.showView(view, process, step)` |
 
 ## Side-by-side
 
@@ -22,9 +22,9 @@ In the unified API the same pattern is expressed by overriding [`showView`](/doc
 import androidx.fragment.app.Fragment
 import com.yuno.sdk.enrollment.render.startEnrollmentRender
 import com.yuno.sdk.enrollment.render.YunoEnrollmentFragmentController
-import com.yuno.sdk.enrollment.render.YunoEnrollmentRenderController
+import com.yuno.sdk.enrollment.render.YunoEnrollmentRenderListener
 
-class EnrollmentActivity : ComponentActivity(), YunoEnrollmentRenderController {
+class EnrollmentActivity : ComponentActivity(), YunoEnrollmentRenderListener {
 
     private var controller: YunoEnrollmentFragmentController? = null
     private var needSubmit: Boolean = false
@@ -46,7 +46,7 @@ class EnrollmentActivity : ComponentActivity(), YunoEnrollmentRenderController {
             .commit()
     }
 
-    override fun loadingController(isLoading: Boolean) { /* show your own loader */ }
+    override fun loadingListener(isLoading: Boolean) { /* show your own loader */ }
 
     override fun returnStatus(resultCode: Int, paymentStatus: String) {
         // resultCode + paymentStatus
@@ -60,13 +60,13 @@ class EnrollmentActivity : ComponentActivity(), YunoEnrollmentRenderController {
 
 ```kotlin After. showView override
 import androidx.fragment.app.Fragment
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.TransactionProcess
-import com.yuno.sdk.TransactionViewStep
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.TransactionProcess
+import com.yuno.payments.sdk.api.models.TransactionViewStep
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class EnrollmentActivity : ComponentActivity(), TransactionController {
 
@@ -92,7 +92,7 @@ class EnrollmentActivity : ComponentActivity(), TransactionController {
 
     override fun showLoading(isLoading: Boolean) { /* show your own loader */ }
 
-    override fun onStatus(status: PaymentStatus) { /* ... */ }
+    override fun onStatus(status: TransactionStatus) { /* ... */ }
 
     fun onEnrollButton() {
         process?.onSubmit()
@@ -111,21 +111,21 @@ The `needSubmit` flag has no equivalent in the unified API. The merchant renders
 | Before | After | Notes |
 |---|---|---|
 | `Activity.startEnrollmentRender(...)` | `Transaction(config).start(paymentSelected = PaymentMethodSelected(...))` + override `showView` | Single entry point. |
-| `YunoEnrollmentRenderController.showView(fragment, needSubmit)` | `TransactionController.showView(view, process, step)` | Same role with `TransactionProcess`. |
+| `YunoEnrollmentRenderListener.showView(fragment, needSubmit)` | `TransactionController.showView(view, process, step)` | Same role with `TransactionProcess`. |
 | `YunoEnrollmentFragmentController.submitForm()` | `process.onSubmit()` | Called on the process you receive. |
-| `loadingController(isLoading:)` | `showLoading(isLoading:)` | Renamed. Fires only when overridden. |
+| `loadingListener(isLoading:)` | `showLoading(isLoading:)` | Renamed. Fires only when overridden. |
 
 ## Behavior changes
 
 - **`needSubmit` is gone.** Drive submit-button visibility from your own state.
-- **`onOneTimeToken` is not invoked** during enrollment.
+- **`createPayment` is not invoked** during enrollment.
 
 ## Checklist
 
-- [ ] Replace conformance to `YunoEnrollmentRenderController` with `TransactionController`.
+- [ ] Replace conformance to `YunoEnrollmentRenderListener` with `TransactionController`.
 - [ ] Move `customerSession`, `countryCode`, `language` into `TransactionConfig`.
 - [ ] Replace `startEnrollmentRender(...)` + `controller.submitForm()` with `showView` override + `process.onSubmit()`.
-- [ ] Rename `loadingController(isLoading:)` to `showLoading(isLoading:)`.
+- [ ] Rename `loadingListener(isLoading:)` to `showLoading(isLoading:)`.
 - [ ] Rename `returnStatus(...)` to `onStatus(status)`.
 - [ ] If you used `needSubmit`, drive submit-button visibility from your own state.
 - [ ] Re-run your sandbox enrollment test suite, including 3DS scenarios.

--- a/docs/yuno-sdk/migration/android/enrollment/render.mdx
+++ b/docs/yuno-sdk/migration/android/enrollment/render.mdx
@@ -4,7 +4,7 @@ title: "Render enrollment"
 description: "Migrate Android Render enrollment (Activity.startEnrollmentRender) to the unified Transaction API."
 ---
 
-Render enrollment let you embed the SDK's enrollment form inside your own layout. You got a `YunoEnrollmentFragmentController` and a `YunoEnrollmentRenderListener.showView(fragment, needSubmit)` callback. The `needSubmit` flag told you whether the form required a submit button at all.
+Render enrollment lets you embed the SDK's enrollment form inside your own layout. You got a `YunoEnrollmentFragmentController` and a `YunoEnrollmentRenderListener.showView(fragment, needSubmit)` callback. The `needSubmit` flag told you whether the form required a submit button at all.
 
 In the unified API the same pattern is expressed by overriding [`showView`](/docs/yuno-sdk/controllers/show-view): the SDK delivers the fragment together with a `TransactionProcess` you call `onSubmit()` on. As with Lite enrollment, you pass a `PaymentMethodSelected` carrying the method type — `start(paymentSelected)` never accepts null.
 

--- a/docs/yuno-sdk/migration/android/payment/full.mdx
+++ b/docs/yuno-sdk/migration/android/payment/full.mdx
@@ -13,7 +13,7 @@ In the unified API the method list is no longer implicit. `Transaction.start(pay
 | `Activity.startCheckout(…)` + `Activity.startPayment(showPaymentStatus)` | `transaction.getPaymentMethodsViews(types, controller)` + `transaction.start(paymentSelected)` |
 | Lambda callbacks (`callbackPaymentState`) | `TransactionController.onStatus(status)` |
 | SDK-rendered embedded method list (implicit) | `transaction.getPaymentMethodsViews(types, controller)` (explicit) |
-| `SDKPayment.initialize(context, apiKey, YunoConfig(…))` | `SDKPayment.initialize(context, apiKey)` (no `YunoConfig`) |
+| `Yuno.initialize(context, apiKey, YunoConfig(…))` | `SdkPayments.initialize(context, apiKey)` (no `YunoConfig`) |
 
 ## Side-by-side
 
@@ -31,7 +31,7 @@ class CheckoutActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup
-        SDKPayment.initialize(
+        Yuno.initialize(
             applicationContext,
             apiKey = "your-public-api-key",
             config = YunoConfig(saveCardEnabled = true, styles = customStyles),
@@ -53,14 +53,14 @@ class CheckoutActivity : ComponentActivity() {
 ```
 
 ```kotlin After. Unified Transaction
-import com.yuno.sdk.Yuno
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.PaymentListController
-import com.yuno.sdk.PaymentMethodType
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
+import com.yuno.payments.sdk.api.SdkPayments
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.PaymentListController
+import com.yuno.payments.sdk.api.models.PaymentMethodType
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class CheckoutActivity :
     ComponentActivity(),
@@ -74,7 +74,7 @@ class CheckoutActivity :
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        SdkPayments.initialize(applicationContext, apiKey = "your-public-api-key")
 
         // 2. Build the transaction and embed the SDK's method list in your layout
         val config = TransactionConfig(
@@ -82,24 +82,23 @@ class CheckoutActivity :
             countryCode = "CO",
             appearance = customAppearance,
             controller = this,
-            showPaymentStatusScreen = true,
+            showStatusScreen = true,
         )
 
         val tx = Transaction(config = config)
         transaction = tx
 
         val views = tx.getPaymentMethodsViews(
+            host = this,
             types = listOf(
-                PaymentMethodType.GOOGLE_PAY,
-                PaymentMethodType.PAYMENT_METHOD_LIST,
+                PaymentMethodType.GooglePay(),
+                PaymentMethodType.PaymentMethodList,
             ),
             controller = this,
         )
 
-        views[PaymentMethodType.PAYMENT_METHOD_LIST]?.let { fragment ->
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.yuno_method_list_container, fragment)
-                .commit()
+        views[PaymentMethodType.PaymentMethodList]?.let { view ->
+            findViewById<ViewGroup>(R.id.yuno_method_list_container).addView(view)
         }
     }
 
@@ -113,7 +112,7 @@ class CheckoutActivity :
         selectedPayment?.let { transaction?.start(paymentSelected = it) }
     }
 
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         // status.value: "SUCCEEDED" / "REJECT" / "FAIL" / "PROCESSING" / "INTERNAL_ERROR" / "USER_CANCEL"
     }
 }
@@ -131,7 +130,7 @@ class CheckoutActivity :
 
 | Before (Full) | After (unified) | Notes |
 |---|---|---|
-| `SDKPayment.initialize(context, apiKey, YunoConfig)` | `SDKPayment.initialize(context, apiKey)` | `YunoConfig` removed. Per-transaction settings move to `TransactionConfig`. |
+| `Yuno.initialize(context, apiKey, YunoConfig)` | `SdkPayments.initialize(context, apiKey)` | `YunoConfig` removed. Per-transaction settings move to `TransactionConfig`. |
 | `YunoConfig.styles` / `YunoConfig.language` | `TransactionConfig.appearance` / `TransactionConfig.language` | Per-transaction now. |
 | `YunoConfig.saveCardEnabled` | *(removed)* | Controlled server-side. |
 | `YunoConfig.keepLoader` | *(removed)* | SDK keeps the loader by default. Override [`showLoading`](/docs/yuno-sdk/controllers/show-loading) to opt out. |
@@ -142,7 +141,7 @@ class CheckoutActivity :
 
 | Before (callback lambda) | After `TransactionController` | Notes |
 |---|---|---|
-| `callbackPaymentState: (state, subState) -> Unit` | `onStatus(status: PaymentStatus)` | `"CANCELED_BY_USER"` renamed to `"USER_CANCEL"`. See [Result mapping in Lite](/docs/yuno-sdk/migration/android/payment/lite#result-mapping). |
+| `callbackPaymentState: (state, subState) -> Unit` | `onStatus(status: TransactionStatus)` | `"CANCELED_BY_USER"` renamed to `"USER_CANCEL"`. See [Result mapping in Lite](/docs/yuno-sdk/migration/android/payment/lite#result-mapping). |
 | `callbackOTT` / `callBackTokenWithInformation` | Override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) on `TransactionController` (only for non-seamless mode) | In Full, these fired in the headless variant only. If you used them, see [Headless migration](/docs/yuno-sdk/migration/android/payment/headless). |
 
 ### Entry points
@@ -150,12 +149,12 @@ class CheckoutActivity :
 | Before (Full) | After (unified) | Notes |
 |---|---|---|
 | `startCheckout(checkoutSession, countryCode, …)` + `startPayment(showPaymentStatus)` | `transaction.getPaymentMethodsViews(…)` + `transaction.start(paymentSelected)` | Two explicit steps. `start` always takes a non-null `PaymentMethodSelected`, so the merchant captures the user's choice in `onPaymentSelected` and passes it to `start` from their own button. |
-| Implicit method list rendering inside the SDK | `transaction.getPaymentMethodsViews(types, controller)` | Required for the Full equivalent. Returns a `Map<PaymentMethodType, Fragment>`. See [Payment Methods List](/docs/yuno-sdk/features/payment-methods-list). |
+| Implicit method list rendering inside the SDK | `transaction.getPaymentMethodsViews(host, types, controller)` | Required for the Full equivalent. Returns a `Map<PaymentMethodType, View?>`. See [Payment Methods List](/docs/yuno-sdk/features/payment-methods-list). |
 
 ## Behavior changes
 
 <Warning>
-**`showPaymentStatusScreen` default flipped.** In Full, `showPaymentStatus` defaulted to `true` and the SDK presented its built-in result screen. In the unified API, `showPaymentStatusScreen` defaults to **`false`**. If you relied on the SDK showing the result screen, set it to `true` explicitly.
+**`showStatusScreen` default flipped.** In Full, `showPaymentStatus` defaulted to `true` and the SDK presented its built-in result screen. In the unified API, `showStatusScreen` defaults to **`false`**. If you relied on the SDK showing the result screen, set it to `true` explicitly.
 </Warning>
 
 - **Single controller.** In Full, callbacks were three separate lambdas (`callbackOTT`, `callbackPaymentState`, `callBackTokenWithInformation`). In the unified API they collapse into the `TransactionController` interface; you implement only the methods you need.
@@ -165,13 +164,13 @@ class CheckoutActivity :
 
 ## Checklist
 
-- [ ] Replace `SDKPayment.initialize(context, apiKey, YunoConfig(…))` with `SDKPayment.initialize(context, apiKey)`.
+- [ ] Replace `Yuno.initialize(context, apiKey, YunoConfig(…))` with `SdkPayments.initialize(context, apiKey)`.
 - [ ] Move `styles` and `language` from `YunoConfig` into `TransactionConfig`. Drop `saveCardEnabled`, `keepLoader`, `isDynamicViewEnabled`.
 - [ ] Implement `TransactionController` on a class you can keep alive (Activity, ViewModel, etc.).
 - [ ] Move `checkoutSession` and `countryCode` from `startCheckout(…)` into `TransactionConfig`.
 - [ ] Replace the `callbackPaymentState` lambda with `onStatus(status)`. Switch `"CANCELED_BY_USER"` → `"USER_CANCEL"`.
 - [ ] Replace the `startCheckout(…)` + `startPayment(…)` pair with: build a `Transaction`, call `transaction.getPaymentMethodsViews(types, controller)`, store the selection from `onPaymentSelected`, and trigger `transaction.start(paymentSelected = selection)` from your own Pay button. `start` never accepts `null`.
-- [ ] Set `showPaymentStatusScreen = true` in `TransactionConfig` if you relied on the SDK showing the result screen.
+- [ ] Set `showStatusScreen = true` in `TransactionConfig` if you relied on the SDK showing the result screen.
 - [ ] Re-run your sandbox test suite.
 
 ## Related

--- a/docs/yuno-sdk/migration/android/payment/full.mdx
+++ b/docs/yuno-sdk/migration/android/payment/full.mdx
@@ -53,6 +53,9 @@ class CheckoutActivity : ComponentActivity() {
 ```
 
 ```kotlin After. Unified Transaction
+import android.os.Bundle
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
 import com.yuno.payments.sdk.api.SdkPayments
 import com.yuno.payments.sdk.api.Transaction
 import com.yuno.payments.sdk.api.TransactionConfig

--- a/docs/yuno-sdk/migration/android/payment/headless.mdx
+++ b/docs/yuno-sdk/migration/android/payment/headless.mdx
@@ -4,7 +4,7 @@ title: "Headless mode"
 description: "Migrate Android Headless integrations (Yuno.apiClientPayment + generateToken) to the unified Transaction API."
 ---
 
-Headless was a pure-tokenization client: the merchant collected card data in their own UI, called `apiClient.generateToken(collectedData, context)`, received a token, and then made their own backend call to create the payment (and optionally triggered 3DS via `apiClient.getThreeDSecureChallenge(…)`).
+Headless was a pure-tokenization client: the merchant collected card data in their own UI, called `apiClient.generateToken(collectedData, context)`, received a token, and then made their own backend call to create the payment (and, when the backend returned a 3DS-required status, continued the payment via `apiClient.continueCardPayment(…)`).
 
 In the unified API the same scenario maps to **non-seamless headless** mode: pass the pre-collected data inside `transactionData` on the `PaymentMethodSelected`, override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) to create the payment from your backend, and let the SDK orchestrate tokenization, 3DS, and status polling automatically. The merchant no longer has to call a separate 3DS endpoint.
 
@@ -12,7 +12,7 @@ In the unified API the same scenario maps to **non-seamless headless** mode: pas
 |---|---|
 | `Yuno.apiClientPayment(checkoutSession, countryCode, context)` → `ApiClientPayment` | `Transaction(config).start(paymentSelected)` |
 | `apiClient.generateToken(collectedData, context)` | Override `createPayment(token)` |
-| `apiClient.getThreeDSecureChallenge(context, checkoutSession)` | *(removed. SDK handles 3DS automatically)* |
+| `apiClient.continueCardPayment(activity, showPaymentStatus, callbackPaymentState)` | *(removed. SDK handles 3DS automatically)* |
 | Free-form callbacks | `TransactionController` |
 
 ## Side-by-side
@@ -23,7 +23,7 @@ In the unified API the same scenario maps to **non-seamless headless** mode: pas
 import com.yuno.sdk.Yuno
 import com.yuno.sdk.ApiClientPayment
 import com.yuno.sdk.ApiClientPayment.Companion.generateToken
-import com.yuno.sdk.ApiClientPayment.Companion.getThreeDSecureChallenge
+import com.yuno.sdk.ApiClientPayment.Companion.continueCardPayment
 import com.yuno.sdk.payments.TokenCollectedData
 import com.yuno.sdk.payments.PaymentMethod
 import com.yuno.sdk.payments.CardData
@@ -37,7 +37,7 @@ class CheckoutActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        Yuno.initialize(applicationContext, apiKey = "your-public-api-key")
 
         // 2. Create the headless client
         apiClient = Yuno.apiClientPayment(
@@ -73,25 +73,27 @@ class CheckoutActivity : ComponentActivity() {
         createPaymentOnBackend(token)   // your code
     }
 
-    // 4. Optional: separately trigger 3DS if your backend asked for it
+    // 4. Optional: continue the payment if your backend returned a 3DS-required status
     fun continue3ds() {
-        apiClient.getThreeDSecureChallenge(context = this).observe(this) { challenge ->
-            // present(challenge.url) in your own WebView
+        apiClient.continueCardPayment(
+            activity = this,
+            showPaymentStatus = false,
+        ) { state, subState ->
+            // handle the final state
         }
     }
 }
 ```
 
 ```kotlin After. Non-seamless headless
-import com.yuno.sdk.Yuno
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
-import com.yuno.sdk.TransactionData
-import com.yuno.sdk.CardTransactionData
-import com.yuno.sdk.OneTimeToken
+import com.yuno.payments.sdk.api.SdkPayments
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
+import com.yuno.payments.sdk.api.models.TransactionData
+import com.yuno.payments.sdk.api.models.CardData
 
 class CheckoutActivity : ComponentActivity(), TransactionController {
 
@@ -99,17 +101,17 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        SdkPayments.initialize(applicationContext, apiKey = "your-public-api-key")
     }
 
     // 2. Override createPayment. The SDK will wait for this suspend fun to return before
     //    querying status. Returning normally signals "payment created, please continue."
     //    Throwing stops the flow (the SDK will not invoke onStatus).
-    override suspend fun createPayment(token: OneTimeToken) {
+    override suspend fun createPayment(token: Map<String, Any>) {
         createPaymentOnBackend(token["token"] as? String ?: "")
     }
 
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         // status.value: "SUCCEEDED" / "REJECT" / ...
     }
 
@@ -118,7 +120,7 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
         val paymentSelected = PaymentMethodSelected(
             paymentMethodType = "CARD",
             transactionData = TransactionData(
-                card = CardTransactionData(
+                card = CardData(
                     number = number,
                     securityCode = cvv,
                     expirationMonth = expMonth,
@@ -146,7 +148,7 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
 
 In Headless the merchant did three things explicitly: tokenize, create the payment on their backend, and trigger 3DS. In the unified API only **payment creation** stays on the merchant side. Tokenization and 3DS are handled by the SDK as part of the `Transaction` lifecycle. You signal "payment created, please continue" by returning from `createPayment`; the SDK then queries the payment status and finishes the flow.
 
-If your old integration showed the 3DS challenge inside your own UI (your own WebView around `getThreeDSecureChallenge(…).url`), you no longer need to. The SDK presents the 3DS WebView full-screen automatically. This is fixed — [`showView`](/docs/yuno-sdk/controllers/show-view) only fires for non-WebView action views (e.g. a QR code), not for 3DS challenges or redirects.
+If your old integration continued 3DS-required payments with a separate `continueCardPayment(…)` call, you no longer need to call anything. The SDK presents the 3DS WebView full-screen automatically. This is fixed — [`showView`](/docs/yuno-sdk/controllers/show-view) only fires for non-WebView action views (e.g. a QR code), not for 3DS challenges or redirects.
 
 ## Field mapping
 
@@ -156,31 +158,31 @@ If your old integration showed the 3DS challenge inside your own UI (your own We
 | `TokenCollectedData.checkoutSession` | `TransactionConfig.checkoutSession` | Moves to config. |
 | `PaymentMethod.type` | `PaymentMethodSelected.paymentMethodType` | Moves to the parent object. |
 | `PaymentMethod.vaultedToken` | `PaymentMethodSelected.vaultedToken` | Same. |
-| `PaymentMethod.card` (`CardData` with nested `Detail`) | `TransactionData.card` (`CardTransactionData`) | Same fields, namespaced under `transactionData`, flat (no `detail` wrapper). |
+| `PaymentMethod.card` (`CardData` with nested `Detail`) | `TransactionData.card` (`CardData`) | Same fields, namespaced under `transactionData`, flat (no `detail` wrapper). |
 | `PaymentMethod.customer` | `TransactionData.customer` | Moves under `transactionData`. |
-| `apiClient.generateToken(data, context)` (suspend, returns `Map<String, Any?>`) | Override `createPayment(token: OneTimeToken)` | The SDK invokes your handler with the token; you create the payment from your backend and return. |
-| `apiClient.getThreeDSecureChallenge(context, checkoutSession)` | *(removed)* | The SDK runs 3DS internally and presents the WebView full-screen. Not customizable via `showView`. |
+| `apiClient.generateToken(data, context)` (suspend, returns `Map<String, Any?>`) | Override `createPayment(token: Map<String, Any>)` | The SDK invokes your handler with the token; you create the payment from your backend and return. |
+| `apiClient.continueCardPayment(activity, showPaymentStatus, callbackPaymentState)` | *(removed)* | The SDK runs 3DS internally and presents the WebView full-screen. Not customizable via `showView`. |
 | Result returned from `generateToken` (`Map<String, Any?>`) | `OneTimeToken` (still a `Map<String, Any>`) | Cross-platform parity. See [`OneTimeToken` reference](/docs/yuno-sdk/reference/one-time-token). |
-| *(no result controller)* | `onStatus(status: PaymentStatus)` | New. The SDK now drives the full lifecycle and reports the final status here. |
+| *(no result controller)* | `onStatus(status: TransactionStatus)` | New. The SDK now drives the full lifecycle and reports the final status here. |
 
 ## Behavior changes
 
 <Warning>
-**3DS is now SDK-driven.** Headless required you to call `getThreeDSecureChallenge(…)` and present the WebView yourself. The unified API runs 3DS automatically as part of the transaction and presents the WebView full-screen. This is fixed — overriding [`showView`](/docs/yuno-sdk/controllers/show-view) does not change it (showView only fires for non-WebView action views like QR codes).
+**3DS is now SDK-driven.** Headless required you to call `continueCardPayment(…)` as a separate step to run 3DS. The unified API runs 3DS automatically as part of the transaction and presents the WebView full-screen. This is fixed — overriding [`showView`](/docs/yuno-sdk/controllers/show-view) does not change it (showView only fires for non-WebView action views like QR codes).
 </Warning>
 
 - **`createPayment` is a suspend function.** Return when your backend has finished creating the payment. If it throws, the SDK stops the flow and `onStatus` is **not** invoked. Surface the error to your user yourself.
 - **No more `apiClient*` objects.** A single `Transaction` covers the full lifecycle.
-- **No more `Context` argument on each call.** `SDKPayment.initialize` keeps the application context; `Transaction` / `TransactionConfig` do not require one.
-- **`getThreeDSecureChallenge(…).observe(…)` (LiveData) is gone.** The SDK runs 3DS internally; you observe progress through `onShowLoading` / `onStatus` instead.
+- **No more `Context` argument on each call.** `SdkPayments.initialize` keeps the application context; `Transaction` / `TransactionConfig` do not require one.
+- **`continueCardPayment(…)` is gone.** The SDK runs 3DS internally; you observe progress through `showLoading` / `onStatus` instead.
 
 ## Checklist
 
 - [ ] Replace `Yuno.apiClientPayment(checkoutSession, countryCode, context)` with `Transaction(config)`. Move `checkoutSession` and `countryCode` into `TransactionConfig`.
-- [ ] Replace `TokenCollectedData` / `PaymentMethod` / `CardData` / `Detail` with `PaymentMethodSelected` + `TransactionData` + `CardTransactionData`.
+- [ ] Replace `TokenCollectedData` / `PaymentMethod` / `CardData` / `Detail` with `PaymentMethodSelected` + `TransactionData` + `CardData`.
 - [ ] Replace your `apiClient.generateToken(data, context)` call with a `TransactionController.createPayment(token)` override. Move your "create payment on backend" code there.
 - [ ] Implement `onStatus(status)`. This is now how you receive the final result.
-- [ ] Remove `apiClient.getThreeDSecureChallenge(…)` and the WebView code. The SDK presents 3DS full-screen automatically.
+- [ ] Remove the `apiClient.continueCardPayment(…)` call. The SDK presents 3DS full-screen automatically.
 - [ ] Replace the explicit tokenize-then-create-payment calls with `Transaction(config).start(paymentSelected = <with transactionData>)`.
 - [ ] Re-run your sandbox test suite, including 3DS scenarios.
 

--- a/docs/yuno-sdk/migration/android/payment/headless.mdx
+++ b/docs/yuno-sdk/migration/android/payment/headless.mdx
@@ -162,7 +162,7 @@ If your old integration continued 3DS-required payments with a separate `continu
 | `PaymentMethod.customer` | `TransactionData.customer` | Moves under `transactionData`. |
 | `apiClient.generateToken(data, context)` (suspend, returns `Map<String, Any?>`) | Override `createPayment(token: Map<String, Any>)` | The SDK invokes your handler with the token; you create the payment from your backend and return. |
 | `apiClient.continueCardPayment(activity, showPaymentStatus, callbackPaymentState)` | *(removed)* | The SDK runs 3DS internally and presents the WebView full-screen. Not customizable via `showView`. |
-| Result returned from `generateToken` (`Map<String, Any?>`) | `OneTimeToken` (still a `Map<String, Any>`) | Cross-platform parity. See [`OneTimeToken` reference](/docs/yuno-sdk/reference/one-time-token). |
+| Result returned from `generateToken` (`Map<String, Any?>`) | The `token` argument of `createPayment` (`Map<String, Any>`) | Conceptually the *OneTimeToken* — same payload on every platform. See [`OneTimeToken` reference](/docs/yuno-sdk/reference/one-time-token). |
 | *(no result controller)* | `onStatus(status: TransactionStatus)` | New. The SDK now drives the full lifecycle and reports the final status here. |
 
 ## Behavior changes

--- a/docs/yuno-sdk/migration/android/payment/lite.mdx
+++ b/docs/yuno-sdk/migration/android/payment/lite.mdx
@@ -10,7 +10,7 @@ Lite mode pre-selected the payment method on the merchant side, then handed off 
 |---|---|
 | `Activity.startCheckout(checkoutSession, countryCode, callbackOTT, callbackPaymentState)` + `Activity.startPaymentLite(paymentSelected, …, showPaymentStatus)` | `Transaction(config).start(paymentSelected)` |
 | Lambda callbacks (`callbackPaymentState`) | `TransactionController.onStatus(status)` |
-| `SDKPayment.initialize(context, apiKey, YunoConfig(…))` | `SDKPayment.initialize(context, apiKey)` (no `YunoConfig`) |
+| `Yuno.initialize(context, apiKey, YunoConfig(…))` | `SdkPayments.initialize(context, apiKey)` (no `YunoConfig`) |
 
 ## Side-by-side
 
@@ -29,7 +29,7 @@ class CheckoutActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup (usually in Application.onCreate)
-        SDKPayment.initialize(
+        Yuno.initialize(
             applicationContext,
             apiKey = "your-public-api-key",
             config = YunoConfig(
@@ -67,12 +67,12 @@ class CheckoutActivity : ComponentActivity() {
 ```
 
 ```kotlin After. Unified Transaction
-import com.yuno.sdk.Yuno
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
+import com.yuno.payments.sdk.api.SdkPayments
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class CheckoutActivity : ComponentActivity(), TransactionController {
 
@@ -80,11 +80,11 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup (usually in Application.onCreate)
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        SdkPayments.initialize(applicationContext, apiKey = "your-public-api-key")
     }
 
     // 2. Implement the controller
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         when (status.value) {
             "SUCCEEDED"      -> println("Success")
             "REJECT"         -> println("Rejected")
@@ -103,7 +103,7 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
             language = "en",
             appearance = customAppearance,      // optional
             controller = this,
-            showPaymentStatusScreen = true,     // see "Behavior changes" below
+            showStatusScreen = true,     // see "Behavior changes" below
         )
 
         Transaction(config = config)
@@ -118,23 +118,23 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
 
 | Before (Lite) | After (unified) | Notes |
 |---|---|---|
-| `SDKPayment.initialize(context, apiKey, YunoConfig)` | `SDKPayment.initialize(context, apiKey)` | `YunoConfig` is removed. See per-field rows below. |
+| `Yuno.initialize(context, apiKey, YunoConfig)` | `SdkPayments.initialize(context, apiKey)` | `YunoConfig` is removed. See per-field rows below. |
 | `YunoConfig.styles` / `YunoConfig.language` | `TransactionConfig.appearance` / `TransactionConfig.language` | Move from app-wide to per-transaction. |
 | `YunoConfig.saveCardEnabled` | *(removed)* | Now controlled server-side via the settings service. The client no longer passes this flag. |
 | `YunoConfig.keepLoader` | *(removed)* | The SDK keeps its loader by default. New: in the unified API you can override [`showLoading`](/docs/yuno-sdk/controllers/show-loading) to render your own. This controller was not invoked in Lite. |
 | `YunoConfig.isDynamicViewEnabled` | *(removed)* | The dynamic view flow is the only flow in the unified API. |
 | `startCheckout(checkoutSession, countryCode, …)` | `TransactionConfig.checkoutSession` / `TransactionConfig.countryCode` | Sessions move into the config object. |
 | `callbackOTT: (String?) -> Unit` | Override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) on `TransactionController` (Non-seamless only) | In Lite, this lambda only fired in the headless variant. For the SDK-managed Lite flow, you don't need it. See [Headless migration](/docs/yuno-sdk/migration/android/payment/headless). |
-| `callbackPaymentState: (state, subState) -> Unit` | `TransactionController.onStatus(status: PaymentStatus)` | See [Result mapping](#result-mapping) below. |
-| `startPaymentLite(paymentSelected, …, showPaymentStatus)` | `Transaction(config).start(paymentSelected)` | The `showPaymentStatus` argument moved into `TransactionConfig.showPaymentStatusScreen`. |
+| `callbackPaymentState: (state, subState) -> Unit` | `TransactionController.onStatus(status: TransactionStatus)` | See [Result mapping](#result-mapping) below. |
+| `startPaymentLite(paymentSelected, …, showPaymentStatus)` | `Transaction(config).start(paymentSelected)` | The `showPaymentStatus` argument moved into `TransactionConfig.showStatusScreen`. |
 | `PaymentSelected` | `PaymentMethodSelected` | Class renamed. Same role. |
 | `merchantSessionId` parameter | Reserved | Anti-fraud session ID is now configured server-side and is no longer passed from the client. |
 
 ### Result mapping
 
-The result type was promoted from a raw `String` pair (state, subState) to a proper `PaymentStatus` object. The string values themselves are mostly the same; one value was renamed for cross-platform parity.
+The result type was promoted from a raw `String` pair (state, subState) to a proper `TransactionStatus` object. The string values themselves are mostly the same; one value was renamed for cross-platform parity.
 
-| Before (`state: String` from `callbackPaymentState`) | After `PaymentStatus.value` |
+| Before (`state: String` from `callbackPaymentState`) | After `TransactionStatus.value` |
 |---|---|
 | `"SUCCEEDED"` | `"SUCCEEDED"` |
 | `"REJECT"` | `"REJECT"` |
@@ -143,12 +143,12 @@ The result type was promoted from a raw `String` pair (state, subState) to a pro
 | `"INTERNAL_ERROR"` | `"INTERNAL_ERROR"` |
 | `"CANCELED_BY_USER"` | `"USER_CANCEL"` |
 
-The `subState` string maps 1-to-1 to `PaymentStatus.substatus`.
+The `subState` string maps 1-to-1 to `TransactionStatus.substatus`.
 
 ## Behavior changes
 
 <Warning>
-**`showPaymentStatusScreen` default flipped.** In Lite, `showPaymentStatus` defaulted to `true` and the SDK presented its built-in result screen. In the unified API, `showPaymentStatusScreen` defaults to **`false`**. If your integration relied on the SDK showing the result screen, set `showPaymentStatusScreen = true` in `TransactionConfig` explicitly.
+**`showStatusScreen` default flipped.** In Lite, `showPaymentStatus` defaulted to `true` and the SDK presented its built-in result screen. In the unified API, `showStatusScreen` defaults to **`false`**. If your integration relied on the SDK showing the result screen, set `showStatusScreen = true` in `TransactionConfig` explicitly.
 </Warning>
 
 - **`onStatus` is always invoked.** In Lite, the lambda fired only on terminal outcomes. `onStatus` is invoked for every terminal status regardless of whether the SDK shows its own result screen, so you can drive your own UI on top.
@@ -158,14 +158,14 @@ The `subState` string maps 1-to-1 to `PaymentStatus.substatus`.
 
 ## Checklist
 
-- [ ] Replace `SDKPayment.initialize(context, apiKey, YunoConfig(…))` with `SDKPayment.initialize(context, apiKey)`.
+- [ ] Replace `Yuno.initialize(context, apiKey, YunoConfig(…))` with `SdkPayments.initialize(context, apiKey)`.
 - [ ] Move `styles` and `language` from `YunoConfig` into `TransactionConfig.appearance` / `TransactionConfig.language`. Drop `saveCardEnabled`, `keepLoader`, `isDynamicViewEnabled`.
 - [ ] Implement `TransactionController` on a class you can keep alive (Activity, ViewModel, etc.).
 - [ ] Move `checkoutSession` and `countryCode` from `startCheckout(…)` arguments into `TransactionConfig`.
 - [ ] Replace the `callbackPaymentState` lambda with `TransactionController.onStatus(status)`. Switch `"CANCELED_BY_USER"` → `"USER_CANCEL"`.
 - [ ] Replace the `startPaymentLite(…)` call with `Transaction(config).start(paymentSelected)`.
 - [ ] Rename `PaymentSelected` to `PaymentMethodSelected`.
-- [ ] Set `showPaymentStatusScreen = true` if you relied on the SDK showing the result screen.
+- [ ] Set `showStatusScreen = true` if you relied on the SDK showing the result screen.
 - [ ] Drop `merchantSessionId` from the client; anti-fraud session ID is now server-side.
 - [ ] Re-run your sandbox test suite.
 

--- a/docs/yuno-sdk/migration/android/payment/render.mdx
+++ b/docs/yuno-sdk/migration/android/payment/render.mdx
@@ -4,7 +4,7 @@ title: "Render mode"
 description: "Migrate Android Render integrations (Activity.startPaymentRender + YunoPaymentRenderListener) to the unified Transaction API."
 ---
 
-Render mode let you embed the SDK's payment form inside your own layout: you called `startPaymentRender(…)` and received a `YunoPaymentFragmentController` plus a `YunoPaymentRenderListener.showView(fragment)` callback that delivered the SDK's `Fragment`. You placed it in your layout and called `controller.submitForm()` (or `controller.continuePayment()` for the 3DS step) from your own button.
+Render mode lets you embed the SDK's payment form inside your own layout: you called `startPaymentRender(…)` and received a `YunoPaymentFragmentController` plus a `YunoPaymentRenderListener.showView(fragment)` callback that delivered the SDK's `Fragment`. You placed it in your layout and called `controller.submitForm()` (or `controller.continuePayment()` for the 3DS step) from your own button.
 
 In the unified API the same pattern is expressed by overriding [`showView`](/docs/yuno-sdk/controllers/show-view). The SDK still hands you a `Fragment`; you receive it together with a `TransactionProcess` control object that exposes `onSubmit()` and `onClose()`. Continuation (3DS / redirect) is no longer a separate call — the SDK emits a second `showView` with `step = ACTION` when it needs to.
 

--- a/docs/yuno-sdk/migration/android/payment/render.mdx
+++ b/docs/yuno-sdk/migration/android/payment/render.mdx
@@ -1,21 +1,21 @@
 ---
 hidden: true
 title: "Render mode"
-description: "Migrate Android Render integrations (Activity.startPaymentRender + YunoPaymentRenderController) to the unified Transaction API."
+description: "Migrate Android Render integrations (Activity.startPaymentRender + YunoPaymentRenderListener) to the unified Transaction API."
 ---
 
-Render mode let you embed the SDK's payment form inside your own layout: you called `startPaymentRender(…)` and received a `YunoPaymentFragmentController` plus a `YunoPaymentRenderController.showView(fragment)` callback that delivered the SDK's `Fragment`. You placed it in your layout and called `controller.submitForm()` (or `controller.continuePayment()` for the 3DS step) from your own button.
+Render mode let you embed the SDK's payment form inside your own layout: you called `startPaymentRender(…)` and received a `YunoPaymentFragmentController` plus a `YunoPaymentRenderListener.showView(fragment)` callback that delivered the SDK's `Fragment`. You placed it in your layout and called `controller.submitForm()` (or `controller.continuePayment()` for the 3DS step) from your own button.
 
 In the unified API the same pattern is expressed by overriding [`showView`](/docs/yuno-sdk/controllers/show-view). The SDK still hands you a `Fragment`; you receive it together with a `TransactionProcess` control object that exposes `onSubmit()` and `onClose()`. Continuation (3DS / redirect) is no longer a separate call — the SDK emits a second `showView` with `step = ACTION` when it needs to.
 
 | Before | After |
 |---|---|
 | `Activity.startPaymentRender(…)` → `YunoPaymentFragmentController` | `Transaction(config).start(paymentSelected)` + override `showView` |
-| `YunoPaymentRenderController.showView(fragment)` | View delivered through `showView(view, process, step)` |
+| `YunoPaymentRenderListener.showView(fragment)` | View delivered through `showView(view, process, step)` |
 | `controller.submitForm()` | `process.onSubmit()` |
 | `controller.continuePayment()` | *(no longer required. SDK emits a second `showView(step = ACTION)`)* |
-| `YunoPaymentRenderController.loadingController(isLoading)` | `TransactionController.showLoading(isLoading)` |
-| `YunoPaymentRenderController.returnStatus(resultCode, status, subStatus)` | `TransactionController.onStatus(status)` |
+| `YunoPaymentRenderListener.loadingListener(isLoading)` | `TransactionController.showLoading(isLoading)` |
+| `YunoPaymentRenderListener.returnStatus(resultCode, status, subStatus)` | `TransactionController.onStatus(status)` |
 
 ## Side-by-side
 
@@ -25,11 +25,11 @@ In the unified API the same pattern is expressed by overriding [`showView`](/doc
 import androidx.fragment.app.Fragment
 import com.yuno.sdk.payments.render.startPaymentRender
 import com.yuno.sdk.payments.render.YunoPaymentFragmentController
-import com.yuno.sdk.payments.render.YunoPaymentRenderController
+import com.yuno.sdk.payments.render.YunoPaymentRenderListener
 import com.yuno.payments.features.payment.models.OneTimeTokenModel
 import com.yuno.presentation.core.components.PaymentSelected
 
-class CheckoutActivity : ComponentActivity(), YunoPaymentRenderController {
+class CheckoutActivity : ComponentActivity(), YunoPaymentRenderListener {
 
     private var controller: YunoPaymentFragmentController? = null
 
@@ -52,7 +52,7 @@ class CheckoutActivity : ComponentActivity(), YunoPaymentRenderController {
             .commit()
     }
 
-    override fun loadingController(isLoading: Boolean) { /* show your own loader */ }
+    override fun loadingListener(isLoading: Boolean) { /* show your own loader */ }
 
     override fun returnStatus(resultCode: Int, paymentStatus: String, paymentSubStatus: String?) {
         // resultCode + paymentStatus
@@ -75,13 +75,13 @@ class CheckoutActivity : ComponentActivity(), YunoPaymentRenderController {
 
 ```kotlin After. showView override
 import androidx.fragment.app.Fragment
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.TransactionProcess
-import com.yuno.sdk.TransactionViewStep
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.TransactionProcess
+import com.yuno.payments.sdk.api.models.TransactionViewStep
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class CheckoutActivity : ComponentActivity(), TransactionController {
 
@@ -110,7 +110,7 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
     override fun showLoading(isLoading: Boolean) { /* show your own loader */ }
 
     // 3. Final status arrives through onStatus
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         // status.value: "SUCCEEDED" / "REJECT" / ...
     }
 
@@ -129,12 +129,12 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
 | `Activity.startPaymentRender(checkoutSession, countryCode, …, paymentSelected, controller)` | `Transaction(config).start(paymentSelected)` | The `Transaction` is the single entry point. `checkoutSession` / `countryCode` move into `TransactionConfig`. |
 | `submitButton: Boolean` | *(removed)* | The submit button is fully owned by the merchant in the unified API. The SDK never renders one when `showView` is overridden. |
 | `coroutineScope` parameter | *(removed)* | The SDK manages its own scope. |
-| `YunoPaymentRenderController.showView(fragment)` | `TransactionController.showView(view, process, step)` | Push, not pull. The SDK delivers the view to your handler when ready. `process` replaces the controller. `step` tells you which step you received (`FORM`, `ACTION`). |
+| `YunoPaymentRenderListener.showView(fragment)` | `TransactionController.showView(view, process, step)` | Push, not pull. The SDK delivers the view to your handler when ready. `process` replaces the controller. `step` tells you which step you received (`FORM`, `ACTION`). |
 | `controller.submitForm()` | `process.onSubmit()` | Same role; called on the `TransactionProcess` you receive in `showView`. |
 | `controller.continuePayment()` | *(removed)* | The SDK now triggers a second `showView(step = ACTION)` itself when a 3DS challenge or redirect is required. You don't need to call anything. |
-| `YunoPaymentRenderController.loadingController(isLoading)` | `TransactionController.showLoading(isLoading)` | Same semantics, renamed. **Render is the legacy mode where the loader callback was actually invoked**, so existing Render integrations almost certainly need to migrate this. |
-| `YunoPaymentRenderController.returnStatus(resultCode, status, subStatus)` | `TransactionController.onStatus(status)` | `resultCode` (`PAYMENT_RESULT_*` ints) is dropped; the status string is now wrapped in `PaymentStatus(value, substatus)`. See [Result mapping in Lite](/docs/yuno-sdk/migration/android/payment/lite#result-mapping). |
-| `YunoPaymentRenderController.returnOneTimeToken(token, additionalData)` | Override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) | Only relevant for the non-seamless headless path. See [Headless migration](/docs/yuno-sdk/migration/android/payment/headless). |
+| `YunoPaymentRenderListener.loadingListener(isLoading)` | `TransactionController.showLoading(isLoading)` | Same semantics, renamed. **Render is the legacy mode where the loader callback was actually invoked**, so existing Render integrations almost certainly need to migrate this. |
+| `YunoPaymentRenderListener.returnStatus(resultCode, status, subStatus)` | `TransactionController.onStatus(status)` | `resultCode` (`PAYMENT_RESULT_*` ints) is dropped; the status string is now wrapped in `TransactionStatus(value, substatus)`. See [Result mapping in Lite](/docs/yuno-sdk/migration/android/payment/lite#result-mapping). |
+| `YunoPaymentRenderListener.returnOneTimeToken(token, additionalData)` | Override [`createPayment`](/docs/yuno-sdk/controllers/create-payment) | Only relevant for the non-seamless headless path. See [Headless migration](/docs/yuno-sdk/migration/android/payment/headless). |
 | `PaymentSelected` | `PaymentMethodSelected` | Class renamed. |
 
 ## Behavior changes
@@ -143,18 +143,18 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
 - **Two view steps.** `showView` can be called more than once per transaction. `step = FORM` for the data-capture form, `step = ACTION` for a 3DS challenge or external redirect. Decide how to embed each in your layout. (In Render this used to require a separate `controller.continuePayment()` call.)
 - **3DS handled by the SDK.** If you previously triggered 3DS yourself via `controller.continuePayment()`, the SDK now does it as another `showView(view, process, step = ACTION)`. You can keep embedding it inside your layout.
 - **No `submitButton` flag.** The submit button is always merchant-owned in the unified API. Render it in your layout and call `process.onSubmit()` when tapped.
-- **`resultCode` ints are gone.** Branch on `PaymentStatus.value` instead.
+- **`resultCode` ints are gone.** Branch on `TransactionStatus.value` instead.
 
 ## Checklist
 
-- [ ] Replace conformance to `YunoPaymentRenderController` with `TransactionController`.
+- [ ] Replace conformance to `YunoPaymentRenderListener` with `TransactionController`.
 - [ ] Move `checkoutSession` and `countryCode` from `startPaymentRender(…)` into `TransactionConfig`.
 - [ ] Remove the `startPaymentRender(…)` call. Use `Transaction(config).start(paymentSelected)` instead.
 - [ ] Remove the `controller` variable. Store the `TransactionProcess` delivered in `showView` and call `process.onSubmit()` from your button.
 - [ ] Remove the `controller.continuePayment()` call. The SDK now triggers a second `showView` with `step = ACTION` if a 3DS challenge is required.
-- [ ] Rename `loadingController(isLoading)` to `showLoading(isLoading)`.
-- [ ] Rename `returnStatus(resultCode, status, subStatus)` to `onStatus(status: PaymentStatus)` and switch `"CANCELED_BY_USER"` → `"USER_CANCEL"`. Drop the `resultCode` int.
-- [ ] Drop the `submitButton`, `coroutineScope`, and `showPaymentStatus` parameters from your call site. Set `showPaymentStatusScreen` on `TransactionConfig` if needed.
+- [ ] Rename `loadingListener(isLoading)` to `showLoading(isLoading)`.
+- [ ] Rename `returnStatus(resultCode, status, subStatus)` to `onStatus(status: TransactionStatus)` and switch `"CANCELED_BY_USER"` → `"USER_CANCEL"`. Drop the `resultCode` int.
+- [ ] Drop the `submitButton`, `coroutineScope`, and `showPaymentStatus` parameters from your call site. Set `showStatusScreen` on `TransactionConfig` if needed.
 - [ ] Rename `PaymentSelected` → `PaymentMethodSelected`.
 - [ ] Re-run your sandbox test suite, including 3DS scenarios.
 

--- a/docs/yuno-sdk/migration/android/payment/seamless.mdx
+++ b/docs/yuno-sdk/migration/android/payment/seamless.mdx
@@ -11,7 +11,7 @@ In the unified API the same flow is the **default behavior** of `Transaction.sta
 | Before | After |
 |---|---|
 | `Activity.startCheckout(…)` + `Activity.startPaymentSeamlessLite(paymentSelected, showPaymentStatus, callbackPaymentState)` | `Transaction(config).start(paymentSelected)` + `onStatus` controller |
-| Free-form lambda `(state, subState) -> Unit` | `TransactionController.onStatus(status: PaymentStatus)` |
+| Free-form lambda `(state, subState) -> Unit` | `TransactionController.onStatus(status: TransactionStatus)` |
 | `PaymentSelected` | `PaymentMethodSelected` |
 
 ## Side-by-side
@@ -30,7 +30,7 @@ class CheckoutActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        Yuno.initialize(applicationContext, apiKey = "your-public-api-key")
 
         // 2. Wire up the checkout launcher
         startCheckout(
@@ -60,12 +60,12 @@ class CheckoutActivity : ComponentActivity() {
 ```
 
 ```kotlin After. Unified Transaction
-import com.yuno.sdk.Yuno
-import com.yuno.sdk.Transaction
-import com.yuno.sdk.TransactionConfig
-import com.yuno.sdk.TransactionController
-import com.yuno.sdk.PaymentMethodSelected
-import com.yuno.sdk.PaymentStatus
+import com.yuno.payments.sdk.api.SdkPayments
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+import com.yuno.payments.sdk.api.TransactionController
+import com.yuno.payments.sdk.api.models.PaymentMethodSelected
+import com.yuno.payments.sdk.api.models.TransactionStatus
 
 class CheckoutActivity : ComponentActivity(), TransactionController {
 
@@ -73,11 +73,11 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
         super.onCreate(savedInstanceState)
 
         // 1. Initialize once at app startup
-        SDKPayment.initialize(applicationContext, apiKey = "your-public-api-key")
+        SdkPayments.initialize(applicationContext, apiKey = "your-public-api-key")
     }
 
     // 2. Implement a minimal controller
-    override fun onStatus(status: PaymentStatus) {
+    override fun onStatus(status: TransactionStatus) {
         when (status.value) {
             "SUCCEEDED"      -> println("Success")
             "REJECT"         -> println("Rejected")
@@ -95,7 +95,7 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
             countryCode = "CO",
             language = "en",
             controller = this,
-            showPaymentStatusScreen = true,
+            showStatusScreen = true,
         )
 
         Transaction(config = config)
@@ -112,14 +112,14 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
 |---|---|---|
 | `startCheckout.checkoutSession` | `TransactionConfig.checkoutSession` | Same. |
 | `startCheckout.countryCode` | `TransactionConfig.countryCode` | Same. |
-| `startPaymentSeamlessLite(paymentSelected, showPaymentStatus, callbackPaymentState)` | `Transaction(config).start(paymentSelected)` | Single entry point. The `showPaymentStatus` argument moved into `TransactionConfig.showPaymentStatusScreen`. |
-| `callbackPaymentState: (state, subState) -> Unit` | `TransactionController.onStatus(status: PaymentStatus)` | See [Result mapping in Lite](/docs/yuno-sdk/migration/android/payment/lite#result-mapping) for the per-value rename. |
+| `startPaymentSeamlessLite(paymentSelected, showPaymentStatus, callbackPaymentState)` | `Transaction(config).start(paymentSelected)` | Single entry point. The `showPaymentStatus` argument moved into `TransactionConfig.showStatusScreen`. |
+| `callbackPaymentState: (state, subState) -> Unit` | `TransactionController.onStatus(status: TransactionStatus)` | See [Result mapping in Lite](/docs/yuno-sdk/migration/android/payment/lite#result-mapping) for the per-value rename. |
 | `PaymentSelected` | `PaymentMethodSelected` | Class renamed. |
 
 ## Behavior changes
 
 <Warning>
-**`showPaymentStatusScreen` default flipped.** In Seamless, `showPaymentStatus` defaulted to `true` and the SDK presented its built-in result screen. In the unified API, `showPaymentStatusScreen` defaults to **`false`**. Set it to `true` in `TransactionConfig` if you relied on the SDK's built-in result screen.
+**`showStatusScreen` default flipped.** In Seamless, `showPaymentStatus` defaulted to `true` and the SDK presented its built-in result screen. In the unified API, `showStatusScreen` defaults to **`false`**. Set it to `true` in `TransactionConfig` if you relied on the SDK's built-in result screen.
 </Warning>
 
 - **You now need a controller instance.** Even for the simplest case you implement `TransactionController` (just `onStatus`). Pass it through `TransactionConfig.controller`.
@@ -132,7 +132,7 @@ class CheckoutActivity : ComponentActivity(), TransactionController {
 - [ ] Move `checkoutSession` and `countryCode` from `startCheckout(…)` arguments into `TransactionConfig`.
 - [ ] Replace the `startPaymentSeamlessLite(…)` call with `Transaction(config).start(paymentSelected)`.
 - [ ] Move the result-handling logic from the `callbackPaymentState` lambda into `onStatus(status)`. Switch `"CANCELED_BY_USER"` → `"USER_CANCEL"`.
-- [ ] Set `showPaymentStatusScreen = true` if you relied on the SDK showing the result screen.
+- [ ] Set `showStatusScreen = true` if you relied on the SDK showing the result screen.
 - [ ] Rename `PaymentSelected` → `PaymentMethodSelected`.
 - [ ] Re-run your sandbox test suite.
 


### PR DESCRIPTION
Fixes the Android findings from the Universal SDK (Alpha) Docs QA Assessment (2026-07-17, Caio Freitas) — [CORECM-18403](https://yunopayments.atlassian.net/browse/CORECM-18403). Every class, package, method and field below was verified against the real `android-sdk` code: v3 names against `release/3.0.0-alpha`, v2 ("before") names against `release/2.20.0`.

## C-2 — Quickstart / migration pages could not compile
- Entry point unified to the real `com.yuno.payments.sdk.api.SdkPayments.initialize(context, apiKey)` (was `SDKPayment` / `com.yuno.payments.Yuno` / `com.yuno.sdk.Yuno` depending on the page).
- All v3 imports now point at the real packages: `com.yuno.payments.sdk.api.{Transaction, TransactionConfig, TransactionController, PaymentListController, SdkPayments}` and `com.yuno.payments.sdk.api.models.{PaymentMethodSelected, TransactionStatus, TransactionData, CardData, PaymentMethodType, TransactionProcess, TransactionViewStep}`.
- v2 "before" snippets now use the real v2 entry point (`Yuno.initialize`) — they were showing `SDKPayment`.

## C-1 — dependency pin
- `get-started.mdx` now pins `com.yuno.payments:android-sdk:3.0.0-alpha` (the artifact that exists in JFrog; `3.0.0` 404s).

## M-14 — headless migration page
- v3 side documents the real contract: `TransactionController.createPayment(token: Map<String, Any>)` override + `Transaction.start(paymentSelected)` — no LiveData, no `generateToken` on v3.
- v2 side keeps the (correct since v2.12.0) suspend `generateToken` signature.

## Additional inaccuracies found while verifying (same pages)
- `getThreeDSecureChallenge` never existed in the v2 SDK — replaced with the real `ApiClientPayment.continueCardPayment(activity, showPaymentStatus, callbackPaymentState)`.
- Fabricated types replaced: `OneTimeToken` → `Map<String, Any>`, `CardTransactionData` → `CardData` (flat), `PaymentStatus` → `TransactionStatus`.
- `TransactionConfig.showPaymentStatusScreen` → real field `showStatusScreen`.
- `getPaymentMethodsViews` corrected to the real signature (`host` param, sealed `PaymentMethodType.GooglePay()` / `PaymentMethodType.PaymentMethodList`, returns `Map<PaymentMethodType, View?>` — not Fragments).
- v2 render listener names corrected: `YunoPaymentRenderListener` / `YunoEnrollmentRenderListener` (docs said `*RenderController`), `loadingListener` (docs said `loadingController`).
- Enrollment pages: `onOneTimeToken` (nonexistent) → `createPayment`.

Android tabs of the shared pages (`controllers/on-status.mdx`, `features/payment-methods-list.mdx`) included. iOS/Web content untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-18403]: https://yunopayments.atlassian.net/browse/CORECM-18403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation corrections with no runtime or application code changes.
> 
> **Overview**
> **Documentation-only** updates so Android Yuno SDK pages match the **`android-sdk` 3.0.0-alpha** binary (QA findings). iOS/Web content is largely unchanged.
> 
> **Get started & install:** Gradle now pins **`com.yuno.payments:android-sdk:3.0.0-alpha`**. Samples use **`SdkPayments.initialize`** and **`com.yuno.payments.sdk.api`** imports instead of mixed **`SDKPayment` / `Yuno`** names.
> 
> **Shared feature pages:** **`onStatus`** documents **`TransactionStatus`**. **Payment methods list** adds the real **`getPaymentMethodsViews(host, …)`** signature, sealed **`PaymentMethodType`**, and **`View`** embedding. **Deeplinks** now cover **Android** (`Transaction.handleDeeplink`) alongside iOS, not iOS-only.
> 
> **Migration guides (v2 → v3):** Unified v3 types (**`TransactionStatus`**, flat **`CardData`**, **`showStatusScreen`**, **`createPayment(token: Map<String, Any>)`**). v2 “before” snippets use real APIs (**`Yuno.initialize`**, **`continueCardPayment`** instead of a nonexistent **`getThreeDSecureChallenge`**). Legacy listener names are corrected (**`*RenderListener`**, **`loadingListener`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ef9332aabf8de271686d161261cd69a2f086fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->