### PR TITLE
docs(direct-integration-use-cases): fix outdated links and add capture/cancel cross-link

### DIFF
--- a/docs/direct-integration-use-cases/cancel-payments.mdx
+++ b/docs/direct-integration-use-cases/cancel-payments.mdx
@@ -14,7 +14,7 @@ If you prefer to have Yuno automatically cancel authorizations after a specified
 <Warning>
 **Cancellable Payments**
 
-Only payments with **PENDING** status can be canceled. Check the [Payment status](/docs/payments-1) page for further details regarding the possible payment status.
+Only payments with **PENDING** status can be canceled. Check the [Payment status](/docs/basic-concepts/payments-1) page for further details regarding the possible payment status.
 </Warning>
 
 ## Requirements
@@ -52,4 +52,8 @@ If the response contains the above values, the cancellation was successful.
 If, for some reason, you need to confirm the payment cancellation:
 
 * Use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant\_order\_id](/reference/retrieve-payment-by-merchant-order-id) to get detailed information about the payment.
-* Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/configure-webhooks) guide to learn how to configure webhooks in Yuno.
+* Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/webhooks/configure-webhooks) guide to learn how to configure webhooks in Yuno.
+
+## See also
+
+* [Capture Payments](/docs/direct-integration-use-cases/capture-payments)

--- a/docs/direct-integration-use-cases/capture-payments.mdx
+++ b/docs/direct-integration-use-cases/capture-payments.mdx
@@ -14,7 +14,7 @@ If you prefer to have Yuno automatically capture payments after a specified dela
 <Warning>
 **Which payments can you capture**
 
-Only payments with **PENDING** status can be captured. Check the [Payment status](/docs/payments-1) page for further details regarding the possible payment status.
+Only payments with **PENDING** status can be captured. Check the [Payment status](/docs/basic-concepts/payments-1) page for further details regarding the possible payment status.
 </Warning>
 
 ## Requirements
@@ -66,4 +66,8 @@ If the response contains the above values, the capture was successful.
 If, for some reason, you need to confirm the payment capture:
 
 * Use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant\_order\_id](/reference/retrieve-payment-by-merchant-order-id) to get detailed information about the payment.
-* Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/configure-webhooks) guide to learn how to configure webhooks in Yuno.
+* Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/webhooks/configure-webhooks) guide to learn how to configure webhooks in Yuno.
+
+## See also
+
+* [Cancel Payments](/docs/direct-integration-use-cases/cancel-payments)

--- a/docs/direct-integration-use-cases/refund-payments.mdx
+++ b/docs/direct-integration-use-cases/refund-payments.mdx
@@ -53,4 +53,4 @@ Refunds processing time varies depending on the payment type. While in test mode
 If, for some reason, you need to confirm the payment refund:
 
 * Use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant\_order\_id](/reference/retrieve-payment-by-merchant-order-id) to get detailed information about the payment.
-* Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/configure-webhooks) guide to learn how to configure webhooks in Yuno.
+* Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/webhooks/configure-webhooks) guide to learn how to configure webhooks in Yuno.


### PR DESCRIPTION
## PR Description
Content audit found two outdated internal links in the Cancel/Capture Payments flow and a missing cross-link between the two related actions. The `payments-1` link only worked via a 308 redirect, and the webhooks link, despite already pointing at the correct concept (the "how to configure" guide, not the general overview), used a short-form URL that also relied on a redirect. Both are canonicalized here. Additionally, Capture Payments and Cancel Payments are the two possible actions for a `PENDING` payment but neither page referenced the other — added a "See also" cross-link to both.

## Changes
- `docs/direct-integration-use-cases/cancel-payments.mdx`: fixed `Payment status` link (`/docs/payments-1` → `/docs/basic-concepts/payments-1`), fixed `Webhooks` link (`/docs/configure-webhooks` → `/docs/webhooks/configure-webhooks`), added "See also: Capture Payments" section.
- `docs/direct-integration-use-cases/capture-payments.mdx`: same `Payment status` link fix, same `Webhooks` link fix, added "See also: Cancel Payments" section.
- `docs/direct-integration-use-cases/refund-payments.mdx`: fixed `Webhooks` link (`/docs/configure-webhooks` → `/docs/webhooks/configure-webhooks`) — same broken pattern found here during the audit, no `payments-1` link present on this page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and cross-reference updates with no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates **direct integration** cancel, capture, and refund guides so internal links use canonical paths instead of redirect-only URLs, and links the two **PENDING** payment actions to each other.
> 
> On **cancel** and **capture**, the **Payment status** link now points to `/docs/basic-concepts/payments-1`, and the **Webhooks** configure guide link uses `/docs/webhooks/configure-webhooks`. **Refund** gets the same webhooks URL fix. **Cancel** and **capture** each add a **See also** section pointing at the sibling guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab18fae6ddd4bfc75709053c61aa5977bdad116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->