### PR TITLE
docs(set-up-payment-connection): fix outdated Yuno Testing Gateway link

### DIFF
--- a/docs/direct-integration-use-cases/set-up-payment-connection.mdx
+++ b/docs/direct-integration-use-cases/set-up-payment-connection.mdx
@@ -17,7 +17,7 @@ You'll learn how to:
 <Note>
 **Yuno Testing Gateway**
 
-Make sure to choose the payment connection that suits your needs when following these instructions. If you want to test credit card payments, use [Yuno Testing Gateway](/docs/yuno-testing-gateway) as your provider.
+Make sure to choose the payment connection that suits your needs when following these instructions. If you want to test credit card payments, use [Yuno Testing Gateway](/docs/direct-integration-use-cases/yuno-testing-gateway) as your provider.
 </Note>
 
 ## Configure payment method


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only URL correction with no runtime or security impact.
> 
> **Overview**
> Updates the **Yuno Testing Gateway** link in `set-up-payment-connection.mdx` so it points to `/docs/direct-integration-use-cases/yuno-testing-gateway` instead of the old `/docs/yuno-testing-gateway` path, matching where that doc lives and aligning with links in other direct-integration guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7328591d02f451c8126d0b73e04a8e6a8ddff165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->