### PR TITLE
docs(C2-17833): document connection_data.name in the payment object reference

### DIFF
--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -4844,7 +4844,7 @@ This object represents the payment created after generating the checkout session
     </ParamField>
 
     <ParamField body="connection_data" type="object">
-      Specifies the connection data object, which represents the connection used to process the transaction.
+      Specifies the connection data object, which represents the connection used to process the transaction. When you operate multiple connections for the same provider, use `connection_data.id` to attribute each transaction to the specific connection that processed it.
 
       <Expandable title="properties">
 
@@ -4852,6 +4852,12 @@ This object represents the payment created after generating the checkout session
           The unique identifier of the payment connection in Yuno (MAX 64 ; MIN 36).
 
           Example: 88292fd3-bf5b-4b23-bb95-7186ba4e7f88
+        </ParamField>
+
+        <ParamField body="name" type="string">
+          The display name of the connection, as configured in the Yuno dashboard. It can be `null` on some events, such as follow-up transactions.
+
+          Example: My Stripe US account
         </ParamField>
 
       </Expandable>


### PR DESCRIPTION
## Summary
- [C2-17833](https://yunopayments.atlassian.net/browse/C2-17833) — related feature request: [OR-1088](https://yunopayments.atlassian.net/browse/OR-1088)
- The `transactions[].connection_data` object returned by `GET /v1/payments/{id}` (and payment webhooks) only documented the `id` field. This adds the missing `name` field and clarifies usage.
- `connection_data.id` is the stable discriminator for merchants running multiple connections of the same provider (verified against real sandbox and prod responses: `{"id": "58cc35f4-...", "name": "Stripe BM US"}`).
- Notes that `name` can be `null` on some events (e.g. follow-up transactions), which matches current platform behavior.

## Page
- `reference/payments/the-payment-object.mdx` → https://docs.y.uno/reference/payments/the-payment-object

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[C2-17833]: https://yunopayments.atlassian.net/browse/C2-17833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OR-1088]: https://yunopayments.atlassian.net/browse/OR-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the payment object reference; no runtime or API behavior is modified.
> 
> **Overview**
> Updates **The Payment Object** reference so `transactions[].connection_data` matches API responses (e.g. `GET /v1/payments/{id}` and payment webhooks).
> 
> The `connection_data` description now explains that when you run **multiple connections for the same provider**, you should use **`connection_data.id`** to tie each transaction to the connection that processed it. A new **`connection_data.name`** field documents the dashboard display name for the connection, with a note that **`name` can be `null`** on some events (such as follow-up transactions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfcb4abbf59548bed6754c9bf799250be2a8723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->