### PR TITLE
docs(direct-integration-use-cases): fix broken links, duplicate labels, and content gaps

### DIFF
--- a/docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx
+++ b/docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx
@@ -63,6 +63,11 @@ Use the scheme-specific cards below to validate 3DS in sandbox. In the preview e
 </Accordion>
 
 <Accordion title="Visa">
+
+<Note>
+  `N/A` means the test case triggers a protocol-level or transport error before the DS or ACS stage is reached, so no DS/ACS response is returned for that card.
+</Note>
+
 <table>
   <thead>
     <tr>
@@ -82,7 +87,7 @@ Use the scheme-specific cards below to validate 3DS in sandbox. In the preview e
     <tr><td>4716429323842524</td><td>NOT_AUTHENTICATED_BROWSER_FRICTIONLESS</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_N</td></tr>
     <tr><td>4234123412340003</td><td>BROWSER_CHALLENGE</td><td>ENROLLED_Y</td><td>TRANSACTION_CHALLENGE_OTP</td></tr>
     <tr><td>4604633194219929</td><td>BROWSER_CHALLENGE</td><td>ENROLLED_Y</td><td>TRANSACTION_CHALLENGE_OTP</td></tr>
-    <tr><td>4485436455354151</td><td>BROWSER_FRICTIONLESS_MISSING_DS_TRANS_ID</td><td></td><td></td></tr>
+    <tr><td>4485436455354151</td><td>BROWSER_FRICTIONLESS_MISSING_DS_TRANS_ID</td><td>N/A</td><td>N/A</td></tr>
     <tr><td>4556962659911995</td><td>APPLICATION_FRICTIONLESS_MISSING_SDK_TRANS_ID</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_N</td></tr>
     <tr><td>4539837572943550</td><td>BROWSER_FRICTIONLESS_MISSING_DS_TRANS_ID</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_N</td></tr>
     <tr><td>4024007176265022</td><td>BROWSER_CHALLENGE_MISSING_ACS_URL</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_N</td></tr>
@@ -91,49 +96,49 @@ Use the scheme-specific cards below to validate 3DS in sandbox. In the preview e
     <tr><td>4234123412340000</td><td>AUTHENTICATED_BROWSER_FRICTIONLESS</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_Y</td></tr>
     <tr><td>4234123412340006</td><td>UNAVAILABLE_BROWSER_FRICTIONLESS</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_U</td></tr>
     <tr><td>4234123412340007</td><td>ATTEMPTED_BROWSER_FRICTIONLESS</td><td>ENROLLED_Y</td><td>TRANSACTION_STATUS_A</td></tr>
-    <tr><td>4234123412340001</td><td>NOT_ENROLLED</td><td>ENROLLED_N</td><td></td></tr>
-    <tr><td>4234123412340002</td><td>NOT ENROLLED (VeRes is error 404 "Card account number not found in card ranges from Directory Server")</td><td>ENROLLED_N (NOT APPLICABLE)</td><td></td></tr>
-    <tr><td>4234123412340100</td><td>MISSING_ROOT</td><td></td><td></td></tr>
-    <tr><td>4234123412340101</td><td>MISSING_MESSAGE</td><td></td><td></td></tr>
-    <tr><td>4234123412340102</td><td>INVALID_MESSAGE</td><td></td><td></td></tr>
-    <tr><td>4234123412340103</td><td>MISSING_VERSION</td><td></td><td></td></tr>
-    <tr><td>4234123412340104</td><td>ILLEGAL_VERSION</td><td></td><td></td></tr>
-    <tr><td>4234123412340105</td><td>MISSING_URL</td><td></td><td></td></tr>
-    <tr><td>4234123412340106</td><td>ILLEGAL_URL</td><td></td><td></td></tr>
-    <tr><td>4234123412340107</td><td>MISSING_ENROLLED</td><td></td><td></td></tr>
-    <tr><td>4234123412340108</td><td>ILLEGAL_ENROLLED</td><td></td><td></td></tr>
-    <tr><td>4234123412340109</td><td>ILLEGAL_EXTENSION</td><td></td><td></td></tr>
-    <tr><td>4234123412340200</td><td>ERROR_CUSTOM</td><td></td><td></td></tr>
-    <tr><td>4234123412340201</td><td>ERROR_1</td><td></td><td></td></tr>
-    <tr><td>4234123412340202</td><td>ERROR_2</td><td></td><td></td></tr>
-    <tr><td>4234123412340203</td><td>ERROR_3</td><td></td><td></td></tr>
-    <tr><td>4234123412340204</td><td>ERROR_4</td><td></td><td></td></tr>
-    <tr><td>4234123412340205</td><td>ERROR_5</td><td></td><td></td></tr>
-    <tr><td>4234123412340206</td><td>ERROR_6</td><td></td><td></td></tr>
-    <tr><td>4234123412340220</td><td>ERROR_CUSTOM_WITH_DIFFERENT_MESSAGE_ID</td><td></td><td></td></tr>
-    <tr><td>4234123412340250</td><td>ERROR_50</td><td></td><td></td></tr>
-    <tr><td>4234123412340251</td><td>ERROR_51</td><td></td><td></td></tr>
-    <tr><td>4234123412340252</td><td>ERROR_52</td><td></td><td></td></tr>
-    <tr><td>4234123412340253</td><td>ERROR_53</td><td></td><td></td></tr>
-    <tr><td>4234123412340258</td><td>ERROR_58</td><td></td><td></td></tr>
-    <tr><td>4234123412340298</td><td>ERROR_98</td><td></td><td></td></tr>
-    <tr><td>4234123412340299</td><td>ERROR_99</td><td></td><td></td></tr>
-    <tr><td>4234123412340300</td><td>IREQ_CUSTOM</td><td></td><td></td></tr>
-    <tr><td>4234123412340301</td><td>IREQ_ENROLLED_Y</td><td></td><td></td></tr>
-    <tr><td>4234123412340350</td><td>IREQ_50</td><td></td><td></td></tr>
-    <tr><td>4234123412340351</td><td>IREQ_51</td><td></td><td></td></tr>
-    <tr><td>4234123412340352</td><td>IREQ_52</td><td></td><td></td></tr>
-    <tr><td>4234123412340353</td><td>IREQ_53</td><td></td><td></td></tr>
-    <tr><td>4234123412340354</td><td>IREQ_54</td><td></td><td></td></tr>
-    <tr><td>4234123412340355</td><td>IREQ_55</td><td></td><td></td></tr>
-    <tr><td>4234123412340356</td><td>IREQ_56</td><td></td><td></td></tr>
-    <tr><td>4234123412340358</td><td>IREQ_58</td><td></td><td></td></tr>
-    <tr><td>4234123412340398</td><td>IREQ_98</td><td></td><td></td></tr>
-    <tr><td>4234123412340399</td><td>IREQ_99</td><td></td><td></td></tr>
-    <tr><td>4234123412340400</td><td>UNSUPPORTED_VERSION</td><td></td><td></td></tr>
-    <tr><td>4234123412340401</td><td>UNRECOGNIZED_CRITICAL_EXTENSION</td><td></td><td></td></tr>
-    <tr><td>4234123412340402</td><td>SERVER_ERROR</td><td></td><td></td></tr>
-    <tr><td>4234123412340403</td><td>TIMEOUT</td><td></td><td></td></tr>
+    <tr><td>4234123412340001</td><td>NOT_ENROLLED</td><td>ENROLLED_N</td><td>N/A</td></tr>
+    <tr><td>4234123412340002</td><td>NOT ENROLLED (VeRes is error 404 "Card account number not found in card ranges from Directory Server")</td><td>ENROLLED_N (NOT APPLICABLE)</td><td>N/A</td></tr>
+    <tr><td>4234123412340100</td><td>MISSING_ROOT</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340101</td><td>MISSING_MESSAGE</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340102</td><td>INVALID_MESSAGE</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340103</td><td>MISSING_VERSION</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340104</td><td>ILLEGAL_VERSION</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340105</td><td>MISSING_URL</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340106</td><td>ILLEGAL_URL</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340107</td><td>MISSING_ENROLLED</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340108</td><td>ILLEGAL_ENROLLED</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340109</td><td>ILLEGAL_EXTENSION</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340200</td><td>ERROR_CUSTOM</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340201</td><td>ERROR_1</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340202</td><td>ERROR_2</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340203</td><td>ERROR_3</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340204</td><td>ERROR_4</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340205</td><td>ERROR_5</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340206</td><td>ERROR_6</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340220</td><td>ERROR_CUSTOM_WITH_DIFFERENT_MESSAGE_ID</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340250</td><td>ERROR_50</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340251</td><td>ERROR_51</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340252</td><td>ERROR_52</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340253</td><td>ERROR_53</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340258</td><td>ERROR_58</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340298</td><td>ERROR_98</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340299</td><td>ERROR_99</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340300</td><td>IREQ_CUSTOM</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340301</td><td>IREQ_ENROLLED_Y</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340350</td><td>IREQ_50</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340351</td><td>IREQ_51</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340352</td><td>IREQ_52</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340353</td><td>IREQ_53</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340354</td><td>IREQ_54</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340355</td><td>IREQ_55</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340356</td><td>IREQ_56</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340358</td><td>IREQ_58</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340398</td><td>IREQ_98</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340399</td><td>IREQ_99</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340400</td><td>UNSUPPORTED_VERSION</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340401</td><td>UNRECOGNIZED_CRITICAL_EXTENSION</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340402</td><td>SERVER_ERROR</td><td>N/A</td><td>N/A</td></tr>
+    <tr><td>4234123412340403</td><td>TIMEOUT</td><td>N/A</td><td>N/A</td></tr>
   </tbody>
 </table>
 </Accordion>

--- a/docs/direct-integration-use-cases/refund-payments.mdx
+++ b/docs/direct-integration-use-cases/refund-payments.mdx
@@ -3,13 +3,13 @@ title: "Refund Payments"
 description: "Shows how to fully or partially refund a captured payment using the Refund Payment endpoint."
 ---
 
-The payment refund process is the procedure by which you will reimburse a customer for a previous payment. In this guide, you will find instructions on refunding a previously created payment on Yuno.
+In this guide, you will find instructions on refunding a previously created payment on Yuno.
 
 ## Requirements
 
 To refund a payment, you need to:
 
-* Access your [API credentials](/docs/developers-credentials) on the Yuno Dashboard, which consist of:
+* Access your [API credentials](/docs/using-yuno/settings/developers-credentials) on the Yuno Dashboard, which consist of:
   * `public-api-key`
   * `private-secret-key`
 * Have the payment identification data received after creating the payment using the [Create Payment](/reference/create-payment) endpoint and the capture data from the capture operation executed using the [Capture Payment](/reference/capture-authorization):
@@ -52,5 +52,5 @@ Refunds processing time varies depending on the payment type. While in test mode
 
 If, for some reason, you need to confirm the payment refund:
 
-* Use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant\_order\_id](/reference/retrieve-payment-by-merchant-order-id) to get detailed information about the payment.
+* Use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant_order_id](/reference/retrieve-payment-by-merchant-order-id) to get detailed information about the payment.
 * Alternatively, set up webhooks to receive notifications for each event. Refer to the [Webhooks](/docs/webhooks/configure-webhooks) guide to learn how to configure webhooks in Yuno.

--- a/docs/direct-integration-use-cases/unreferenced-refunds-overview.mdx
+++ b/docs/direct-integration-use-cases/unreferenced-refunds-overview.mdx
@@ -7,7 +7,7 @@ Yuno offers a complete suite of refund flows that cover every stage of the custo
 
 - **[Referenced refunds](https://docs.y.uno/docs/direct-integration-use-cases/refund-payments)** — reverse a single Yuno-captured payment through the API. The standard customer-service reimbursement flow.
 - **[Batch refunds](https://docs.y.uno/docs/using-yuno/dashboard-overview/payments#batch-refunds)** — process up to 1,000 refunds at once by uploading a CSV in the Yuno Dashboard. Used by operations teams for recall events, fraud sweeps, and bulk reimbursements.
-- **Unreferenced refunds** — push funds directly to a payment method through the API, without referencing an original Yuno payment. Used for refunding customers whose original charge lives outside Yuno (legacy billing system, external subscription engine) or for sending goodwill / promotional credits.
+- **Unreferenced refunds** — push funds to a payment method without referencing an original Yuno payment. See [Unreferenced Refunds](#unreferenced-refunds) below.
 
 ---
 
@@ -29,8 +29,11 @@ A referenced refund reimburses a Yuno-captured payment. You call `POST /v1/payme
 
 When a referenced refund succeeds, the parent payment transitions to `status = REFUNDED` / `sub_status = REFUNDED`, and a new transaction is appended with `transaction.type = REFUND` and `transaction.status = SUCCEEDED`. Webhooks fire as usual.
 
-> 💡 **Refund processing time**
-> Refunds are processed instantly in Sandbox. In Production, processing time varies depending on the payment method and provider — card refunds typically settle within 1–5 business days, while ACH and SEPA can take 3–10 business days.
+<Tip>
+**Refund processing time**
+
+Refunds are processed instantly in Sandbox. In Production, processing time varies depending on the payment method and provider — card refunds typically settle within 1–5 business days, while ACH and SEPA can take 3–10 business days.
+</Tip>
 
 ### Batch refund (bulk, via Dashboard)
 

--- a/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
+++ b/docs/direct-integration-use-cases/yuno-testing-gateway.mdx
@@ -34,12 +34,12 @@ This connection is available for sandbox testing only and cannot be used in prod
 
 ## Set up the Yuno Test Payment Gateway
 
-1. Complete the Test Payment Gateway [Integration configuration](/docs/yuno-testing-gateway#integration-configuration).
+1. Complete the Test Payment Gateway [Integration configuration](/docs/direct-integration-use-cases/yuno-testing-gateway#integration-configuration).
 2. After establishing the connection, you must designate the Yuno Test Payment Gateway as your card payment provider in your routing section. Access [Routing](https://dashboard.y.uno/routing) on the Yuno Dashboard, select **Not published**, find the **Card** option, and click **Set Up**.
 
 <Frame><img src="/images/reference/yuno-testing-gateway/image1.png" /></Frame>
 
-3. Create a new route for **Card**. If you are unsure how to create it, check the [Configure dynamic routing](/docs/routing#configuring-the-dynamic-routing).
+3. Create a new route for **Card**. If you are unsure how to create it, check the [Configure dynamic routing](/docs/using-yuno/dashboard-overview/routing#configuring-the-dynamic-routing).
    1. On the Routing dashboard, add conditions to trigger the card payment. You can use card brand or country as trigger conditions, for example.
    2. For the created condition, add the Yuno Test Payment Gateway.
    3. For the **All other payments** options, select the **Cancel** option. The below image presents an example of a routing configuration where the card brand condition was used, accepting payments with Visa and Mastercard brands.
@@ -50,25 +50,25 @@ This connection is available for sandbox testing only and cannot be used in prod
 
 <Frame><img src="/images/reference/yuno-testing-gateway/image3.png" /></Frame>
 
-Use the [Create payment](/docs/create-payment-basic) guide to learn how to test card payments.
+Use the [Create payment](/docs/direct-integration-use-cases/create-payment-basic) guide to learn how to test card payments.
 
 ## Test card payments with Yuno Testing Gateway
 
-On this page, you will find a walk-through guide on creating a card payment using the [Yuno Testing Gateway](/docs/yuno-testing-gateway).
+On this page, you will find a walk-through guide on creating a card payment using the [Yuno Testing Gateway](/docs/direct-integration-use-cases/yuno-testing-gateway).
 
-[Yuno Testing Gateway](/docs/yuno-testing-gateway) is a Yuno solution to test card payment in general. It works as a connection. However, it is only available in the sandbox environment.
+[Yuno Testing Gateway](/docs/direct-integration-use-cases/yuno-testing-gateway) is a Yuno solution to test card payment in general. It works as a connection. However, it is only available in the sandbox environment.
 
 ### Requirements
 
 Before starting following the steps described in this guide, you need to:
 
-* Access your [API credentials](/docs/developers-credentials) on the Yuno Dashboard, which are composed of:
+* Access your [API credentials](/docs/using-yuno/settings/developers-credentials) on the Yuno Dashboard, which are composed of:
   * `public-api-key`
   * `private-secret-key`
   * `account_id`
-* Set up the Yuno Testing Gateway connection on your Yuno Dashboard account. You find a step-by-step guide on connecting it in the [Integration configuration section](/docs/yuno-testing-gateway#integration-configuration).
-* [Build a route](/docs/routing#configuring-the-dynamic-routing) for the Yuno Testing Gateway to define it as your card payment provider. You find a step-by-step guide on how to do it in the Set up the [Yuno Testing Gateway section](/docs/yuno-testing-gateway#set-up-the-yuno-test-payment-gateway).
-* [Configure the checkout builder](/docs/checkout-builder) to make the Yuno Testing Gateway available.
+* Set up the Yuno Testing Gateway connection on your Yuno Dashboard account. You find a step-by-step guide on connecting it in the [Integration configuration section](/docs/direct-integration-use-cases/yuno-testing-gateway#integration-configuration).
+* [Build a route](/docs/using-yuno/dashboard-overview/routing#configuring-the-dynamic-routing) for the Yuno Testing Gateway to define it as your card payment provider. You find a step-by-step guide on how to do it in the Set up the [Yuno Testing Gateway section](/docs/direct-integration-use-cases/yuno-testing-gateway#set-up-the-yuno-test-payment-gateway).
+* [Configure the checkout builder](/docs/using-yuno/dashboard-overview/checkout-builder) to make the Yuno Testing Gateway available.
 
 The create payment process normally requires finishing the two steps listed below.
 
@@ -221,7 +221,7 @@ Another option to get the expected payment results is to use one of the testing 
 </table>
 </Accordion>
 
-<Accordion title="Mastercard">
+<Accordion title="Mastercard (test data)">
 <table>
     <thead>
     <tr>
@@ -576,7 +576,7 @@ Use these cards and OTP codes to test 3DS flows through our preview environment 
 </table>
 </Accordion>
 
-<Accordion title="Mastercard">
+<Accordion title="Mastercard (3DS)">
 <table>
   <thead>
     <tr>
@@ -790,4 +790,4 @@ The same OTP codes are valid for Visa, Mastercard and Amex scenarios.
 
 After performing the request to the [Create Payment](/reference/create-payment), you can check the payment status by analyzing the `status` and `sub_status` from the response. Check the [Payment Status](/reference/payment) page to see all the options you can receive in response to the payment creation request.
 
-Depending on the processor and payment method, the status may take some time to update. Therefore, you may need to use endpoints to recover the payment status. To perform this task, you can use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant\_order\_id](/reference/retrieve-payment-by-merchant-order-id) endpoints. Another option is to use webhooks to receive notifications after each event. Yuno recommends you use webhooks to monitor asynchronous payments better. Check the [Webhooks](/docs/configure-webhooks) guide to learn how to configure the webhooks solution provided by Yuno.
+Depending on the processor and payment method, the status may take some time to update. Therefore, you may need to use endpoints to recover the payment status. To perform this task, you can use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) or [Retrieve Payment by merchant_order_id](/reference/retrieve-payment-by-merchant-order-id) endpoints. Another option is to use webhooks to receive notifications after each event. Yuno recommends you use webhooks to monitor asynchronous payments better. Check the [Webhooks](/docs/webhooks/configure-webhooks) guide to learn how to configure the webhooks solution provided by Yuno.


### PR DESCRIPTION
## PR Description
Content audit across four Direct Integration pages found broken/outdated links, ambiguous blank table cells, duplicate component labels, and a few redundant or circular passages. Fixes are scoped to what was verified against the current file content and site-wide conventions — a handful of originally-reported items (a nonexistent anchor, a stale test-data example, and a claimed "no em dash" style rule that doesn't actually exist on this site) were checked and excluded rather than applied blindly.

## Changes
- `docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx`: filled ~40 blank `<td>` cells in the Visa 3DS table (DS/ACS response columns) with `N/A`, and added a note explaining that `N/A` means the test case errors out before reaching the DS/ACS stage.
- `docs/direct-integration-use-cases/yuno-testing-gateway.mdx`: canonicalized 8 short-form redirect links to their full URLs (`/docs/yuno-testing-gateway`, `/docs/routing#...`, `/docs/create-payment-basic`, `/docs/developers-credentials`, `/docs/checkout-builder`, `/docs/configure-webhooks`); renamed the two duplicate "Mastercard" accordion titles to "Mastercard (test data)" and "Mastercard (3DS)"; removed an unnecessary backslash escape from `merchant_order_id`.
- `docs/direct-integration-use-cases/unreferenced-refunds-overview.mdx`: converted a `> 💡` blockquote callout into a native `<Tip>` component; trimmed the redundant "Unreferenced refunds" definition in the intro bullet list to a short pointer linking to the full definition further down the page.
- `docs/direct-integration-use-cases/refund-payments.mdx`: cut a circular opening sentence ("the refund process is the procedure by which you refund..."); canonicalized the `/docs/developers-credentials` short-form link; removed an unnecessary backslash escape from `merchant_order_id`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to MDX documentation with no application or API behavior impact.
> 
> **Overview**
> Documentation-only cleanup across four **Direct Integration** guides: broken or short-form internal links are updated to canonical paths (credentials, routing, checkout builder, webhooks, create payment, and self-references under `direct-integration-use-cases`).
> 
> On **3DS Configuration and Testing**, the Visa accordion now documents **`N/A`** in empty 3DS 1.x DS/ACS columns for protocol-error test cards, with a **Note** explaining that no DS/ACS response is returned when the case fails before those stages.
> 
> **Yuno Testing Gateway** renames duplicate **Mastercard** accordions to distinguish card test data from 3DS tables. **Unreferenced refunds** swaps a blockquote callout for a **`<Tip>`** and shortens the intro bullet. **Refund payments** drops a redundant opening line and fixes link/markdown for `merchant_order_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f08574c9a3d5e199c5c77ded9022d7bce05994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->