### PR TITLE
docs(build-reports): fix broken anchor and correct steps summary count

### DIFF
--- a/docs/direct-integration-use-cases/build-reports.mdx
+++ b/docs/direct-integration-use-cases/build-reports.mdx
@@ -28,14 +28,15 @@ Yuno provides [Postman Collections](/reference/postman-collections) that you can
 
 ## Steps summary
 
-The process to receive a report when using Yuno is composed of two steps:
+The process to receive a report when using Yuno is composed of three steps:
 
 1. [Create a Report](/reference/create-a-report)
-2. [Download a Report](/reference/download-a-report)
+2. [Check if the report is ready](/reference/retrieve-a-report)
+3. [Download a Report](/reference/download-a-report)
 
 ## Access a report
 
-As shown in the summary of the steps, you need to complete two steps before accessing your report.
+As shown in the summary of the steps, you need to complete three steps before accessing your report.
 
 ### Step 1: Create a report
 
@@ -64,7 +65,7 @@ When defining the filter values, provide them in a string value list, such as in
 
 For Payment or Transaction reports, you also have the option to select the fields included in the final report using the parameter `columns`.
 
-When you use the [Create a Report endpoint](/reference/create-a-report) to request a report creation, on the response, you will receive the report `id` and `status`. You will use the `id` when requesting the report download on [Step 3](/docs/build-reports#3-download-your-report). The `status` informs if it is ready to download.
+When you use the [Create a Report endpoint](/reference/create-a-report) to request a report creation, on the response, you will receive the report `id` and `status`. You will use the `id` when requesting the report download on [Step 3](/docs/direct-integration-use-cases/build-reports#step-3-download-your-report). The `status` informs if it is ready to download.
 
 ### Step 2: Check if the report is ready
 


### PR DESCRIPTION
## PR Description
Content audit of the Build Reports page found a broken anchor link and an inaccurate steps summary. The "Step 3" link used both an outdated base URL and a wrong anchor ID, so it never actually jumped to the right section. Separately, the "Steps summary" said the report flow has two steps, but the page body describes three (Create → Check if ready → Download) — the intermediate status-check step was missing from the summary entirely.

## Changes
- `docs/direct-integration-use-cases/build-reports.mdx`: fixed the "Step 3" link (`/docs/build-reports#3-download-your-report` → `/docs/direct-integration-use-cases/build-reports#step-3-download-your-report`) — corrects both the outdated short-form URL and the anchor ID, which didn't match the actual heading slug.
- `docs/direct-integration-use-cases/build-reports.mdx`: updated the "Steps summary" section to list all three real steps (Create a Report, Check if the report is ready, Download a Report), and corrected the "two steps" reference in the "Access a report" intro to "three steps" to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Aligns the **Build Reports** doc with the three-step flow already described in the page body (create → check readiness → download).
> 
> The **Steps summary** and **Access a report** intro now say **three** steps instead of two, and the numbered list includes **Check if the report is ready** with a link to Retrieve a Report. The in-page **Step 3** link from the create-report section is updated to `/docs/direct-integration-use-cases/build-reports#step-3-download-your-report` so it uses the correct path and heading anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ccac6da72de64dadede48e33b1a181ec73bb2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->