### PR TITLE
[DEM-17766] docs: vault_on_success for BANK_TRANSFER (Fintoc) — save-during-payment guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -154,7 +154,8 @@
                 "group": "Enrollment",
                 "pages": [
                   "docs/payment-features/enrollment/enroll-payment-methods",
-                  "docs/payment-features/enrollment/enroll-cards-with-payment-link"
+                  "docs/payment-features/enrollment/enroll-cards-with-payment-link",
+                  "docs/payment-features/enrollment/save-bank-transfer-during-payment"
                 ]
               },
               {

--- a/docs/payment-features/enrollment/enroll-payment-methods.mdx
+++ b/docs/payment-features/enrollment/enroll-payment-methods.mdx
@@ -75,6 +75,7 @@ The enrollment workflow varies by payment method type:
 * **Direct workflow**: Available for Cards only (PCI compliant merchants). Proceed directly to Step 3 using the customer `id` generated in Step 1.
 * **SDK workflow**: Payment methods like Nequi and Bancolombia Tokenbox require SDK implementation. WALLET\_CONNECT (MercadoPago) supports both SDK and Checkout workflows. Consult the [SDK documentation](/docs/sdks/overview/quickstart) for details.
 * **SDK Seamless workflow**: You can enroll payment methods during the seamless payment flow by setting `vault_on_success: true` when creating the payment. The payment method will be automatically enrolled if the payment succeeds.
+* **Save during a payment (Bank Transfer)**: For `BANK_TRANSFER` through Fintoc (Chile), you can enroll the customer's bank account during a regular payment by setting `vault_on_success: true` and referencing an existing customer through `customer_payer.id`. The `vaulted_token` arrives asynchronously through the `enrollment.enroll` webhook. See [Save a Bank Transfer During a Payment](/docs/payment-features/enrollment/save-bank-transfer-during-payment).
 </Warning>
 
 Create a customer session to store the customer's payment preferences using the [Create Customer Session](/reference/create-customer-session) endpoint. Use the `id` from Step 1 as the `customer_id`.

--- a/docs/payment-features/enrollment/save-bank-transfer-during-payment.mdx
+++ b/docs/payment-features/enrollment/save-bank-transfer-during-payment.mdx
@@ -1,0 +1,81 @@
+---
+title: "Save a Bank Transfer During a Payment"
+description: "Let customers pay by bank transfer and save their bank account for future payments in a single redirect"
+---
+
+Save-during-payment lets your customer pay with a bank transfer and opt in to saving their bank account in the same flow — one redirect, one bank login. After the payment succeeds and the customer opts in, Yuno enrolls the bank account and delivers a `vaulted_token` you can use for future payments.
+
+This flow is available for the `BANK_TRANSFER` payment method through Fintoc in Chile (`CLP`).
+
+<Note>
+**One redirect instead of two**
+
+Without this feature, collecting a payment and enrolling a bank account requires two separate customer-facing flows: a one-time payment plus a standalone enrollment (`BANK_TRANSFER_ENROLLMENT`) — two redirects and two bank logins. Save-during-payment combines them.
+</Note>
+
+## Requirements
+
+* An active Fintoc connection with the `BANK_TRANSFER` payment method [connected and routed](/docs/connections) for Chile.
+* An existing Yuno customer: create one with the [Create Customer](/reference/create-customer) endpoint before the payment. The payment must reference the customer through `customer_payer.id`.
+* [Webhooks configured](/docs/webhooks) to receive `enrollment.enroll` notifications.
+
+## Request the save inside Create Payment
+
+Set `payment_method.vault_on_success` to `true` and reference the customer in the [Create Payment](/reference/create-payment) request:
+
+```json
+{
+  "amount": { "value": 5000, "currency": "CLP" },
+  "customer_payer": { "id": "<yuno_customer_id>" },
+  "payment_method": {
+    "type": "BANK_TRANSFER",
+    "vault_on_success": true
+  }
+}
+```
+
+The synchronous payment response echoes `payment_method.vault_on_success: true` and returns the redirect for the customer to complete the payment, as in a regular one-time bank transfer payment. During the Fintoc-hosted flow, the customer chooses whether to save their bank account.
+
+<Warning>
+**The `vaulted_token` is delivered asynchronously**
+
+Unlike cards, the bank account cannot exist at payment-creation time — it is saved only after the customer completes the redirect and opts in. The `vaulted_token` is **not** returned in the synchronous payment response. You receive it through the `enrollment.enroll` webhook once the payment method reaches `ENROLLED`, and you can also fetch it with [Retrieve Enrolled Payment Methods](/reference/retrieve-enrolled-payment-methods-api).
+</Warning>
+
+<Note>
+**The saved method is typed `BANK_TRANSFER_ENROLLMENT`**
+
+Although the originating payment uses `BANK_TRANSFER`, the saved payment method is created with type `BANK_TRANSFER_ENROLLMENT` — the same type used by the standalone enrollment flow. This is the type reported in the `enrollment.enroll` webhook and in [Retrieve Enrolled Payment Methods](/reference/retrieve-enrolled-payment-methods-api), and it is what makes the saved bank account appear among the customer's enrolled payment methods in the SDK checkout.
+</Note>
+
+## Outcomes
+
+| Scenario | Payment | Enrollment |
+| --- | --- | --- |
+| Customer pays and opts in to save | Processed normally | `enrollment.enroll` webhook delivers the `vaulted_token` |
+| Customer pays without opting in | Processed normally | No enrollment is created |
+| `vault_on_success: true` without `customer_payer.id` | Processed normally as a one-time payment | No enrollment is created — same degrade behavior as cards |
+| `vault_on_success` absent or `false` | Processed normally as a one-time payment | No enrollment is created |
+
+<Note>
+**Customer required**
+
+As with cards, sending customer details inline inside the payment request does not create the customer on Yuno's side. Without `customer_payer.id` referencing an existing Yuno customer, no vaulting occurs.
+</Note>
+
+## Pay with the saved bank account
+
+Use the `vaulted_token` from the enrollment webhook in future [Create Payment](/reference/create-payment) requests, with `payment_method.type` set to `BANK_TRANSFER_ENROLLMENT`:
+
+```json
+{
+  "amount": { "value": 5000, "currency": "CLP" },
+  "customer_payer": { "id": "<yuno_customer_id>" },
+  "payment_method": {
+    "type": "BANK_TRANSFER_ENROLLMENT",
+    "vaulted_token": "<vaulted_token>"
+  }
+}
+```
+
+The customer is redirected directly to their bank's approval step, without logging in with their bank credentials again.


### PR DESCRIPTION
## What
- New page **Save a Bank Transfer During a Payment** (`docs/payment-features/enrollment/save-bank-transfer-during-payment.mdx`): request contract (`vault_on_success` + `customer_payer.id`), the four outcome scenarios (opt-in, no opt-in, degrade without customer, flag absent), the async `vaulted_token` delivery via `enrollment.enroll`, and pay-with-saved usage.
- Pointer bullet in the enrollment guide's workflow panel; `docs.json` nav entry (validated).

## Why
Fintoc save-during-payment (PRIOR-689) extends `vault_on_success` — documented today as card-only — to `BANK_TRANSFER` (Chile/CLP), with an asynchronous token delivery that differs from the card behavior merchants know.

## Notes
- Base is **`main`** (the repo's content mainline; the default branch `master` is empty mid-migration).
- Publish after the implementation PRs merge — merge order ⑦ of 7 (epic DEM-17667).

- Jira: [DEM-17766](https://yunopayments.atlassian.net/browse/DEM-17766) · Epic: [DEM-17667](https://yunopayments.atlassian.net/browse/DEM-17667) · Commercial: [PRIOR-689](https://yunopayments.atlassian.net/browse/PRIOR-689)

**2026-07-29** — refreshed for the reopened Option 1 design (save-during-payment, PRIOR-689): pay-with-saved now uses `payment_method.type: BANK_TRANSFER_ENROLLMENT` + `vaulted_token`, and the guide states the saved method is minted as `BANK_TRANSFER_ENROLLMENT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEM-17766]: https://yunopayments.atlassian.net/browse/DEM-17766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEM-17667]: https://yunopayments.atlassian.net/browse/DEM-17667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PRIOR-689]: https://yunopayments.atlassian.net/browse/PRIOR-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior in this PR.
> 
> **Overview**
> Documents **save-during-payment** for Chile Fintoc `BANK_TRANSFER`: merchants can set `payment_method.vault_on_success: true` with `customer_payer.id` on [Create Payment](/reference/create-payment) so pay and bank-account save happen in one redirect instead of separate payment and `BANK_TRANSFER_ENROLLMENT` flows.
> 
> Adds **`save-bank-transfer-during-payment.mdx`** with requirements, request/response behavior, an outcomes table (opt-in, no opt-in, missing customer degrade, flag off), async `vaulted_token` via **`enrollment.enroll`** (not in the sync payment response), and follow-up payments using `vaulted_token`.
> 
> Wires the page into **Enrollment** nav (`docs.json`) and adds a **Save during a payment (Bank Transfer)** bullet in the enrollment guide workflow warning, linking to the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8c9e3f0d7c10f31c151310bf976447eeb8102e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
