### PR TITLE
docs(yuno-sdk): align Web SDK alpha docs with the v2 integration branch

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -953,7 +953,8 @@
                   "docs/yuno-sdk/migration/web/seamless",
                   "docs/yuno-sdk/migration/web/seamless-lite",
                   "docs/yuno-sdk/migration/web/enrollment",
-                  "docs/yuno-sdk/migration/web/fraud"
+                  "docs/yuno-sdk/migration/web/fraud",
+                  "docs/yuno-sdk/migration/web/status"
                 ]
               }
             ]

--- a/docs/yuno-sdk/features/enrollment.mdx
+++ b/docs/yuno-sdk/features/enrollment.mdx
@@ -29,15 +29,17 @@ Rendering and selecting the payment method to enroll is your responsibility. The
 const transaction = sdkPayments.transaction({
     customerSession: 'session-from-backend',
     countryCode: 'US',
-    language: 'en',            // optional, falls back to browser language
+    language: 'en', // optional, falls back to browser language
     onStatus: (result) => {
         console.log('Enrollment status:', result.status)
     },
 })
 
 await transaction.start({
-    paymentMethodType: 'CARD',
-    // transactionData: { ... } // optional. See "Skip the form" below.
+    paymentMethod: { type: 'CARD' },
+    elementSelector: '#enrollment-form',
+    // For headless enrollment, pass `data` on paymentMethod and omit
+    // elementSelector. See "Skip the form" below.
 })
 ```
 
@@ -90,7 +92,7 @@ Transaction(config)
 
 ### Skip the form
 
-If you collect the customer's data in your own UI, pass it via `transactionData` on the `PaymentMethodSelected`. The SDK will skip its built-in form and tokenize directly. See [`TransactionData`](/docs/yuno-sdk/reference/transaction-data) for the full data shape.
+If you collect the customer's data in your own UI, pass it via `transactionData` (`data` on Web) on the `PaymentMethodSelected`. The SDK will skip its built-in form and tokenize directly — a headless flow, so `elementSelector` is not needed. See [`TransactionData`](/docs/yuno-sdk/reference/transaction-data) for the full data shape.
 
 <Note>
 `vaultedToken` on `PaymentMethodSelected` is ignored during enrollment. The flow's purpose is to produce a new vaulted token, so there's nothing linked yet to reference.

--- a/docs/yuno-sdk/features/payment-methods-list.mdx
+++ b/docs/yuno-sdk/features/payment-methods-list.mdx
@@ -95,6 +95,7 @@ selectedPayment?.let { transaction.start(paymentSelected = it) }
 |---|---|---|
 | `APPLE_PAY` | iOS, Web | The native Apple Pay button, wired to start the payment flow. |
 | `GOOGLE_PAY` | Android, Web | The native Google Pay button, wired to start the payment flow. |
+| `PAYPAL` | Web | The native PayPal button, wired to start the payment flow. |
 | `PAYMENT_METHOD_LIST` | iOS, Android, Web | Full list of payment methods enabled in your Yuno dashboard. |
 
 If a requested type does not apply to the current platform or configuration, the corresponding entry in the returned map is `null`.

--- a/docs/yuno-sdk/get-started.mdx
+++ b/docs/yuno-sdk/get-started.mdx
@@ -29,8 +29,13 @@ npm install @yuno-payments/sdk-web@2.0.0-alpha.2
 **CDN**
 
 ````html
-<script src="https://sdk-web.y.uno/v2.0.0-alpha.2/main.js"></script>
+<script
+  src="https://sdk-web.y.uno/v2.0.0-alpha.2/main.js"
+  integrity="sha384-<paste-hash-here>"
+  crossorigin="anonymous"></script>
 ````
+
+Get the `integrity` hash from [`versions-sri.json`](https://sdk-web.y.uno/versions-sri.json) — use `latest.integrity`, or the entry that matches your pinned version under `history`. `crossorigin="anonymous"` lets the browser validate the hash for the cross-origin script. See [Subresource Integrity](/docs/sdks/resources/references/web#subresource-integrity-sri) for details.
 
   </Tab>
 

--- a/docs/yuno-sdk/get-started.mdx
+++ b/docs/yuno-sdk/get-started.mdx
@@ -23,13 +23,13 @@ You need:
 **npm**
 
 ````bash
-npm install @yuno-payments/sdk-web@2.0.0
+npm install @yuno-payments/sdk-web@2.0.0-alpha.2
 ````
 
 **CDN**
 
 ````html
-<script src="https://sdk-web.y.uno/v2.0.0-alpha.1/main.js"></script>
+<script src="https://sdk-web.y.uno/v2.0.0-alpha.2/main.js"></script>
 ````
 
   </Tab>
@@ -138,7 +138,7 @@ Controllers are how your code receives the SDK's events. At minimum `onStatus`, 
 const transaction = sdkPayments.transaction({
     checkoutSession: 'session-from-backend',
     countryCode: 'US',
-    language: 'en',            // optional, falls back to browser language
+    language: 'en', // optional, falls back to browser language
     onStatus: (result) => {
         console.log('Final status:', result.status)
     },
@@ -148,7 +148,8 @@ const transaction = sdkPayments.transaction({
 // See "Where does paymentSelected come from?" below.
 const paymentMethod = { type: 'CARD' }
 
-await transaction.start({ paymentMethod })
+// elementSelector: the DOM element the form renders into (required for form payments).
+await transaction.start({ paymentMethod, elementSelector: '#payment-form' })
 ````
 
   </Tab>
@@ -244,6 +245,10 @@ The SDK presents the form, tokenizes the input, creates the payment, handles 3DS
 | `controller` | Yes (mobile only) | Object implementing `TransactionController`. Not present on Web — events are wired inline on the config. |
 
 For the full list of fields, including `showStatusScreen`, see [`TransactionConfig`](/docs/yuno-sdk/reference/transaction-config).
+
+<Note>
+On Web, `start()` also takes `elementSelector` — the DOM element the form renders into. It's required for form-based payments and not accepted for headless flows.
+</Note>
 
 ### Where does `paymentSelected` come from?
 

--- a/docs/yuno-sdk/migration/web/enrollment.mdx
+++ b/docs/yuno-sdk/migration/web/enrollment.mdx
@@ -8,7 +8,7 @@ Enrollment had two sub-modes that paralleled the payment modes: a UI-driven flow
 
 | Before | After |
 |---|---|
-| `yuno.mountEnrollmentLite({ customerSession, … })` (UI) | `sdkPayments.transaction({ customerSession, … }).start()` |
+| `yuno.mountEnrollmentLite({ customerSession, elementSelector, … })` (UI) | `sdkPayments.transaction({ customerSession, … }).start({ elementSelector })` |
 | `yuno.apiClientEnroll({ customerSession })` + manual backend call (Headless) | `sdkPayments.transaction({ customerSession }).start({ paymentMethod: { type: 'CARD', data } })` |
 | `yunoEnrollmentStatus({ status, vaultedToken })` controller | `onStatus(result)` — same payload shape as payment flows |
 
@@ -50,7 +50,7 @@ const transaction = sdkPayments.transaction({
     },
 })
 
-await transaction.start()
+await transaction.start({ elementSelector: '#root' })
 ```
 
 </CodeGroup>
@@ -112,16 +112,16 @@ await transaction.start({
 
 | Before (Enrollment) | After (unified) | Notes |
 |---|---|---|
-| `yuno.mountEnrollmentLite({ customerSession, … })` | `sdkPayments.transaction({ customerSession, … }).start()` | Single factory. `start()` called with no argument for UI enrollment. |
+| `yuno.mountEnrollmentLite({ customerSession, … })` | `sdkPayments.transaction({ customerSession, … }).start({ elementSelector })` | Single factory. Pass `elementSelector` to `start()` for the form-based UI enrollment. |
 | `yuno.apiClientEnroll({ customerSession })` + `.generateVaultedToken(cardData)` | `sdkPayments.transaction({ customerSession }).start({ paymentMethod: { type: 'CARD', data: CardData } })` | Pre-collected card data goes inline on `start()`. |
 | `yunoEnrollmentStatus({ status, vaultedToken })` | `onStatus(result)` | `result` carries `status` (literal union), `substatus`, and `message` — same shape as payment flows. `vaultedToken` is no longer delivered to the client; fetch it from your backend. |
-| `elementSelector: '#root'` (auto-mount) | `elementSelector` (on `TransactionConfig`) | Pass it at the root of the transaction config; the enrollment form renders inside that element. Modal mode no longer exists. |
-| `showPaymentStatus: true` | `showStatusScreen: true` | Same field on `TransactionConfig`. Defaults to `false`. |
-| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` (`result.status === 'ERROR'`) and `StartResult.error`. |
+| `elementSelector: '#root'` (auto-mount) | `elementSelector` (on `start()`) | No longer a config field. Pass it to `start({ elementSelector })`; the enrollment form renders inside that element. Modal mode no longer exists. |
+| `showPaymentStatus: true` | `showStatusScreen: true` | Same field on `TransactionConfig`. Defaults to `true` for enrollment. |
+| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` (a `TransactionStatus` with `message` set), or a rejected `start()` Promise. |
 
 ### Result mapping
 
-`result.status` uses the same 11-value literal union as v1's `EnrollmentStatus`:
+`result.status` uses the same 12-value literal union as the `Enrollment.Status` enum:
 
 ```typescript
 type EnrollmentStatus =
@@ -136,6 +136,7 @@ type EnrollmentStatus =
     | 'CANCELED'
     | 'ERROR'
     | 'UNENROLLED'
+    | 'PENDING'
 ```
 
 When `status === 'CREATED'`, the enrollment succeeded. The vaulted token is not delivered to the client — retrieve it from your backend's list-customer-payment-methods endpoint and store it against your customer.
@@ -147,18 +148,20 @@ When `status === 'CREATED'`, the enrollment succeeded. The vaulted token is not 
   - `customerSession` → enrollment
 
   The `onStatus` payload has the same shape in both cases.
-- **`start()` with no argument == enrollment UI.** The SDK presents the enrollment form for the customer to pick a method and fill in card data.
-- **`start({ paymentMethod: { type, data } })` == enrollment headless.** Same shape as headless payment, but with `customerSession`.
-- **No `createPayment` for enrollment.** Even if you wire it on the config, it's ignored — there's no `/v1/payments` equivalent for enrollment.
+- **`elementSelector` moved to `start()`.** It's no longer a config field — pass it to `start({ elementSelector })` for the form-based UI enrollment.
+- **`start({ elementSelector })` == enrollment UI.** The SDK presents the enrollment form inside that element for the customer to pick a method and fill in card data.
+- **`start({ paymentMethod: { type, data } })` == enrollment headless.** Same shape as headless payment, but with `customerSession` and no `elementSelector`.
+- **No payment-only fields for enrollment.** `createPayment`, `showPayButton`, and the other payment-only config fields aren't part of the enrollment config — there's no `/v1/payments` equivalent for enrollment.
 
 ## Checklist
 
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
-- [ ] Replace `yuno.mountEnrollmentLite(...)` with `sdkPayments.transaction({ customerSession, … }).start()`.
+- [ ] Replace `yuno.mountEnrollmentLite(...)` with `sdkPayments.transaction({ customerSession, … }).start({ elementSelector })`.
 - [ ] Replace `yuno.apiClientEnroll(...).generateVaultedToken(cardData)` with `transaction.start({ paymentMethod: { type: 'CARD', data: CardData } })`.
 - [ ] Rename `cardHolderName` → `holderName`, `cardNumber` → `number`, `cvv` → `securityCode` in the data payload.
 - [ ] Replace `yunoEnrollmentStatus({ status, vaultedToken })` with `onStatus(result)` and read `result.status`. Retrieve the vaulted token from your backend instead of the callback.
-- [ ] Drop `elementSelector`, `yunoError`.
+- [ ] Pass `elementSelector` to `start()` (not the config) for the form-based UI enrollment.
+- [ ] Drop `yunoError`.
 - [ ] Re-run your sandbox test suite.
 
 ## Related

--- a/docs/yuno-sdk/migration/web/full.mdx
+++ b/docs/yuno-sdk/migration/web/full.mdx
@@ -76,12 +76,12 @@ views.paymentMethodList?.mount({ elementSelector: '#root' })
 | `yuno.startCheckout({ elementSelector: '#root' })` | `transaction.getPaymentMethodsViews({ types: ['paymentMethodList'], onPaymentSelected })` → `views.paymentMethodList?.mount({ elementSelector: '#root' })` | Get a view handle, then call `.mount(...)` with the selector + any per-view config. |
 | `paymentListConfig` | `paymentListConfig` (on `TransactionConfig`) | Same shape, same fields. |
 | `yunoPaymentMethodSelected({ type, name })` | `onPaymentSelected(paymentMethod)` inside `getPaymentMethodsViews` | Receives a typed `PaymentMethodSelected` you pass to `start()`. |
-| `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | `PaymentResult` wrapper with `.status` and `.substatus`. |
+| `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | `TransactionStatus` object with `.status`, `.substatus`, and `.message`. |
 | `yunoCreatePayment(ott, info)` | `createPayment(token)` | Promise-based, single argument. |
-| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` and `StartResult.error`. |
+| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus`, or a rejected `start()` Promise. |
 | `onLoading({ isLoading, type })` | `showLoading(isLoading)` | Boolean signal only. |
 | `onRendered()` | *(removed)* | |
-| `renderMode: { type, elementSelector }` | `elementSelector` (on `TransactionConfig`) | Modal mode no longer exists. Pass `elementSelector` at the root of the transaction config and the SDK renders its views there. |
+| `renderMode: { type, elementSelector }` | `elementSelector` (on `start()`) | Modal mode no longer exists. Pass `elementSelector` to `start({ paymentMethod, elementSelector })` to render a selected method's form; the payment-method list itself renders where you pass `elementSelector` to `views.paymentMethodList.mount({ elementSelector })`. |
 | `yuno.continuePayment()` | *(automatic)* | SDK orchestrates 3DS / status polling internally. |
 | `yuno.mountStatusPayment(...)` | *(removed)* | SDK's built-in result screen is controlled by `showStatusScreen` on the config; defaults to `false`. |
 
@@ -100,7 +100,7 @@ views.paymentMethodList?.mount({ elementSelector: '#root' })
 - [ ] Replace `yunoPaymentResult` with `onStatus` (read `result.status` / `result.substatus`).
 - [ ] If you implemented `yunoCreatePayment`, switch to `createPayment` (Promise-based).
 - [ ] Drop `yunoError`, `onLoading`, `onRendered`, `onCreateOneTimeToken`, `mountStatusPayment`, `continuePayment`.
-- [ ] If you used `renderMode`, pass `elementSelector` at the root of `TransactionConfig` instead — the SDK no longer has a modal mode.
+- [ ] If you used `renderMode`, pass `elementSelector` to `start()` for form-based payments (and to `views.paymentMethodList.mount()` for the list) instead — the SDK no longer has a modal mode.
 - [ ] Re-run your sandbox test suite.
 
 ## Related

--- a/docs/yuno-sdk/migration/web/lite.mdx
+++ b/docs/yuno-sdk/migration/web/lite.mdx
@@ -58,6 +58,7 @@ const transaction = sdkPayments.transaction({
 
 await transaction.start({
     paymentMethod: { type: 'PIX' },
+    elementSelector: '#root',
 })
 ```
 
@@ -69,12 +70,12 @@ await transaction.start({
 |---|---|---|
 | `window.Yuno.initialize(...)` | `SdkPayments.initialize(...)` | Global renamed for clarity. |
 | `yuno.startCheckout({ checkoutSession, countryCode, language, … })` | `sdkPayments.transaction({ checkoutSession, countryCode, language, … })` | Same fields, single factory. |
-| `elementSelector` (where to mount the SDK) | `elementSelector` (on `TransactionConfig`) | Pass it at the root of the transaction config; `start()` renders the form inside that element. |
-| `renderMode: { type: 'modal' \| 'element', elementSelector }` | `elementSelector` (on `TransactionConfig`) | Modal mode no longer exists. The SDK renders its views inside the element you pass via `elementSelector`. |
+| `elementSelector` (where to mount the SDK) | `elementSelector` (on `start()`) | Pass it to `start({ paymentMethod, elementSelector })`; the form renders inside that element. Required for form-based payments. |
+| `renderMode: { type: 'modal' \| 'element', elementSelector }` | `elementSelector` (on `start()`) | Modal mode no longer exists. The form renders inside the element you pass to `start()`. |
 | `card: CardConfig` | `card: CardConfig` | Same shape. |
 | `yunoCreatePayment(ott, info)` | `createPayment(token) => Promise<void>` | Promise-based, single argument (full `OneTimeToken`). |
-| `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | Single `PaymentResult` wrapper. |
-| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` (`PaymentResult.status` and `StartResult.error`). |
+| `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | Single `TransactionStatus` object (`status`, `substatus`, `message`). |
+| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` (a `TransactionStatus` with `message` set), or a rejected `start()` Promise. |
 | `onLoading({ isLoading, type })` | `showLoading(isLoading)` | Drops the deprecated `type` field. |
 | `onRendered()` / `onCreateOneTimeToken()` | *(removed)* | Not exposed in the unified API. |
 | `yuno.mountCheckoutLite({ paymentMethodType, vaultedToken })` | `transaction.start({ paymentMethod: { type: paymentMethodType, vaultedToken } })` | The Lite pre-selection becomes the `paymentMethod` argument of `start()`. |
@@ -82,9 +83,9 @@ await transaction.start({
 
 ### Result mapping
 
-The result shape is now wrapped — `onStatus` receives a `PaymentResult` instead of two positional arguments.
+The result shape is now wrapped — `onStatus` receives a `TransactionStatus` object instead of two positional arguments.
 
-| Before `yunoPaymentResult` args | After `PaymentResult` fields |
+| Before `yunoPaymentResult` args | After `TransactionStatus` fields |
 |---|---|
 | `status: 'SUCCEEDED' \| 'REJECT' \| 'FAIL' \| 'PROCESSING' \| 'READY'` | `result.status` (same literal union) |
 | `subStatus: string?` | `result.substatus` |
@@ -92,8 +93,8 @@ The result shape is now wrapped — `onStatus` receives a `PaymentResult` instea
 ## Behavior changes
 
 - **`continuePayment` is internal.** Lite required calling `yuno.continuePayment()` from inside `yunoCreatePayment` to advance the flow. The unified API orchestrates 3DS and status polling automatically when `createPayment` resolves.
-- **`yunoError` removed.** All terminal outcomes flow through `onStatus` (or `StartResult.error` from the `start()` Promise).
-- **`elementSelector` removed at session level.** Mounting points are per-view (see [`getPaymentMethodsViews`](/docs/yuno-sdk/features/payment-methods-list)).
+- **`yunoError` removed.** All terminal outcomes flow through `onStatus`, or a rejected `start()` Promise.
+- **`elementSelector` moved to `start()`.** It's no longer a config field — pass it to `start({ paymentMethod, elementSelector })` for form-based payments. Wallet/list views take their own `elementSelector` on `.mount()` (see [`getPaymentMethodsViews`](/docs/yuno-sdk/features/payment-methods-list)).
 - **Global rename.** `window.Yuno` → `window.SdkPayments`.
 
 ## Checklist
@@ -101,6 +102,7 @@ The result shape is now wrapped — `onStatus` receives a `PaymentResult` instea
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
 - [ ] Replace `yuno.startCheckout(...)` + `yuno.mountCheckoutLite(...)` with a single `sdkPayments.transaction(...).start({ paymentMethod })` call.
 - [ ] Move `checkoutSession`, `countryCode`, `language`, `card`, etc. into `TransactionConfig`.
+- [ ] Pass `elementSelector` to `start()` (not the config) for form-based payments.
 - [ ] Replace `yunoPaymentResult` with `onStatus` and read `result.status` / `result.substatus`.
 - [ ] If you implemented `yunoCreatePayment` for manual payment creation, switch to `createPayment` (Promise-based, single argument).
 - [ ] Drop `yuno.continuePayment()` calls — handled internally now.

--- a/docs/yuno-sdk/migration/web/seamless-lite.mdx
+++ b/docs/yuno-sdk/migration/web/seamless-lite.mdx
@@ -10,7 +10,7 @@ In the unified API it collapses to a single `transaction.start({ paymentMethod }
 
 | Before | After |
 |---|---|
-| `yuno.startSeamlessCheckout(config)` + `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `sdkPayments.transaction(config).start({ paymentMethod: { type, vaultedToken } })` |
+| `yuno.startSeamlessCheckout(config)` + `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `sdkPayments.transaction(config).start({ paymentMethod: { type, vaultedToken }, elementSelector })` |
 | `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod })` (single call) |
 | Managed payment creation | Managed payment creation (no `createPayment` on config) |
 
@@ -52,7 +52,10 @@ const transaction = sdkPayments.transaction({
 })
 
 document.getElementById('pay').addEventController('click', async () => {
-    await transaction.start({ paymentMethod: { type: 'PIX' } })
+    await transaction.start({
+        paymentMethod: { type: 'PIX' },
+        elementSelector: '#root',
+    })
 })
 ```
 
@@ -63,10 +66,11 @@ document.getElementById('pay').addEventController('click', async () => {
 | Before (Seamless Lite) | After (unified) | Notes |
 |---|---|---|
 | `yuno.startSeamlessCheckout(config)` | `sdkPayments.transaction(config)` | Single factory. Don't wire `createPayment` — Seamless was always managed. |
-| `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `transaction.start({ paymentMethod: { type, vaultedToken } })` | Pre-selection becomes the `paymentMethod` argument of `start()`. |
+| `elementSelector` (on `startSeamlessCheckout` config) | `elementSelector` (on `start()`) | No longer a config field. Pass it to `start({ paymentMethod, elementSelector })`; the form renders inside that element. Required for form-based payments. |
+| `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `transaction.start({ paymentMethod: { type, vaultedToken }, elementSelector })` | Pre-selection becomes the `paymentMethod` argument of `start()`; `elementSelector` is where the form renders. |
 | `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod })` | The trigger and the pre-selection collapse into a single `start()` call. |
 | `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | `PaymentResult` wrapper with `.status` and `.substatus`. |
-| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` and `StartResult.error`. |
+| `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus`, or a rejected `start()` Promise. |
 | `onLoading({ isLoading, type })` | `showLoading(isLoading)` | Boolean signal only. |
 
 ## Behavior changes
@@ -78,9 +82,10 @@ document.getElementById('pay').addEventController('click', async () => {
 ## Checklist
 
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
-- [ ] Replace `yuno.startSeamlessCheckout(...)` + `yuno.mountSeamlessCheckoutLite(...)` + `yuno.startPayment()` with a single `transaction.start({ paymentMethod })` call.
+- [ ] Replace `yuno.startSeamlessCheckout(...)` + `yuno.mountSeamlessCheckoutLite(...)` + `yuno.startPayment()` with a single `transaction.start({ paymentMethod, elementSelector })` call.
 - [ ] **Do not** wire `createPayment` on the config — that would flip to manual mode.
 - [ ] Move `checkoutSession`, `countryCode`, `language`, `card`, etc. into `TransactionConfig`.
+- [ ] Pass `elementSelector` to `start()` (not the config) for form-based payments.
 - [ ] Replace `yunoPaymentResult` with `onStatus` (read `result.status` / `result.substatus`).
 - [ ] Drop `yunoError`, `onLoading` (use `showLoading` if you need a custom loader).
 - [ ] Re-run your sandbox test suite.

--- a/docs/yuno-sdk/migration/web/seamless.mdx
+++ b/docs/yuno-sdk/migration/web/seamless.mdx
@@ -51,7 +51,8 @@ const transaction = sdkPayments.transaction({
 
 const views = transaction.getPaymentMethodsViews({
     types: ['paymentMethodList'],
-    onPaymentSelected: (paymentMethod) => transaction.start({ paymentMethod }),
+    onPaymentSelected: (paymentMethod) =>
+        transaction.start({ paymentMethod, elementSelector: '#root' }),
 })
 
 views.paymentMethodList?.mount({ elementSelector: '#root' })
@@ -107,14 +108,14 @@ views.paypal?.mount({ elementSelector: '#paypal' })
 | `yuno.startSeamlessCheckout(config)` | `sdkPayments.transaction(config)` | Single factory. Don't wire `createPayment` — that would flip to manual mode (non-Seamless behavior). |
 | `yuno.mountSeamlessCheckout()` | `getPaymentMethodsViews({ types: ['paymentMethodList'], onPaymentSelected })` → `views.paymentMethodList?.mount({ elementSelector })` | Get a view handle, then call `.mount(...)` with the selector. |
 | `yuno.mountSeamlessExternalButtons([{ elementSelector, paymentMethodType }])` | `getPaymentMethodsViews({ types: ['applePay', 'googlePay', 'paypal'], onPaymentSelected })` → `views.applePay?.mount({ elementSelector, ...config })`, etc. | Per-view styling (button color, type, etc.) lives on each `.mount()` call. |
-| `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod })` | Called from `onPaymentSelected` after the user picks a method. |
+| `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod, elementSelector })` | Called from `onPaymentSelected` after the user picks a method. Pass `elementSelector` (the form's container) when the chosen method renders a form. |
 | `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | `PaymentResult` wrapper with `.status` and `.substatus`. |
 | `yuno.unmountSeamlessExternalButton(type)` / `yuno.unmountSeamlessExternalButtons()` | *(handled by `transaction.cancel()` or letting the transaction complete)* | Per-button unmount removed. |
 
 ## Behavior changes
 
 - **`Seamless` factory is gone.** Use the regular `sdkPayments.transaction(...)` factory. Don't wire `createPayment` — its absence keeps the SDK in managed mode (the same model Seamless had).
-- **`yuno.startPayment()` is gone.** The merchant-triggered start is now `transaction.start({ paymentMethod })`, called with the method the user picked.
+- **`yuno.startPayment()` is gone.** The merchant-triggered start is now `transaction.start({ paymentMethod })`, called with the method the user picked. When the chosen method renders a form, pass `elementSelector` (the form's container) to `start()` — the list/wallet views keep their own `elementSelector` on `.mount()`.
 - **Per-button unmount removed.** Use `transaction.cancel()` or let the transaction complete.
 
 ## Checklist
@@ -123,7 +124,7 @@ views.paypal?.mount({ elementSelector: '#paypal' })
 - [ ] Replace `yuno.startSeamlessCheckout(...)` with `sdkPayments.transaction(...)`. **Do not** wire `createPayment` — Seamless was always managed.
 - [ ] Replace `mountSeamlessCheckout` with `getPaymentMethodsViews({ types: ['paymentMethodList'], onPaymentSelected })` + `views.paymentMethodList?.mount({ elementSelector })`.
 - [ ] Replace `mountSeamlessExternalButtons([{...}])` with `getPaymentMethodsViews({ types: [...], onPaymentSelected })` + per-view `.mount({ elementSelector, ...config })` calls.
-- [ ] Replace `yuno.startPayment()` with `transaction.start({ paymentMethod })`, called from inside `onPaymentSelected`.
+- [ ] Replace `yuno.startPayment()` with `transaction.start({ paymentMethod })`, called from inside `onPaymentSelected`. Pass `elementSelector` when the chosen method renders a form.
 - [ ] Replace `yunoPaymentResult` with `onStatus` (read `result.status` / `result.substatus`).
 - [ ] Drop `unmountSeamlessExternalButton[s]`.
 - [ ] Re-run your sandbox test suite.

--- a/docs/yuno-sdk/migration/web/status.mdx
+++ b/docs/yuno-sdk/migration/web/status.mdx
@@ -1,0 +1,74 @@
+---
+hidden: true
+title: "Payment status"
+description: "Migrate the Web standalone status screen (yuno.mountStatusPayment) to the unified SDK."
+---
+
+`yuno.mountStatusPayment(...)` rendered a standalone payment result screen for a checkout session — typically shown after the shopper returned from an external redirect. In the unified API this becomes a top-level method on `SdkPayments`: `sdkPayments.transactionStatus(...)`.
+
+It is not part of a `Transaction`. Like `antifraud`, it's a standalone operation, so it lives directly on the `SdkPayments` instance.
+
+| Before | After |
+|---|---|
+| `yuno.mountStatusPayment({...})` | `sdkPayments.transactionStatus({...})` |
+| Rendered into the SDK's default container | `elementSelector` — you choose the mount target (required) |
+| `paymentResult(data)` callback | *(removed)* — the screen renders the outcome; confirm server-side |
+
+## Side-by-side
+
+<CodeGroup>
+
+```typescript Before. mountStatusPayment
+const yuno = await window.Yuno.initialize('your-public-api-key')
+
+yuno.mountStatusPayment({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',
+    language: 'en',
+    paymentResult(data) {
+        console.log('paymentResult', data)
+    },
+})
+```
+
+```typescript After. sdkPayments.transactionStatus
+const sdkPayments = await SdkPayments.initialize('your-public-api-key')
+
+await sdkPayments.transactionStatus({
+    checkoutSession: 'session-from-backend',
+    countryCode: 'CO',           // optional
+    language: 'en',              // optional
+    elementSelector: '#status',  // required
+})
+```
+
+</CodeGroup>
+
+## Field mapping
+
+| Before | After | Notes |
+|---|---|---|
+| `yuno.mountStatusPayment({...})` | `sdkPayments.transactionStatus({...})` | Top-level method on `SdkPayments`, not on `Transaction`. Returns a `Promise<void>`. |
+| `checkoutSession` | `checkoutSession` | Same. Required. |
+| `countryCode` | `countryCode?` | Now optional. |
+| `language` | `language?` | Now optional. |
+| *(default container)* | `elementSelector` | Now required — you pass the CSS selector of the element to render into. |
+| `paymentResult(data)` | *(removed)* | The screen renders the outcome. Confirm the result server-side via [webhooks](/docs/webhooks) or the payments API. |
+
+## Behavior changes
+
+- **`transactionStatus` lives on `SdkPayments`, not on `Transaction`.** It's a standalone operation, not part of a transaction lifecycle.
+- **`elementSelector` is required.** You choose the mount target explicitly instead of relying on a default container.
+- **No result callback.** `paymentResult` is gone; the status screen is display-only. Use webhooks or the payments API as the source of truth for fulfillment — see [`onStatus`](/docs/yuno-sdk/controllers/on-status).
+
+## Checklist
+
+- [ ] Replace `yuno.mountStatusPayment(...)` with `sdkPayments.transactionStatus(...)`.
+- [ ] Pass an `elementSelector` for the mount target.
+- [ ] Move result handling to your server (webhooks / payments API); the `paymentResult` callback is gone.
+- [ ] Re-run your sandbox test suite.
+
+## Related
+
+- [`onStatus`](/docs/yuno-sdk/controllers/on-status). Receives the final status inside a `Transaction`.
+- [Get Started](/docs/yuno-sdk/get-started). Full integration walkthrough.

--- a/docs/yuno-sdk/reference/one-time-token.mdx
+++ b/docs/yuno-sdk/reference/one-time-token.mdx
@@ -6,7 +6,7 @@ description: "The tokenized payment payload delivered to createPayment when you 
 
 `OneTimeToken` is what the SDK delivers to your `createPayment` handler when you've taken over payment creation. You POST it to `/v1/payments` from your backend.
 
-The three platforms deliver the token as a dictionary/map with exactly the fields the backend returns — there is no SDK-side reshaping. The container type per platform is shown in [`createPayment`](/docs/yuno-sdk/controllers/create-payment).
+On iOS and Android the token is delivered as a dictionary/map (`[String: Any]` / `Map<String, Any>`) with exactly the fields the backend returns — there is no SDK-side reshaping. On Web it is a **typed object** with the same fields (`token`, `vaulted_token`, `vault_on_success`, `type`, `card_data`, `customer`); the value passed to `createPayment` additionally carries `recognitionToken` and `checkout_session`. The container type per platform is shown in [`createPayment`](/docs/yuno-sdk/controllers/create-payment).
 
 For the structure and meaning of each field, see [One-time use token](https://docs.y.uno/docs/basic-concepts/tokens#one-time-use-token).
 

--- a/docs/yuno-sdk/reference/transaction-config.mdx
+++ b/docs/yuno-sdk/reference/transaction-config.mdx
@@ -23,7 +23,6 @@ On web, `TransactionConfig` is a plain object passed directly to `sdkPayments.tr
 | [`language`](#language) | String? | No | Browser language |
 | [`showStatusScreen`](#showstatusscreen) | Bool | No | `false` |
 | [`autoContinuePayment`](#autocontinuepayment) | Bool | No | `true` |
-| [`elementSelector`](#elementselector-web-only) | String? | No |  |
 
 On Web there is no `controller` field — wire events (`onStatus`, `showLoading`, `createPayment`) directly as fields on the config. See [`controller`](#controller-ios-android).
 
@@ -116,12 +115,6 @@ Controls whether the SDK automatically continues the payment flow after creating
 
 With `false`, the SDK stops once the payment is created: it does not poll status, does not run 3DS, and `onStatus` is not invoked for the transaction.
 
-## `elementSelector` (web only)
-
-Optional CSS selector of the DOM element where the SDK renders its views (payment forms, action views). The SDK no longer has a modal mode on web — when provided, views render inside this element.
-
-This field exists only on web. On iOS and Android, view presentation is handled through [`showView`](/docs/yuno-sdk/controllers/show-view) or the SDK's default full-screen presentation.
-
 ## `appearance` (iOS, Android)
 
 Visual customization object for the SDK's built-in views (colors, fonts, corner radius, etc.). Not available on Web.
@@ -146,9 +139,11 @@ The config rejects both `checkoutSession` and `customerSession` being set, or ne
 |---|---|
 | iOS | Compile-time. `TransactionConfig` has two non-throwing initializers — `init(checkoutSession:...)` and `init(customerSession:...)` — so a config with both or neither sessions cannot be constructed. No `try` is needed. |
 | Android | Runtime. `IllegalArgumentException` |
-| Web | Runtime. `TypeError` |
+| Web | Runtime. Throws a Yuno SDK error |
 
-The SDK does not validate `countryCode`, `language`, or any other field. Invalid values may surface later as backend errors or unexpected behavior.
+On Web, the constructor also throws if `countryCode` is missing.
+
+Beyond those checks, the SDK does not validate the *values* of `countryCode`, `language`, or other fields. Invalid values may surface later as backend errors or unexpected behavior.
 
 ## Related
 


### PR DESCRIPTION
Audited the **Universal SDK Web docs (2.0.0-alpha.2)** against sdk-web `feature/CORECM-16454-v2-integration` (core `8.0.0-v2.0.0-alpha.9`) — the actual integration branch, not `release/v2` (which is alpha.1 and behind).

## Main corrections
- **`elementSelector` moved from `TransactionConfig` to `start()`** — it is a `start()` parameter, not a config field. Overloads: form payment → **required**; headless payment → **not accepted** (`data` on `paymentMethod`); enrollment → **optional**. Accepts `string | HTMLElement`. Fixed across `transaction-config`, `get-started`, `features/enrollment`, and all `migration/web/*` guides.
- **`onStatus` payload is `TransactionStatus`** `{ status, substatus, message }` — removed references to the non-existent `PaymentResult` / `EnrollmentResult` / `StartResult` types (`start()` returns `Promise<void>`).
- **`payment-methods-list`**: added the `PAYPAL` view (Web-only, verified iOS/Android don't expose it).
- **`one-time-token`**: Web delivers a typed object (mobile keeps dict/map).
- **New `migration/web/status.mdx`**: `yuno.mountStatusPayment` → `sdkPayments.transactionStatus` (+ nav entry).
- **Enrollment mapping fixes**: `Enrollment.Status` (12 values incl. `PENDING`), `showStatusScreen` defaults **`true`** for enrollment, `createPayment` is never-typed on enrollment config.
- **Install/CDN** bumped to `2.0.0-alpha.2`.

## Verified already matching (no change)
`initialize`, `transaction()`, controllers (`onStatus`/`showLoading`/`createPayment`/`showView`), `showStatusScreen`, `autoContinuePayment`, `countryCode`, `language`, sessions, `getPaymentMethodsViews`, `reference/status`, `reference/transaction-data`, `payment-method-selected`, `migration/web/headless`.

## Left for human review (not changed — need runtime/v1 confirmation)
- Enrollment success status **`CREATED` vs `ENROLLED`** for the UI flow (NOTES says UI emits `ENROLLED`, headless `CREATED`; docs use `CREATED` for both).
- Enrollment v1 method name `apiClientEnroll().generateVaultedToken` may not exist (NOTES: `continueEnrollment`).
- Seamless **wallet buttons** call `start({ paymentMethod })` without `elementSelector`; the `FormPaymentMethod` type would demand it but wallets render no form — a type-vs-behavior gap in the alpha.2 beta.
- **`secureFields()`** exists in code but its docs live on the separate `add-secure-fields-v2-docs` PR (not this branch); audited there and found accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API code; risk is limited to integrators following outdated patterns if docs are wrong.
> 
> **Overview**
> Aligns **Yuno SDK (Alpha)** Web documentation with `@yuno-payments/sdk-web@2.0.0-alpha.2`, especially where the unified API differs from earlier doc drafts.
> 
> **`elementSelector` is no longer on `TransactionConfig`** — it belongs on `transaction.start()` for form-based payments and enrollment UI (headless flows omit it). That change is reflected in `get-started`, enrollment, `transaction-config`, and all `migration/web/*` guides.
> 
> **Status and errors** are documented as **`TransactionStatus`** (`status`, `substatus`, `message`) via `onStatus`, with legacy `PaymentResult` / `StartResult.error` references removed; Web config validation notes now mention missing `countryCode` and Yuno SDK errors.
> 
> **New and reference updates:** adds hidden **`migration/web/status.mdx`** (`mountStatusPayment` → `sdkPayments.transactionStatus`) plus nav entry; documents Web **`PAYPAL`** in payment-methods-list; clarifies Web **`OneTimeToken`** as a typed object; bumps install/CDN to **alpha.2** with SRI guidance; enrollment examples use `paymentMethod: { type }` and expanded enrollment migration notes (`PENDING`, `showStatusScreen` default for enrollment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe32ebef0ce36f006a28d8f797ed8e38d487966b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->