### PR TITLE
docs(YSHUB-6005): document acquirer_reference_number in the payment object

### DIFF
--- a/docs/security-and-compliance/3d-secure.mdx
+++ b/docs/security-and-compliance/3d-secure.mdx
@@ -165,6 +165,7 @@ After executing the 3DS for each scenario, you'll receive all the necessary info
                 "soft_descriptor": "",
                 "authorization_code": "",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "John Doe",

--- a/docs/security-and-compliance/card-verification.mdx
+++ b/docs/security-and-compliance/card-verification.mdx
@@ -294,6 +294,7 @@ The code block below presents an example of card verification using the payment 
                 "soft_descriptor": "",
                 "authorization_code": "",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "Pepito Perez2",
@@ -378,6 +379,7 @@ The code block below presents an example of card verification using the payment 
                     "soft_descriptor": "",
                     "authorization_code": "",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "Pepito Perez2",
@@ -517,6 +519,7 @@ The code block below presents an example of card verification using the payment 
                 "soft_descriptor": "",
                 "authorization_code": "",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JOHN DOE",
@@ -601,6 +604,7 @@ The code block below presents an example of card verification using the payment 
                     "soft_descriptor": "",
                     "authorization_code": "",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JOHN DOE",

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -210,6 +210,7 @@ The next JSON object presents an example of a data structure related to a paymen
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                                 "holder_name": "HARRY POTTER",
@@ -298,6 +299,7 @@ The next JSON object presents an example of a data structure related to a paymen
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                     "holder_name": "HARRY POTTER",
@@ -495,6 +497,7 @@ The next JSON object presents an example of a data structure related to a paymen
                   "soft_descriptor":"",
                   "authorization_code":"",
                   "retrieval_reference_number":"",
+                  "acquirer_reference_number":"",
                   "voucher":null,
                   "card_data":{
                      "holder_name":"APROBADO",
@@ -743,6 +746,7 @@ The next JSON object presents an example of a data structure related to a paymen
                      "soft_descriptor":"",
                      "authorization_code":"373761",
                      "retrieval_reference_number":"",
+                     "acquirer_reference_number":"",
                      "voucher":null,
                      "card_data":{
                         "holder_name":"YOANA CALAM",
@@ -842,6 +846,7 @@ The next JSON object presents an example of a data structure related to a paymen
                         "soft_descriptor":"",
                         "authorization_code":"373761",
                         "retrieval_reference_number":"",
+                        "acquirer_reference_number":"",
                         "voucher":null,
                         "card_data":{
                            "holder_name":"YOANA CALAM",
@@ -940,6 +945,7 @@ The next JSON object presents an example of a data structure related to a paymen
                         "soft_descriptor":"",
                         "authorization_code":"373761",
                         "retrieval_reference_number":"",
+                        "acquirer_reference_number":"",
                         "voucher":null,
                         "card_data":{
                            "holder_name":"YOANA CALAM",
@@ -1220,6 +1226,7 @@ The next JSON object presents an example of a data structure related to a paymen
                   "soft_descriptor":"",
                   "authorization_code":"",
                   "retrieval_reference_number":"",
+                  "acquirer_reference_number":"",
                   "voucher":null,
                   "card_data":{
                      "holder_name":"APROBADO",
@@ -2223,6 +2230,7 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
             "soft_descriptor": "",
             "authorization_code": "658571",
             "retrieval_reference_number": "",
+            "acquirer_reference_number": "",
             "voucher": null,
             "card_data": {
               "holder_name": "Pepito Perez",

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -2716,6 +2716,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "5305c582-a192-41ff-ad98-3636d2758ed5",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -2823,6 +2824,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "5305c582-a192-41ff-ad98-3636d2758ed5",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -2906,6 +2908,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "5305c582-a192-41ff-ad98-3636d2758ed5",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -3016,6 +3019,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "517862",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -3124,6 +3128,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "517862",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -3222,6 +3227,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -3407,6 +3413,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -3548,6 +3555,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "redirect_url": "https://checkout.staging.y.uno/payment?session=14c263bd-e01d-400f-885a-70205df8b417",
                                   "card_data": {
@@ -3652,6 +3660,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "445975",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -3746,6 +3755,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -3845,6 +3855,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -3942,6 +3953,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4041,6 +4053,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4138,6 +4151,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4256,6 +4270,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4353,6 +4368,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4432,6 +4448,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4529,6 +4546,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4608,6 +4626,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4705,6 +4724,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4784,6 +4804,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4881,6 +4902,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4960,6 +4982,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -5176,6 +5199,10 @@
                                       "example": "5305c582-a192-41ff-ad98-3636d2758ed5"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -5520,6 +5547,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -5800,6 +5831,10 @@
                                           "example": "5305c582-a192-41ff-ad98-3636d2758ed5"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -6167,6 +6202,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -6504,6 +6543,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -6818,6 +6861,10 @@
                                       "example": ""
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -7364,6 +7411,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -7802,6 +7853,10 @@
                                                 "type": "string",
                                                 "example": ""
                                               },
+                                              "acquirer_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
                                               "voucher": {},
                                               "redirect_url": {
                                                 "type": "string",
@@ -8237,6 +8292,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -8552,6 +8611,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -8887,6 +8950,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -9202,6 +9269,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -9534,6 +9605,10 @@
                                       "example": "123456"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -9918,6 +9993,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -10250,6 +10329,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -10485,6 +10568,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -10820,6 +10907,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -11058,6 +11149,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -11393,6 +11488,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -11628,6 +11727,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -11963,6 +12066,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -12198,6 +12305,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -4149,6 +4149,7 @@
                           "soft_descriptor": "",
                           "authorization_code": "748912",
                           "retrieval_reference_number": "",
+                          "acquirer_reference_number": "",
                           "voucher": null,
                           "card_data": {
                             "holder_name": "John Doe",
@@ -4264,6 +4265,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "748912",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4367,6 +4369,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "748912",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4510,6 +4513,7 @@
                           "soft_descriptor": "",
                           "authorization_code": "748912",
                           "retrieval_reference_number": "",
+                          "acquirer_reference_number": "",
                           "voucher": null,
                           "card_data": {
                             "holder_name": "John Doe",
@@ -4625,6 +4629,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "748912",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -4721,6 +4726,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "748912",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -4978,6 +4984,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "835631",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "Fannie Weissnat",
@@ -5165,6 +5172,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "835631",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "Fannie Weissnat",
@@ -5261,6 +5269,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "835631",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "Fannie Weissnat",
@@ -5395,6 +5404,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "748912",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -5510,6 +5520,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "748912",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -5606,6 +5617,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "748912",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -5734,6 +5746,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "483790",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -5902,6 +5915,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "483790",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -5998,6 +6012,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "483790",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -6126,6 +6141,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "964016",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -6230,6 +6246,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "964016",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -6326,6 +6343,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "964016",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -6455,6 +6473,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "880788",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -6570,6 +6589,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "880788",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -6666,6 +6686,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "880788",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -6794,6 +6815,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "620399",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -6935,6 +6957,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "620399",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -7031,6 +7054,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "620399",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -7159,6 +7183,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "360480",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -7252,6 +7277,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "360480",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -7348,6 +7374,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "360480",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -7476,6 +7503,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "744160",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -7569,6 +7597,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "744160",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -7665,6 +7694,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "744160",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -7793,6 +7823,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "744160",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -7886,6 +7917,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "744160",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -7986,6 +8018,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "744160",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -8118,6 +8151,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "655119",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -8216,6 +8250,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "655119",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -8312,6 +8347,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "655119",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -8440,6 +8476,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "267390",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -8555,6 +8592,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "267390",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -8651,6 +8689,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "267390",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -8779,6 +8818,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "248213",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -8894,6 +8934,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "248213",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -8990,6 +9031,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "248213",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -9322,6 +9364,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "08bb27be-1256-4067-976f-7f589707e90e",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -9452,6 +9495,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "08bb27be-1256-4067-976f-7f589707e90e",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -9537,6 +9581,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "08bb27be-1256-4067-976f-7f589707e90e",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -9651,6 +9696,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "517862",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "network_token": {
                               "network": "MASTERCARD",
@@ -9747,6 +9793,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "517862",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "network_token": {
                                 "network": "MASTERCARD",
@@ -9846,6 +9893,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "161102",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -9987,6 +10035,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "161102",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -10083,6 +10132,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "161102",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -10828,6 +10878,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -11430,6 +11484,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -11722,6 +11780,10 @@
                                             "example": "835631"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -12132,6 +12194,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -12372,6 +12438,10 @@
                                           "example": "cd174cd4-8f05-48e9-9b5b-cfd338074ab5"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -12652,6 +12722,10 @@
                                           "example": "cd174cd4-8f05-48e9-9b5b-cfd338074ab5"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -13108,6 +13182,10 @@
                                       "example": "d54fffab-0a82-456e-9703-1bf6a8cda3ec"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -13594,6 +13672,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -13871,6 +13953,10 @@
                                           "example": "d54fffab-0a82-456e-9703-1bf6a8cda3ec"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -14330,6 +14416,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -14665,6 +14755,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -14942,6 +15036,10 @@
                                           "example": "28d3d22e-21d4-4a3a-a7e1-bac6051650ce"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -15401,6 +15499,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -15804,6 +15906,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -16081,6 +16187,10 @@
                                           "example": "6a01dff2-2f2b-469f-b5e1-748b4bff74e0"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -16453,6 +16563,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -16788,6 +16902,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -17065,6 +17183,10 @@
                                           "example": "50fb98cb-57c8-4008-bc50-c7bede574dbf"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -17437,6 +17559,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -17772,6 +17898,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -18049,6 +18179,10 @@
                                           "example": "44b0c463-d567-4e1c-b9c0-9ab8b7876b67"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -18421,6 +18555,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -18756,6 +18894,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -19049,6 +19191,10 @@
                                           "example": "44b0c463-d567-4e1c-b9c0-9ab8b7876b67"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -19437,6 +19583,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -19769,6 +19919,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -20046,6 +20200,10 @@
                                           "example": "acf8d864-8e87-42b4-8041-59216e3f1a88"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -20418,6 +20576,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -20757,6 +20919,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -21034,6 +21200,10 @@
                                           "example": "67fe53c7-0c94-4880-9599-411bc2373096"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -21406,6 +21576,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -21749,6 +21923,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -22030,6 +22208,10 @@
                                           "example": "e0d334a5-b4d0-4623-bcc3-b9c64b5cc7cb"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -22968,6 +23150,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -23378,6 +23564,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -23655,6 +23845,10 @@
                                           "example": "08bb27be-1256-4067-976f-7f589707e90e"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -24026,6 +24220,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "network_token": {
                                       "type": "object",
@@ -24337,6 +24535,10 @@
                                           "example": "517862"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -24658,6 +24860,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -24915,6 +25121,10 @@
                                           "example": "0a3666b1-ea6e-4ebb-937d-5a9f69ef2b77"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -25198,6 +25408,10 @@
                                             "example": "0a3666b1-ea6e-4ebb-937d-5a9f69ef2b77"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -25676,6 +25890,10 @@
                                       "type": "string",
                                       "example": "2206177255"
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": "2206177255"
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -26090,6 +26308,10 @@
                                           "example": "847277"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": "2206177255"
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": "2206177255"
                                         },
@@ -27090,6 +27312,10 @@
                                             "example": "847277"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": "2206177255"
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": "2206177255"
                                           },

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -2418,7 +2418,7 @@
                               },
                               "acquirer_reference_number": {
                                 "type": "string",
-                                "description": "Unique identifier assigned by the card acquirer to track transactions through the network (MAX; 30)."
+                                "description": "Unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks."
                               },
                               "stored_credentials": {
                                 "type": "object",

--- a/openapi/payments/disputes.json
+++ b/openapi/payments/disputes.json
@@ -190,6 +190,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "393119",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Diaz",
@@ -692,6 +693,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "393119",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "Pepito Perez",
@@ -922,6 +924,10 @@
                                   "example": "393119"
                                 },
                                 "retrieval_reference_number": {
+                                  "type": "string",
+                                  "example": ""
+                                },
+                                "acquirer_reference_number": {
                                   "type": "string",
                                   "example": ""
                                 },
@@ -2073,6 +2079,10 @@
                                       "example": "393119"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },

--- a/openapi/payments/refund-payment.json
+++ b/openapi/payments/refund-payment.json
@@ -577,6 +577,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "216303",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -679,6 +680,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "216303",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -796,6 +798,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "344836",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -898,6 +901,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "344836",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1112,6 +1116,10 @@
                                       "example": "216303"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -1426,6 +1434,10 @@
                                           "example": "216303"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -1763,6 +1775,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -2074,6 +2090,10 @@
                                           "example": "344836"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -306,6 +306,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "517862",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -418,6 +419,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "517862",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -523,6 +525,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -700,6 +703,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -865,6 +869,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "redirect_url": "https://checkout.staging.y.uno/payment?session=14c263bd-e01d-400f-885a-70205df8b417",
                                   "card_data": {
@@ -975,6 +980,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "445975",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1078,6 +1084,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1188,6 +1195,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1298,6 +1306,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1427,6 +1436,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1537,6 +1547,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1647,6 +1658,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1757,6 +1769,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1867,6 +1880,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1977,6 +1991,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -2087,6 +2102,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -2197,6 +2213,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -2308,6 +2325,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -2419,6 +2437,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -2530,6 +2549,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -4299,6 +4319,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -4656,6 +4680,10 @@
                                                 "type": "string",
                                                 "example": ""
                                               },
+                                              "acquirer_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
                                               "voucher": {},
                                               "card_data": {
                                                 "type": "object",
@@ -4994,6 +5022,10 @@
                                           "example": ""
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -5581,6 +5613,10 @@
                                                 "type": "string",
                                                 "example": ""
                                               },
+                                              "acquirer_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
                                               "voucher": {},
                                               "card_data": {
                                                 "type": "object",
@@ -6118,6 +6154,10 @@
                                                 "type": "string",
                                                 "example": ""
                                               },
+                                              "acquirer_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
                                               "voucher": {},
                                               "redirect_url": {
                                                 "type": "string",
@@ -6586,6 +6626,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -6943,6 +6987,10 @@
                                                 "example": "123456"
                                               },
                                               "retrieval_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
+                                              "acquirer_reference_number": {
                                                 "type": "string",
                                                 "example": ""
                                               },
@@ -7317,6 +7365,10 @@
                                           "example": "123456"
                                         },
                                         "retrieval_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
+                                        "acquirer_reference_number": {
                                           "type": "string",
                                           "example": ""
                                         },
@@ -7743,6 +7795,10 @@
                                                 "type": "string",
                                                 "example": ""
                                               },
+                                              "acquirer_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
                                               "voucher": {},
                                               "card_data": {
                                                 "type": "object",
@@ -8117,6 +8173,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -8474,6 +8534,10 @@
                                                 "example": "123456"
                                               },
                                               "retrieval_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
+                                              "acquirer_reference_number": {
                                                 "type": "string",
                                                 "example": ""
                                               },
@@ -8851,6 +8915,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -9208,6 +9276,10 @@
                                                 "example": "123456"
                                               },
                                               "retrieval_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
+                                              "acquirer_reference_number": {
                                                 "type": "string",
                                                 "example": ""
                                               },
@@ -9585,6 +9657,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -9945,6 +10021,10 @@
                                                 "example": "123456"
                                               },
                                               "retrieval_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
+                                              "acquirer_reference_number": {
                                                 "type": "string",
                                                 "example": ""
                                               },
@@ -10322,6 +10402,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -10689,6 +10773,10 @@
                                                 "example": "123456"
                                               },
                                               "retrieval_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
+                                              "acquirer_reference_number": {
                                                 "type": "string",
                                                 "example": ""
                                               },
@@ -11070,6 +11158,10 @@
                                           "type": "string",
                                           "example": ""
                                         },
+                                        "acquirer_reference_number": {
+                                          "type": "string",
+                                          "example": ""
+                                        },
                                         "voucher": {},
                                         "card_data": {
                                           "type": "object",
@@ -11437,6 +11529,10 @@
                                                 "example": "123456"
                                               },
                                               "retrieval_reference_number": {
+                                                "type": "string",
+                                                "example": ""
+                                              },
+                                              "acquirer_reference_number": {
                                                 "type": "string",
                                                 "example": ""
                                               },

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -300,6 +300,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "517862",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -408,6 +409,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "517862",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -507,6 +509,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -680,6 +683,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -835,6 +839,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "redirect_url": "https://checkout.staging.y.uno/payment?session=14c263bd-e01d-400f-885a-70205df8b417",
                                 "card_data": {
@@ -945,6 +950,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "445975",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -1044,6 +1050,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -1150,6 +1157,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -1254,6 +1262,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -1380,6 +1389,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -1484,6 +1494,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -1590,6 +1601,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -1694,6 +1706,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -1800,6 +1813,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -1904,6 +1918,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -2010,6 +2025,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -2114,6 +2130,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -2221,6 +2238,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -2326,6 +2344,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "123456",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Doe",
@@ -2433,6 +2452,7 @@
                                 "soft_descriptor": "",
                                 "authorization_code": "123456",
                                 "retrieval_reference_number": "",
+                                "acquirer_reference_number": "",
                                 "voucher": null,
                                 "card_data": {
                                   "holder_name": "John Doe",
@@ -3915,6 +3935,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -4253,6 +4277,10 @@
                                             "type": "string",
                                             "example": ""
                                           },
+                                          "acquirer_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
                                           "voucher": {},
                                           "card_data": {
                                             "type": "object",
@@ -4568,6 +4596,10 @@
                                       "example": ""
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -5136,6 +5168,10 @@
                                             "type": "string",
                                             "example": ""
                                           },
+                                          "acquirer_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
                                           "voucher": {},
                                           "card_data": {
                                             "type": "object",
@@ -5631,6 +5667,10 @@
                                             "type": "string",
                                             "example": ""
                                           },
+                                          "acquirer_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
                                           "voucher": {},
                                           "redirect_url": {
                                             "type": "string",
@@ -6085,6 +6125,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -6423,6 +6467,10 @@
                                             "example": "123456"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -6774,6 +6822,10 @@
                                       "example": "123456"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },
@@ -7185,6 +7237,10 @@
                                             "type": "string",
                                             "example": ""
                                           },
+                                          "acquirer_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
                                           "voucher": {},
                                           "card_data": {
                                             "type": "object",
@@ -7536,6 +7592,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -7874,6 +7934,10 @@
                                             "example": "123456"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -8228,6 +8292,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -8566,6 +8634,10 @@
                                             "example": "123456"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -8920,6 +8992,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -9261,6 +9337,10 @@
                                             "example": "123456"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -9615,6 +9695,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -9963,6 +10047,10 @@
                                             "example": "123456"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },
@@ -10321,6 +10409,10 @@
                                       "type": "string",
                                       "example": ""
                                     },
+                                    "acquirer_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
                                     "voucher": {},
                                     "card_data": {
                                       "type": "object",
@@ -10669,6 +10761,10 @@
                                             "example": "123456"
                                           },
                                           "retrieval_reference_number": {
+                                            "type": "string",
+                                            "example": ""
+                                          },
+                                          "acquirer_reference_number": {
                                             "type": "string",
                                             "example": ""
                                           },

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -274,6 +274,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "517862",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -382,6 +383,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "517862",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -489,6 +491,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -736,6 +739,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "redirect_url": "https://checkout.staging.y.uno/payment?session=14c263bd-e01d-400f-885a-70205df8b417",
                                   "card_data": {
@@ -846,6 +850,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "445975",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -947,6 +952,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1053,6 +1059,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1159,6 +1166,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1284,6 +1292,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1390,6 +1399,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1496,6 +1506,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1602,6 +1613,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1708,6 +1720,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -1814,6 +1827,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -1920,6 +1934,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -2026,6 +2041,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -2133,6 +2149,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -2240,6 +2257,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "123456",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "John Doe",
@@ -2347,6 +2365,7 @@
                                   "soft_descriptor": "",
                                   "authorization_code": "123456",
                                   "retrieval_reference_number": "",
+                                  "acquirer_reference_number": "",
                                   "voucher": null,
                                   "card_data": {
                                     "holder_name": "John Doe",
@@ -3951,6 +3970,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "acquirer_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
                                       "voucher": {},
                                       "card_data": {
                                         "type": "object",
@@ -4271,6 +4294,10 @@
                                               "example": "517862"
                                             },
                                             "retrieval_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
+                                            "acquirer_reference_number": {
                                               "type": "string",
                                               "example": ""
                                             },
@@ -4595,6 +4622,10 @@
                                         "example": ""
                                       },
                                       "retrieval_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
+                                      "acquirer_reference_number": {
                                         "type": "string",
                                         "example": ""
                                       },
@@ -5379,6 +5410,10 @@
                                               "type": "string",
                                               "example": ""
                                             },
+                                            "acquirer_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
                                             "voucher": {},
                                             "redirect_url": {
                                               "type": "string",
@@ -5818,6 +5853,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "acquirer_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
                                       "voucher": {},
                                       "card_data": {
                                         "type": "object",
@@ -6141,6 +6180,10 @@
                                               "example": "123456"
                                             },
                                             "retrieval_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
+                                            "acquirer_reference_number": {
                                               "type": "string",
                                               "example": ""
                                             },
@@ -6480,6 +6523,10 @@
                                         "example": "123456"
                                       },
                                       "retrieval_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
+                                      "acquirer_reference_number": {
                                         "type": "string",
                                         "example": ""
                                       },
@@ -6872,6 +6919,10 @@
                                               "type": "string",
                                               "example": ""
                                             },
+                                            "acquirer_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
                                             "voucher": {},
                                             "card_data": {
                                               "type": "object",
@@ -7208,6 +7259,10 @@
                                         "example": "123456"
                                       },
                                       "retrieval_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
+                                      "acquirer_reference_number": {
                                         "type": "string",
                                         "example": ""
                                       },
@@ -7670,6 +7725,10 @@
                                               "type": "string",
                                               "example": ""
                                             },
+                                            "acquirer_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
                                             "voucher": {},
                                             "card_data": {
                                               "type": "object",
@@ -8009,6 +8068,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "acquirer_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
                                       "voucher": {},
                                       "card_data": {
                                         "type": "object",
@@ -8332,6 +8395,10 @@
                                               "example": "123456"
                                             },
                                             "retrieval_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
+                                            "acquirer_reference_number": {
                                               "type": "string",
                                               "example": ""
                                             },
@@ -8674,6 +8741,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "acquirer_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
                                       "voucher": {},
                                       "card_data": {
                                         "type": "object",
@@ -9000,6 +9071,10 @@
                                               "example": "123456"
                                             },
                                             "retrieval_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
+                                            "acquirer_reference_number": {
                                               "type": "string",
                                               "example": ""
                                             },
@@ -9342,6 +9417,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "acquirer_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
                                       "voucher": {},
                                       "card_data": {
                                         "type": "object",
@@ -9675,6 +9754,10 @@
                                               "example": "123456"
                                             },
                                             "retrieval_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
+                                            "acquirer_reference_number": {
                                               "type": "string",
                                               "example": ""
                                             },
@@ -10021,6 +10104,10 @@
                                         "type": "string",
                                         "example": ""
                                       },
+                                      "acquirer_reference_number": {
+                                        "type": "string",
+                                        "example": ""
+                                      },
                                       "voucher": {},
                                       "card_data": {
                                         "type": "object",
@@ -10354,6 +10441,10 @@
                                               "example": "123456"
                                             },
                                             "retrieval_reference_number": {
+                                              "type": "string",
+                                              "example": ""
+                                            },
+                                            "acquirer_reference_number": {
                                               "type": "string",
                                               "example": ""
                                             },

--- a/openapi/payments/update-dispute.json
+++ b/openapi/payments/update-dispute.json
@@ -179,6 +179,7 @@
                             "soft_descriptor": "",
                             "authorization_code": "393119",
                             "retrieval_reference_number": "",
+                            "acquirer_reference_number": "",
                             "voucher": null,
                             "card_data": {
                               "holder_name": "John Diaz",
@@ -681,6 +682,7 @@
                               "soft_descriptor": "",
                               "authorization_code": "393119",
                               "retrieval_reference_number": "",
+                              "acquirer_reference_number": "",
                               "voucher": null,
                               "card_data": {
                                 "holder_name": "Pepito Perez",
@@ -912,6 +914,10 @@
                                   "example": "393119"
                                 },
                                 "retrieval_reference_number": {
+                                  "type": "string",
+                                  "example": ""
+                                },
+                                "acquirer_reference_number": {
                                   "type": "string",
                                   "example": ""
                                 },
@@ -2063,6 +2069,10 @@
                                       "example": "393119"
                                     },
                                     "retrieval_reference_number": {
+                                      "type": "string",
+                                      "example": ""
+                                    },
+                                    "acquirer_reference_number": {
                                       "type": "string",
                                       "example": ""
                                     },

--- a/reference/payments/payment-examples/cards.mdx
+++ b/reference/payments/payment-examples/cards.mdx
@@ -117,6 +117,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "554791",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JANE SMITH",
@@ -213,6 +214,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "554791",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JANE SMITH",
@@ -309,6 +311,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "554791",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "JANE SMITH",
@@ -577,6 +580,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "349399",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "SARAH CONNOR",
@@ -780,6 +784,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "349399",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "SARAH CONNOR",
@@ -876,6 +881,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "349399",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "SARAH CONNOR",
@@ -1053,6 +1059,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "330936",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JOHN DOE",
@@ -1146,6 +1153,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "330936",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JOHN DOE",
@@ -1242,6 +1250,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "330936",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "JOHN DOE",
@@ -1466,6 +1475,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "226813",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JOHN DOE",
@@ -1606,6 +1616,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "226813",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JOHN DOE",
@@ -1702,6 +1713,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "226813",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "JOHN DOE",
@@ -1881,6 +1893,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "206417",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JOHN DOE",
@@ -1996,6 +2009,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "206417",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JOHN DOE",
@@ -2092,6 +2106,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "206417",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "JOHN DOE",
@@ -2260,6 +2275,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "819502",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JOHN DOE",
@@ -2375,6 +2391,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "819502",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JOHN DOE",
@@ -2471,6 +2488,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "819502",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "JOHN DOE",
@@ -2651,6 +2669,7 @@ curl --request POST \
                 "soft_descriptor": "",
                 "authorization_code": "422885",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "JOHN DOE",
@@ -2766,6 +2785,7 @@ curl --request POST \
                     "soft_descriptor": "",
                     "authorization_code": "422885",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "JOHN DOE",
@@ -2862,6 +2882,7 @@ curl --request POST \
                         "soft_descriptor": "",
                         "authorization_code": "422885",
                         "retrieval_reference_number": "",
+                        "acquirer_reference_number": "",
                         "voucher": null,
                         "card_data": {
                             "holder_name": "JOHN DOE",

--- a/reference/payments/payment-examples/index.mdx
+++ b/reference/payments/payment-examples/index.mdx
@@ -88,6 +88,7 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
                 "soft_descriptor": "",
                 "authorization_code": "385876",
                 "retrieval_reference_number": "",
+                "acquirer_reference_number": "",
                 "voucher": null,
                 "card_data": {
                     "holder_name": "Fannie Weissnat",
@@ -179,6 +180,7 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
                     "soft_descriptor": "",
                     "authorization_code": "385876",
                     "retrieval_reference_number": "",
+                    "acquirer_reference_number": "",
                     "voucher": null,
                     "card_data": {
                         "holder_name": "Fannie Weissnat",

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -326,9 +326,9 @@ This object represents the payment created after generating the checkout session
             </ParamField>
 
             <ParamField body="acquirer_reference_number" type="string">
-              The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+              The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks.
 
-              For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+              For providers that return an acquirer reference (for example, Adyen), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
               Example: 7C9F8E2A1B3D
             </ParamField>
@@ -788,9 +788,9 @@ This object represents the payment created after generating the checkout session
             </ParamField>
 
             <ParamField body="acquirer_reference_number" type="string">
-              The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+              The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks.
 
-              For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+              For providers that return an acquirer reference (for example, Adyen), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
               Example: 7C9F8E2A1B3D
             </ParamField>
@@ -3111,9 +3111,9 @@ This object represents the payment created after generating the checkout session
                 </ParamField>
 
                 <ParamField body="acquirer_reference_number" type="string">
-                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks.
 
-                  For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+                  For providers that return an acquirer reference (for example, Adyen), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
                   Example: 7C9F8E2A1B3D
                 </ParamField>
@@ -3746,9 +3746,9 @@ This object represents the payment created after generating the checkout session
                 </ParamField>
 
                 <ParamField body="acquirer_reference_number" type="string">
-                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks.
 
-                  For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+                  For providers that return an acquirer reference (for example, Adyen), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
                   Example: 7C9F8E2A1B3D
                 </ParamField>
@@ -4221,9 +4221,9 @@ This object represents the payment created after generating the checkout session
                 </ParamField>
 
                 <ParamField body="acquirer_reference_number" type="string">
-                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks.
 
-                  For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+                  For providers that return an acquirer reference (for example, Adyen), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
                   Example: 7C9F8E2A1B3D
                 </ParamField>

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -325,6 +325,14 @@ This object represents the payment created after generating the checkout session
               Example: 200000000012
             </ParamField>
 
+            <ParamField body="acquirer_reference_number" type="string">
+              The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+
+              For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+
+              Example: 7914775043235970
+            </ParamField>
+
             <ParamField body="voucher" type="string">
               The unique identifier of the payment receipt assigned by the issuing bank for a card transaction.
                                 This field is empty if the gateway does not provide information about the transaction (MAX 255; MIN 3).
@@ -777,6 +785,14 @@ This object represents the payment created after generating the checkout session
               The unique identifier assigned by an acquirer to an authorization.In case of Brazil, you'll receive the nsu.
 
               Example: 200000000012
+            </ParamField>
+
+            <ParamField body="acquirer_reference_number" type="string">
+              The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+
+              For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+
+              Example: 7914775043235970
             </ParamField>
 
             <ParamField body="payment_instruction" type="string">
@@ -3094,6 +3110,14 @@ This object represents the payment created after generating the checkout session
                   Example: 200000000012
                 </ParamField>
 
+                <ParamField body="acquirer_reference_number" type="string">
+                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+
+                  For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+
+                  Example: 7914775043235970
+                </ParamField>
+
                 <ParamField body="voucher" type="string">
                   The unique identifier of the payment receipt assigned by the issuing bank for a card
                                         transaction.
@@ -3721,6 +3745,14 @@ This object represents the payment created after generating the checkout session
                   Example: 200000000012
                 </ParamField>
 
+                <ParamField body="acquirer_reference_number" type="string">
+                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+
+                  For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+
+                  Example: 7914775043235970
+                </ParamField>
+
                 <ParamField body="payment_instruction" type="string">
                   Payments instructions related to the payment (MAX 255; MIN 3).
 
@@ -4186,6 +4218,14 @@ This object represents the payment created after generating the checkout session
                   The unique identifier assigned by an acquirer to an authorization. In case of Brazil, you'll receive the nsu.
 
                   Example: 200000000012
+                </ParamField>
+
+                <ParamField body="acquirer_reference_number" type="string">
+                  The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks (MAX 30).
+
+                  For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
+
+                  Example: 7914775043235970
                 </ParamField>
 
                 <ParamField body="voucher" type="string">

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -330,7 +330,7 @@ This object represents the payment created after generating the checkout session
 
               For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
-              Example: 7914775043235970
+              Example: 7C9F8E2A1B3D
             </ParamField>
 
             <ParamField body="voucher" type="string">
@@ -792,7 +792,7 @@ This object represents the payment created after generating the checkout session
 
               For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
-              Example: 7914775043235970
+              Example: 7C9F8E2A1B3D
             </ParamField>
 
             <ParamField body="payment_instruction" type="string">
@@ -3115,7 +3115,7 @@ This object represents the payment created after generating the checkout session
 
                   For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
-                  Example: 7914775043235970
+                  Example: 7C9F8E2A1B3D
                 </ParamField>
 
                 <ParamField body="voucher" type="string">
@@ -3750,7 +3750,7 @@ This object represents the payment created after generating the checkout session
 
                   For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
-                  Example: 7914775043235970
+                  Example: 7C9F8E2A1B3D
                 </ParamField>
 
                 <ParamField body="payment_instruction" type="string">
@@ -4225,7 +4225,7 @@ This object represents the payment created after generating the checkout session
 
                   For providers that return an acquirer reference (for example, Adyen and Checkout.com), this field carries that value, and `retrieval_reference_number` may be empty for those providers.
 
-                  Example: 7914775043235970
+                  Example: 7C9F8E2A1B3D
                 </ParamField>
 
                 <ParamField body="voucher" type="string">


### PR DESCRIPTION
## docs(YSHUB-6005): document `acquirer_reference_number`

### What & why
`acquirer_reference_number` (ARN) is returned on the payment object and in webhook payloads but was **not documented** anywhere a merchant reads a response. Its sibling `retrieval_reference_number` (RRN) was documented; ARN was not.

Driven by **YSHUB-6005**: for **Adyen**, the acquirer reference is delivered in `acquirer_reference_number`, and `retrieval_reference_number` may be empty. Merchants (e.g. Reface, who read it from the **webhook**) need a documented field. Per Core's position (Ale/Irene on YSHUB-6005), each field keeps its own strict meaning (RRN = card retrieval reference / NSU, ARN = acquirer reference) — so we document ARN rather than overloading RRN. This also answers Irene's explicit request for a written statement of the two fields' semantics.

### Scope — ARN documented everywhere RRN appears
1. **`reference/payments/the-payment-object.mdx`** — `acquirer_reference_number` `ParamField` next to each `retrieval_reference_number` (5). Canonical definition + description.
2. **Example payloads** — ARN next to RRN in `docs/webhooks/object-and-examples.mdx` (8), `reference/payments/payment-examples/cards.mdx` (21), `payment-examples/index.mdx` (2), `docs/security-and-compliance/3d-secure.mdx` (1), `card-verification.mdx` (4).
3. **`openapi/payments/*.json`** — ARN next to RRN across authorize-payment, create-payment, refund-payment, disputes, update-dispute, retrieve-payment-by-id, retrieve-payment-by-id-v2, retrieve-payment-by-merchant-order-id (270). Plus corrected the pre-existing create-payment request-field description (see below).

All JSON re-validates; no duplicate keys.

### Copy added (payment object reference, for review)
> The unique identifier assigned by the card acquirer to track the transaction through the card network. Used for reconciliation and chargebacks.
>
> For providers that return an acquirer reference (for example, Adyen), this field carries that value, and `retrieval_reference_number` may be empty for those providers.

### Reviewed against backend code + tickets (3 independent passes)
- **Adyen populates ARN** — confirmed (adyen-int `builder.go` maps `acquirerReference`→ARN; no RRN assignment).
- **Provider naming** — kept **Adyen only**; `checkout-int` does not populate ARN on the card flow, so Checkout.com was intentionally *not* named.
- **No length claim** — the DB column is `VARCHAR(255)` with no 30-char validation and ~12–23-char real values, so the inherited "(MAX; 30)" was removed (both from the new copy and the pre-existing request-field description).
- **"may be empty" kept hedged** — the Adyen webhook path can still copy the value into RRN, so RRN is not *always* empty for Adyen.
- **ARN is a valid request field** — verified `acquirer_reference_number` is accepted and forwarded on the Create Payment request (`public-api/request/card.go`, `paymentMethodDetail.go`), so its request-schema entry is correct and retained.

### Notes for reviewer (Andrea)
- Copy validation is yours — wording + the example value (`7C9F8E2A1B3D` is a placeholder; happy to use a canonical acquirer-reference format).
- `reports-fields.mdx` intentionally unchanged — ARN is not currently an exported report field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)