### PR TITLE
docs(CORECM-18326): Checkout Builder — Create Checkout (POST) & Manage Checkout Lifecycle (PATCH)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -372,8 +372,10 @@
             "tag": "Beta",
             "pages": [
               "reference/checkout-builder/overview",
+              "reference/checkout-builder/create-checkout",
               "reference/checkout-builder/fetch-checkout-configuration",
-              "reference/checkout-builder/publish-checkout-configuration"
+              "reference/checkout-builder/publish-checkout-configuration",
+              "reference/checkout-builder/manage-checkout-lifecycle"
             ]
           },
           {

--- a/openapi/checkout-builder/create-checkout.json
+++ b/openapi/checkout-builder/create-checkout.json
@@ -1,0 +1,228 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.y.uno/v1"
+    },
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "publicApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PUBLIC-API-KEY",
+        "description": "Merchant public API key. Found in Yuno dashboard → Settings → API Keys."
+      },
+      "privateSecretKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PRIVATE-SECRET-KEY",
+        "description": "Merchant private secret key, paired with the public key. Never embed in client-side code."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Account-Code",
+        "description": "UUID of the merchant account scope for the request. The tenant is resolved only from this header."
+      }
+    },
+    "schemas": {
+      "CheckoutMutationResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Checkout identifier (UUID). Use it as the checkout_code in the fetch, publish, and lifecycle endpoints."
+          },
+          "name": {
+            "type": "string",
+            "description": "Checkout name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Checkout description."
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "Whether this checkout is the account's default. A newly created checkout is never the default."
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "Whether the checkout is active (serving traffic)."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp (ISO-8601)."
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "publicApiKey": [],
+      "privateSecretKey": [],
+      "accountCode": []
+    }
+  ],
+  "paths": {
+    "/checkouts": {
+      "post": {
+        "summary": "Create Checkout",
+        "description": "Creates a new custom checkout as a published clone of the account's default checkout: payment methods — including icon/name overrides and required-field condition sets — are copied from the default; general settings and styling inherit the account baseline until the checkout's first publish. The new checkout is born with status PUBLISHED and is never the account's default. The identifier is exposed as the top-level `id`.",
+        "operationId": "create-checkout",
+        "parameters": [
+          {
+            "name": "X-Idempotency-Key",
+            "in": "header",
+            "description": "Optional client key, up to 64 characters. Best-effort — re-sending the same key is not guaranteed to be de-duplicated.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Checkout name. Required, non-blank, and unique per account (a duplicate name is rejected with 409)."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Optional free-text description."
+                  }
+                }
+              },
+              "examples": {
+                "Name only": {
+                  "value": {
+                    "name": "Promo Checkout"
+                  }
+                },
+                "Name and description": {
+                  "value": {
+                    "name": "Promo Checkout",
+                    "description": "Seasonal promo storefront"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created checkout. Born PUBLISHED as a clone of the account's default; `is_default` is always false on creation. Use `id` as the checkout_code in the other Checkout Builder endpoints.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckoutMutationResponse"
+                },
+                "examples": {
+                  "Created": {
+                    "value": {
+                      "id": "0b28ff66-15f1-44c1-8d1e-bd1fefbc0a19",
+                      "name": "Promo Checkout",
+                      "description": "Seasonal promo storefront",
+                      "is_default": false,
+                      "is_active": true,
+                      "created_at": "2026-07-17T10:02:33.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or blank `name`, or a malformed JSON body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "Missing name": {
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": ["name is required"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated, or the account is not in the beta allowlist.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "NOT_AUTHENTICATED",
+                      "messages": ["Not authenticated"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The account has no default checkout to clone from.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "No default checkout": {
+                    "value": {
+                      "code": "DEFAULT_CHECKOUT_NOT_FOUND",
+                      "messages": ["No default Custom Checkout found for account: 78163a7c-c63c-4fdd-b72b-d5f77093a927"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A checkout with the same name already exists for the account.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Duplicate name": {
+                    "value": {
+                      "code": "DUPLICATE_CHECKOUT_NAME",
+                      "messages": ["A Custom Checkout with name 'Promo Checkout' already exists for this account"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/checkout-builder/manage-checkout-lifecycle.json
+++ b/openapi/checkout-builder/manage-checkout-lifecycle.json
@@ -256,6 +256,14 @@
                       }
                     }
                   }
+                },
+                "examples": {
+                  "Checkout not found": {
+                    "value": {
+                      "code": "CHECKOUT_NOT_FOUND",
+                      "messages": ["No Custom Checkout found for checkout_code: 0b28ff66-15f1-44c1-8d1e-bd1fefbc0a19"]
+                    }
+                  }
                 }
               }
             }

--- a/openapi/checkout-builder/manage-checkout-lifecycle.json
+++ b/openapi/checkout-builder/manage-checkout-lifecycle.json
@@ -1,0 +1,294 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "checkout-builder",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.y.uno/v1"
+    },
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "publicApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PUBLIC-API-KEY",
+        "description": "Merchant public API key. Found in Yuno dashboard → Settings → API Keys."
+      },
+      "privateSecretKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PRIVATE-SECRET-KEY",
+        "description": "Merchant private secret key, paired with the public key. Never embed in client-side code."
+      },
+      "accountCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Account-Code",
+        "description": "UUID of the merchant account scope for the request. The tenant is resolved only from this header."
+      }
+    },
+    "schemas": {
+      "CheckoutMutationResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Checkout identifier (UUID)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Checkout name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Checkout description."
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "Whether this checkout is the account's default."
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "Whether the checkout is active (serving traffic)."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp (ISO-8601)."
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "publicApiKey": [],
+      "privateSecretKey": [],
+      "accountCode": []
+    }
+  ],
+  "paths": {
+    "/checkouts/{checkout_code}": {
+      "patch": {
+        "summary": "Manage Checkout Lifecycle",
+        "description": "Renames, publishes, unpublishes, archives, restores, or promotes the checkout. The body carries any combination of `name`, `description`, `status`, and `is_default` — at least one field is required (an empty body is rejected with 400). Status transitions follow the lifecycle state machine: publish (`PUBLISHED`) is only valid from `NOT_PUBLISHED`; an ARCHIVED checkout is restored in two steps (`status: NOT_PUBLISHED` first, then `status: PUBLISHED`); patching to the current status is rejected. Metadata (`name`/`description`) remains editable while ARCHIVED. `is_default` accepts only `true`: it promotes the checkout to account default, force-publishing it from any state, and atomically demotes the previous default; when `is_default: true` is sent together with `status`, the promotion wins and `status` is ignored. The default checkout cannot be archived or unpublished.",
+        "operationId": "manage-checkout-lifecycle",
+        "parameters": [
+          {
+            "name": "checkout_code",
+            "in": "path",
+            "description": "The unique identifier of the checkout to update (UUID, 36 chars). Non-UUID values are rejected with 400 before processing.",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "X-Idempotency-Key",
+            "in": "header",
+            "description": "Optional client key, up to 64 characters. Best-effort — re-sending the same key is not guaranteed to be de-duplicated.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "New checkout name. Unique per account (a duplicate name is rejected with 409). Editable in any status, including ARCHIVED."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "New checkout description. Editable in any status, including ARCHIVED."
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": ["PUBLISHED", "NOT_PUBLISHED", "ARCHIVED"],
+                    "description": "Target lifecycle status. PUBLISHED is only reachable from NOT_PUBLISHED; NOT_PUBLISHED is reachable from PUBLISHED (unpublish) or ARCHIVED (restore); ARCHIVED is reachable from PUBLISHED or NOT_PUBLISHED. Any other transition — including patching to the current status — is rejected with 400. Unknown values are rejected with 400."
+                  },
+                  "is_default": {
+                    "type": "boolean",
+                    "description": "Only `true` is accepted: promotes this checkout to account default, force-publishing it from any state and atomically demoting the previous default. `false` is rejected with 400 — demote by promoting another checkout instead."
+                  }
+                }
+              },
+              "examples": {
+                "Rename": {
+                  "value": {
+                    "name": "Promo Checkout (renamed)"
+                  }
+                },
+                "Publish": {
+                  "value": {
+                    "status": "PUBLISHED"
+                  }
+                },
+                "Unpublish": {
+                  "value": {
+                    "status": "NOT_PUBLISHED"
+                  }
+                },
+                "Archive": {
+                  "value": {
+                    "status": "ARCHIVED"
+                  }
+                },
+                "Restore an archived checkout (step 1 of 2)": {
+                  "value": {
+                    "status": "NOT_PUBLISHED"
+                  }
+                },
+                "Promote to default": {
+                  "value": {
+                    "is_default": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated checkout summary. The identifier is exposed as the top-level `id`. Read the resulting `status` with the Fetch endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckoutMutationResponse"
+                },
+                "examples": {
+                  "Updated": {
+                    "value": {
+                      "id": "0b28ff66-15f1-44c1-8d1e-bd1fefbc0a19",
+                      "name": "Promo Checkout (renamed)",
+                      "description": "Seasonal promo storefront",
+                      "is_default": false,
+                      "is_active": true,
+                      "created_at": "2026-07-17T10:02:33.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Empty body, invalid or same-status transition, unknown `status` value, `is_default: false`, a non-UUID `checkout_code`, or a malformed JSON body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "Invalid transition (e.g. direct ARCHIVED → PUBLISHED)": {
+                    "value": {
+                      "code": "INVALID_STATUS_TRANSITION",
+                      "messages": ["Cannot transition from 'ARCHIVED' via this operation"]
+                    }
+                  },
+                  "Empty body": {
+                    "value": {
+                      "code": "INVALID_PATCH_BODY",
+                      "messages": ["body is empty"]
+                    }
+                  },
+                  "is_default false": {
+                    "value": {
+                      "code": "INVALID_OPERATION",
+                      "messages": ["isDefault: false direct demotion is not allowed; promote another checkout instead"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated, or the account is not in the beta allowlist.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unauthorized": {
+                    "value": {
+                      "code": "NOT_AUTHENTICATED",
+                      "messages": ["Not authenticated"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The checkout was not found for this account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate name, or the checkout is the account's default and cannot be archived or unpublished.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Duplicate name": {
+                    "value": {
+                      "code": "DUPLICATE_CHECKOUT_NAME",
+                      "messages": ["A Custom Checkout with name 'Promo Checkout' already exists for this account"]
+                    }
+                  },
+                  "Archive the default": {
+                    "value": {
+                      "code": "CANNOT_ARCHIVE_DEFAULT_CHECKOUT",
+                      "messages": ["Cannot archive the default Custom Checkout. Promote another checkout as default first."]
+                    }
+                  },
+                  "Unpublish the default": {
+                    "value": {
+                      "code": "CANNOT_UNPUBLISH_DEFAULT_CHECKOUT",
+                      "messages": ["Cannot unpublish the default Custom Checkout. Promote another checkout as default first."]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/checkout-builder/create-checkout.mdx
+++ b/reference/checkout-builder/create-checkout.mdx
@@ -1,0 +1,13 @@
+---
+title: "Create Checkout"
+openapi: "/openapi/checkout-builder/create-checkout.json POST /checkouts"
+description: "Creates a new custom checkout as a published clone of the account's default checkout"
+---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>
+
+The new checkout is born **`PUBLISHED`** as a clone of the account's default: payment methods — including icon/name overrides and required-field condition sets — are copied; general settings and styling inherit the account baseline until the checkout's first [Publish](/reference/checkout-builder/publish-checkout-configuration). It is never created as the account's default.
+
+The response's top-level `id` is the `checkout_code` used by the [Fetch](/reference/checkout-builder/fetch-checkout-configuration), [Publish](/reference/checkout-builder/publish-checkout-configuration), and [Manage Checkout Lifecycle](/reference/checkout-builder/manage-checkout-lifecycle) endpoints.
+
+`name` is required, non-blank, and unique per account — a duplicate is rejected with `409`. If the account has no default checkout to clone from, the request is rejected with `404`.

--- a/reference/checkout-builder/manage-checkout-lifecycle.mdx
+++ b/reference/checkout-builder/manage-checkout-lifecycle.mdx
@@ -1,0 +1,27 @@
+---
+title: "Manage Checkout Lifecycle"
+openapi: "/openapi/checkout-builder/manage-checkout-lifecycle.json PATCH /checkouts/{checkout_code}"
+description: "Renames, publishes, unpublishes, archives, restores, or promotes a checkout by its checkout code"
+---
+
+<Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>
+
+The body carries any combination of `name`, `description`, `status`, and `is_default` — at least one field is required. Metadata (`name`/`description`) is editable in **any** status, including `ARCHIVED`; configuration and styling of an archived checkout stay frozen (the [Publish](/reference/checkout-builder/publish-checkout-configuration) endpoint rejects it).
+
+## Lifecycle state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> PUBLISHED: Create Checkout
+    PUBLISHED --> NOT_PUBLISHED: unpublish
+    NOT_PUBLISHED --> PUBLISHED: publish
+    PUBLISHED --> ARCHIVED: archive
+    NOT_PUBLISHED --> ARCHIVED: archive
+    ARCHIVED --> NOT_PUBLISHED: restore (step 1 of 2)
+```
+
+- **Publish** (`status: PUBLISHED`) is only valid from `NOT_PUBLISHED`.
+- **Restore is two-step**: an `ARCHIVED` checkout goes back to draft first (`status: NOT_PUBLISHED`), then can be published (`status: PUBLISHED`). A direct `ARCHIVED → PUBLISHED` patch is rejected with `400 INVALID_STATUS_TRANSITION`.
+- Patching to the **current** status is also rejected with `400`.
+- **Promote** (`is_default: true`) force-publishes the checkout from any state — including `ARCHIVED` — and atomically demotes the previous default. When sent together with `status`, the promotion wins and `status` is ignored. `is_default: false` is rejected with `400`; demote a default by promoting another checkout.
+- The **default checkout is guarded**: archiving or unpublishing it is rejected with `409` so the account's storefront is never left without a live checkout.

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -38,7 +38,7 @@ Every request is authenticated with your merchant API credentials and scoped to 
 | `PRIVATE-SECRET-KEY` | Yes | Merchant private secret key, paired with the public key. Server-side only — never embed it in client-side code. |
 | `X-Account-Code` | Yes | UUID of the merchant account. The account is resolved **only** from this header (never from the request body or path) and must be in the beta allowlist. |
 | `X-Idempotency-Key` | No | Optional client key, up to 64 characters. Best-effort — see [Idempotency](#idempotency). |
-| `Content-Type` | Yes (PUT) | `application/json` |
+| `Content-Type` | Yes (POST/PUT/PATCH) | `application/json` |
 
 </div>
 
@@ -48,17 +48,19 @@ The organization is resolved by Yuno from your credentials — **do not send** a
 
 ## Endpoints
 
-A **custom checkout** is identified by a `checkout_code` (a UUID). Its configuration and styling are read and written through the same resource — two operations:
+A **custom checkout** is identified by a `checkout_code` (a UUID). It is created, read, written, and lifecycle-managed through the same resource — four operations:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
+| `POST` | `/v1/checkouts` | Create a new custom checkout as a published clone of the account's default. |
 | `GET` | `/v1/checkouts/{checkout_code}` | Fetch the full custom checkout — configuration **and** styling, together. |
 | `PUT` | `/v1/checkouts/{checkout_code}` | Publish configuration and/or styling. |
+| `PATCH` | `/v1/checkouts/{checkout_code}` | Manage the lifecycle — rename, publish, unpublish, archive, restore, or promote to default. |
 
 `{checkout_code}` must be a valid UUID; other values are rejected with `400` before any processing.
 
 <Note>
-You obtain a `checkout_code` when the custom checkout is created in the Yuno dashboard / embedded Checkout Builder; Yuno delivers the generated UUID to your integration. Creating and listing checkouts via the public API is planned for a later phase — today the API reads and writes an **existing** checkout.
+You obtain a `checkout_code` by calling [Create Checkout](/reference/checkout-builder/create-checkout) (the response's top-level `id`), or when the custom checkout is created in the Yuno dashboard / embedded Checkout Builder. Listing checkouts via the public API is planned for a later phase.
 </Note>
 
 ## Key behaviors
@@ -72,6 +74,7 @@ You obtain a `checkout_code` when the custom checkout is created in the Yuno das
 - **Order is driven by `order_to_show`**, not by array position. Lower values are shown first.
 - **At most one condition set per required field.** Sending more than one condition set on a field is rejected with `400` (`conditions_to_override must contain at most one condition set`).
 - **Enrolled and non-enrolled flows are independent.** For CARD, configure the non-enrolled flow via `fields` and the enrolled (saved-card) flow via `enrollment_fields`. To leave one flow untouched, pass an empty array for that side.
+- **Lifecycle transitions follow a state machine.** Publish is only valid from `NOT_PUBLISHED`; an `ARCHIVED` checkout is restored in two steps (`NOT_PUBLISHED` first, then `PUBLISHED`); the default checkout cannot be archived or unpublished. See [Manage Checkout Lifecycle](/reference/checkout-builder/manage-checkout-lifecycle) for the full rules.
 - **Changes take effect immediately.** Validate payloads against the sandbox base URL before applying to production.
 - Each request body is validated independently; on any rule failure the whole request is rejected with a single aggregated `400` and nothing is applied. See the [Publish](/reference/checkout-builder/publish-checkout-configuration) endpoint for the full request shape, allowed values, and error catalog.
 
@@ -89,7 +92,7 @@ Validation failures return HTTP `400` with a single aggregated body listing ever
 }
 ```
 
-Other statuses: `401` (authentication / account not allowlisted), `404` (checkout not found for the account). The full per-rule error catalog is on the [Publish](/reference/checkout-builder/publish-checkout-configuration) page.
+Other statuses: `401` (authentication / account not allowlisted), `404` (checkout not found for the account, or no default checkout to clone on create), `409` (duplicate checkout name, or archiving/unpublishing the default checkout). The full per-rule error catalog is on the [Publish](/reference/checkout-builder/publish-checkout-configuration) page.
 
 ## Idempotency
 


### PR DESCRIPTION
Documents the two new Checkout Builder Management API endpoints shipped in [CORECM-18326](https://yunopayments.atlassian.net/browse/CORECM-18326) ([public-api#2014](https://github.com/yuno-payments/public-api/pull/2014)):

| Method | Path | Page |
| --- | --- | --- |
| `POST` | `/v1/checkouts` | Create Checkout — published clone of the account's default |
| `PATCH` | `/v1/checkouts/{checkout_code}` | Manage Checkout Lifecycle — rename, publish, unpublish, archive, restore, promote to default |

## What's included

- **OpenAPI specs** (`openapi/checkout-builder/create-checkout.json`, `manage-checkout-lifecycle.json`) following the existing per-endpoint spec pattern, with real error codes verified against checkout-ms and the staging E2E suite (37/37 passed): `DUPLICATE_CHECKOUT_NAME`, `DEFAULT_CHECKOUT_NOT_FOUND`, `INVALID_STATUS_TRANSITION`, `INVALID_PATCH_BODY`, `INVALID_OPERATION`, `CANNOT_ARCHIVE_DEFAULT_CHECKOUT`, `CANNOT_UNPUBLISH_DEFAULT_CHECKOUT`.
- **MDX reference pages** with the lifecycle state machine (mermaid diagram) and the contract confirmed with the dev team on 2026-07-17: publish only from `NOT_PUBLISHED`, **two-step restore** for `ARCHIVED` checkouts (`NOT_PUBLISHED` first, then `PUBLISHED`), metadata (`name`/`description`) editable while `ARCHIVED`, `is_default: true` force-publishes from any state and atomically demotes the previous default, and the default checkout guarded against archive/unpublish.
- **Overview updates**: endpoints table now lists the four operations, the "creating checkouts is planned for a later phase" note replaced (create is now available via API), lifecycle key-behavior bullet, and `409` added to the error summary.
- **Navigation** (`docs.json`): the two new pages added to the Checkout Builder group.

## Coordination

- [#613](https://github.com/yuno-payments/yuno-docs/pull/613) (CORECM-18325, List Checkouts) touches the same overview/docs.json and renames the path param `checkout_code` → `checkout_id`. This PR keeps `main`'s current `checkout_code` naming; whoever merges second reconciles the rename (trivial).
- Heads-up for #613: its list spec documents the status enum as `DRAFT`, while the PATCH surface accepts and returns `NOT_PUBLISHED` (verified on staging). Worth aligning when both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to API reference; no runtime or security-sensitive code.
> 
> **Overview**
> Documents **Create Checkout** (`POST /v1/checkouts`) and **Manage Checkout Lifecycle** (`PATCH /v1/checkouts/{checkout_code}`) for the beta Checkout Builder API, with OpenAPI specs, MDX reference pages, nav entries, and overview updates.
> 
> **Create** clones the account default as a published checkout (payment methods copied; `name` required, unique per account). Response `id` is the `checkout_code` for fetch/publish/lifecycle.
> 
> **Lifecycle PATCH** supports rename, publish/unpublish, archive, two-step restore from `ARCHIVED`, and promote via `is_default: true` (with state-machine rules and guards on the default checkout). The lifecycle page includes a mermaid state diagram and verified error codes.
> 
> The **overview** now lists four operations (was two), notes API create for `checkout_code`, adds a lifecycle behavior bullet, extends `Content-Type` to POST/PATCH, and documents `404`/`409` cases including clone and default-checkout conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da16a5d8834ab1d94094b1bf44a483c561566ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[CORECM-18326]: https://yunopayments.atlassian.net/browse/CORECM-18326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ