### PR TITLE
docs(C2-16615): per-card Account Updater field + bulk registration endpoint

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -375,6 +375,7 @@
             "pages": [
               "reference/payment-methods-direct-workflow/the-payment-method-object-api",
               "reference/payment-methods-direct-workflow/enroll-payment-method-api",
+              "reference/payment-methods-direct-workflow/register-cards-for-account-updater-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api",
               "reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api",

--- a/docs/additional-services/card-account-updater.mdx
+++ b/docs/additional-services/card-account-updater.mdx
@@ -124,7 +124,7 @@ By default, when Card Account Updater is enabled for your account, every eligibl
 * Set `account_updater` to `false` to **exclude** that specific card from Card Account Updater. The card will not receive automatic card-detail updates.
 * Omit the field (or set it to `true`) to keep the card under your account's Card Account Updater configuration.
 
-The `account_updater` field is available when enrolling a card through the [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api) endpoint (Direct workflow), through the SDK enrollment flow, and in the `payment_method` object of the [Create Payment](/reference/payments/create-payment) request when a card is vaulted during a payment.
+The `account_updater` field is available when enrolling a card through the [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api) endpoint (Direct workflow), through the SDK enrollment flow, and in the `payment_method` object of the [Create Payment](/reference/payments/create-payment) and [Authorize Payment](/reference/payments/authorize-payment) requests when a card is vaulted during a payment.
 
 ## Registering stored cards in bulk
 

--- a/docs/additional-services/card-account-updater.mdx
+++ b/docs/additional-services/card-account-updater.mdx
@@ -117,6 +117,19 @@ The following code block presents a notification example:
 
 ```
 
+## Controlling Account Updater per card
+
+By default, when Card Account Updater is enabled for your account, every eligible card enrolled under it is kept up to date automatically. You can override this behavior for an individual card at enrollment using the `account_updater` field:
+
+* Set `account_updater` to `false` to **exclude** that specific card from Card Account Updater. The card will not receive automatic card-detail updates.
+* Omit the field (or set it to `true`) to keep the card under your account's Card Account Updater configuration.
+
+The `account_updater` field is available when enrolling a card through the [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api) endpoint (Direct workflow), through the SDK enrollment flow, and in the `payment_method` object of the [Create Payment](/reference/payments/create-payment) request when a card is vaulted during a payment.
+
+## Registering stored cards in bulk
+
+For cards that were stored before enabling Card Account Updater — or enrolled with it excluded — you can register them in batches with the [Register Stored Cards for Account Updater](/reference/payment-methods-direct-workflow/register-cards-for-account-updater-api) endpoint. Send up to 100 payment method ids (`vaulted_token`) per request. Validation is synchronous and all-or-nothing, and registration runs asynchronously in the background.
+
 ## Card networks' compatibility
 
 Card Account Updater is currently available for Visa and Mastercard.

--- a/openapi/payment-methods-checkout/enroll-payment-method-checkout.json
+++ b/openapi/payment-methods-checkout/enroll-payment-method-checkout.json
@@ -104,6 +104,10 @@
                       "UY"
                     ]
                   },
+                  "account_updater": {
+                    "type": "boolean",
+                    "description": "Per-card control for Card Account Updater. When set to `false`, this card is excluded from Card Account Updater and will not receive automatic card-detail updates. When omitted, the card follows your account's Account Updater configuration. Applies at enrollment."
+                  },
                   "verify": {
                     "type": "object",
                     "description": "Indicates whether to verify the payment with a verify transaction or not. You’ll need to have a provider defined in your CARD route. False by default. Access the [Card Verification](/docs/card-verification) page for more details.",

--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -124,6 +124,10 @@
                     "type": "string",
                     "description": "Type of the parent payment method, used when enrolling a tokenized/derived method (e.g. `CARD`)."
                   },
+                  "account_updater": {
+                    "type": "boolean",
+                    "description": "Per-card control for Card Account Updater. When set to `false`, this card is excluded from Card Account Updater and will not receive automatic card-detail updates. When omitted, the card follows your account's Account Updater configuration. Applies at enrollment."
+                  },
                   "card_data": {
                     "type": "object",
                     "description": "Specifies the details of the card. Only for `DIRECT` workflow integration.",

--- a/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json
+++ b/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json
@@ -1,0 +1,223 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "customer-api-register-payment-method",
+    "version": "1.0.2"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "x-default": "<Your private-secret-key>",
+        "name": "private-secret-key"
+      },
+      "sec2": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Idempotency-Key",
+        "x-default": "<Your X-Idempotency-Key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": [],
+      "sec2": []
+    }
+  ],
+  "paths": {
+    "/payment-methods/account-updater": {
+      "post": {
+        "summary": "Register stored cards for Account Updater",
+        "description": "Register up to 100 stored cards for Card Account Updater in a single request, identified by their payment method id (`vaulted_token`). Validation is synchronous and all-or-nothing: if any id is invalid the whole request is rejected. Registration itself runs asynchronously, so a `200` response confirms the cards were accepted, not that the update completed. Your account must be enabled for Card Account Updater to use this endpoint.",
+        "operationId": "register-cards-for-account-updater-api",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "examples": {
+                "Register cards": {
+                  "value": {
+                    "payment_method_ids": [
+                      "cbdcc878-ceb4-4dd8-b0f0-49d444855de0",
+                      "03c3aae1-ed42-4be6-bc24-de5487f58491"
+                    ]
+                  }
+                }
+              },
+              "schema": {
+                "type": "object",
+                "required": [
+                  "payment_method_ids"
+                ],
+                "properties": {
+                  "payment_method_ids": {
+                    "type": "array",
+                    "description": "List of stored payment method ids (`vaulted_token`) to register for Card Account Updater. Between 1 and 100 items; each must be a valid UUID.",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "cbdcc878-ceb4-4dd8-b0f0-49d444855de0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "accepted": 2
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "accepted": {
+                      "type": "integer",
+                      "description": "Number of cards accepted for Card Account Updater registration.",
+                      "example": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Bad Request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Invalid request"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "INVALID_CREDENTIALS",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_CREDENTIALS"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid credentials"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Forbidden": {
+                    "value": {
+                      "code": "AUTHORIZATION_REQUIRED",
+                      "messages": [
+                        "The merchant has no authorization to use this API."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "AUTHORIZATION_REQUIRED"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "The merchant has no authorization to use this API."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "key": "charset",
+        "value": "utf-8"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json
+++ b/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json
@@ -41,7 +41,7 @@
   "paths": {
     "/payment-methods/account-updater": {
       "post": {
-        "summary": "Register stored cards for Account Updater",
+        "summary": "Register Stored Cards for Account Updater",
         "description": "Register up to 100 stored cards for Card Account Updater in a single request, identified by their payment method id (`vaulted_token`). Validation is synchronous and all-or-nothing: if any id is invalid the whole request is rejected. Registration itself runs asynchronously, so a `200` response confirms the cards were accepted, not that the update completed. Your account must be enabled for Card Account Updater to use this endpoint.",
         "operationId": "register-cards-for-account-updater-api",
         "requestBody": {

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -2112,6 +2112,10 @@
                       "vault_on_success": {
                         "type": "boolean",
                         "description": "Flag to enroll the card after a successful payment"
+                      },
+                      "account_updater": {
+                        "type": "boolean",
+                        "description": "Per-card control for Card Account Updater. When set to `false`, the card enrolled or used in this payment is excluded from Card Account Updater and will not receive automatic card-detail updates. When omitted, the card follows your account's Account Updater configuration."
                       }
                     }
                   },

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -2830,6 +2830,10 @@
                         "type": "boolean",
                         "description": "Flag to enroll the card after a successful payment (requires `customer_payer.id`)."
                       },
+                      "account_updater": {
+                        "type": "boolean",
+                        "description": "Per-card control for Card Account Updater. When set to `false`, the card enrolled or used in this payment is excluded from Card Account Updater and will not receive automatic card-detail updates. When omitted, the card follows your account's Account Updater configuration."
+                      },
                       "otp": {
                         "type": "object",
                         "properties": {

--- a/reference/payment-methods-direct-workflow/register-cards-for-account-updater-api.mdx
+++ b/reference/payment-methods-direct-workflow/register-cards-for-account-updater-api.mdx
@@ -1,0 +1,16 @@
+---
+title: "Register Stored Cards for Account Updater"
+openapi: "/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json POST /payment-methods/account-updater"
+description: "Registers up to 100 stored cards for Card Account Updater in a single request"
+---
+
+Register a batch of already-stored cards for [Card Account Updater](/docs/additional-services/card-account-updater), so their details are kept current automatically. Send the payment method ids (the `vaulted_token` received when enrolling each card) in a single request.
+
+<Note>
+**How registration behaves**
+
+- You can register between **1 and 100** cards per request; each id must be a valid `vaulted_token`.
+- Validation is **all-or-nothing**: if any id is invalid, the whole request is rejected.
+- Registration runs **asynchronously**. A `200` response with `accepted` confirms the cards were accepted, not that the update already happened — updates are notified later through the enrollment webhook.
+- Your account must be enabled for Card Account Updater. Otherwise the request returns `403`.
+</Note>


### PR DESCRIPTION
## What

Documents the per-card **Card Account Updater** controls shipped in **C2-16615** (per-card control of Yuno Account Updater via a payment payload parameter).

### Changes
- **`account_updater` field** added to:
  - Enrollment requests: `openapi/payment-methods-direct-workflow/enroll-payment-method-api.json` (Direct) and `openapi/payment-methods-checkout/enroll-payment-method-checkout.json` (Checkout/SDK).
  - **Payment requests** — the `payment_method` object of `openapi/payments/create-payment.json` and `openapi/payments/authorize-payment.json` (this is the payment-payload parameter the ticket is named after).

  Boolean, optional. `false` excludes the card from Card Account Updater; omitted follows the account's configuration.
- **New endpoint page** `POST /v1/payment-methods/account-updater` — *Register Stored Cards for Account Updater* (bulk, up to 100 `vaulted_token`s, sync all-or-nothing validation + async registration). New OpenAPI spec + `reference/` MDX + nav entry under *Payment Methods (Direct Workflow)*.
- **Guide** `docs/additional-services/card-account-updater.mdx` — *Controlling Account Updater per card* and *Registering stored cards in bulk* sections.

### Source of truth
Field names, endpoint route and semantics taken from the public-api contract on branch `feature/C2-16615-account-updater-per-card` (PR yuno-payments/public-api#1966). In public-api the field lives on the `payment_method` object (alongside `vault_on_success`), so it was added next to it in the request schemas.

### Notes for review
- Descriptions are merchant-facing; please sanity-check wording.
- Only additive changes — no existing spec was reformatted.
- `account_updater` documented on **request** schemas only (input intent), not on response echoes.

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI-only additions with no application code changes; low risk unless published API semantics diverge from the shipped public-api contract.
> 
> **Overview**
> Documents **C2-16615** Card Account Updater controls: an optional **`account_updater`** boolean on enrollment and payment **request** payloads, plus a new bulk-registration API.
> 
> Merchants can set **`account_updater`** to `false` on a single card (Direct enroll, Checkout/SDK enroll, or **`payment_method`** on Create/Authorize Payment when vaulting) to opt that card out of automatic updates; omitting it keeps the account default. OpenAPI is updated in the enroll specs and next to **`vault_on_success`** on create/authorize payment schemas—request-only, not on responses.
> 
> A new **`POST /payment-methods/account-updater`** reference is added (OpenAPI, MDX, API nav): register up to 100 stored **`vaulted_token`** ids with synchronous all-or-nothing validation and async registration; the Card Account Updater guide gains matching **per-card** and **bulk registration** sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a34c3d1a0b8006c178fafbe9e4bbcfbaac408df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->