### PR TITLE
docs(apple-pay): add domain verification file requirement note

### DIFF
--- a/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
+++ b/docs/wallets/apple-pay/prerequisites-apple-pay.mdx
@@ -209,6 +209,15 @@ Register your domains directly in the Yuno Dashboard — Yuno registers each dom
 1. In the Dashboard, go to **Connections › Certificates & Domains › Apple Pay** and open the **Domains** tab.
 2. Click **Add domain**.
 3. Enter the domains where the Apple Pay button will appear, **one per line** (up to 10 at a time).
+
+<Warning>
+  Before adding the domain, you must host a verification file on each registered domain as plain text (do not leave it as a downloadable file), using the following hosting path:
+
+  `/.well-known/apple-developer-merchantid-domain-association`
+
+  You can find this file in the Dashboard section for domain registration (Connections › Certificates & Domains › Apple Pay › Domains).
+</Warning>
+
 4. Click **Add**. Each domain appears in the table with a status of **Verifying** while Yuno completes registration with Apple.
 5. When registration succeeds, the status changes to **Active** — the domain is ready to show Apple Pay.
 


### PR DESCRIPTION
## PR Description
Apple Pay domain registration steps were missing a mandatory prerequisite: merchants must host a verification file (plain text, not downloadable) at `/.well-known/apple-developer-merchantid-domain-association` on each domain before adding it in the Dashboard. Without this file, Apple's domain verification fails. Added a `<Warning>` between steps 3 and 4 of the "Dashboard (recommended)" flow to surface this before merchants click **Add**.

## Changes
- `docs/wallets/apple-pay/prerequisites-apple-pay.mdx` (Dashboard (recommended) section, between steps 3 and 4): added a `<Warning>` explaining the required verification file, its hosting path, and where to find it in the Dashboard (Connections › Certificates & Domains › Apple Pay › Domains).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a **Warning** to the **Dashboard (recommended)** Apple Pay domain registration flow in `prerequisites-apple-pay.mdx`, placed after step 3 and before **Add**, so merchants see the prerequisite before submitting domains.
> 
> The warning states that each domain must already serve Apple’s verification file as **plain text** (not as a download) at `/.well-known/apple-developer-merchantid-domain-association`, and that the file is available in **Connections › Certificates & Domains › Apple Pay › Domains** in the Dashboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254ccb598ca511b52c3fa0f459ecae513b9e682b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->