### PR TITLE
docs(vtex): document order modifications (changed order totals)

### DIFF
--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -43,6 +43,12 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
   When a shopper's cart contains products from different sellers or franchises, VTEX splits the purchase into multiple suborders and charges each one independently. Yuno processes every suborder so the whole order is paid — not just the first part — sharing a single antifraud session across all of them. You can control which antifraud providers receive that shared session with the **Antifraud Providers for Split Orders** field. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#advanced-scenarios) for details.
 </Accordion>
 
+<Accordion title="Can I change an order's total after checkout?">
+  Yes. VTEX lets you modify an order after it has been placed — useful when the final amount is only known later, such as products sold by weight. If the final total is the same or lower, Yuno captures only the final amount. If it is higher, Yuno charges the difference automatically against the card used on the original order, without the shopper needing to re-enter it.
+
+  Automatic charges for **increased** totals apply to **credit cards** and must be enabled in advance: set **Vault Card for Order Modification** and **Create Customer** to **Yes** in your provider configuration before the orders are placed. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#order-modifications-changed-order-totals) for the full setup.
+</Accordion>
+
 <Accordion title="Where can I troubleshoot a specific order?">
   Open the order in your **Yuno dashboard** to see the full lifecycle of every payment attempt, including provider responses and errors. Cross-reference the VTEX order ID with the Yuno payment ID to follow the transaction end-to-end.
 </Accordion>

--- a/docs/plugins/vtex/index.mdx
+++ b/docs/plugins/vtex/index.mdx
@@ -42,12 +42,13 @@ The plugin is composed of three pieces that work together behind the scenes:
 
 You configure the **Payment Connector** in VTEX. The **Payment App** is installed afterward, and the **SDK Web** is loaded automatically during checkout — there is no separate setup for it.
 
-## Recurring payments and multi-seller orders
+## Recurring payments, multi-seller & modified orders
 
-Beyond one-off checkout, the Yuno integration also handles two common VTEX scenarios automatically:
+Beyond one-off checkout, the Yuno integration also handles three common VTEX scenarios automatically:
 
 *   **VTEX subscriptions (recurring payments)** — for products sold on a recurring basis, Yuno processes both the first purchase and the automatic renewals that follow. See the [FAQs](/docs/plugins/vtex/faqs) for details.
 *   **Multi-seller (split) orders** — when a cart combines products from different sellers or franchises, VTEX splits it into separate orders and Yuno charges every one of them, not just the first. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#advanced-scenarios).
+*   **Modified orders (changed totals)** — when an order's total changes after checkout (for example, products sold by weight), Yuno adjusts to the final amount: if it goes **down**, only the final (lower) amount is captured; if it goes **up**, the difference is charged automatically (when enabled). See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#order-modifications-changed-order-totals).
 
 ---
 

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -47,6 +47,7 @@ Have the following ready:
       | **Payment Mode** | Optional | **Payment App** (modern) or **Legacy** (redirect). |
       | **Transaction Identification From** | Optional | **Yuno TID** or **Provider TID**. |
       | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, `CIELO_CYBERSOURCE_FRAUD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
+      | **Vault Card for Order Modification** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores the card used on each order so that, if the order total later increases, the additional amount can be charged automatically. See [Order modifications](#order-modifications-changed-order-totals). |
     </Accordion>
 
     <Accordion title="Settlement Options">
@@ -146,3 +147,26 @@ When these fields are set, the plugin reads catalog and order data from the main
 When a shopper's cart contains products from **different sellers or franchises**, VTEX splits the purchase into multiple suborders and authorizes each one independently. The Yuno integration detects this and processes **every** suborder — so the entire order is paid, not just the first part — while sharing a single antifraud session across all of them.
 
 This works automatically; no extra setup is required. If you want to control which antifraud providers receive the shared session, use the **Antifraud Providers for Split Orders** field in the provider configuration (see the field reference in Step 1). Valid values are `RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, and `CIELO_CYBERSOURCE_FRAUD`; when left empty, it defaults to `RISKIFIED` + `CYBERSOURCE`.
+
+### Order modifications (changed order totals)
+
+VTEX lets you **change an order after checkout**, when the final total turns out to be different from the amount that was authorized — for example if you sell products **by weight**, where the exact total is only known once the order is picked and packed.
+
+*   If the final total is the **same or lower**, VTEX captures only the final amount. No extra setup is required.
+*   If the final total is **higher**, VTEX charges the difference as a **separate, automatic charge**. Since the shopper is no longer present and does not re-enter their card, Yuno charges the difference against the card they already used on the original order.
+
+To enable automatic charges when an order total **increases**, configure the following in your provider settings **before** the orders you expect to modify are placed:
+
+| Field | Value |
+| :--- | :--- |
+| **Vault Card for Order Modification** | **Yes** — stores the card on the original order so it can be charged again for the difference. |
+| **Create Customer** | **Yes** — required, so the card is stored against a Yuno customer. Both fields must be enabled together. |
+| **Automatic Settlement** | **Disabled** — recommended. The original payment is authorized at checkout and captured at invoicing. If the final total is **lower** than the authorized amount, only that lower amount is captured (a partial capture); if it is higher, the difference is charged as a separate additional charge. |
+
+<Note>
+  Order-total **increases** are supported for **credit cards only** (a VTEX restriction). The card is stored at the time of the original payment, so **Vault Card for Order Modification** and **Create Customer** must be enabled **before** the order is placed — turning them on later does not apply to orders that already exist.
+</Note>
+
+<Note>
+  **Franchises / multiple accounts:** enable **Vault Card for Order Modification** and **Create Customer** on **every** affiliation you use (each franchise or sub-account), and set the **Main Account** fields as described under [Multi-account](#multi-account).
+</Note>


### PR DESCRIPTION
## What

Documents the connector's new **order-modification** support in the VTEX plugin docs (merchant-facing).

When a merchant changes an order's total after checkout (for example, products sold by weight):
- if the final total is the **same or lower**, VTEX captures only the final amount;
- if it is **higher**, VTEX charges the difference as a separate automatic charge, using the card the shopper already used on the original order — no CVV, no shopper present. This is supported for **credit cards** and must be enabled in advance.

## Changes

- **`set-up-yuno-on-vtex.mdx`** — adds the new `Vault Card for Order Modification` field to the Field reference table, and a new **Order modifications (changed order totals)** subsection under *Advanced Scenarios* (config: Vault Card + Create Customer + recommended Disabled settlement, credit-cards-only, enable-before-the-order, franchise notes).
- **`index.mdx`** — extends the automatic-scenarios section (subscriptions / split orders) to also cover modified orders.
- **`faqs.mdx`** — adds a FAQ on changing an order's total after checkout.

Mirrors the pattern already used for subscriptions and split orders. Pairs with connector release **v4.2.330** (sdk-vtex-connector PR #238).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or payment-processing code touched.
> 
> **Overview**
> Adds merchant-facing VTEX plugin documentation for **post-checkout order total changes**, aligned with subscriptions and split-order coverage.
> 
> **`set-up-yuno-on-vtex.mdx`** documents the new **`Vault Card for Order Modification`** provider field and an **Order modifications (changed order totals)** advanced scenario: lower/same totals vs automatic difference charges when totals increase, required **Create Customer** pairing, recommended **Disabled** settlement, credit-card-only increases, enable-before-order, and franchise/multi-affiliation notes.
> 
> **`index.mdx`** expands the automatic-scenarios section to a third bullet for modified orders. **`faqs.mdx`** adds a FAQ on changing totals after checkout with a link to the setup section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f9821142e66f2c2f856042f0fd8361a0c7a549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->