### PR TITLE
chore: web sdk changelog 1.9.17

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,45 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.17",
+      "release_date": "2026-07-20",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.17",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Payment method radio moved to the leading edge (RTL-aware)",
+          "description": "BREAKING (visual default): the payment-method selection radio now renders at the leading (left) edge of each row, mirrored to the right automatically in RTL locales (Arabic, Hebrew, Persian, Urdu). Merchants with custom CSS targeting the old right-aligned radio may need to adjust their selectors. The trailing position remains available via the RadioButton showRadioLeft={false} prop in sdk-web-core.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Braintree Device Data Collection",
+          "description": "",
+          "group": "Fraud & Risk",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Six New Checkout Languages",
+          "description": "Adds Greek, Hebrew, Romanian, Slovak, Serbian (Latin), and Ukrainian localization to the Web SDK checkout.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17647",
+        "CORECM-18090",
+        "CORECM-18109"
+      ]
+    },
+    {
       "version": "1.9.16",
       "release_date": "2026-07-14",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,22 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.17
+*July 20, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Payment method radio moved to the leading edge (RTL-aware)**  
+  BREAKING (visual default): the payment-method selection radio now renders at the leading (left) edge of each row, mirrored to the right automatically in RTL locales (Arabic, Hebrew, Persian, Urdu). Merchants with custom CSS targeting the old right-aligned radio may need to adjust their selectors. The trailing position remains available via the RadioButton showRadioLeft={false} prop in sdk-web-core.
+
+- <ChangelogBadge type="added" /> **Six New Checkout Languages**  
+  Adds Greek, Hebrew, Romanian, Slovak, Serbian (Latin), and Ukrainian localization to the Web SDK checkout.
+
+**Fraud & Risk**
+
+- <ChangelogBadge type="added" /> **Braintree Device Data Collection**  
+  
+
 ## v1.9.16
 *July 14, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.17`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.17

3 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changelog sync; no runtime or SDK code changes in this PR.
> 
> **Overview**
> Documents **Web SDK v1.9.17** (July 20, 2026) in the structured source (`changelog/source/web.json`) and the public Web changelog page (`changelog/web.mdx`), including the `npm install @yuno-payments/sdk-web@1.9.17` upgrade snippet and tickets CORECM-17647, CORECM-18090, CORECM-18109.
> 
> **Core SDK:** Payment-method selection radios default to the **leading** edge with RTL mirroring (called out as a visual breaking change for custom CSS; trailing layout via `showRadioLeft={false}`). Six new checkout locales: Greek, Hebrew, Romanian, Slovak, Serbian (Latin), and Ukrainian.
> 
> **Fraud & Risk:** New changelog entry for **Braintree Device Data Collection** (no body text in the generated entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d64d1c70f53a4e62d343ddab4d05b1ab4f72257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->