### PR TITLE
docs(sdks): add Additional Features section with onInstallmentSelected page (Web/iOS/Android)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -789,22 +789,6 @@
             ]
           },
           {
-            "group": "Customization",
-            "pages": [
-              "docs/sdks/customization/android",
-              "docs/sdks/customization/ios",
-              {
-                "group": "Web",
-                "pages": [
-                  "docs/sdks/customization/web/styling",
-                  "docs/sdks/customization/web/white-label",
-                  "docs/sdks/customization/web/payment-link-white-label",
-                  "docs/sdks/customization/web/white-label-proxy-server"
-                ]
-              }
-            ]
-          },
-          {
             "group": "Card Enrollment",
             "pages": [
               "docs/sdks/card-enrollment/web-enrollment",
@@ -821,7 +805,23 @@
           {
             "group": "Additional Features",
             "pages": [
-              "docs/sdks/additional-features/installments"
+              "docs/sdks/additional-features/installments",
+              {
+                "group": "Customization",
+                "pages": [
+                  "docs/sdks/customization/android",
+                  "docs/sdks/customization/ios",
+                  {
+                    "group": "Web",
+                    "pages": [
+                      "docs/sdks/customization/web/styling",
+                      "docs/sdks/customization/web/white-label",
+                      "docs/sdks/customization/web/payment-link-white-label",
+                      "docs/sdks/customization/web/white-label-proxy-server"
+                    ]
+                  }
+                ]
+              }
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -819,6 +819,12 @@
             ]
           },
           {
+            "group": "Additional Features",
+            "pages": [
+              "docs/sdks/additional-features/installments"
+            ]
+          },
+          {
             "group": "Resources",
             "pages": [
               {

--- a/docs/sdks/additional-features/installments.mdx
+++ b/docs/sdks/additional-features/installments.mdx
@@ -1,0 +1,183 @@
+---
+title: Installments
+deprecated: false
+hidden: false
+metadata:
+  robots: index
+description: "Get notified when the shopper selects an installment option in the card form on Web, iOS, and Android"
+---
+
+Register the optional `onInstallmentSelected` callback to keep your cart total in sync with the installment plan the shopper picks in the card form. The SDK notifies you when a default installment is pre-selected, every time the shopper changes the selection, and when the plan is recalculated (for example, after a BIN change).
+
+The callback is optional on all platforms: if you don't register it, the SDK behavior is unchanged. Exceptions thrown inside your callback are caught by the SDK and never interrupt the payment flow.
+
+| Platform | Available from | Where to register |
+| -------- | -------------- | ----------------- |
+| Web      | SDK `1.6.7`    | `card.onInstallmentSelected` in `startCheckout` |
+| iOS      | SDK `2.21.0`   | `onInstallmentSelected(_:)` on `YunoPaymentDelegate` |
+| Android  | SDK `2.20.0`   | `onInstallmentSelected` parameter of `startCheckout` |
+
+## Implementation
+
+<Tabs>
+<Tab title="Web">
+
+Pass the callback inside the `card` options of `startCheckout`:
+
+```javascript
+await yuno.startCheckout({
+  checkoutSession: session.checkout_session,
+  elementSelector: '#payment-form',
+  countryCode: 'BR',
+  card: {
+    onInstallmentSelected: ({ installment, label, amount, isMerchantInstallment }) => {
+      // Update your cart total, e.g. with amount?.total_value
+      console.log('Installment selected:', { installment, label, amount, isMerchantInstallment })
+    },
+  },
+  // ...
+})
+```
+
+The callback receives a single object argument:
+
+```typescript
+type OnInstallmentSelected = (args: {
+  installment: number
+  label: string
+  amount?: {
+    currency: string
+    value: string
+    total_value: string
+  }
+  additionalData?: Record<string, unknown>
+  isMerchantInstallment: boolean
+}) => void
+```
+
+| Field                   | Type      | Description                                                                                                                                    |
+| ----------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `installment`           | `number`  | Number of installments selected (e.g. `3`).                                                                                                    |
+| `label`                 | `string`  | The exact installment label rendered in the form, localized (e.g. `3x de R$875.00 - Total R$2,625.00`).                                        |
+| `amount`                | `object`  | Optional. `currency`, `value`, and `total_value` as raw strings, exactly as reported by the installments plan.                                 |
+| `additionalData`        | `object`  | Reserved for future use. Currently always `undefined`.                                                                                         |
+| `isMerchantInstallment` | `boolean` | `true` when the selected option was supplied by your own `onGetInstallments` callback (merchant installments); `false` for Yuno-provided plans. |
+
+Firing semantics:
+
+* Fires with the current selection as soon as the plan renders and a default installment is pre-selected, so your total is correct from first paint.
+* Fires on every selection the shopper makes.
+* Re-fires the current selection when the available options change (for example, a BIN change recalculates the plan).
+* Does not fire when installments stop being available — there is no clear notification on Web.
+* Works across all card flows, including secure fields and Click to Pay.
+
+</Tab>
+
+<Tab title="iOS">
+
+Implement the optional `onInstallmentSelected(_:)` method of `YunoPaymentDelegate`:
+
+```swift
+class ViewController: UIViewController, YunoPaymentDelegate {
+
+    // ... required YunoPaymentDelegate implementation ...
+
+    func onInstallmentSelected(_ installmentSelected: YunoInstallmentSelected?) {
+        guard let installmentSelected else {
+            // Installments are no longer available — restore your base total
+            return
+        }
+        // Update your cart total, e.g. with installmentSelected.amount?.totalValue
+    }
+}
+```
+
+The method receives a `YunoInstallmentSelected?` payload:
+
+```swift
+@objc public final class YunoInstallmentSelected: NSObject {
+    @objc public let installment: Int
+    @objc public let label: String
+    @objc public let amount: YunoInstallmentAmount?
+    @objc public let additionalData: [String: Any]?
+    public let isMerchantInstallment: Bool?
+}
+
+@objc public final class YunoInstallmentAmount: NSObject {
+    @objc public let currency: String
+    @objc public let value: String
+    @objc public let totalValue: String
+}
+```
+
+| Field                   | Type                     | Description                                                                                               |
+| ----------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `installment`           | `Int`                    | Number of installments selected (e.g. `3`).                                                               |
+| `label`                 | `String`                 | The exact installment label rendered in the form, localized (e.g. `3x of R$ 500,31 - Total R$ 1.500,93`). |
+| `amount`                | `YunoInstallmentAmount?` | `currency`, `value`, and `totalValue` as raw strings, exactly as reported by the installments plan.       |
+| `additionalData`        | `[String: Any]?`         | The `additional_data` object of the selected option, when the installments service provides it.           |
+| `isMerchantInstallment` | `Bool?`                  | Reserved for the merchant-installments feature. Currently always `nil` on iOS. Not visible from Objective-C. |
+
+Firing semantics:
+
+* Fires once when a default installment is pre-selected as the plan loads, so your total is correct from first paint.
+* Fires on every selection the shopper makes, and with the recalculated default after the plan changes (for example, a BIN change).
+* Fires once with `nil` when a previously reported selection no longer applies (for example, the shopper switches to a card without installments) — restore your base total. It is never called with `nil` before the first selection is reported.
+* Delivered on the main thread. The method is optional — omitting it keeps the SDK behavior unchanged.
+
+</Tab>
+
+<Tab title="Android">
+
+Pass the callback when calling `startCheckout`:
+
+```kotlin
+startCheckout(
+  checkoutSession = "checkout_session",
+  countryCode = "country_code_iso",
+  callbackPaymentState = { state, subState -> /* ... */ },
+  onInstallmentSelected = { selection ->
+    if (selection != null) {
+      // Update your cart total, e.g. with selection.amount?.totalValue
+    } else {
+      // Installments are no longer available — restore your base total
+    }
+  },
+)
+```
+
+The callback receives an `InstallmentSelected?` payload:
+
+```kotlin
+data class InstallmentSelected(
+    val installment: Int,
+    val label: String,
+    val amount: InstallmentAmount? = null,
+    val additionalData: Map<String, Any?>? = null,
+    val isMerchantInstallment: Boolean? = null,
+)
+
+data class InstallmentAmount(
+    val currency: String,
+    val value: String,
+    val totalValue: String,
+)
+```
+
+| Field                   | Type                 | Description                                                                                             |
+| ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------- |
+| `installment`           | `Int`                | Number of installments selected (e.g. `3`).                                                             |
+| `label`                 | `String`             | The exact installment label rendered in the form, localized (e.g. `3x de R$875.00 - Total R$2,625.00`). |
+| `amount`                | `InstallmentAmount?` | `currency`, `value`, and `totalValue` as raw strings, exactly as reported by the installments plan.     |
+| `additionalData`        | `Map<String, Any?>?` | Reserved for future use. Currently always `null`.                                                       |
+| `isMerchantInstallment` | `Boolean?`           | Reserved for the merchant-installments feature. Currently always `null` on Android.                     |
+
+Firing semantics:
+
+* Fires once when a default installment is pre-selected as the plan renders, so your total is correct from first paint.
+* Fires on every selection the shopper makes, and with the recalculated default after the plan changes (for example, a BIN change).
+* Fires once with `null` when installments stop being available after a selection was already reported (for example, the shopper switches to a card without installments) — restore your base total.
+* Does not fire when the card form renders without installments. The callback runs on the main thread, and registering no callback keeps the SDK behavior unchanged.
+
+</Tab>
+</Tabs>

--- a/docs/sdks/additional-features/installments.mdx
+++ b/docs/sdks/additional-features/installments.mdx
@@ -100,7 +100,6 @@ The method receives a `YunoInstallmentSelected?` payload:
     @objc public let label: String
     @objc public let amount: YunoInstallmentAmount?
     @objc public let additionalData: [String: Any]?
-    public let isMerchantInstallment: Bool?
 }
 
 @objc public final class YunoInstallmentAmount: NSObject {
@@ -116,7 +115,6 @@ The method receives a `YunoInstallmentSelected?` payload:
 | `label`                 | `String`                 | The exact installment label rendered in the form, localized (e.g. `3x of R$ 500,31 - Total R$ 1.500,93`). |
 | `amount`                | `YunoInstallmentAmount?` | `currency`, `value`, and `totalValue` as raw strings, exactly as reported by the installments plan.       |
 | `additionalData`        | `[String: Any]?`         | The `additional_data` object of the selected option, when the installments service provides it.           |
-| `isMerchantInstallment` | `Bool?`                  | Reserved for the merchant-installments feature. Currently always `nil` on iOS. Not visible from Objective-C. |
 
 Firing semantics:
 
@@ -154,7 +152,6 @@ data class InstallmentSelected(
     val label: String,
     val amount: InstallmentAmount? = null,
     val additionalData: Map<String, Any?>? = null,
-    val isMerchantInstallment: Boolean? = null,
 )
 
 data class InstallmentAmount(
@@ -170,7 +167,6 @@ data class InstallmentAmount(
 | `label`                 | `String`             | The exact installment label rendered in the form, localized (e.g. `3x de R$875.00 - Total R$2,625.00`). |
 | `amount`                | `InstallmentAmount?` | `currency`, `value`, and `totalValue` as raw strings, exactly as reported by the installments plan.     |
 | `additionalData`        | `Map<String, Any?>?` | Reserved for future use. Currently always `null`.                                                       |
-| `isMerchantInstallment` | `Boolean?`           | Reserved for the merchant-installments feature. Currently always `null` on Android.                     |
 
 Firing semantics:
 


### PR DESCRIPTION
## Context
The onInstallmentSelected card callback shipped on the three SDKs (Web 1.6.7, Android 2.20.0 via CORECM-18470, iOS 2.21.0 via CORECM-18468 — epic CORECM-18467). This adds a single self-contained cross-platform page so merchants integrating any SDK find it in one place.

## What's added
- New "Additional Features" group in the SDKs tab (placed before Resources), registered in docs.json.
- New page docs/sdks/additional-features/installments.mdx: availability table, then per-platform tabs (Web / iOS / Android), each with the registration code, the public payload classes/types (TS type, YunoInstallmentSelected/YunoInstallmentAmount, InstallmentSelected/InstallmentAmount), the payload field table, and the firing semantics.

The page is self-contained: it does not link to or modify any other page.

## Notes
- Content verified against SDK source, not PR descriptions: sdk-web (use-installment-effects.ts, sdk.ts), yuno-ios release-v2.21.0 (Yuno+PublicDelegates.swift, YunoInstallmentSelected.swift), android-sdk release/2.20.0 (PaymentsFlow.kt, InstallmentSelected.kt — nullable InstallmentSelected? payload, post-#1775 follow-up).

## Testing
- [x] docs.json remains valid JSON
- [x] mint validate passes (strict build validation)
- [x] Local preview (mint dev): page renders with the three tabs and tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Mintlify navigation only; no runtime, API, or SDK code changes.
> 
> **Overview**
> Adds cross-platform SDK documentation for the optional **`onInstallmentSelected`** callback so merchants can sync cart totals when shoppers pick installment plans in the card form.
> 
> A new **Additional Features** nav group (before Resources) includes **`docs/sdks/additional-features/installments.mdx`**, with platform tabs for Web, iOS, and Android covering registration, payload types, field tables, and firing semantics (including platform differences such as `nil`/`null` when installments disappear vs. no clear signal on Web). **Customization** is nested under this group instead of appearing as a top-level SDK section; page URLs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58c87b68de950521d2feabce55c83d2a55d8a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->