### PR TITLE
docs(fingerprint,mcp): fix RUM frustration-signal pages

### DIFF
--- a/docs/ai-capabilities/remote-yuno-mcp-server.mdx
+++ b/docs/ai-capabilities/remote-yuno-mcp-server.mdx
@@ -35,7 +35,7 @@ The Remote MCP Server exposes an HTTP transport endpoint. Configure your MCP cli
 
 Sample configuration (HTTP transport):
 
-The header keys below carry the values of your `YUNO_PUBLIC_API_KEY`, `YUNO_PRIVATE_SECRET_KEY`, and `YUNO_ACCOUNT_CODE`.
+Replace the placeholder header values below with your `YUNO_PUBLIC_API_KEY`, `YUNO_PRIVATE_SECRET_KEY`, and `YUNO_ACCOUNT_CODE` credentials.
 
 ```json
 {
@@ -44,9 +44,9 @@ The header keys below carry the values of your `YUNO_PUBLIC_API_KEY`, `YUNO_PRIV
       "transport": "http",
       "url": "https://mcp.prod.y.uno/mcp",
       "headers": {
-        "public-api-key": "<YOUR_PUBLIC_API_KEY>",
-        "private-secret-key": "<YOUR_PRIVATE_SECRET_KEY>",
-        "account-code": "<YOUR_ACCOUNT_CODE>"
+        "public-api-key": "<YUNO_PUBLIC_API_KEY>",
+        "private-secret-key": "<YUNO_PRIVATE_SECRET_KEY>",
+        "account-code": "<YUNO_ACCOUNT_CODE>"
       }
     }
   }

--- a/docs/ai-capabilities/remote-yuno-mcp-server.mdx
+++ b/docs/ai-capabilities/remote-yuno-mcp-server.mdx
@@ -35,6 +35,8 @@ The Remote MCP Server exposes an HTTP transport endpoint. Configure your MCP cli
 
 Sample configuration (HTTP transport):
 
+The header keys below carry the values of your `YUNO_PUBLIC_API_KEY`, `YUNO_PRIVATE_SECRET_KEY`, and `YUNO_ACCOUNT_CODE`.
+
 ```json
 {
   "mcpServers": {
@@ -52,7 +54,7 @@ Sample configuration (HTTP transport):
 ```
 
 <Note>
-  Your `PUBLIC_API_KEY`, `PRIVATE_SECRET_KEY`, and `ACCOUNT_CODE` can all be obtained from the [Yuno dashboard](https://dashboard.y.uno/).
+  Your `YUNO_PUBLIC_API_KEY`, `YUNO_PRIVATE_SECRET_KEY`, and `YUNO_ACCOUNT_CODE` can all be obtained from the [Yuno dashboard](https://dashboard.y.uno/).
 </Note>
 
 ## Related information

--- a/docs/security-and-compliance/fingerprint.mdx
+++ b/docs/security-and-compliance/fingerprint.mdx
@@ -12,6 +12,12 @@ Card fingerprints are a cryptographic hash of the card's PAN that uniquely ident
 * **Protects PCI compliance** by not exposing the full card number
 * **Enables deduplication** without storing or accessing sensitive card data
 
+<Warning>
+  You cannot check fingerprints before the customer enters their card information. This is a PCI compliance requirement.
+</Warning>
+
+**Workaround:** Display existing saved cards before the enrollment form so customers can see what they already have saved.
+
 ## How It Works
 
 ### Same Card, Multiple Enrollments
@@ -126,6 +132,8 @@ async function checkForDuplicates(customerId, newCardFingerprint) {
 
 You have several options when a duplicate is detected:
 
+**Recommended:** Option A (prevent enrollment) for most integrations. Use B or C only if your product intentionally allows multiple saved copies of the same card.
+
 #### Option A: Prevent Enrollment (Recommended for Best UX)
 
 ```javascript
@@ -238,14 +246,6 @@ const enrollmentFlow = {
 ```
 
 ## Important Considerations
-
-### Timing Limitation
-
-<Warning>
-  You cannot check fingerprints before the customer enters their card information. This is a PCI compliance requirement.
-</Warning>
-
-**Workaround:** Display existing saved cards before the enrollment form so customers can see what they already have saved.
 
 ### Fingerprint Availability
 


### PR DESCRIPTION
## Summary

- Source: Datadog RUM analytics report for docs.y.uno (first 6 days live), flagging the two highest frustration-signal pages on the site.
- `docs/security-and-compliance/fingerprint.mdx` (2 in frustration, matches known ticket CORECM-16676):
  - Moves the PCI timing-limitation warning from two-thirds down the page up to right after the "Key Properties" list, before "How It Works"
  - Adds an explicit "Recommended: Option A" line under "Step 3: Handle Duplicates", replacing an easy-to-miss parenthetical
- `docs/ai-capabilities/remote-yuno-mcp-server.mdx` (1 in frustration, ~36% of all signals):
  - Fixes a 3-way credential naming inconsistency: env vars, JSON sample headers, and the note below the sample each named the same three credentials differently
  - Adds one sentence clarifying that the JSON sample's header keys map to the env vars

## Files changed

- `docs/security-and-compliance/fingerprint.mdx`
- `docs/ai-capabilities/remote-yuno-mcp-server.mdx`

## Test plan

- `mint dev` preview: fingerprint.mdx warning renders correctly in its new position, no broken anchors from the moved block
- `mint dev` preview: MCP server page note and new clarifying sentence render correctly
- Cross-check fingerprint.mdx coverage against CORECM-16676's exact ticket scope before merging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation edits only; no runtime code, APIs, or security behavior changes.
> 
> **Overview**
> Documentation-only updates on two high-frustration docs pages (Datadog RUM).
> 
> On **Card Fingerprint**, the PCI timing warning and its workaround move from *Important Considerations* to immediately after **Key Properties**, so readers see the constraint before the implementation flow. **Step 3: Handle Duplicates** now calls out **Option A** as the recommended default in plain text instead of a buried parenthetical.
> 
> On **Remote Yuno MCP Server**, MCP JSON sample placeholders and the dashboard note now use the same `YUNO_*` credential names as the security section, with a short sentence telling readers to substitute their real keys for those placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd31ef5fa74af278af86fabeda8cd7478de3b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->