### PR TITLE
docs(C2-17831): add connection_data to payment webhook examples

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -73,6 +73,10 @@ The next JSON object presents an example of a data structure related to a paymen
   Webhook payloads for events corresponding to a bank transfer payment method include `payment.payment_method.payment_method_detail.bank_transfer.bank_id`. The field mirrors the `bank_id` sent in the original payment request and is omitted when no bank was selected.
 </Info>
 
+<Info>
+  Each transaction includes `connection_data`, which identifies the provider connection that processed it. Use `connection_data.id` as the stable identifier to attribute transactions to a specific connection when you operate multiple connections for the same provider. `connection_data.name` is the display name configured in the Yuno dashboard and can be `null` on some events, such as follow-up transactions.
+</Info>
+
 ```json
 {
     "type": "payment",
@@ -264,6 +268,10 @@ The next JSON object presents an example of a data structure related to a paymen
                     "third_party_transaction_id": "",
                     "third_party_account_id": ""
                 },
+                "connection_data": {
+                    "id": "88292fd3-bf5b-4b23-bb95-7186ba4e7f88",
+                    "name": "dLocal US"
+                },
                 "simplified_mode": false,
                 "third_party_session_id": "third_party_session_id"
             },
@@ -352,6 +360,10 @@ The next JSON object presents an example of a data structure related to a paymen
                         "response_code": "200",
                         "third_party_transaction_id": "",
                         "third_party_account_id": ""
+                    },
+                    "connection_data": {
+                        "id": "88292fd3-bf5b-4b23-bb95-7186ba4e7f88",
+                        "name": "dLocal US"
                     },
                     "simplified_mode": false,
                     "third_party_session_id": "json object"
@@ -563,6 +575,10 @@ The next JSON object presents an example of a data structure related to a paymen
             "status":"APPROVAL",
             "status_detail":"Transacción aprobada",
             "response_message":"Transacción aprobada"
+         },
+         "connection_data":{
+            "id":"88292fd3-bf5b-4b23-bb95-7186ba4e7f88",
+            "name":"Kushki Colombia"
          }
       },
       "callback_url":null,


### PR DESCRIPTION
## Summary
- [C2-17831](https://yunopayments.atlassian.net/browse/C2-17831) — related feature request: [OR-1088](https://yunopayments.atlassian.net/browse/OR-1088)
- The Payment Webhook V1 and V2 examples were missing `transactions.connection_data`, although the platform has been sending it in payment webhooks since Feb 2026, and the chargeback/payout/refund webhook examples on the same page already include it.
- Adds `connection_data {id, name}` to both payment examples (`transactions` and `transactions_history`), verified against real webhook bodies persisted by organization-webhook-ms (sandbox and prod).
- Adds an Info note: `connection_data.id` is the stable identifier to attribute transactions to a specific connection for merchants running multiple connections of the same provider; `name` can be `null` on some events (e.g. follow-up transactions).

## Page
- `docs/webhooks/object-and-examples.mdx` → https://docs.y.uno/docs/webhooks/object-and-examples

## Note
- This PR covers the documentation part of C2-17831 only; the write-path fixes (populate `connection_data` on the PayPal enrollment rail, propagate `name` to follow-up transactions) are code changes tracked in the same ticket.
- A pre-existing invalid JSON fence in the Refunds example (~line 2082) was detected but is unrelated and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[C2-17831]: https://yunopayments.atlassian.net/browse/C2-17831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OR-1088]: https://yunopayments.atlassian.net/browse/OR-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to example JSON and an Info note; no runtime or API behavior changes.
> 
> **Overview**
> Payment webhook docs now reflect **`connection_data`** on transactions, which the platform already sends but the Payment V1/V2 samples omitted (unlike chargeback/refund examples on the same page).
> 
> Under **Payment Webhook V2**, a new **Info** callout explains that each transaction includes `connection_data` with `id` (stable connection identifier for multi-connection merchants) and `name` (dashboard display name, sometimes `null` on follow-up events). The V2 JSON example adds `connection_data` on both **`transactions`** and **`transactions_history`**. The **Payment Webhook V1** example adds the same object on **`transactions`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90e63a5c56efb1173ba75bcbe82a9c8613702d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->