### PR TITLE
docs:[CORECM-18109] add six new SDK languages to Supported Languages

### DIFF
--- a/docs/sdks/resources/languages-supported.mdx
+++ b/docs/sdks/resources/languages-supported.mdx
@@ -19,8 +19,8 @@ Use these locale codes with Yuno SDKs to specify your desired display language. 
 * Polish (Poland): `pl-PL`
 * Romanian (Romania): `ro-RO`
 * Russian (Russia): `ru-RU`
-* Serbian (Latin script): `sr-Latn`
 * Slovak (Slovakia): `sk-SK`
+* Serbian (Latin script): `sr-Latn`
 * Swedish (Sweden): `sv-SE`
 * Turkish (Turkey): `tr-TR`
 * Ukrainian (Ukraine): `uk-UA`

--- a/docs/sdks/resources/languages-supported.mdx
+++ b/docs/sdks/resources/languages-supported.mdx
@@ -11,18 +11,24 @@ Use these locale codes with Yuno SDKs to specify your desired display language. 
 ## Europe
 
 * German (Germany): `de-DE`
+* Greek (Greece): `el-GR`
 * English (United Kingdom): `en-GB`
 * French (France): `fr-FR`
 * Italian (Italy): `it-IT`
 * Dutch (Netherlands): `nl-NL`
 * Polish (Poland): `pl-PL`
+* Romanian (Romania): `ro-RO`
 * Russian (Russia): `ru-RU`
+* Serbian (Latin script): `sr-Latn`
+* Slovak (Slovakia): `sk-SK`
 * Swedish (Sweden): `sv-SE`
 * Turkish (Turkey): `tr-TR`
+* Ukrainian (Ukraine): `uk-UA`
 
 ## Middle East & Africa
 
 * Arabic: `ar`
+* Hebrew (Israel): `he-IL`
 
 ## Asia
 


### PR DESCRIPTION
Adds the six new SDK locales from [CORECM-18109](https://yunopayments.atlassian.net/browse/CORECM-18109) to the [Supported Languages](https://docs.y.uno/docs/sdks/resources/languages-supported) reference: Greek (`el-GR`), Hebrew (`he-IL`), Romanian (`ro-RO`), Serbian Latin (`sr-Latn`), Slovak (`sk-SK`) and Ukrainian (`uk-UA`), placed in their regional sections following the page's existing format.

Ships with: [sdk-web #2321](https://github.com/yuno-payments/sdk-web/pull/2321) (client bundles) and [checkout-ui-ms #25](https://github.com/yuno-payments/checkout-ui-ms/pull/25) (backend form strings).

**Hold merge until sdk-web 1.10.0 is released** so the docs do not advertise languages the published SDK does not serve yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-18109]: https://yunopayments.atlassian.net/browse/CORECM-18109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a locale reference page; no runtime, auth, or data-handling code.
> 
> **Overview**
> Updates the **Supported Languages** reference so integrators can set the SDK `language` parameter for six new locales from CORECM-18109.
> 
> **Europe:** Greek (`el-GR`), Romanian (`ro-RO`), Slovak (`sk-SK`), Serbian Latin (`sr-Latn`), Ukrainian (`uk-UA`). **Middle East & Africa:** Hebrew (`he-IL`). Each entry follows the existing regional list format.
> 
> This doc should stay aligned with sdk-web client bundles and checkout-ui-ms form strings; the PR description notes holding merge until sdk-web **1.10.0** ships so published SDK behavior matches the docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c7b0993e2139251cc008e36ca118abb6449a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->