### PR TITLE
docs(yuno-sdk): Web quickstart is CDN-only (v2 alpha not on npm yet)

### DIFF
--- a/docs/yuno-sdk/get-started.mdx
+++ b/docs/yuno-sdk/get-started.mdx
@@ -20,13 +20,7 @@ You need:
 <Tabs>
   <Tab title="Web">
 
-**npm**
-
-````bash
-npm install @yuno-payments/sdk-web@2.0.0-alpha.2
-````
-
-**CDN**
+Load the SDK from the CDN. It exposes a global `SdkPayments` and dispatches a `sdk-payments-ready` event on `window` once it's ready to use.
 
 ````html
 <script
@@ -83,10 +77,13 @@ Initialize the SDK once, at app or page startup. The constructor only takes your
 <Tabs>
   <Tab title="Web">
 
-````typescript
-import { SdkPayments } from '@yuno-payments/sdk-web';
+The CDN script exposes `SdkPayments` on `window`. Wait for the `sdk-payments-ready` event, then initialize:
 
-const sdkPayments = await SdkPayments.initialize('your-public-api-key');
+````javascript
+window.addEventListener('sdk-payments-ready', async () => {
+    const sdkPayments = await SdkPayments.initialize('your-public-api-key');
+    // Build a transaction from here (see step 3).
+});
 ````
 
 `SdkPayments.initialize` returns a Promise. `await` it before using the SDK.


### PR DESCRIPTION
The v2 alpha is not published to npm yet, so the `npm install @yuno-payments/sdk-web@2.0.0-alpha.2` step and the `import { SdkPayments } from '@yuno-payments/sdk-web'` example in the Web quickstart were misleading (both need the package to exist on npm).

Switch the Web quickstart to **CDN-only**:
- Drop the **npm** install block; keep the CDN `<script>` (with SRI + `crossorigin`).
- Initialize via the global the CDN exposes, on the `sdk-payments-ready` event:

```js
window.addEventListener('sdk-payments-ready', async () => {
    const sdkPayments = await SdkPayments.initialize('your-public-api-key');
});
```

Verified against sdk-web `release/v2.0.0-alpha.2` `src/main.ts`: the bundle sets `window.SdkPayments` and dispatches `sdk-payments-ready` (`STYLE_CLASS_PREFIX = "sdk-payments"`).

Follow-up to #639 (already merged). Restore the npm/import path once the package ships to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Web install/init examples; no runtime or API behavior.
> 
> **Overview**
> Updates the **Web** tab of the Yuno SDK **Get Started** guide so install and init match v2 alpha availability: the package is not on npm yet, so npm/import steps were removed.
> 
> **Install (step 1):** Drops the `npm install @yuno-payments/sdk-web@2.0.0-alpha.2` block and documents **CDN-only** loading—the script tag with SRI/`crossorigin` stays, plus copy that the bundle exposes global `SdkPayments` and fires `sdk-payments-ready` on `window`.
> 
> **Initialize (step 2):** Replaces the ES module `import` + top-level `await SdkPayments.initialize(...)` with a `javascript` snippet that listens for `sdk-payments-ready`, then calls `SdkPayments.initialize('your-public-api-key')`.
> 
> iOS/Android tabs and the rest of the guide are unchanged. npm/import guidance is expected to return once the package ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110194f5e02defa79bc0346219097a00607eea36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->