### PR TITLE
docs(fingerprint,mcp,fraud): fix RUM frustration-signal pages and document CORECM-16676 fingerprint pitfalls

### DIFF
--- a/docs/basic-concepts/fraud.mdx
+++ b/docs/basic-concepts/fraud.mdx
@@ -13,6 +13,12 @@ When using Yuno's SDK, no additional development is required. Simply add the fra
 
 When a payment is created, Yuno generates different transactions based on the payment method route. If fraud verification is enabled in the route, Yuno creates a `FRAUD_SCREENING` transaction and associates it with the payment. This transaction contains details about the fraud verification outcome, which you can also view in the [payment details](/docs/transactions#transaction-types-and-statuses) on your Yuno dashboard.
 
+<Note>
+**Session ID collection is route-specific**
+
+The SDK only collects a device fingerprint or `session_id` for fraud providers configured in the merchant's active fraud route. If you need to collect a `session_id` for a specific provider, make sure that provider is added to the route for that payment method on your Yuno dashboard.
+</Note>
+
 ### Forter Session Token Capture
 
 If you are using **Forter** for fraud detection, the Yuno SDK provides a reliable way to capture the session token.

--- a/docs/sdks/headless-web/payment.mdx
+++ b/docs/sdks/headless-web/payment.mdx
@@ -78,6 +78,31 @@ const apiClientPayment = await yuno.apiClientPayment({
 });
 ```
 
+### Preloading fraud fingerprints
+
+If your account uses [fraud screening](/docs/basic-concepts/fraud) with a provider whose fingerprinting script can take longer than the fraud timeout (`max_fraud_timeout_ms`, default `3000`), call `executeFraudCheck` when the payment form renders, not at the moment your customer clicks "Pay". Some providers' fingerprinting scripts take longer than the timeout to load in certain regions. Calling `apiClientPayment` and `generateToken` back to back at click time can generate the one-time token before the fingerprint finishes loading, so the token is created without a device fingerprint.
+
+```javascript
+// Wrong: calling everything at "Pay" click time
+payButton.onclick = async () => {
+  const apiClientPayment = await yuno.apiClientPayment({ country_code, checkout_session });
+  const oneTimeToken = await apiClientPayment.generateToken({ checkout_session, payment_method });
+};
+// The fraud provider's beacon may not have loaded in time, so the fingerprint can be missing from the token
+```
+
+```javascript
+// Correct: preload the fraud fingerprint when the form renders
+await yuno.executeFraudCheck({ checkout_session, country_code });
+
+// Later, when the customer clicks "Pay":
+payButton.onclick = async () => {
+  const apiClientPayment = await yuno.apiClientPayment({ country_code, checkout_session });
+  const oneTimeToken = await apiClientPayment.generateToken({ checkout_session, payment_method });
+  // The fingerprint is already cached, no race condition
+};
+```
+
 ## Step 4: Generate token
 
 After collecting all user information, you can start the payment. First, you need to create a one-time token (OTT) using the function `apiClientpayment.generateToken`. As it is an asynchronous function, you can use `try/catch` to ensure you will correctly handle triggered errors. The following examples show different scenarios to create the one-time token:

--- a/docs/sdks/headless-web/payment.mdx
+++ b/docs/sdks/headless-web/payment.mdx
@@ -80,7 +80,7 @@ const apiClientPayment = await yuno.apiClientPayment({
 
 ### Preloading fraud fingerprints
 
-If your account uses [fraud screening](/docs/basic-concepts/fraud) with a provider whose fingerprinting script can take longer than the fraud timeout (`max_fraud_timeout_ms`, default `3000`), call `executeFraudCheck` when the payment form renders, not at the moment your customer clicks "Pay". Some providers' fingerprinting scripts take longer than the timeout to load in certain regions. Calling `apiClientPayment` and `generateToken` back to back at click time can generate the one-time token before the fingerprint finishes loading, so the token is created without a device fingerprint.
+If your account uses [fraud screening](/docs/basic-concepts/fraud) with a provider whose fingerprinting script can take longer than the configured fraud timeout, call `executeFraudCheck` when the payment form renders, not at the moment your customer clicks "Pay". Some providers' fingerprinting scripts take longer than the timeout to load in certain regions. Calling `apiClientPayment` and `generateToken` back to back at click time can generate the one-time token before the fingerprint finishes loading, so the token is created without a device fingerprint.
 
 ```javascript
 // Wrong: calling everything at "Pay" click time

--- a/reference/payments/create-payment.mdx
+++ b/reference/payments/create-payment.mdx
@@ -30,6 +30,12 @@ To test all possible transaction outcomes within Yuno in **Sandbox**, refer to t
 If you use metadata to drive routing logic, it must also be set in the **[Checkout Session](/reference/checkout-sessions/create-checkout-session)**. Filling it only in the Payment object will not activate route logic.
 </Danger>
 
+<Warning>
+**`vaulted_token` overrides device fingerprint**
+
+If `payment_method.vaulted_token` is provided alongside `payment_method.token`, the `vaulted_token` replaces all payment data, including the device fingerprint (`third_party_session_id`). If you need fraud screening with a device fingerprint, do not send both fields together.
+</Warning>
+
 For Two-Step payments (Authorization then Capture), send `payment_method.detail.card.capture` as `false`, then use the [Capture Authorization](/reference/payments/capture-authorization) endpoint.
 
 This request requires an `X-Idempotency-Key`. See [Authentication](/reference/authentication#idempotency) for details.


### PR DESCRIPTION
## Summary

- Source: Datadog RUM analytics report for docs.y.uno (first 6 days live), flagging the two highest frustration-signal pages on the site, plus the full scope of CORECM-16676 shared by Carolina Torneiro on 2026-07-23 (three fingerprint integration pitfalls that were not yet documented anywhere in the repo).
- `docs/security-and-compliance/fingerprint.mdx` (#2 in frustration, related to CORECM-16676 but a separate readability fix):
  - Moves the PCI timing-limitation warning from two-thirds down the page up to right after the "Key Properties" list, before "How It Works"
  - Adds an explicit "Recommended: Option A" line under "Step 3: Handle Duplicates", replacing an easy-to-miss parenthetical
- `docs/ai-capabilities/remote-yuno-mcp-server.mdx` (#1 in frustration, ~36% of all signals):
  - Fixes a 3-way credential naming inconsistency: env vars, JSON sample headers, and the note below the sample each named the same three credentials differently
  - Adds one sentence clarifying that the JSON sample's header keys map to the env vars
- `docs/sdks/headless-web/payment.mdx` (CORECM-16676, item 1, YSHUB-3902):
  - Adds a "Preloading fraud fingerprints" section before Step 4, with wrong/correct code samples, explaining the `executeFraudCheck` race condition against `max_fraud_timeout_ms`
- `reference/payments/create-payment.mdx` (CORECM-16676, item 2, YSHUB-3753):
  - Adds a `<Warning>` box stating that `vaulted_token` overrides all payment data including the device fingerprint (`third_party_session_id`) when sent alongside `token`
- `docs/basic-concepts/fraud.mdx` (CORECM-16676, item 3, YSHUB-3561):
  - Adds a `<Note>` clarifying that fingerprint/`session_id` collection is scoped to providers configured in the merchant's active fraud route

## Files changed

- `docs/security-and-compliance/fingerprint.mdx`
- `docs/ai-capabilities/remote-yuno-mcp-server.mdx`
- `docs/sdks/headless-web/payment.mdx`
- `reference/payments/create-payment.mdx`
- `docs/basic-concepts/fraud.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Documents **CORECM-16676** device-fingerprint integration pitfalls so merchants avoid missing fraud signals.
> 
> **Fraud basics** (`fraud.mdx`): Adds a note that SDK `session_id` / fingerprint collection only runs for providers on the merchant’s **active fraud route** for that payment method.
> 
> **Headless Web** (`payment.mdx`): New **Preloading fraud fingerprints** section before token generation—call `executeFraudCheck` when the form loads (not on Pay click) to avoid racing `max_fraud_timeout_ms` (default 3000ms) when `apiClientPayment` and `generateToken` run back-to-back.
> 
> **Create Payment** (`create-payment.mdx`): Adds a warning that sending **`vaulted_token` with `token`** replaces all payment data, including **`third_party_session_id`**, so fraud screening that needs a device fingerprint must not combine both.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b66b344ee3399f7c875f69a340ebf1138bc7f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->