### PR TITLE
docs(SUB-48): document Plans & Subscriptions API additions

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -169,6 +169,7 @@
                 "group": "Subscriptions",
                 "pages": [
                   "docs/payment-features/subscriptions/index",
+                  "docs/payment-features/subscriptions/plans",
                   "docs/payment-features/subscriptions/retries",
                   "docs/payment-features/subscriptions/soft-descriptor"
                 ]
@@ -543,7 +544,18 @@
               "reference/subscriptions/retry-subscription",
               "reference/subscriptions/pause-subscription",
               "reference/subscriptions/resume-subscription",
-              "reference/subscriptions/cancel-subscription"
+              "reference/subscriptions/cancel-subscription",
+              "reference/subscriptions/list-subscription-payments"
+            ]
+          },
+          {
+            "group": "Plans",
+            "pages": [
+              "reference/plans/the-plan-object",
+              "reference/plans/create-plan",
+              "reference/plans/retrieve-plan",
+              "reference/plans/list-plans",
+              "reference/plans/cancel-plan"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -534,6 +534,16 @@
             ]
           },
           {
+            "group": "Subscriptions Plans",
+            "pages": [
+              "reference/plans/the-plan-object",
+              "reference/plans/create-plan",
+              "reference/plans/retrieve-plan",
+              "reference/plans/list-plans",
+              "reference/plans/cancel-plan"
+            ]
+          },
+          {
             "group": "Subscriptions",
             "pages": [
               "reference/subscriptions/status-subscriptions",
@@ -546,16 +556,6 @@
               "reference/subscriptions/resume-subscription",
               "reference/subscriptions/cancel-subscription",
               "reference/subscriptions/list-subscription-payments"
-            ]
-          },
-          {
-            "group": "Plans",
-            "pages": [
-              "reference/plans/the-plan-object",
-              "reference/plans/create-plan",
-              "reference/plans/retrieve-plan",
-              "reference/plans/list-plans",
-              "reference/plans/cancel-plan"
             ]
           },
           {

--- a/docs/payment-features/subscriptions/plans.mdx
+++ b/docs/payment-features/subscriptions/plans.mdx
@@ -1,0 +1,64 @@
+---
+title: "Plans"
+description: "Define a reusable pricing catalog once, then subscribe customers to it instead of setting amount and frequency per subscription"
+---
+
+A plan is a reusable pricing definition — name, price (optionally per country), billing frequency, and an optional trial phase ladder. Instead of specifying `amount`/`frequency` on every [subscription](/docs/payment-features/subscriptions/index) you create, subscribe the customer to a plan and Yuno resolves the price for their country automatically.
+
+<Note>
+**Plans vs raw subscriptions**
+
+Raw subscriptions (`amount` + `frequency`, no `plan_id`) remain fully supported — plans are additive, not a replacement. A subscription created without a plan simply omits the plan fields (`plan_id`, `billing_phases`, `current_phase`, …) from its responses — they're absent, not `null`.
+</Note>
+
+## Creating and using a plan
+
+Say you're launching a "Streaming Pro" tier that costs \$20/month in the US, but you want to charge R\$99.90 in Brazil instead of a straight currency conversion. Here's the whole flow:
+
+1. **Create the plan once.** Call [Create a Plan](/reference/plans/create-plan) with a name, a `base_amount` (the default price — \$20 USD in our example), a `frequency` (monthly), and, if you need country-specific pricing, a `country_prices` list (`BR` → R\$99.90). This gives you back a `plan_id`.
+2. **Subscribe customers to it, as many as you want.** When you call [Create Subscription](/reference/subscriptions/create-subscription), send that `plan_id` instead of an `amount`. Yuno looks up the subscriber's `country` and charges them the right price automatically — no need to compute or send the amount yourself on every subscription.
+3. **The price resolves per subscriber, in this order:** does the plan have an explicit price for their country? Use that. If not, fall back to `base_amount`. So in our example, a US customer pays \$20, a Brazilian customer pays R\$99.90, and a customer anywhere else also pays \$20 (the `base_amount` fallback covers every country you didn't list explicitly).
+
+<Warning>
+**`plan_id` takes over pricing and cadence — but not all conflicting fields are rejected the same way**
+
+- `amount` is mutually exclusive with `plan_id` — send exactly one of the two.
+- `trial_period` and `billing_date` sent alongside `plan_id` are rejected with `400 BAD_REQUEST` — the plan already defines the trial ladder and cadence, so these would conflict with it.
+- `frequency` sent alongside `plan_id` is **not** rejected — it's silently ignored and overridden by the plan's own frequency. If you send one anyway expecting it to apply, it won't; nothing will tell you that.
+
+Simplest rule: when subscribing with `plan_id`, just omit `amount`, `frequency`, `trial_period`, and `billing_date` entirely — the plan supplies all of them. (Raw subscriptions without a plan still work exactly as before — plans are an addition, not a replacement.)
+</Warning>
+
+## Plans are immutable — here's why that matters
+
+You can't edit a plan's price after creating it — there's no update endpoint. This is deliberate: it means every subscriber keeps the exact price they signed up for, forever, even if you change your pricing later. Nobody gets a surprise price increase because you tweaked the plan.
+
+In practice, this means a "price change" is really "create a new plan": if Streaming Pro goes from \$20 to \$25/month, you create a new plan for \$25 and start pointing new signups at it — your existing \$20 subscribers keep paying \$20 until they cancel. When you're ready to stop offering the old price entirely, see **Canceling a plan** below.
+
+## Trial phases — offering a discounted or free intro period
+
+If you want new subscribers to pay less (or nothing) for a while before the regular price kicks in — a 14-day free trial, or \$9.99/month for the first 3 months before jumping to \$20/month — that's what `phases` on the plan are for.
+
+Think of it as a short ladder the subscriber walks through: one or more `TRIAL` steps (any price you want, including \$0), followed by exactly one `REGULAR` step at the end, which is always priced from the plan's normal `base_amount`/`country_prices`. For example, a 3-month-then-regular plan has two phases: phase 1 is `TRIAL`, 3 months, \$9.99; phase 2 is `REGULAR` with no set duration — it just runs at the plan's normal price from then on.
+
+While a subscriber is inside a `TRIAL` phase, their subscription's `status` reads `TRIALING` (instead of `ACTIVE`) and `current_phase` reads `TRIAL`, so you can tell at a glance that they're still in the discounted period. The moment they reach the `REGULAR` phase, both flip automatically — `status` becomes `ACTIVE`, `current_phase` becomes `REGULAR` — with no action needed on your end.
+
+If you don't need a trial or intro discount at all, just omit `phases` — the plan charges its regular price from the first bill.
+
+See [The Plan Object](/reference/plans/the-plan-object) for every field on a phase, and [The Subscription Object](/reference/subscriptions/the-subscription-object) for how a subscription reports back which phase it's in (`plan_id`, `billing_phases`, `current_phase`). To see what was actually charged for each phase — provider, per-charge amounts, which phase a payment belonged to — use [List Subscription Payments](/reference/subscriptions/list-subscription-payments).
+
+## Canceling a plan
+
+<Danger>
+**This cancels every subscriber on the plan immediately — there is no way to opt out of that.**
+
+Calling [Cancel Plan](/reference/plans/cancel-plan) does two things at once, synchronously, in the same request:
+1. Blocks anyone new from subscribing to this plan.
+2. **Cancels every subscription currently on it, right now.** Not "on their next renewal," not "after a grace period" — immediately, as part of this same API call.
+
+There is no soft-cancel, no grandfathering, and no way to retire a plan for new signups while letting existing subscribers keep paying on it. If that's what you need, don't cancel the plan — just stop pointing new signups at it (step 2 above) and leave it active for as long as its current subscribers should keep billing.
+</Danger>
+
+Before you call this, check the plan's `subscribers_count` (via [List Plans](/reference/plans/list-plans) — this field isn't on the single-plan [Retrieve Plan](/reference/plans/retrieve-plan) response) so you know exactly how many active subscriptions are about to be canceled — the response also echoes back `affected_subscriptions` so you can confirm afterward that the number matches what you expected.
+
+<Note>If you're not sure a previous cancel call fully finished canceling every subscriber, it's safe to call it again — re-canceling an already-canceled plan re-runs the cascade and returns `200`, it does not error.</Note>

--- a/openapi/plans/cancel-plan.json
+++ b/openapi/plans/cancel-plan.json
@@ -1,0 +1,99 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "plans", "version": "1.0.0" },
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "private-secret-key", "x-default": "<Your private-secret-key>" }
+    }
+  },
+  "security": [{ "sec0": [], "sec1": [] }],
+  "paths": {
+    "/plans/{plan_id}/status": {
+      "post": {
+        "summary": "Cancel Plan",
+        "description": "The only supported status transition. Canceling a plan blocks new subscriptions AND synchronously cascade-cancels every subscription currently linked to it.",
+        "operationId": "cancel-plan",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "description": "The unique identifier of the plan.",
+            "schema": { "type": "string" },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["status"],
+                "properties": {
+                  "status": { "type": "string", "enum": ["CANCELED"] }
+                }
+              },
+              "examples": { "Result": { "value": { "status": "CANCELED" } } }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "00000000-0000-4000-8000-000000000001",
+                      "status": "CANCELED",
+                      "affected_subscriptions": 3
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "status": { "type": "string" },
+                    "affected_subscriptions": {
+                      "type": "integer",
+                      "description": "The number of subscriptions that were cascade-canceled along with the plan."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400. Reserved for a plan status outside ACTIVE/CANCELED — not currently reachable, since those are the plan's only two statuses today. Re-canceling an already-CANCELED plan does NOT hit this: it re-runs the cascade and returns 200.",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "INVALID_STATE",
+                      "messages": ["The subscription state does not support the action requested."]
+                    },
+                    "summary": "Result"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "INVALID_STATE" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": { "headers": [{ "value": "utf-8", "key": "charset" }], "explorer-enabled": true, "proxy-enabled": true },
+  "x-readme-fauxas": true
+}

--- a/openapi/plans/create-plan.json
+++ b/openapi/plans/create-plan.json
@@ -1,0 +1,326 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "plans",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/plans": {
+      "post": {
+        "summary": "Create Plan",
+        "description": "Creates a reusable pricing plan. Plans are immutable once created — a price change means creating a new plan; existing subscriptions on the old plan are unaffected.",
+        "operationId": "create-plan",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name", "base_amount", "frequency"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The plan name (MAX 255; MIN 3)."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The plan description. No length limit is currently enforced."
+                  },
+                  "merchant_reference": {
+                    "type": "string",
+                    "description": "Your own identifier for the plan. No length limit is currently enforced."
+                  },
+                  "base_amount": {
+                    "type": "object",
+                    "description": "The default price used for any country without an explicit entry in `country_prices`.",
+                    "required": ["currency", "value"],
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "description": "MAX 3; MIN 3; [ISO 4217](/reference/country-reference)."
+                      },
+                      "value": {
+                        "type": "number",
+                        "description": "Multiple of 0.0001.",
+                        "format": "float"
+                      }
+                    }
+                  },
+                  "frequency": {
+                    "type": "object",
+                    "description": "The billing frequency for the plan. Subscriptions created from this plan inherit it.",
+                    "required": ["type", "value"],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["DAY", "WEEK", "MONTH", "YEAR"]
+                      },
+                      "value": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "country_prices": {
+                    "type": "array",
+                    "description": "Optional explicit per-country prices. A country not listed falls back to `base_amount`.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "country": {
+                          "type": "string",
+                          "description": "[ISO 3166-1](/reference/country-reference)."
+                        },
+                        "amount": {
+                          "type": "object",
+                          "properties": {
+                            "currency": { "type": "string" },
+                            "value": { "type": "number", "format": "float" }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "allowed_payment_methods": {
+                    "type": "array",
+                    "description": "Payment method types accepted for subscriptions on this plan.",
+                    "items": { "type": "string" }
+                  },
+                  "metadata": {
+                    "type": "array",
+                    "description": "Key-value pairs attached to the plan. Independent of any metadata set on a subscription created from it.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": { "type": "string", "description": "MAX 48." },
+                        "value": { "type": "string", "description": "MAX 512." }
+                      }
+                    }
+                  },
+                  "phases": {
+                    "type": "array",
+                    "description": "Optional leading ladder (for example, a trial) before the plan's regular price. Omit for a flat plan. The last entry must be the terminal REGULAR phase with no `duration`.",
+                    "items": {
+                      "type": "object",
+                      "required": ["order", "type", "name"],
+                      "properties": {
+                        "order": { "type": "integer", "format": "int32" },
+                        "name": {
+                          "type": "string",
+                          "description": "Required, non-empty — each phase must have a name."
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": ["TRIAL", "REGULAR"]
+                        },
+                        "duration": {
+                          "type": "object",
+                          "description": "Required on every non-terminal phase, omitted on the terminal REGULAR phase.",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": ["DAY", "WEEK", "MONTH", "YEAR"]
+                            },
+                            "value": { "type": "integer", "format": "int32" }
+                          }
+                        },
+                        "frequency": {
+                          "type": "object",
+                          "description": "Optional. If omitted, the phase bills as a single lump-sum charge covering the whole `duration`. If set, the phase bills every `frequency` interval instead, and the server computes `total_payments = duration / frequency` (both in the same unit) — e.g. a 3-month duration with a 1-month frequency produces 3 charges. Not applicable to the terminal phase.",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": ["DAY", "WEEK", "MONTH", "YEAR"]
+                            },
+                            "value": { "type": "integer", "format": "int32" }
+                          }
+                        },
+                        "amount": {
+                          "type": "object",
+                          "description": "Flat price for the phase. 0 is allowed (a free trial). On a **non-terminal** phase, this or `country_prices` is required (one of the two). On the **terminal** REGULAR phase, omit this entirely — sending it is rejected with `400 BAD_REQUEST` (\"The terminal phase price comes from the plan base_amount/country_prices - remove the phase amount\"); the terminal price always comes from the plan's own `base_amount`/`country_prices`.",
+                          "properties": {
+                            "currency": { "type": "string" },
+                            "value": { "type": "number", "format": "float" }
+                          }
+                        },
+                        "country_prices": {
+                          "type": "array",
+                          "description": "Per-country prices for this phase. On a non-terminal phase, this or `amount` is required. Not applicable to the terminal phase — its pricing always comes from the plan's own `country_prices`.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "country": { "type": "string" },
+                              "amount": {
+                                "type": "object",
+                                "properties": {
+                                  "currency": { "type": "string" },
+                                  "value": { "type": "number", "format": "float" }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "Plan": {
+                  "value": {
+                    "name": "Streaming Pro",
+                    "description": "Access to Pro features, billed monthly",
+                    "merchant_reference": "streaming-pro-monthly",
+                    "base_amount": { "currency": "USD", "value": 20.0 },
+                    "frequency": { "type": "MONTH", "value": 1 },
+                    "country_prices": [
+                      { "country": "US", "amount": { "currency": "USD", "value": 20.0 } },
+                      { "country": "BR", "amount": { "currency": "BRL", "value": 99.9 } }
+                    ],
+                    "allowed_payment_methods": ["CARD", "PIX"],
+                    "metadata": [{ "key": "campaign", "value": "app_store" }],
+                    "phases": [
+                      {
+                        "order": 1,
+                        "name": "Intro",
+                        "type": "TRIAL",
+                        "duration": { "type": "MONTH", "value": 3 },
+                        "frequency": { "type": "MONTH", "value": 1 },
+                        "amount": { "currency": "USD", "value": 9.99 }
+                      },
+                      { "order": 2, "name": "Regular", "type": "REGULAR" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "00000000-0000-4000-8000-000000000001",
+                      "account_id": "00000000-0000-4000-8000-000000000002",
+                      "name": "Streaming Pro",
+                      "description": "Access to Pro features, billed monthly",
+                      "merchant_reference": "streaming-pro-monthly",
+                      "status": "ACTIVE",
+                      "base_amount": { "currency": "USD", "value": 20.0 },
+                      "frequency": { "type": "MONTH", "value": 1 },
+                      "country_prices": [
+                        { "country": "US", "amount": { "currency": "USD", "value": 20.0 } },
+                        { "country": "BR", "amount": { "currency": "BRL", "value": 99.9 } }
+                      ],
+                      "allowed_payment_methods": ["CARD", "PIX"],
+                      "metadata": [{ "key": "campaign", "value": "app_store" }],
+                      "phases": [],
+                      "created_at": "2024-01-15T10:30:00.000000Z",
+                      "updated_at": "2024-01-15T10:30:00.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "account_id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "merchant_reference": { "type": "string" },
+                    "status": { "type": "string", "example": "ACTIVE" },
+                    "base_amount": {
+                      "type": "object",
+                      "properties": {
+                        "currency": { "type": "string" },
+                        "value": { "type": "number" }
+                      }
+                    },
+                    "frequency": {
+                      "type": "object",
+                      "properties": {
+                        "type": { "type": "string" },
+                        "value": { "type": "integer" }
+                      }
+                    },
+                    "country_prices": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "country": { "type": "string" },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": { "type": "string" },
+                              "value": { "type": "number" }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "allowed_payment_methods": { "type": "array", "items": { "type": "string" } },
+                    "metadata": { "type": "array", "items": { "type": "object" } },
+                    "phases": { "type": "array", "items": { "type": "object" } },
+                    "created_at": { "type": "string" },
+                    "updated_at": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": "{\n Refer to the HTTP Response Codes section for more details: 'https://docs.y.uno/reference/response-codes'\n}",
+                    "summary": "Result"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/plans/create-plan.json
+++ b/openapi/plans/create-plan.json
@@ -114,7 +114,7 @@
                   },
                   "metadata": {
                     "type": "array",
-                    "description": "Key-value pairs attached to the plan. Independent of any metadata set on a subscription created from it.",
+                    "description": "Key-value pairs attached to the plan. Independent of any `metadata` set on a subscription created from it.",
                     "items": {
                       "type": "object",
                       "properties": {

--- a/openapi/plans/list-plans.json
+++ b/openapi/plans/list-plans.json
@@ -1,0 +1,125 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "plans", "version": "1.0.0" },
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "private-secret-key", "x-default": "<Your private-secret-key>" }
+    }
+  },
+  "security": [{ "sec0": [], "sec1": [] }],
+  "paths": {
+    "/plans": {
+      "get": {
+        "summary": "List Plans",
+        "description": "Returns a paginated, grid-ready list of plans for the authenticated account. 1-indexed pagination.",
+        "operationId": "list-plans",
+        "parameters": [
+          { "name": "page", "in": "query", "description": "1-indexed page number. Must be >= 1, else `400 BAD_REQUEST` (\"The page must be greater than or equal to 1\").", "schema": { "type": "integer", "default": 1, "minimum": 1 } },
+          { "name": "size", "in": "query", "description": "Page size. Must be between 1 and 100 inclusive, else `400 BAD_REQUEST` (\"The size must be greater than or equal to 1\" if too low, \"The size must be at most 100\" if too high).", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 } }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "items": [
+                        {
+                          "id": "00000000-0000-4000-8000-000000000001",
+                          "account_id": "00000000-0000-4000-8000-000000000002",
+                          "name": "Streaming Pro",
+                          "merchant_reference": "streaming-pro-monthly",
+                          "status": "ACTIVE",
+                          "base_amount": { "currency": "USD", "value": 20.0 },
+                          "frequency": { "type": "MONTH", "value": 1 },
+                          "subscribers_count": 3,
+                          "countries": ["BR", "US"],
+                          "created_at": "2024-01-15T10:30:00.000000Z"
+                        }
+                      ],
+                      "pagination": { "page": 1, "size": 20, "total": 1, "total_pages": 1 }
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "account_id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "merchant_reference": { "type": "string" },
+                          "status": { "type": "string" },
+                          "base_amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": { "type": "string" },
+                              "value": { "type": "number" }
+                            }
+                          },
+                          "frequency": {
+                            "type": "object",
+                            "properties": {
+                              "type": { "type": "string" },
+                              "value": { "type": "integer" }
+                            }
+                          },
+                          "subscribers_count": { "type": "integer" },
+                          "countries": { "type": "array", "items": { "type": "string" } },
+                          "created_at": { "type": "string" }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "page": { "type": "integer" },
+                        "size": { "type": "integer" },
+                        "total": { "type": "integer" },
+                        "total_pages": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": ["The page must be greater than or equal to 1"]
+                    },
+                    "summary": "Result"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "BAD_REQUEST" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": { "headers": [{ "value": "utf-8", "key": "charset" }], "explorer-enabled": true, "proxy-enabled": true },
+  "x-readme-fauxas": true
+}

--- a/openapi/plans/retrieve-plan.json
+++ b/openapi/plans/retrieve-plan.json
@@ -1,0 +1,146 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "plans", "version": "1.0.0" },
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "private-secret-key", "x-default": "<Your private-secret-key>" }
+    }
+  },
+  "security": [{ "sec0": [], "sec1": [] }],
+  "paths": {
+    "/plans/{plan_id}": {
+      "get": {
+        "summary": "Retrieve Plan",
+        "description": "",
+        "operationId": "retrieve-plan",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "description": "The unique identifier of the plan.",
+            "schema": { "type": "string" },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "00000000-0000-4000-8000-000000000001",
+                      "account_id": "00000000-0000-4000-8000-000000000002",
+                      "name": "Streaming Pro",
+                      "description": "Access to Pro features, billed monthly",
+                      "merchant_reference": "streaming-pro-monthly",
+                      "status": "ACTIVE",
+                      "base_amount": { "currency": "USD", "value": 20.0 },
+                      "frequency": { "type": "MONTH", "value": 1 },
+                      "country_prices": [
+                        { "country": "US", "amount": { "currency": "USD", "value": 20.0 } },
+                        { "country": "BR", "amount": { "currency": "BRL", "value": 99.9 } }
+                      ],
+                      "allowed_payment_methods": ["CARD", "PIX"],
+                      "metadata": [{ "key": "campaign", "value": "app_store" }],
+                      "phases": [
+                        {
+                          "order": 1,
+                          "name": "Intro",
+                          "type": "TRIAL",
+                          "duration": { "type": "MONTH", "value": 3 },
+                          "frequency": { "type": "MONTH", "value": 1 },
+                          "amount": { "currency": "USD", "value": 9.99 },
+                          "total_payments": 3,
+                          "country_prices": []
+                        },
+                        {
+                          "order": 2,
+                          "name": "Regular",
+                          "type": "REGULAR",
+                          "duration": null,
+                          "frequency": null,
+                          "amount": null,
+                          "total_payments": null,
+                          "country_prices": []
+                        }
+                      ],
+                      "created_at": "2024-01-15T10:30:00.000000Z",
+                      "updated_at": "2024-01-15T10:30:00.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "account_id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "merchant_reference": { "type": "string" },
+                    "status": { "type": "string" },
+                    "base_amount": {
+                      "type": "object",
+                      "properties": { "currency": { "type": "string" }, "value": { "type": "number" } }
+                    },
+                    "frequency": {
+                      "type": "object",
+                      "properties": { "type": { "type": "string" }, "value": { "type": "integer" } }
+                    },
+                    "country_prices": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "country": { "type": "string" },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": { "type": "string" },
+                              "value": { "type": "number" }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "allowed_payment_methods": { "type": "array", "items": { "type": "string" } },
+                    "metadata": { "type": "array", "items": { "type": "object" } },
+                    "phases": { "type": "array", "items": { "type": "object" } },
+                    "created_at": { "type": "string" },
+                    "updated_at": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": { "code": "PLAN_NOT_FOUND", "messages": ["Plan not found."] },
+                    "summary": "Result"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "PLAN_NOT_FOUND" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": { "headers": [{ "value": "utf-8", "key": "charset" }], "explorer-enabled": true, "proxy-enabled": true },
+  "x-readme-fauxas": true
+}

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -77,7 +77,7 @@
                   },
                   "amount": {
                     "type": "object",
-                    "description": "Specifies the `amount` object, with the value of each subscription payment and the used currency.",
+                    "description": "Specifies the `amount` object, with the value of each subscription payment and the used currency. Mutually exclusive with `plan_id` — send exactly one of the two.",
                     "required": [
                       "currency",
                       "value"
@@ -93,6 +93,10 @@
                         "format": "float"
                       }
                     }
+                  },
+                  "plan_id": {
+                    "type": "string",
+                    "description": "The unique identifier of a [plan](/reference/plans/the-plan-object) to subscribe this customer to. Mutually exclusive with `amount` — send exactly one of the two. Omit `trial_period` and `billing_date` when set: both are inherited from the plan and the request is rejected with `400 BAD_REQUEST` if you send them. Also omit `frequency` — it's inherited from the plan too, but sending it anyway is not rejected: it's silently ignored and overridden by the plan's frequency."
                   },
                   "additional_data": {
                     "type": "object",
@@ -648,6 +652,44 @@
                       }
                     },
                     "metadata": {},
+                    "plan_id": {
+                      "type": "string",
+                      "description": "Only present when the subscription is linked to a plan."
+                    },
+                    "plan_assigned_at": {
+                      "type": "string",
+                      "description": "Only present on plan-linked subscriptions. The moment the plan was attached — at creation from a plan, migration onto a plan, or a plan change."
+                    },
+                    "previous_subscription_id": {
+                      "type": "string",
+                      "description": "Only present when this subscription was created by a plan change (switching an existing subscription to a different plan)."
+                    },
+                    "current_phase": {
+                      "type": "string",
+                      "description": "Only present on plan-linked subscriptions."
+                    },
+                    "billing_phases": {
+                      "type": "array",
+                      "description": "Only present on plan-linked subscriptions whose plan has phases. Contains the leading TRIAL phases only, snapshotted at creation — the terminal REGULAR phase is never included, since its price isn't pinned and instead resolves from the plan at every billing.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "order": { "type": "integer" },
+                          "type": { "type": "string", "description": "Always TRIAL — the terminal REGULAR phase is never in this array." },
+                          "name": { "type": "string" },
+                          "amount": {
+                            "type": "object",
+                            "properties": { "currency": { "type": "string" }, "value": { "type": "number" } }
+                          },
+                          "frequency": {
+                            "type": "object",
+                            "properties": { "type": { "type": "string" }, "value": { "type": "integer" } }
+                          },
+                          "start_cycle": { "type": "integer" },
+                          "end_cycle": { "type": "integer" }
+                        }
+                      }
+                    },
                     "subscription_agreement_id": {
                       "type": "string",
                       "example": "sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa"

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -195,11 +195,12 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "description": "The type of interval the subscription will have in time (DAY, WEEK, MONTH). If not set, defaults to MONTH.",
+                        "description": "The type of interval the subscription will have in time (DAY, WEEK, MONTH, YEAR). If not set, defaults to MONTH.",
                         "enum": [
                           "DAY",
                           "WEEK",
-                          "MONTH"
+                          "MONTH",
+                          "YEAR"
                         ]
                       },
                       "value": {

--- a/openapi/subscriptions/list-subscription-payments.json
+++ b/openapi/subscriptions/list-subscription-payments.json
@@ -1,0 +1,182 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "subscription", "version": "1.0.2" },
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "private-secret-key", "x-default": "<Your private-secret-key>" }
+    }
+  },
+  "security": [{ "sec0": [], "sec1": [] }],
+  "paths": {
+    "/subscriptions/{subscription_id}/payments": {
+      "get": {
+        "summary": "List Subscription Payments",
+        "description": "Returns the charge history for a subscription — one row per billing attempt, including plan/phase context when the subscription is linked to a plan. This is a net-new endpoint (there was no payments subresource before Plans), so it ships as a single, clean shape with no legacy fields to carry.",
+        "operationId": "list-subscription-payments",
+        "parameters": [
+          {
+            "name": "subscription_id",
+            "in": "path",
+            "description": "The unique identifier of the subscription.",
+            "schema": { "type": "string" },
+            "required": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max items to return. 1-100, defaults to 20.",
+            "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of items to skip. Must be a non-negative multiple of `limit`, else `400 BAD_REQUEST` — a non-aligned offset would re-serve rows you already saw and corrupt `has_more`. Defaults to 0.",
+            "schema": { "type": "integer", "default": 0, "minimum": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "items": [
+                        {
+                          "id": "00000000-0000-4000-8000-000000000010",
+                          "payment_id": "00000000-0000-4000-8000-000000000011",
+                          "idempotency_key": null,
+                          "status": "SUCCEEDED",
+                          "sub_status": null,
+                          "provider": "PROVIDER_TEST",
+                          "payment_method": { "id": "00000000-0000-4000-8000-000000000012", "type": "CARD" },
+                          "amount": { "currency": "USD", "value": 9.99 },
+                          "currency": "USD",
+                          "subtotal": 9.99,
+                          "total": 9.99,
+                          "plan_id": "00000000-0000-4000-8000-000000000001",
+                          "line_items": [
+                            {
+                              "type": "PLAN",
+                              "label": "Intro",
+                              "service_period": { "start": "2024-04-01T09:00:00Z", "end": "2024-05-01T09:00:00Z" },
+                              "amount": { "currency": "USD", "value": 9.99 }
+                            }
+                          ],
+                          "phase": { "index": 1, "name": "Intro", "type": "TRIAL" },
+                          "phase_payment": 1,
+                          "billing_cycle": null,
+                          "retry": { "count": 0, "forced": false },
+                          "trace_id": null,
+                          "created_at": "2024-04-01T09:00:00.000000Z",
+                          "updated_at": "2024-04-01T09:00:00.000000Z"
+                        }
+                      ],
+                      "pagination": { "total": 1, "limit": 20, "offset": 0, "has_more": false }
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "description": "Every payment attempt for this subscription, most recent first.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "payment_id": { "type": "string" },
+                          "idempotency_key": { "type": "string" },
+                          "status": {
+                            "type": "string",
+                            "description": "Platform vocabulary: SUCCEEDED, DECLINED, REJECTED, ERROR, PENDING, CREATED, CANCELED — not the engine's internal EXECUTED."
+                          },
+                          "sub_status": { "type": "string" },
+                          "provider": {
+                            "type": "string",
+                            "description": "null for $0 cycles, the starter row, and rows charged before the provider-capture field existed."
+                          },
+                          "payment_method": {
+                            "type": "object",
+                            "properties": { "id": { "type": "string" }, "type": { "type": "string" } }
+                          },
+                          "amount": {
+                            "type": "object",
+                            "properties": { "currency": { "type": "string" }, "value": { "type": "number" } }
+                          },
+                          "currency": { "type": "string" },
+                          "subtotal": { "type": "number" },
+                          "total": { "type": "number" },
+                          "plan_id": { "type": "string", "description": "null for raw (non-plan) subscriptions." },
+                          "line_items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": { "type": "string" },
+                                "label": { "type": "string" },
+                                "service_period": {
+                                  "type": "object",
+                                  "properties": { "start": { "type": "string" }, "end": { "type": "string" } }
+                                },
+                                "amount": {
+                                  "type": "object",
+                                  "properties": { "currency": { "type": "string" }, "value": { "type": "number" } }
+                                }
+                              }
+                            }
+                          },
+                          "phase": {
+                            "type": "object",
+                            "description": "null for the starter row and for legacy (non-plan) rows.",
+                            "properties": {
+                              "index": { "type": "integer" },
+                              "name": { "type": "string" },
+                              "type": { "type": "string" }
+                            }
+                          },
+                          "phase_payment": { "type": "integer", "description": "1..N within the current phase. null on the starter row." },
+                          "billing_cycle": {
+                            "type": "integer",
+                            "description": "0 = starter row, null = TRIAL-phase rows, 1.. from the first REGULAR-phase payment."
+                          },
+                          "retry": {
+                            "type": "object",
+                            "properties": { "count": { "type": "integer" }, "forced": { "type": "boolean" } }
+                          },
+                          "trace_id": { "type": "string" },
+                          "created_at": { "type": "string" },
+                          "updated_at": { "type": "string" }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "total": { "type": "integer" },
+                        "limit": { "type": "integer" },
+                        "offset": { "type": "integer" },
+                        "has_more": { "type": "boolean" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [{ "value": "utf-8", "key": "charset" }],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/subscriptions/retrieve-subscription.json
+++ b/openapi/subscriptions/retrieve-subscription.json
@@ -116,6 +116,20 @@
                         "5104911d-5df9-229e-8468-bd41abea1a4s"
                       ],
                       "subscription_agreement_id": null,
+                      "plan_id": "00000000-0000-4000-8000-000000000001",
+                      "plan_assigned_at": "2023-12-16T20:46:54.786342Z",
+                      "current_phase": "REGULAR",
+                      "billing_phases": [
+                        {
+                          "order": 1,
+                          "type": "TRIAL",
+                          "name": "Intro",
+                          "amount": { "currency": "USD", "value": 9.99 },
+                          "frequency": { "type": "MONTH", "value": 1 },
+                          "start_cycle": 0,
+                          "end_cycle": 2
+                        }
+                      ],
                       "created_at": "2023-12-16T20:46:54.786342Z",
                       "updated_at": "2023-12-16T21:00:54.786342Z"
                     }
@@ -330,6 +344,53 @@
                     "subscription_agreement_id": {
                       "type": "string",
                       "example": "sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa"
+                    },
+                    "plan_id": {
+                      "type": "string",
+                      "description": "Only present when the subscription is linked to a plan.",
+                      "example": "00000000-0000-4000-8000-000000000001"
+                    },
+                    "plan_assigned_at": {
+                      "type": "string",
+                      "description": "Only present on plan-linked subscriptions. The moment the plan was attached — at creation from a plan, migration onto a plan, or a plan change.",
+                      "example": "2023-12-16T20:46:54.786342Z"
+                    },
+                    "previous_subscription_id": {
+                      "type": "string",
+                      "description": "Only present when this subscription was created by a plan change (switching an existing subscription to a different plan)."
+                    },
+                    "current_phase": {
+                      "type": "string",
+                      "description": "Only present on plan-linked subscriptions.",
+                      "example": "REGULAR"
+                    },
+                    "billing_phases": {
+                      "type": "array",
+                      "description": "Only present on plan-linked subscriptions whose plan has phases. Contains the leading TRIAL phases only, snapshotted at creation — the terminal REGULAR phase is never included, since its price isn't pinned and instead resolves from the plan at every billing. `current_phase: \"REGULAR\"` is how you know the ladder is exhausted.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "order": { "type": "integer" },
+                          "type": { "type": "string", "description": "Always TRIAL — the terminal REGULAR phase is never in this array." },
+                          "name": { "type": "string" },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": { "type": "string" },
+                              "value": { "type": "number" }
+                            }
+                          },
+                          "frequency": {
+                            "type": "object",
+                            "properties": {
+                              "type": { "type": "string" },
+                              "value": { "type": "integer" }
+                            }
+                          },
+                          "start_cycle": { "type": "integer" },
+                          "end_cycle": { "type": "integer" }
+                        }
+                      }
                     },
                     "created_at": {
                       "type": "string",

--- a/reference/plans/cancel-plan.mdx
+++ b/reference/plans/cancel-plan.mdx
@@ -1,0 +1,13 @@
+---
+title: "Cancel Plan"
+openapi: "/openapi/plans/cancel-plan.json POST /plans/{plan_id}/status"
+description: "Cancels a plan and cascade-cancels every subscription currently linked to it."
+---
+
+<Danger>
+**Cascade cancellation is synchronous and immediate**
+
+Canceling a plan cancels every subscription on it right away — there's no way to cancel the plan without also canceling its subscribers. Check `affected_subscriptions` in the response to know how many were affected.
+
+Re-canceling an already-`CANCELED` plan is safe and re-runs the cascade — it returns `200` again, not an error. This is deliberate: it's the recovery path if a previous cascade partially failed to cancel some subscriptions, so retry a cancel call if you're unsure it fully completed. `INVALID_STATE` (`400`) is reserved for a plan status outside `ACTIVE`/`CANCELED`, which isn't currently reachable given those are the only two plan statuses.
+</Danger>

--- a/reference/plans/create-plan.mdx
+++ b/reference/plans/create-plan.mdx
@@ -1,0 +1,13 @@
+---
+title: "Create Plan"
+openapi: "/openapi/plans/create-plan.json POST /plans"
+description: "Creates a reusable pricing plan with optional per-country pricing and a trial phase ladder."
+---
+
+<Note>
+**Plans are immutable**
+
+There's no update endpoint. A price change means creating a new plan — existing subscriptions stay on the plan (and price) they were created with.
+</Note>
+
+Refer to the [HTTP Response Codes](/reference/response-codes) section for details on possible error outcomes.

--- a/reference/plans/list-plans.mdx
+++ b/reference/plans/list-plans.mdx
@@ -1,0 +1,11 @@
+---
+title: "List Plans"
+openapi: "/openapi/plans/list-plans.json GET /plans"
+description: "Returns a paginated list of your plans."
+---
+
+<Warning>
+**List items are a summary, not the full plan**
+
+`metadata` and `phases` are only returned by [Retrieve Plan](/reference/plans/retrieve-plan), not by this list endpoint. If you need either one for every plan in a grid, call Retrieve Plan per item.
+</Warning>

--- a/reference/plans/retrieve-plan.mdx
+++ b/reference/plans/retrieve-plan.mdx
@@ -1,0 +1,5 @@
+---
+title: "Retrieve Plan"
+openapi: "/openapi/plans/retrieve-plan.json GET /plans/{plan_id}"
+description: "Get the full details of a plan, including its phases and per-country pricing."
+---

--- a/reference/plans/the-plan-object.mdx
+++ b/reference/plans/the-plan-object.mdx
@@ -1,0 +1,192 @@
+---
+title: "The Plan Object"
+description: "Documents the plan object's attributes, including per-country pricing, phases, and metadata."
+---
+
+## Attributes
+
+A plan is a reusable pricing catalog entry. Subscribe a customer to a plan instead of setting `amount`/`frequency` directly on the subscription, and every field that defines "how much, how often" is resolved from the plan.
+
+<ParamField body="id" type="string">
+  The unique identifier of the plan (MAX 64; MIN 36).
+
+  Example: 00000000-0000-4000-8000-000000000001
+</ParamField>
+
+<ParamField body="account_id" type="string">
+  The unique identifier of the account the plan belongs to (MAX 64; MIN 36).
+
+  Example: 00000000-0000-4000-8000-000000000002
+</ParamField>
+
+<ParamField body="name" type="string">
+  The plan name (MAX 255; MIN 3).
+
+  Example: Streaming Pro
+</ParamField>
+
+<ParamField body="description" type="string">
+  The plan description. No length limit is currently enforced.
+
+  Example: Access to Pro features, billed monthly
+</ParamField>
+
+<ParamField body="merchant_reference" type="string">
+  Your own identifier for the plan. No length limit is currently enforced.
+
+  Example: streaming-pro-monthly
+</ParamField>
+
+<ParamField body="status" type="enum">
+  Status of the plan.
+
+  Possible values:
+  - `ACTIVE` = The plan can be subscribed to.
+  - `CANCELED` = The plan no longer accepts new subscriptions. Canceling a plan also cancels every subscription currently linked to it.
+</ParamField>
+
+<ParamField body="base_amount" type="object">
+  The default price charged in any country without an explicit entry in `country_prices`.
+
+  <Expandable title="properties">
+    <ParamField body="currency" type="enum">
+      The currency used to make the payment (MAX 3; MIN 3; <a href="/reference/country-reference">ISO 4217</a>).
+    </ParamField>
+
+    <ParamField body="value" type="number">
+      The payment amount (multiple of 0.0001).
+
+      Example: 20.00
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="frequency" type="object">
+  The billing frequency for the plan. Every subscription created from this plan inherits it — do not send `frequency` when subscribing with a `plan_id`.
+
+  <Expandable title="properties">
+    <ParamField body="type" type="enum">
+      Possible enum values: `DAY`, `WEEK`, `MONTH`, or `YEAR`.
+    </ParamField>
+
+    <ParamField body="value" type="int">
+      Example: 1
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="country_prices" type="array of objects">
+  Explicit per-country prices. A country not listed here falls back to `base_amount`.
+
+  <Expandable title="properties">
+    <ParamField body="country" type="string">
+      MAX 2; MIN 2; <a href="/reference/country-reference">ISO 3166-1</a>.
+    </ParamField>
+
+    <ParamField body="amount" type="object">
+      <Expandable title="properties">
+        <ParamField body="currency" type="enum" />
+        <ParamField body="value" type="number" />
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="allowed_payment_methods" type="array of strings">
+  Payment method types accepted for subscriptions on this plan.
+
+  Example: `["CARD", "PIX"]`
+</ParamField>
+
+<ParamField body="metadata" type="array of objects">
+  Key-value pairs attached to the plan itself. This is independent of any `metadata` set directly on a subscription — see the [Subscription object](/reference/subscriptions/the-subscription-object) for that.
+
+  <Expandable title="properties">
+    <ParamField body="key" type="string">
+      Example: campaign
+    </ParamField>
+
+    <ParamField body="value" type="string">
+      Example: app_store
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="phases" type="array of objects">
+  An optional leading ladder of phases (for example, a trial) before the plan's regular price applies. Omit for a flat plan with no trial.
+
+  <Expandable title="properties">
+    <ParamField body="order*" type="int">
+      1-indexed position in the ladder. The highest `order` is the terminal, regular-price phase and has no `duration`. Required.
+    </ParamField>
+
+    <ParamField body="name*" type="string">
+      Required, non-empty — every phase must have a name.
+    </ParamField>
+
+    <ParamField body="type*" type="enum">
+      Required. Possible values: `TRIAL` (any leading phase, any price including 0), `REGULAR` (the terminal phase).
+    </ParamField>
+
+    <ParamField body="duration" type="object">
+      Required on every non-terminal phase; omitted on the terminal phase.
+
+      <Expandable title="properties">
+        <ParamField body="type" type="enum">
+          `DAY`, `WEEK`, `MONTH`, or `YEAR`.
+        </ParamField>
+        <ParamField body="value" type="int" />
+      </Expandable>
+    </ParamField>
+
+    <ParamField body="frequency" type="object">
+      Optional. If omitted, the phase bills as a single lump-sum charge covering the whole `duration`. If set, the phase bills every `frequency` interval instead. Not applicable to the terminal phase.
+
+      <Expandable title="properties">
+        <ParamField body="type" type="enum">
+          `DAY`, `WEEK`, `MONTH`, or `YEAR`.
+        </ParamField>
+        <ParamField body="value" type="int" />
+      </Expandable>
+    </ParamField>
+
+    <ParamField body="amount" type="object">
+      The phase's flat price. 0 is allowed (a free trial).
+
+      <Warning>On a **non-terminal** phase, this or `country_prices` is required — one of the two. On the **terminal** REGULAR phase, omit this entirely: sending an `amount` there is rejected with `400 BAD_REQUEST` ("The terminal phase price comes from the plan base_amount/country_prices - remove the phase amount"). The terminal phase's price always comes from the plan's own `base_amount`/`country_prices`, never from a phase-level field.</Warning>
+    </ParamField>
+
+    <ParamField body="country_prices" type="array of objects">
+      Per-country prices for this phase, same shape as the plan-level `country_prices`. On a non-terminal phase, this or `amount` is required. Not applicable to the terminal phase.
+    </ParamField>
+
+    <ParamField body="total_payments" type="int">
+      Server-computed. If `frequency` is omitted, always `1` (one lump-sum charge for the whole phase). If `frequency` is set, `duration / frequency` (both in the same unit) — e.g. a 3-month duration billed monthly (`frequency: {type: MONTH, value: 1}`) produces `3`. `null` on the terminal phase.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="subscribers_count" type="int">
+  The number of live subscriptions (in any non-terminal status) currently on this plan. This is the set a cancel would affect.
+
+  Example: 12
+
+  <Note>Only returned by [List Plans](/reference/plans/list-plans) — not present on [Create Plan](/reference/plans/create-plan) or [Retrieve Plan](/reference/plans/retrieve-plan) responses.</Note>
+</ParamField>
+
+<ParamField body="countries" type="array of strings">
+  Sorted ISO α2 codes — the distinct union of every country this plan explicitly prices, at the plan level or inside any phase. An empty array means the plan applies globally via `base_amount`, not that it has no coverage.
+
+  <Note>Only returned by [List Plans](/reference/plans/list-plans) — not present on [Create Plan](/reference/plans/create-plan) or [Retrieve Plan](/reference/plans/retrieve-plan) responses.</Note>
+</ParamField>
+
+<ParamField body="created_at" type="Timestamp" />
+<ParamField body="updated_at" type="Timestamp" />
+
+## Related
+
+* [Create Plan](/reference/plans/create-plan)
+* [Retrieve Plan](/reference/plans/retrieve-plan)
+* [List Plans](/reference/plans/list-plans)
+* [Cancel Plan](/reference/plans/cancel-plan)
+* [The Subscription Object](/reference/subscriptions/the-subscription-object) — see `plan_id` for how a subscription links back to its plan

--- a/reference/subscriptions/list-subscription-payments.mdx
+++ b/reference/subscriptions/list-subscription-payments.mdx
@@ -1,0 +1,23 @@
+---
+title: "List Subscription Payments"
+openapi: "/openapi/subscriptions/list-subscription-payments.json GET /subscriptions/{subscription_id}/payments"
+description: "Returns the charge history for a subscription, including plan/phase context when applicable."
+---
+
+<Note>
+**This is a net-new endpoint**
+
+There was no payments subresource before Plans — the `payments` array on [the subscription object](/reference/subscriptions/the-subscription-object) is a legacy, always-empty field. Since there's no prior merchant integration to preserve here, this endpoint ships as one clean `items[]` shape with full plan/phase context — no legacy fields.
+</Note>
+
+<Warning>
+**`offset` must be a multiple of `limit`**
+
+A non-aligned `offset` would re-serve rows you already saw and corrupt `has_more`, so it's rejected with `400 BAD_REQUEST` instead of being silently floored.
+</Warning>
+
+<Warning>
+**Free cycles are `total: 0`, not a distinct status**
+
+A $0 billing cycle (e.g. a free trial payment) is recognizable by `total == 0` — there's no separate "free" status.
+</Warning>

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -53,10 +53,64 @@ This object represents a subscription that can be associated with a customer.
   Status of the subscription.
 
   Possible values:
+  - `CREATED` = Transitory status while the initial payment hasn't been processed yet. Only occurs when the subscription is created with `initial_payment_validation: true`; it transitions to `ACTIVE` once the first payment succeeds (or to `CANCELED` if it fails and retries are exhausted).
   - `ACTIVE` = The subscription has been created with an associated customer and is already active.
+  - `TRIALING` = The subscription is inside a plan's leading trial phase (see `plan_id`/`current_phase`). Transitions to `ACTIVE` automatically once the trial ends — this is webhooked like any other status change.
   - `PAUSED` = The subscription has been paused and can be reactivated.
   - `COMPLETED` = The subscription is completed because it reached the end date and time.
   - `CANCELED` = Subscription canceled.
+</ParamField>
+
+<ParamField body="plan_id" type="string">
+  The unique identifier of the [plan](/reference/plans/the-plan-object) this subscription was created from, if any (MAX 64; MIN 36). Only present when the subscription is linked to a plan — absent (not `null`) for subscriptions created with a raw `amount`/`frequency` instead of a `plan_id`.
+
+  Example: 00000000-0000-4000-8000-000000000001
+</ParamField>
+
+<ParamField body="plan_assigned_at" type="Timestamp">
+  When the subscription is linked to a plan, the moment the plan was attached — at creation from a plan, migration onto a plan, or a plan change. Only present on plan-linked subscriptions.
+</ParamField>
+
+<ParamField body="previous_subscription_id" type="string">
+  When this subscription was created by a [plan change](/docs/payment-features/subscriptions/plans) (switching an existing subscription to a different plan), this is the `id` of the subscription it replaced. Only present in that case.
+</ParamField>
+
+<ParamField body="current_phase" type="enum">
+  Which phase of the linked plan's trial ladder the subscription is currently in. Only present on plan-linked subscriptions.
+
+  Possible values: `TRIAL`, `REGULAR`.
+</ParamField>
+
+<ParamField body="billing_phases" type="array of objects">
+  The plan's leading TRIAL phases, snapshotted for this subscriber's country at creation time. Only present on plan-linked subscriptions whose plan has phases.
+
+  <Warning>**The terminal REGULAR phase is never included here.** Its price isn't pinned at creation — it resolves from the plan at every billing, so plan price edits reach running subscriptions. When `current_phase` is `REGULAR`, the ladder is exhausted and the subscription bills the plan's regular price; there's no corresponding row in this array for that.</Warning>
+
+  <Expandable title="properties">
+    <ParamField body="order" type="int" />
+    <ParamField body="type" type="enum">
+      Always `TRIAL` — see the note above.
+    </ParamField>
+    <ParamField body="name" type="string">
+      The only field not always present, mirroring the phase's own optional `name`.
+    </ParamField>
+    <ParamField body="amount" type="object">
+      <Expandable title="properties">
+        <ParamField body="currency" type="string" />
+        <ParamField body="value" type="number" />
+      </Expandable>
+    </ParamField>
+    <ParamField body="frequency" type="object">
+      <Expandable title="properties">
+        <ParamField body="type" type="enum">
+          `DAY`, `WEEK`, `MONTH`, or `YEAR`.
+        </ParamField>
+        <ParamField body="value" type="int" />
+      </Expandable>
+    </ParamField>
+    <ParamField body="start_cycle" type="int" />
+    <ParamField body="end_cycle" type="int" />
+  </Expandable>
 </ParamField>
 
 <ParamField body="amount" type="object">
@@ -82,9 +136,9 @@ This object represents a subscription that can be associated with a customer.
 
   <Expandable title="properties">
     <ParamField body="type" type="enum">
-      The type of interval the subscription will have in time (DAY, WEEK, MONTH). If not set, always MONTH by default.
+      The type of interval the subscription will have in time. If not set, always MONTH by default.
 
-      Possible enum values: `DAY`, `MONTH`, or `YEAR`.
+      Possible enum values: `DAY`, `WEEK`, `MONTH`, or `YEAR`.
     </ParamField>
 
     <ParamField body="value" type="int">
@@ -323,7 +377,7 @@ This object represents a subscription that can be associated with a customer.
   Specifies the payments array.
 
   <Note>
-    This array is currently always empty in webhook payloads. Subscribe to `payment.*` webhooks to track charges.
+    This array is currently always empty in webhook payloads. Subscribe to `payment.*` webhooks to track charges. For the subscription's full charge history (amounts, provider, phase context), use [List Subscription Payments](/reference/subscriptions/list-subscription-payments) instead of this field.
   </Note>
 
   <Expandable title="properties">

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -92,7 +92,7 @@ This object represents a subscription that can be associated with a customer.
       Always `TRIAL` — see the note above.
     </ParamField>
     <ParamField body="name" type="string">
-      The only field not always present, mirroring the phase's own optional `name`.
+      Mirrors the phase's own required `name`.
     </ParamField>
     <ParamField body="amount" type="object">
       <Expandable title="properties">


### PR DESCRIPTION
## Summary
- Adds the Plans resource: Create/Retrieve/List/Cancel Plan endpoints + The Plan Object reference
- Documents the new plan-linked subscription fields on Create/Retrieve Subscription and The Subscription Object: `plan_id`, `plan_assigned_at`, `previous_subscription_id`, `current_phase`, `billing_phases` (absent, not null, when not applicable)
- Adds the List Subscription Payments endpoint (single `items[]` shape, `limit`/`offset` pagination)
- Adds the `CREATED` subscription status and `WEEK` frequency value, previously undocumented
- All field claims cross-checked against `subscription-ms`/`payment-api`/`public-api` source and the internal SoT vault

## Test plan
- [ ] Copy review (descriptions, English wording, gating notes) — per the team's contribution flow, this is a human pass before merge
- [ ] Spot-check rendered pages on the Mintlify preview once deployed
- [ ] Confirm no broken links/anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI only; no application or payment-processing code changes. Integrators should still treat cancel-plan cascade behavior as operationally critical when using the API.
> 
> **Overview**
> Documents the **Plans** catalog and how subscriptions attach to it, without changing runtime code.
> 
> **Plans** get a new guide (`docs/payment-features/subscriptions/plans.mdx`), a **Subscriptions Plans** reference section (plan object + create, retrieve, list, cancel), and matching OpenAPI specs under `openapi/plans/`. The guide covers immutable pricing, per-country `country_prices`, trial **phases**, `plan_id` vs raw `amount`, and the synchronous cascade when a plan is canceled.
> 
> **Subscriptions** are updated so create/retrieve OpenAPI and **The Subscription Object** describe `plan_id` (mutually exclusive with `amount`), plan-linked fields (`plan_assigned_at`, `previous_subscription_id`, `current_phase`, `billing_phases`), **`TRIALING`** and **`CREATED`** statuses, and **`WEEK`/`YEAR`** on frequency. A new **`GET /subscriptions/{subscription_id}/payments`** reference and OpenAPI spec document charge history with plan/phase context.
> 
> **Navigation** in `docs.json` adds the plans guide under Payment Features → Subscriptions and wires the new reference pages plus **List Subscription Payments**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee9a2c017cf2031880178a007a16cc163469772a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->