### PR TITLE
Add brand-specific acquirer BIN guidance to 3DS credential requirements

### DIFF
--- a/docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx
+++ b/docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx
@@ -270,6 +270,10 @@ Name the connection and enable the 3D Secure credentials checkbox. Provide the f
 * Acquirer Country Code
 * SIRET (optional)
 
+<Note>
+The **Acquirer BIN** and **Acquirer Merchant ID** are brand-specific values registered with each card scheme's Directory Server — a BIN registered for one brand does not work for another, and membership identifiers such as the Mastercard ICA or the Amex Seller ID are not acquirer BINs. See [Configuring 3D Secure for your payments](/docs/security-and-compliance/3d-secure#requirements) for how to request the correct values from your acquirer.
+</Note>
+
 Click **Next** to complete all steps and **Save** your connection.
 
 Next, configure your 3DS provider (we'll use Cybersource 3DS in this example). In Connections, select the provider and click **Connect**.

--- a/docs/security-and-compliance/3d-secure.mdx
+++ b/docs/security-and-compliance/3d-secure.mdx
@@ -97,12 +97,24 @@ To create payments with the 3DS DIRECT workflow, you need to fulfill some requir
 
 Before using 3DS DIRECT, you need to enable 3DS in your [Yuno Dashboard](https://dashboard.y.uno/) and specify the scenarios in which you want your customers to be able to use it. This can be configured in the Yuno Dashboard under: **Routing > Card Routes > 3DS Step**. These scenarios must be indicated on your CARD route. Additionally, you will require the following 3DS setup data in the payment provider connection:
 
-* **Acquirer BIN**: This is the Bank Identification Number (BIN) used to clear and settle the transaction, along with the country in which it is licensed for use.
+* **Acquirer BIN**: This is the Bank Identification Number (BIN) used to clear and settle the transaction, along with the country in which it is licensed for use. This value is brand-specific — request one per card brand you will authenticate (see the warning below).
 * **Merchant ID**: This is the affiliation number provided by the acquirer.
 * **Merchant Category Code (MCC)**: The acquirer will provide a specific code representing your merchant category.
 * **Merchant's Name**: Refers to the official name or business name of the company or entity conducting the commercial transaction.
 * **Merchant URL**: The merchant's website or online platform.
 * **Country Code**: The country where the payment needs to be processed, following the [ISO 3166-1](/reference/country-reference) Standard Country Codes.
+
+<Warning>
+**The acquirer BIN is brand-specific — and it is not the ICA or Seller ID**
+
+Each card scheme's Directory Server only accepts authentication requests that carry an acquirer BIN registered with that specific scheme. When collecting 3DS credentials from your acquirer, keep in mind:
+
+* Request one acquirer BIN **per card brand** you plan to authenticate (Visa, Mastercard, American Express, Discover/Diners). A BIN registered for one brand does not work for another — for example, a Visa acquiring BIN (starting with 4) is not valid for Mastercard authentications.
+* For **Mastercard**, acquirers sometimes share their ICA number (a Mastercard membership identifier, often zero-prefixed) instead of an acquirer BIN. The Mastercard Directory Server does not accept the ICA: authentications fail with EMV 3DS error `303` — "Access denied, invalid endpoint / acquirerBIN not recognized". Ask your acquirer specifically for the **Mastercard acquiring BIN registered for Identity Check (EMV 3DS)** — a value within Mastercard's BIN ranges (2-series or 5-series).
+* For **American Express and Discover**, the Seller ID or SE number is your merchant identifier in those networks (it maps to the Acquirer Merchant ID) — it is not the brand's acquirer BIN. Both values are required.
+
+If an authentication fails with error `303` from the Directory Server, the acquirer BIN configured for that brand is wrong or not registered for 3DS — request the correct value from your acquirer, for example: *"For each card network (Visa, Mastercard, American Express, Discover), please provide the acquirer BIN registered with the scheme's Directory Server for EMV 3DS authentication with an external 3DS Server, together with our Acquirer Merchant ID and MCC as registered with the scheme."*
+</Warning>
 
 <Note>
 **Using an External MPI for Authentication**


### PR DESCRIPTION
## What it documents

When merchants set up **external 3DS** (Yuno 3DS / external MPI), they must collect per-brand acquirer credentials from their acquirer. The docs listed *which* fields are needed (Acquirer BIN, MID, MCC…) but not that the **acquirer BIN is brand-specific** and that common values acquirers hand out — the **Mastercard ICA** (membership number) or the **Amex Seller ID / Discover SE number** — are **not** acquirer BINs. Configuring them makes the scheme's Directory Server reject every authentication with EMV 3DS error `303` ("Access denied, invalid endpoint / acquirerBIN not recognized").

This has cost several merchant onboardings multiple days each (most recently again this week); the resolution is always the same conversation with the acquirer, so this PR documents it.

## Changes

- `docs/security-and-compliance/3d-secure.mdx` — Requirements section: note on the Acquirer BIN bullet + a `<Warning>` explaining brand-specific BINs, the ICA / Seller ID pitfall, the error-303 symptom, and a ready-to-send request template for the acquirer.
- `docs/direct-integration-use-cases/3ds-configuration-and-testing.mdx` — short `<Note>` after the connection credentials list, cross-linking to the guidance above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> Documents that **acquirer BINs are per card brand** and that common acquirer-supplied values (Mastercard **ICA**, Amex/Discover **Seller ID**) are **not** valid acquirer BINs—misconfiguration causes Directory Server EMV 3DS error **`303`**.
> 
> In **`3d-secure.mdx`**, the Requirements **Acquirer BIN** bullet now calls out brand-specific BINs, and a new **`<Warning>`** covers one BIN per brand, the ICA vs Identity Check BIN pitfall, Seller ID vs BIN for Amex/Discover, the `303` symptom, and a copy-paste acquirer request template.
> 
> In **`3ds-configuration-and-testing.mdx`**, a **`<Note>`** after the connection credential list points readers to that Requirements section for how to obtain correct values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d0041e20f8a8c34a575d76d84fffcb9bbbb330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->