### PR TITLE
chore: vtex sdk changelog 4.2.331

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.331
+*July 22, 2026*
+
+**Order Modifications**
+
+- <ChangelogBadge type="added" /> **Additional charges for modified orders**  
+  When an order's total increases after checkout — VTEX order modifications, such as items sold by weight — the connector now charges the difference automatically using the card saved on the original order, with the shopper absent and no security code. Enable it per affiliation with the new "Vault Card for Order Modification" setting (requires "Create Customer" to also be enabled); orders and affiliations without it are unaffected.
+
 ## v4.2.324
 *July 14, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.331",
+      "release_date": "2026-07-22",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.331",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Additional charges for modified orders",
+          "description": "When an order's total increases after checkout — VTEX order modifications, such as items sold by weight — the connector now charges the difference automatically using the card saved on the original order, with the shopper absent and no security code. Enable it per affiliation with the new \"Vault Card for Order Modification\" setting (requires \"Create Customer\" to also be enabled); orders and affiliations without it are unaffected.",
+          "group": "Order Modifications",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.324",
       "release_date": "2026-07-14",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.331`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.331

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changelog sync; no runtime or payment code changes in this PR.
> 
> **Overview**
> Documents **VTEX plugin release 4.2.331** (2026-07-22) in the public changelog by prepending a new release block to `changelog/source/vtex.json` and mirroring it at the top of `changelog/plugins/vtex.mdx`.
> 
> The new entry describes **additional charges when a VTEX order total increases after checkout** (e.g. weight-based items): the connector can charge the difference with the **original vaulted card**, shopper absent and without CVV, when **Vault Card for Order Modification** is enabled on the affiliation (and **Create Customer** is on). Affiliations and orders without that setting are unchanged.
> 
> Also fixes a trailing newline on `vtex.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3e3300057566e451c5518cc612c63f46217f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->