### PR TITLE
Update iOS SDK release notes for version 2.21.0

### DIFF
--- a/changelog/ios.mdx
+++ b/changelog/ios.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno iOS SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.21.0
+*July 23, 2026*
+
+- <ChangelogBadge type="added" /> **Installment Selection Callback**  
+  Introduced an optional callback to notify merchants whenever an installment option is selected or changed in the card form. This helps in keeping the cart total in sync with the selected installment options.
+
 ## v2.20.0
 *July 8, 2026*
 

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -24,14 +24,6 @@
           "group": null,
           "migration_guide": null,
           "links": []
-        },
-        {
-          "type": "FIXED",
-          "title": "Installment Options Clearing",
-          "description": "Resolved an issue where installment options were not cleared when they were no longer applicable, such as when the card number changes or does not support installments. This prevents outdated installment options from being displayed.",
-          "group": null,
-          "migration_guide": null,
-          "links": []
         }
       ]
     },

--- a/changelog/source/ios.json
+++ b/changelog/source/ios.json
@@ -2,6 +2,40 @@
   "sdk": "ios",
   "releases": [
     {
+      "version": "2.21.0",
+      "release_date": "2026-07-23",
+      "upgrade": [
+        {
+          "label": "Swift Package Manager",
+          "snippet": ".package(url: \"https://github.com/yuno-payments/yuno-sdk-ios.git\", from: \"2.21.0\")",
+          "language": "swift"
+        },
+        {
+          "label": "CocoaPods",
+          "snippet": "pod 'YunoSDK', '2.21.0'",
+          "language": "ruby"
+        }
+      ],
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Installment Selection Callback",
+          "description": "Introduced an optional callback to notify merchants whenever an installment option is selected or changed in the card form. This helps in keeping the cart total in sync with the selected installment options.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Installment Options Clearing",
+          "description": "Resolved an issue where installment options were not cleared when they were no longer applicable, such as when the card number changes or does not support installments. This prevents outdated installment options from being displayed.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.20.0",
       "release_date": "2026-07-08",
       "upgrade": [


### PR DESCRIPTION
Automated update of iOS SDK release notes for version 2.21.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or SDK code changes.
> 
> **Overview**
> Documents **iOS SDK v2.21.0** (July 23, 2026) in the public changelog and structured release source.
> 
> `changelog/ios.mdx` adds a new **v2.21.0** section describing an optional **Installment Selection Callback** so merchants are notified when installment options change in the card form, supporting cart total sync.
> 
> `changelog/source/ios.json` adds the matching release record with SPM/CocoaPods upgrade snippets (`2.21.0`) and the same **ADDED** entry metadata used to drive changelog generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8bdc3c875f388f32b6f0f2d9ab3373f1bb85fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->