### PR TITLE
docs(yuno-sdk): add secure fields feature and migration guides

### DIFF
--- a/docs/yuno-sdk/features/secure-fields.mdx
+++ b/docs/yuno-sdk/features/secure-fields.mdx
@@ -1,0 +1,215 @@
+---
+title: "Secure Fields"
+description: "Collect card data in PCI-compliant fields you place and style individually, then pay or enroll with start()."
+---
+
+Secure fields are PCI-compliant card inputs — card number, expiry, CVV — that the SDK renders inside isolated iframes. Unlike the SDK's built-in form, you **create and place each field independently** in your own layout, with your own labels and styling. Raw card data never touches your page.
+
+<Note>
+This is the **Web-only** granular, per-field API. If you'd rather embed a single SDK-composed card form, use [`showView`](/docs/yuno-sdk/controllers/show-view) instead — same PCI guarantees, less layout work.
+</Note>
+
+Secure fields work for **both** payment (`checkoutSession`) and enrollment (`customerSession`). The fields inherit everything — session, country, language, callbacks — from the `Transaction` that creates them. There is no second configuration surface.
+
+## Quick start
+
+```typescript
+const sdkPayments = await SdkPayments.initialize('your-public-api-key')
+
+const transaction = sdkPayments.transaction({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    onStatus: (result) => showResult(result),
+})
+
+const secureFields = await transaction.secureFields()
+
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#expiration')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+
+payButton.addEventListener('click', () => {
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { card: { holderName: nameInput.value } } },
+    })
+})
+```
+
+`start()` tokenizes the mounted fields, creates the payment, handles 3DS, and reports the result through [`onStatus`](/docs/yuno-sdk/controllers/on-status). The fields supply the card number, expiry, and CVV — those never leave the iframes. Non-PCI details — `holderName`, and optionally `installment`, `customer`, or `vaultOnSuccess` — travel on `start()` via `paymentMethod.data`.
+
+<Note>
+Passing `number`, `expirationMonth`, `expirationYear`, or `securityCode` in `paymentMethod.data.card` while secure fields are mounted throws — the iframes own the PCI data.
+</Note>
+
+## Managed vs manual
+
+By default the SDK creates the payment. Provide [`createPayment`](/docs/yuno-sdk/controllers/create-payment) on the config to POST the token from your own backend instead:
+
+```typescript
+const transaction = sdkPayments.transaction({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    createPayment: async (token) => {
+        await myBackend.pay({
+            oneTimeToken: token.token,
+            checkoutSession: token.checkout_session,
+        })
+    },
+    onStatus: (result) => showResult(result),
+})
+```
+
+<Warning>
+Always read `token.checkout_session` from the token instead of reusing the session you created the transaction with. After a declined payment the SDK rotates the session automatically — the token always carries the one it actually tokenized against.
+</Warning>
+
+Either way the SDK handles 3DS and reports through `onStatus`.
+
+## Declined payments and retry
+
+When a card payment is **DECLINED** or fails with **ERROR**, the SDK prepares the retry for you:
+
+1. The checkout session is cloned server-side and rotated into the mounted fields automatically.
+2. Field-level errors (invalid card number, invalid CVV, insufficient funds) are painted inside the matching iframes.
+3. `onStatus` receives the `DECLINED` / `ERROR` result.
+
+The fields stay mounted with what the user typed. To retry, just call `start()` again — it is **repeatable** while secure fields are mounted, and the new attempt tokenizes against the rotated session. You do no session bookkeeping.
+
+```typescript
+const transaction = sdkPayments.transaction({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    onStatus: (result) => {
+        if (result.status === 'DECLINED' || result.status === 'ERROR') {
+            payButton.disabled = false
+            return
+        }
+        showResult(result)
+    },
+})
+
+payButton.addEventListener('click', () => {
+    payButton.disabled = true
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { card: { holderName: nameInput.value } } },
+    })
+})
+```
+
+<Note>
+Disable your Pay button while a `start()` is in flight. Calling `start()` again before the previous attempt finishes throws — two tokenizations would mean two payments.
+</Note>
+
+## Enrollment
+
+With a `customerSession`, secure fields vault a card instead of charging it. The flow is identical — `create`, `render`, `start()`.
+
+```typescript
+const transaction = sdkPayments.transaction({
+    customerSession: 'session-from-backend',
+    countryCode: 'CO',
+    onStatus: (result) => showResult(result),
+})
+
+const secureFields = await transaction.secureFields()
+
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#expiration')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+
+saveButton.addEventListener('click', () => {
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { card: { holderName: nameInput.value } } },
+    })
+})
+```
+
+## Installments
+
+Enable installments when creating the fields:
+
+```typescript
+const secureFields = await transaction.secureFields({ installmentEnable: true })
+```
+
+Available plans arrive on the `pan` field's `onChange` as the user types — `data.installments`, `data.fullInstallmentsInfo`, and `data.isInstallmentLoading`. Render your own selector from that data and pass the chosen plan on `start()`:
+
+```typescript
+transaction.start({
+    paymentMethod: {
+        type: 'CARD',
+        data: {
+            card: { holderName: nameInput.value },
+            installment: { id: selected.id, value: selected.value },
+        },
+    },
+})
+```
+
+## Fields
+
+Create each field by name, then render it into any element in your layout.
+
+| Name | What |
+|---|---|
+| `pan` | Card number. Emits brand, IIN, and installment data through `onChange`. |
+| `expiration` | Expiration date. |
+| `cvv` | Security code. |
+| `cardLoadPreview` | Optional animated card preview. |
+| `cardPin` | PIN entry, for markets that require it. |
+
+## Field options
+
+Pass `options` to `create` to label, style, and observe a field.
+
+| Option | Type | Purpose |
+|---|---|---|
+| `label` | string | Accessible label. |
+| `placeholder` | string | Placeholder text. |
+| `showError` | boolean | Render validation errors under the field. |
+| `validationType` | string | When to validate (e.g. `on_blur_full`). |
+| `onChange` | function | `({ error, data, isDirty })`. For `pan`, `data` carries brand, IIN, and installments. |
+| `onBlur` / `onFocus` | function | Focus lifecycle — e.g. to flip a card preview. |
+
+## Field methods
+
+Each field returned by `create` (or fetched later with `getElement({ name })`) exposes:
+
+| Method | Purpose |
+|---|---|
+| `render('#sel')` | Render the field into an element. |
+| `focus()` | Focus the field. |
+| `validate()` | Validate on demand; resolves to a boolean. |
+| `clearValue()` | Clear the input. |
+| `setError(message)` / `clearError()` | Show or clear a custom error under the field. |
+| `hide()` / `show()` | Toggle visibility without unmounting. |
+| `updateProps(props)` | Update label, placeholder, or styles in place. |
+| `setCardType(type)` | Force credit or debit on dual-brand cards. |
+| `setCardHolderName(name)` | Set the holder name on the card preview. |
+| `toggleFrontCardVisibility(visible)` | Flip the card preview. |
+| `unmountSync()` | Remove the field's iframe. |
+
+## Instance members
+
+| Member | Purpose |
+|---|---|
+| `create({ name, options })` | Create a field. |
+| `getElement({ name })` | Fetch a previously created field. |
+| `unmountSync()` | Remove all field iframes. `transaction.unmount()` calls this for you. |
+
+<Note>
+To point the transaction at a new checkout session, call `transaction.updateCheckoutSession()` — the mounted fields pick it up automatically.
+</Note>
+
+## Notes
+
+- **One completion path.** Tokenization, payment creation, 3DS, and status all live inside `start()` — there is no `generateToken` or `continuePayment()` to sequence yourself. To create the payment from your own backend, use manual mode ([`createPayment`](/docs/yuno-sdk/controllers/create-payment)) — the SDK still owns 3DS and the result.
+- **PCI scope is unchanged.** Raw card data stays inside the SDK's iframes; your code never reads it.
+- **One card surface per page.** Create secure fields on one transaction at a time. Wallet buttons and the payment methods list from [`getPaymentMethodsViews`](/docs/yuno-sdk/features/payment-methods-list) can share the page and the transaction — a `CARD` `start()` routes to your fields, wallet buttons drive themselves.
+
+## Related
+
+- [Migration — Secure Fields](/docs/yuno-sdk/migration/web/secure-fields). Coming from v1 `yuno.secureFields`.
+- [Payment Methods List](/docs/yuno-sdk/features/payment-methods-list). Prebuilt widgets — wallets and the methods list.
+- [`createPayment`](/docs/yuno-sdk/controllers/create-payment). Take over payment creation (manual mode).
+- [`onStatus`](/docs/yuno-sdk/controllers/on-status). Receive the final result.

--- a/docs/yuno-sdk/features/secure-fields.mdx
+++ b/docs/yuno-sdk/features/secure-fields.mdx
@@ -6,7 +6,7 @@ description: "Collect card data in PCI-compliant fields you place and style indi
 Secure fields are PCI-compliant card inputs — card number, expiry, CVV — that the SDK renders inside isolated iframes. Unlike the SDK's built-in form, you **create and place each field independently** in your own layout, with your own labels and styling. Raw card data never touches your page.
 
 <Note>
-This is the **Web-only** granular, per-field API. If you'd rather embed a single SDK-composed card form, use [`showView`](/docs/yuno-sdk/controllers/show-view) instead — same PCI guarantees, less layout work.
+This is the **Web-only** granular, per-field API. If you'd rather let the SDK render its own pre-built card form instead of laying out each input yourself, use the [Payment Methods List](/docs/yuno-sdk/features/payment-methods-list) — the SDK composes and renders the form into your `elementSelector`, with the same PCI guarantees and less layout work.
 </Note>
 
 Secure fields work for **both** payment (`checkoutSession`) and enrollment (`customerSession`). The fields inherit everything — session, country, language, callbacks — from the `Transaction` that creates them. There is no second configuration surface.
@@ -24,9 +24,9 @@ const transaction = sdkPayments.transaction({
 
 const secureFields = await transaction.secureFields()
 
-secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
-secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#expiration')
-secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).mount('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).mount('#expiration')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).mount('#cvv')
 
 payButton.addEventListener('click', () => {
     transaction.start({
@@ -102,7 +102,7 @@ Disable your Pay button while a `start()` is in flight. Calling `start()` again 
 
 ## Enrollment
 
-With a `customerSession`, secure fields vault a card instead of charging it. The flow is identical — `create`, `render`, `start()`.
+With a `customerSession`, secure fields vault a card instead of charging it. The flow is identical — `create`, `mount`, `start()`.
 
 ```typescript
 const transaction = sdkPayments.transaction({
@@ -113,9 +113,9 @@ const transaction = sdkPayments.transaction({
 
 const secureFields = await transaction.secureFields()
 
-secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
-secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#expiration')
-secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).mount('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).mount('#expiration')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).mount('#cvv')
 
 saveButton.addEventListener('click', () => {
     transaction.start({
@@ -148,7 +148,7 @@ transaction.start({
 
 ## Fields
 
-Create each field by name, then render it into any element in your layout.
+Create each field by name, then mount it into any element in your layout.
 
 | Name | What |
 |---|---|
@@ -177,7 +177,7 @@ Each field returned by `create` (or fetched later with `getElement({ name })`) e
 
 | Method | Purpose |
 |---|---|
-| `render('#sel')` | Render the field into an element. |
+| `mount('#sel')` | Mount the field's iframe into an element. |
 | `focus()` | Focus the field. |
 | `validate()` | Validate on demand; resolves to a boolean. |
 | `clearValue()` | Clear the input. |

--- a/docs/yuno-sdk/migration/web/secure-fields.mdx
+++ b/docs/yuno-sdk/migration/web/secure-fields.mdx
@@ -1,0 +1,109 @@
+---
+title: "Secure Fields"
+description: "Migrate Web Secure Fields (yuno.secureFields) integrations to the unified Transaction API."
+---
+
+Secure Fields collected card data in PCI-compliant iframes — your code never touched the raw PAN. You created each field (`pan`, `expiration`, `cvv`), placed it in your layout, generated a token, POSTed it from your backend, and called `yuno.continuePayment()` to finish.
+
+In the unified API **your field code does not change**. `create({ name: 'pan' }).render('#sel')` is the same call, same names, same options. What changes is everything around it: the fields come from the `Transaction` (no second argument bag), and the three-step finish — `generateTokenWithInformation` → backend POST → `continuePayment()` — collapses into one repeatable `start()`.
+
+| Before | After |
+|---|---|
+| `yuno.secureFields({ checkoutSession, countryCode, language, ... })` | `sdkPayments.transaction({ checkoutSession, countryCode, language, ... }).secureFields()` |
+| `.create({ name: 'pan' }).render('#sel')` | **unchanged** |
+| `.generateTokenWithInformation(...)` + backend POST + `yuno.continuePayment()` | `transaction.start(...)` — tokenize, create, and 3DS in one call |
+| `continuePayment({ paymentResult })` for the outcome | `onStatus` on the transaction config |
+
+## Side-by-side
+
+<CodeGroup>
+
+```typescript Before. Secure Fields
+const yuno = await window.Yuno.initialize('your-public-api-key')
+
+const secureFields = await yuno.secureFields({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    installmentEnable: true,
+})
+
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#exp')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+
+document.getElementById('pay').addEventListener('click', async () => {
+    const ott = await secureFields.generateTokenWithInformation({
+        cardHolderName: 'John Doe',
+    })
+    await myBackend.pay({ oneTimeToken: ott.token, checkoutSession: ott.checkout_session })
+    yuno.continuePayment()
+})
+```
+
+```typescript After. Unified Transaction
+const sdkPayments = await SdkPayments.initialize('your-public-api-key')
+
+const transaction = sdkPayments.transaction({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    createPayment: async (token) => {
+        await myBackend.pay({ oneTimeToken: token.token, checkoutSession: token.checkout_session })
+    },
+    onStatus: (result) => showResult(result),
+})
+
+const secureFields = await transaction.secureFields({ installmentEnable: true })
+
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#exp')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+
+document.getElementById('pay').addEventListener('click', () => {
+    transaction.start({
+        paymentMethod: { type: 'CARD', data: { card: { holderName: 'John Doe' } } },
+    })
+})
+```
+
+</CodeGroup>
+
+The field lines are byte-identical. Omit `createPayment` to let the SDK create the payment for you (managed); provide it to POST the token from your backend (manual).
+
+## Argument mapping
+
+Every `yuno.secureFields()` argument except one moves to the transaction config — the fields inherit the transaction's context instead of duplicating it.
+
+| Before (`yuno.secureFields({...})`) | After | Notes |
+|---|---|---|
+| `checkoutSession` / `customerSession` | `transaction` config | Payment vs enrollment stays implicit in which session you pass. |
+| `countryCode` | `transaction` config | |
+| `language` | `transaction` config | |
+| `deviceFingerprints` | `transaction` config | |
+| `installmentEnable` | `transaction.secureFields({ installmentEnable })` | The one knob the transaction can't derive. |
+| `enableV2`, `enableMultiplesCard` | *(removed)* | Dead in v1 — declared, never read. |
+
+## Behavior changes
+
+- **Field code is preserved.** Names (`pan`, `expiration`, `cvv`, `cardLoadPreview`, `cardPin`), `render()`, options, and `onChange` payloads are all unchanged.
+- **Tokenization moved into `start()`.** `holderName` and other non-PCI details travel on `paymentMethod.data` instead of `generateTokenWithInformation` args.
+- **`continuePayment()` is gone.** In v1, forgetting it silently skipped 3DS and the result. `start()` runs the full chain automatically.
+- **The result arrives on `onStatus`.** In v1 you only got a status by remembering `continuePayment({ paymentResult })` — an easy miss. In the unified API `onStatus` is part of the transaction config.
+- **Declined payments are retryable in place.** As in v1, the SDK rotates the checkout session and paints field errors after a decline. New: `onStatus` receives the `DECLINED` result so you know to re-enable your Pay button, and `start()` is **repeatable** — the next call tokenizes against the rotated session. In v1 this loop required re-running your token → POST → `continuePayment` sequence by hand.
+- **Raw tokenization is no longer public.** `generateToken*` / `generateVaultedToken*` are gone from the unified API — the instance keeps only `create`, `getElement`, and `unmountSync`, and all tokenization runs inside `start()`. Session updates go through `transaction.updateCheckoutSession()` instead of the instance. There is also no `continuePayment()`: a payment created outside `start()` could never run 3DS or report a status. If you own the payment POST, use manual mode (`createPayment` + `start()`) — you keep the backend call, the SDK keeps 3DS and the result.
+
+## Checklist
+
+- [ ] Replace `window.Yuno.initialize(...)` with `SdkPayments.initialize(...)`.
+- [ ] Move `yuno.secureFields({...})` args onto `sdkPayments.transaction({...})`; keep only `installmentEnable` on `transaction.secureFields({...})`.
+- [ ] Keep every `create(...).render(...)` line as is.
+- [ ] Replace `generateTokenWithInformation` + backend POST + `continuePayment()` with `transaction.start({ paymentMethod: { type: 'CARD', data: { card: { holderName } } } })`.
+- [ ] Provide `createPayment` if you create the payment on your backend (manual); read the session from `token.checkout_session`, never a cached value.
+- [ ] Handle `DECLINED` / `ERROR` in `onStatus` by re-enabling your Pay button — `start()` again to retry.
+- [ ] Re-run your sandbox test suite, including a declined-card retry.
+
+## Related
+
+- [Secure Fields](/docs/yuno-sdk/features/secure-fields). The full feature reference — fields, options, methods, retry.
+- [`createPayment`](/docs/yuno-sdk/controllers/create-payment). Take over payment creation (manual mode).
+- [`onStatus`](/docs/yuno-sdk/controllers/on-status). Receive the final result.
+- [`OneTimeToken`](/docs/yuno-sdk/reference/one-time-token). Token payload sent to your backend.

--- a/docs/yuno-sdk/migration/web/secure-fields.mdx
+++ b/docs/yuno-sdk/migration/web/secure-fields.mdx
@@ -5,12 +5,12 @@ description: "Migrate Web Secure Fields (yuno.secureFields) integrations to the 
 
 Secure Fields collected card data in PCI-compliant iframes — your code never touched the raw PAN. You created each field (`pan`, `expiration`, `cvv`), placed it in your layout, generated a token, POSTed it from your backend, and called `yuno.continuePayment()` to finish.
 
-In the unified API **your field code does not change**. `create({ name: 'pan' }).render('#sel')` is the same call, same names, same options. What changes is everything around it: the fields come from the `Transaction` (no second argument bag), and the three-step finish — `generateTokenWithInformation` → backend POST → `continuePayment()` — collapses into one repeatable `start()`.
+In the unified API **your field code is nearly unchanged** — same field names, same options, same `onChange`. The one rename: mount a field with `.mount('#sel')` instead of `.render('#sel')`. What changes around it is bigger: the fields come from the `Transaction` (no second argument bag), and the three-step finish — `generateTokenWithInformation` → backend POST → `continuePayment()` — collapses into one repeatable `start()`.
 
 | Before | After |
 |---|---|
 | `yuno.secureFields({ checkoutSession, countryCode, language, ... })` | `sdkPayments.transaction({ checkoutSession, countryCode, language, ... }).secureFields()` |
-| `.create({ name: 'pan' }).render('#sel')` | **unchanged** |
+| `.create({ name: 'pan' }).render('#sel')` | `.create({ name: 'pan' }).mount('#sel')` — `.render()` renamed to `.mount()` |
 | `.generateTokenWithInformation(...)` + backend POST + `yuno.continuePayment()` | `transaction.start(...)` — tokenize, create, and 3DS in one call |
 | `continuePayment({ paymentResult })` for the outcome | `onStatus` on the transaction config |
 
@@ -54,9 +54,9 @@ const transaction = sdkPayments.transaction({
 
 const secureFields = await transaction.secureFields({ installmentEnable: true })
 
-secureFields.create({ name: 'pan', options: { label: 'Card number' } }).render('#pan')
-secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).render('#exp')
-secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).render('#cvv')
+secureFields.create({ name: 'pan', options: { label: 'Card number' } }).mount('#pan')
+secureFields.create({ name: 'expiration', options: { label: 'Expiry' } }).mount('#exp')
+secureFields.create({ name: 'cvv', options: { label: 'CVV' } }).mount('#cvv')
 
 document.getElementById('pay').addEventListener('click', () => {
     transaction.start({
@@ -67,7 +67,7 @@ document.getElementById('pay').addEventListener('click', () => {
 
 </CodeGroup>
 
-The field lines are byte-identical. Omit `createPayment` to let the SDK create the payment for you (managed); provide it to POST the token from your backend (manual).
+The field lines are unchanged except `.render()` is now `.mount()`. Omit `createPayment` to let the SDK create the payment for you (managed); provide it to POST the token from your backend (manual).
 
 ## Argument mapping
 
@@ -84,18 +84,18 @@ Every `yuno.secureFields()` argument except one moves to the transaction config 
 
 ## Behavior changes
 
-- **Field code is preserved.** Names (`pan`, `expiration`, `cvv`, `cardLoadPreview`, `cardPin`), `render()`, options, and `onChange` payloads are all unchanged.
+- **Field code is nearly preserved.** Names (`pan`, `expiration`, `cvv`, `cardLoadPreview`, `cardPin`), options, and `onChange` payloads are all unchanged. The one rename: the field's `.render('#sel')` is now `.mount('#sel')`.
 - **Tokenization moved into `start()`.** `holderName` and other non-PCI details travel on `paymentMethod.data` instead of `generateTokenWithInformation` args.
 - **`continuePayment()` is gone.** In v1, forgetting it silently skipped 3DS and the result. `start()` runs the full chain automatically.
 - **The result arrives on `onStatus`.** In v1 you only got a status by remembering `continuePayment({ paymentResult })` — an easy miss. In the unified API `onStatus` is part of the transaction config.
 - **Declined payments are retryable in place.** As in v1, the SDK rotates the checkout session and paints field errors after a decline. New: `onStatus` receives the `DECLINED` result so you know to re-enable your Pay button, and `start()` is **repeatable** — the next call tokenizes against the rotated session. In v1 this loop required re-running your token → POST → `continuePayment` sequence by hand.
-- **Raw tokenization is no longer public.** `generateToken*` / `generateVaultedToken*` are gone from the unified API — the instance keeps only `create`, `getElement`, and `unmountSync`, and all tokenization runs inside `start()`. Session updates go through `transaction.updateCheckoutSession()` instead of the instance. There is also no `continuePayment()`: a payment created outside `start()` could never run 3DS or report a status. If you own the payment POST, use manual mode (`createPayment` + `start()`) — you keep the backend call, the SDK keeps 3DS and the result.
+- **Raw tokenization is no longer public.** `generateToken*` / `generateVaultedToken*` are no longer part of the public API — the typed instance exposes only `create`, `getElement`, and `unmountSync`, and all tokenization runs inside `start()`. Session updates go through `transaction.updateCheckoutSession()` instead of the instance. There is also no `continuePayment()`: a payment created outside `start()` could never run 3DS or report a status. If you own the payment POST, use manual mode (`createPayment` + `start()`) — you keep the backend call, the SDK keeps 3DS and the result.
 
 ## Checklist
 
 - [ ] Replace `window.Yuno.initialize(...)` with `SdkPayments.initialize(...)`.
 - [ ] Move `yuno.secureFields({...})` args onto `sdkPayments.transaction({...})`; keep only `installmentEnable` on `transaction.secureFields({...})`.
-- [ ] Keep every `create(...).render(...)` line as is.
+- [ ] Rename each field's `.render('#sel')` to `.mount('#sel')`; names and options stay as is.
 - [ ] Replace `generateTokenWithInformation` + backend POST + `continuePayment()` with `transaction.start({ paymentMethod: { type: 'CARD', data: { card: { holderName } } } })`.
 - [ ] Provide `createPayment` if you create the payment on your backend (manual); read the session from `token.checkout_session`, never a cached value.
 - [ ] Handle `DECLINED` / `ERROR` in `onStatus` by re-enabling your Pay button — `start()` again to retry.


### PR DESCRIPTION
## What

Adds two new docs pages for the v2 (unified `Transaction`) Secure Fields API:

- `docs/yuno-sdk/features/secure-fields.mdx` — feature guide for the PCI-compliant per-field API (`transaction.secureFields()`), quick start, and usage.
- `docs/yuno-sdk/migration/web/secure-fields.mdx` — migration guide from `yuno.secureFields` / `continuePayment()` to the unified `Transaction` + `start()` flow.

## Base

Targets `2026-05-13-universal-sdk-proposal` because these pages reference `SdkPayments` / `Transaction` APIs that only exist on that branch (stacked docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, config, or security-sensitive code changes.
> 
> **Overview**
> Adds **Secure Fields** documentation for the unified Web `Transaction` API: a feature guide and a v1→v2 migration page.
> 
> The feature doc (`secure-fields.mdx`) documents `transaction.secureFields()` — per-field PCI iframes (`pan`, `expiration`, `cvv`, etc.), `.mount()` placement, and a single **`start()`** path for tokenization, payment/enrollment, 3DS, and **`onStatus`**. It also covers managed vs manual **`createPayment`**, declined-payment retry with session rotation, installments via `installmentEnable`, and reference tables for field options and instance APIs.
> 
> The migration doc maps **`yuno.secureFields`** to transaction config + **`transaction.secureFields()`**, **`.render()` → `.mount()`**, and replaces **`generateTokenWithInformation` + backend POST + `continuePayment()`** with **`transaction.start()`**, with side-by-side samples and a migration checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5ffddc37acc526f3aa85caf686fc5979a8ddc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->