### PR TITLE
docs(yuno-sdk): elementSelector as an optional transaction-config field

### DIFF
--- a/docs/yuno-sdk/features/enrollment.mdx
+++ b/docs/yuno-sdk/features/enrollment.mdx
@@ -30,6 +30,7 @@ const transaction = sdkPayments.transaction({
     customerSession: 'session-from-backend',
     countryCode: 'US',
     language: 'en', // optional, falls back to browser language
+    elementSelector: '#enrollment-form',
     onStatus: (result) => {
         console.log('Enrollment status:', result.status)
     },
@@ -37,9 +38,8 @@ const transaction = sdkPayments.transaction({
 
 await transaction.start({
     paymentMethod: { type: 'CARD' },
-    elementSelector: '#enrollment-form',
-    // For headless enrollment, pass `data` on paymentMethod and omit
-    // elementSelector. See "Skip the form" below.
+    // For headless enrollment, pass `data` on paymentMethod. The config's
+    // elementSelector is ignored. See "Skip the form" below.
 })
 ```
 
@@ -92,7 +92,7 @@ Transaction(config)
 
 ### Skip the form
 
-If you collect the customer's data in your own UI, pass it via `transactionData` (`data` on Web) on the `PaymentMethodSelected`. The SDK will skip its built-in form and tokenize directly — a headless flow, so `elementSelector` is not needed. See [`TransactionData`](/docs/yuno-sdk/reference/transaction-data) for the full data shape.
+If you collect the customer's data in your own UI, pass it via `transactionData` (`data` on Web) on the `PaymentMethodSelected`. The SDK will skip its built-in form and tokenize directly — a headless flow, which ignores the `elementSelector` on the transaction config (it applies only to form-based flows). See [`TransactionData`](/docs/yuno-sdk/reference/transaction-data) for the full data shape.
 
 <Note>
 `vaultedToken` on `PaymentMethodSelected` is ignored during enrollment. The flow's purpose is to produce a new vaulted token, so there's nothing linked yet to reference.

--- a/docs/yuno-sdk/get-started.mdx
+++ b/docs/yuno-sdk/get-started.mdx
@@ -141,6 +141,8 @@ const transaction = sdkPayments.transaction({
     checkoutSession: 'session-from-backend',
     countryCode: 'US',
     language: 'en', // optional, falls back to browser language
+    // elementSelector: the DOM element the form renders into (form payments only).
+    elementSelector: '#payment-form',
     onStatus: (result) => {
         console.log('Final status:', result.status)
     },
@@ -150,8 +152,7 @@ const transaction = sdkPayments.transaction({
 // See "Where does paymentSelected come from?" below.
 const paymentMethod = { type: 'CARD' }
 
-// elementSelector: the DOM element the form renders into (required for form payments).
-await transaction.start({ paymentMethod, elementSelector: '#payment-form' })
+await transaction.start({ paymentMethod })
 ````
 
   </Tab>
@@ -249,7 +250,7 @@ The SDK presents the form, tokenizes the input, creates the payment, handles 3DS
 For the full list of fields, including `showStatusScreen`, see [`TransactionConfig`](/docs/yuno-sdk/reference/transaction-config).
 
 <Note>
-On Web, `start()` also takes `elementSelector` — the DOM element the form renders into. It's required for form-based payments and not accepted for headless flows.
+On Web, `transaction()` takes an optional `elementSelector` — the DOM element the form renders into. It's used only by form-based payments; headless flows ignore it.
 </Note>
 
 ### Where does `paymentSelected` come from?

--- a/docs/yuno-sdk/migration/web/enrollment.mdx
+++ b/docs/yuno-sdk/migration/web/enrollment.mdx
@@ -8,7 +8,7 @@ Enrollment had two sub-modes that paralleled the payment modes: a UI-driven flow
 
 | Before | After |
 |---|---|
-| `yuno.mountEnrollmentLite({ customerSession, elementSelector, … })` (UI) | `sdkPayments.transaction({ customerSession, … }).start({ elementSelector })` |
+| `yuno.mountEnrollmentLite({ customerSession, elementSelector, … })` (UI) | `sdkPayments.transaction({ customerSession, elementSelector, … }).start()` |
 | `yuno.apiClientEnroll({ customerSession })` + manual backend call (Headless) | `sdkPayments.transaction({ customerSession }).start({ paymentMethod: { type: 'CARD', data } })` |
 | `yunoEnrollmentStatus({ status, vaultedToken })` controller | `onStatus(result)` — same payload shape as payment flows |
 
@@ -41,6 +41,7 @@ const transaction = sdkPayments.transaction({
     customerSession: 'session-from-backend',
     countryCode: 'CO',
     language: 'en',
+    elementSelector: '#root',
     onStatus: (result) => {
         // Same payload shape as payment flows: status / substatus / message.
         if (result.status === 'CREATED') {
@@ -50,7 +51,7 @@ const transaction = sdkPayments.transaction({
     },
 })
 
-await transaction.start({ elementSelector: '#root' })
+await transaction.start()
 ```
 
 </CodeGroup>
@@ -112,10 +113,10 @@ await transaction.start({
 
 | Before (Enrollment) | After (unified) | Notes |
 |---|---|---|
-| `yuno.mountEnrollmentLite({ customerSession, … })` | `sdkPayments.transaction({ customerSession, … }).start({ elementSelector })` | Single factory. Pass `elementSelector` to `start()` for the form-based UI enrollment. |
+| `yuno.mountEnrollmentLite({ customerSession, … })` | `sdkPayments.transaction({ customerSession, elementSelector, … }).start()` | Single factory. Set `elementSelector` on the transaction config for the form-based UI enrollment. |
 | `yuno.apiClientEnroll({ customerSession })` + `.generateVaultedToken(cardData)` | `sdkPayments.transaction({ customerSession }).start({ paymentMethod: { type: 'CARD', data: CardData } })` | Pre-collected card data goes inline on `start()`. |
 | `yunoEnrollmentStatus({ status, vaultedToken })` | `onStatus(result)` | `result` carries `status` (literal union), `substatus`, and `message` — same shape as payment flows. `vaultedToken` is no longer delivered to the client; fetch it from your backend. |
-| `elementSelector: '#root'` (auto-mount) | `elementSelector` (on `start()`) | No longer a config field. Pass it to `start({ elementSelector })`; the enrollment form renders inside that element. Modal mode no longer exists. |
+| `elementSelector: '#root'` (auto-mount) | `elementSelector` (on `sdkPayments.transaction(config)`) | Optional field on the transaction config; the enrollment form renders inside that element. Used only by form-based flows — headless enrollment ignores it. Not required. Modal mode no longer exists. |
 | `showPaymentStatus: true` | `showStatusScreen: true` | Same field on `TransactionConfig`. Defaults to `true` for enrollment. |
 | `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus` (a `TransactionStatus` with `message` set), or a rejected `start()` Promise. |
 
@@ -148,19 +149,19 @@ When `status === 'CREATED'`, the enrollment succeeded. The vaulted token is not 
   - `customerSession` → enrollment
 
   The `onStatus` payload has the same shape in both cases.
-- **`elementSelector` moved to `start()`.** It's no longer a config field — pass it to `start({ elementSelector })` for the form-based UI enrollment.
-- **`start({ elementSelector })` == enrollment UI.** The SDK presents the enrollment form inside that element for the customer to pick a method and fill in card data.
-- **`start({ paymentMethod: { type, data } })` == enrollment headless.** Same shape as headless payment, but with `customerSession` and no `elementSelector`.
+- **`elementSelector` is an optional transaction-config field.** Set it on `sdkPayments.transaction({ ..., elementSelector })` for the form-based UI enrollment. It's used only by form-based flows; headless enrollment ignores it, and it's not required.
+- **`start()` == enrollment UI.** With `elementSelector` on the config, the SDK presents the enrollment form inside that element for the customer to pick a method and fill in card data.
+- **`start({ paymentMethod: { type, data } })` == enrollment headless.** Same shape as headless payment, but with `customerSession`; the config's `elementSelector` is ignored.
 - **No payment-only fields for enrollment.** `createPayment`, `showPayButton`, and the other payment-only config fields aren't part of the enrollment config — there's no `/v1/payments` equivalent for enrollment.
 
 ## Checklist
 
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
-- [ ] Replace `yuno.mountEnrollmentLite(...)` with `sdkPayments.transaction({ customerSession, … }).start({ elementSelector })`.
+- [ ] Replace `yuno.mountEnrollmentLite(...)` with `sdkPayments.transaction({ customerSession, elementSelector, … }).start()`.
 - [ ] Replace `yuno.apiClientEnroll(...).generateVaultedToken(cardData)` with `transaction.start({ paymentMethod: { type: 'CARD', data: CardData } })`.
 - [ ] Rename `cardHolderName` → `holderName`, `cardNumber` → `number`, `cvv` → `securityCode` in the data payload.
 - [ ] Replace `yunoEnrollmentStatus({ status, vaultedToken })` with `onStatus(result)` and read `result.status`. Retrieve the vaulted token from your backend instead of the callback.
-- [ ] Pass `elementSelector` to `start()` (not the config) for the form-based UI enrollment.
+- [ ] Set `elementSelector` on the transaction config (`sdkPayments.transaction({ ..., elementSelector })`) for the form-based UI enrollment — it's optional and ignored by headless enrollment.
 - [ ] Drop `yunoError`.
 - [ ] Re-run your sandbox test suite.
 

--- a/docs/yuno-sdk/migration/web/full.mdx
+++ b/docs/yuno-sdk/migration/web/full.mdx
@@ -48,6 +48,7 @@ const transaction = sdkPayments.transaction({
     checkoutSession: 'session-from-backend',
     countryCode: 'CO',
     language: 'en',
+    elementSelector: '#root',
     paymentListConfig: {
         scrollContainerSelector: '#scroll-container',
         bottomOffsetPx: 0,
@@ -81,7 +82,7 @@ views.paymentMethodList?.mount({ elementSelector: '#root' })
 | `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus`, or a rejected `start()` Promise. |
 | `onLoading({ isLoading, type })` | `showLoading(isLoading)` | Boolean signal only. |
 | `onRendered()` | *(removed)* | |
-| `renderMode: { type, elementSelector }` | `elementSelector` (on `start()`) | Modal mode no longer exists. Pass `elementSelector` to `start({ paymentMethod, elementSelector })` to render a selected method's form; the payment-method list itself renders where you pass `elementSelector` to `views.paymentMethodList.mount({ elementSelector })`. |
+| `renderMode: { type, elementSelector }` | `elementSelector` (on `sdkPayments.transaction(config)`) | Modal mode no longer exists. Set `elementSelector` on the transaction config to render a selected method's form — it's optional and used only by form-based flows; the payment-method list itself renders where you pass `elementSelector` to `views.paymentMethodList.mount({ elementSelector })`. |
 | `yuno.continuePayment()` | *(automatic)* | SDK orchestrates 3DS / status polling internally. |
 | `yuno.mountStatusPayment(...)` | *(removed)* | SDK's built-in result screen is controlled by `showStatusScreen` on the config; defaults to `false`. |
 
@@ -100,7 +101,7 @@ views.paymentMethodList?.mount({ elementSelector: '#root' })
 - [ ] Replace `yunoPaymentResult` with `onStatus` (read `result.status` / `result.substatus`).
 - [ ] If you implemented `yunoCreatePayment`, switch to `createPayment` (Promise-based).
 - [ ] Drop `yunoError`, `onLoading`, `onRendered`, `onCreateOneTimeToken`, `mountStatusPayment`, `continuePayment`.
-- [ ] If you used `renderMode`, pass `elementSelector` to `start()` for form-based payments (and to `views.paymentMethodList.mount()` for the list) instead — the SDK no longer has a modal mode.
+- [ ] If you used `renderMode`, set `elementSelector` on the transaction config for form-based payments (and pass it to `views.paymentMethodList.mount()` for the list) instead — the SDK no longer has a modal mode.
 - [ ] Re-run your sandbox test suite.
 
 ## Related

--- a/docs/yuno-sdk/migration/web/lite.mdx
+++ b/docs/yuno-sdk/migration/web/lite.mdx
@@ -51,6 +51,7 @@ const transaction = sdkPayments.transaction({
     checkoutSession: 'session-from-backend',
     countryCode: 'CO',
     language: 'en',
+    elementSelector: '#root',
     onStatus: (result) => {
         console.log('Final status:', result.status)
     },
@@ -58,7 +59,6 @@ const transaction = sdkPayments.transaction({
 
 await transaction.start({
     paymentMethod: { type: 'PIX' },
-    elementSelector: '#root',
 })
 ```
 
@@ -70,8 +70,8 @@ await transaction.start({
 |---|---|---|
 | `window.Yuno.initialize(...)` | `SdkPayments.initialize(...)` | Global renamed for clarity. |
 | `yuno.startCheckout({ checkoutSession, countryCode, language, … })` | `sdkPayments.transaction({ checkoutSession, countryCode, language, … })` | Same fields, single factory. |
-| `elementSelector` (where to mount the SDK) | `elementSelector` (on `start()`) | Pass it to `start({ paymentMethod, elementSelector })`; the form renders inside that element. Required for form-based payments. |
-| `renderMode: { type: 'modal' \| 'element', elementSelector }` | `elementSelector` (on `start()`) | Modal mode no longer exists. The form renders inside the element you pass to `start()`. |
+| `elementSelector` (where to mount the SDK) | `elementSelector` (on `sdkPayments.transaction(config)`) | Optional field on the transaction config; the form renders inside that element. Used only by form-based flows — headless and other flows ignore it. Not required. |
+| `renderMode: { type: 'modal' \| 'element', elementSelector }` | `elementSelector` (on `sdkPayments.transaction(config)`) | Modal mode no longer exists. The form renders inside the element you pass on the transaction config. |
 | `card: CardConfig` | `card: CardConfig` | Same shape. |
 | `yunoCreatePayment(ott, info)` | `createPayment(token) => Promise<void>` | Promise-based, single argument (full `OneTimeToken`). |
 | `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | Single `TransactionStatus` object (`status`, `substatus`, `message`). |
@@ -94,7 +94,7 @@ The result shape is now wrapped — `onStatus` receives a `TransactionStatus` ob
 
 - **`continuePayment` is internal.** Lite required calling `yuno.continuePayment()` from inside `yunoCreatePayment` to advance the flow. The unified API orchestrates 3DS and status polling automatically when `createPayment` resolves.
 - **`yunoError` removed.** All terminal outcomes flow through `onStatus`, or a rejected `start()` Promise.
-- **`elementSelector` moved to `start()`.** It's no longer a config field — pass it to `start({ paymentMethod, elementSelector })` for form-based payments. Wallet/list views take their own `elementSelector` on `.mount()` (see [`getPaymentMethodsViews`](/docs/yuno-sdk/features/payment-methods-list)).
+- **`elementSelector` is an optional transaction-config field.** Pass it to `sdkPayments.transaction({ ..., elementSelector })`. It's used only by form-based flows; headless and other flows ignore it (no error), and it's not required. Wallet/list views take their own `elementSelector` on `.mount()` (see [`getPaymentMethodsViews`](/docs/yuno-sdk/features/payment-methods-list)).
 - **Global rename.** `window.Yuno` → `window.SdkPayments`.
 
 ## Checklist
@@ -102,7 +102,7 @@ The result shape is now wrapped — `onStatus` receives a `TransactionStatus` ob
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
 - [ ] Replace `yuno.startCheckout(...)` + `yuno.mountCheckoutLite(...)` with a single `sdkPayments.transaction(...).start({ paymentMethod })` call.
 - [ ] Move `checkoutSession`, `countryCode`, `language`, `card`, etc. into `TransactionConfig`.
-- [ ] Pass `elementSelector` to `start()` (not the config) for form-based payments.
+- [ ] Set `elementSelector` on the transaction config (`sdkPayments.transaction({ ..., elementSelector })`) for form-based payments — it's optional and ignored by non-form flows.
 - [ ] Replace `yunoPaymentResult` with `onStatus` and read `result.status` / `result.substatus`.
 - [ ] If you implemented `yunoCreatePayment` for manual payment creation, switch to `createPayment` (Promise-based, single argument).
 - [ ] Drop `yuno.continuePayment()` calls — handled internally now.

--- a/docs/yuno-sdk/migration/web/seamless-lite.mdx
+++ b/docs/yuno-sdk/migration/web/seamless-lite.mdx
@@ -10,7 +10,7 @@ In the unified API it collapses to a single `transaction.start({ paymentMethod }
 
 | Before | After |
 |---|---|
-| `yuno.startSeamlessCheckout(config)` + `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `sdkPayments.transaction(config).start({ paymentMethod: { type, vaultedToken }, elementSelector })` |
+| `yuno.startSeamlessCheckout(config)` + `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `sdkPayments.transaction({ ...config, elementSelector }).start({ paymentMethod: { type, vaultedToken } })` |
 | `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod })` (single call) |
 | Managed payment creation | Managed payment creation (no `createPayment` on config) |
 
@@ -47,6 +47,7 @@ const transaction = sdkPayments.transaction({
     checkoutSession: 'session-from-backend',
     countryCode: 'CO',
     language: 'en',
+    elementSelector: '#root',
     // managed mode — no createPayment wired
     onStatus: (result) => console.log('done:', result.status),
 })
@@ -54,7 +55,6 @@ const transaction = sdkPayments.transaction({
 document.getElementById('pay').addEventController('click', async () => {
     await transaction.start({
         paymentMethod: { type: 'PIX' },
-        elementSelector: '#root',
     })
 })
 ```
@@ -66,8 +66,8 @@ document.getElementById('pay').addEventController('click', async () => {
 | Before (Seamless Lite) | After (unified) | Notes |
 |---|---|---|
 | `yuno.startSeamlessCheckout(config)` | `sdkPayments.transaction(config)` | Single factory. Don't wire `createPayment` — Seamless was always managed. |
-| `elementSelector` (on `startSeamlessCheckout` config) | `elementSelector` (on `start()`) | No longer a config field. Pass it to `start({ paymentMethod, elementSelector })`; the form renders inside that element. Required for form-based payments. |
-| `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `transaction.start({ paymentMethod: { type, vaultedToken }, elementSelector })` | Pre-selection becomes the `paymentMethod` argument of `start()`; `elementSelector` is where the form renders. |
+| `elementSelector` (on `startSeamlessCheckout` config) | `elementSelector` (on `sdkPayments.transaction(config)`) | Optional field on the transaction config; the form renders inside that element. Used only by form-based flows — headless and other flows ignore it. Not required. |
+| `yuno.mountSeamlessCheckoutLite({ paymentMethodType, vaultedToken })` | `transaction.start({ paymentMethod: { type, vaultedToken } })` | Pre-selection becomes the `paymentMethod` argument of `start()`; the form renders inside the `elementSelector` set on the transaction config. |
 | `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod })` | The trigger and the pre-selection collapse into a single `start()` call. |
 | `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | `PaymentResult` wrapper with `.status` and `.substatus`. |
 | `yunoError(message, data?)` | *(removed)* | Errors flow through `onStatus`, or a rejected `start()` Promise. |
@@ -82,10 +82,10 @@ document.getElementById('pay').addEventController('click', async () => {
 ## Checklist
 
 - [ ] Rename `window.Yuno.initialize(...)` to `SdkPayments.initialize(...)`.
-- [ ] Replace `yuno.startSeamlessCheckout(...)` + `yuno.mountSeamlessCheckoutLite(...)` + `yuno.startPayment()` with a single `transaction.start({ paymentMethod, elementSelector })` call.
+- [ ] Replace `yuno.startSeamlessCheckout(...)` + `yuno.mountSeamlessCheckoutLite(...)` + `yuno.startPayment()` with a single `transaction.start({ paymentMethod })` call.
 - [ ] **Do not** wire `createPayment` on the config — that would flip to manual mode.
 - [ ] Move `checkoutSession`, `countryCode`, `language`, `card`, etc. into `TransactionConfig`.
-- [ ] Pass `elementSelector` to `start()` (not the config) for form-based payments.
+- [ ] Set `elementSelector` on the transaction config (`sdkPayments.transaction({ ..., elementSelector })`) for form-based payments — it's optional and ignored by non-form flows.
 - [ ] Replace `yunoPaymentResult` with `onStatus` (read `result.status` / `result.substatus`).
 - [ ] Drop `yunoError`, `onLoading` (use `showLoading` if you need a custom loader).
 - [ ] Re-run your sandbox test suite.

--- a/docs/yuno-sdk/migration/web/seamless.mdx
+++ b/docs/yuno-sdk/migration/web/seamless.mdx
@@ -45,6 +45,7 @@ const transaction = sdkPayments.transaction({
     checkoutSession: 'session-from-backend',
     countryCode: 'CO',
     language: 'en',
+    elementSelector: '#root', // form container for the selected method (form flows only)
     // managed mode — no createPayment wired
     onStatus: (result) => console.log('done:', result.status),
 })
@@ -52,7 +53,7 @@ const transaction = sdkPayments.transaction({
 const views = transaction.getPaymentMethodsViews({
     types: ['paymentMethodList'],
     onPaymentSelected: (paymentMethod) =>
-        transaction.start({ paymentMethod, elementSelector: '#root' }),
+        transaction.start({ paymentMethod }),
 })
 
 views.paymentMethodList?.mount({ elementSelector: '#root' })
@@ -108,14 +109,14 @@ views.paypal?.mount({ elementSelector: '#paypal' })
 | `yuno.startSeamlessCheckout(config)` | `sdkPayments.transaction(config)` | Single factory. Don't wire `createPayment` — that would flip to manual mode (non-Seamless behavior). |
 | `yuno.mountSeamlessCheckout()` | `getPaymentMethodsViews({ types: ['paymentMethodList'], onPaymentSelected })` → `views.paymentMethodList?.mount({ elementSelector })` | Get a view handle, then call `.mount(...)` with the selector. |
 | `yuno.mountSeamlessExternalButtons([{ elementSelector, paymentMethodType }])` | `getPaymentMethodsViews({ types: ['applePay', 'googlePay', 'paypal'], onPaymentSelected })` → `views.applePay?.mount({ elementSelector, ...config })`, etc. | Per-view styling (button color, type, etc.) lives on each `.mount()` call. |
-| `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod, elementSelector })` | Called from `onPaymentSelected` after the user picks a method. Pass `elementSelector` (the form's container) when the chosen method renders a form. |
+| `yuno.startPayment()` (merchant trigger) | `transaction.start({ paymentMethod })` | Called from `onPaymentSelected` after the user picks a method. The form renders into the optional `elementSelector` set on `sdkPayments.transaction(config)`. |
 | `yunoPaymentResult(status, subStatus?)` | `onStatus(result)` | `PaymentResult` wrapper with `.status` and `.substatus`. |
 | `yuno.unmountSeamlessExternalButton(type)` / `yuno.unmountSeamlessExternalButtons()` | *(handled by `transaction.cancel()` or letting the transaction complete)* | Per-button unmount removed. |
 
 ## Behavior changes
 
 - **`Seamless` factory is gone.** Use the regular `sdkPayments.transaction(...)` factory. Don't wire `createPayment` — its absence keeps the SDK in managed mode (the same model Seamless had).
-- **`yuno.startPayment()` is gone.** The merchant-triggered start is now `transaction.start({ paymentMethod })`, called with the method the user picked. When the chosen method renders a form, pass `elementSelector` (the form's container) to `start()` — the list/wallet views keep their own `elementSelector` on `.mount()`.
+- **`yuno.startPayment()` is gone.** The merchant-triggered start is now `transaction.start({ paymentMethod })`, called with the method the user picked. When the chosen method renders a form, it uses the optional `elementSelector` set on `sdkPayments.transaction(config)` — the list/wallet views keep their own `elementSelector` on `.mount()`.
 - **Per-button unmount removed.** Use `transaction.cancel()` or let the transaction complete.
 
 ## Checklist

--- a/docs/yuno-sdk/reference/transaction-config.mdx
+++ b/docs/yuno-sdk/reference/transaction-config.mdx
@@ -23,6 +23,7 @@ On web, `TransactionConfig` is a plain object passed directly to `sdkPayments.tr
 | [`language`](#language) | String? | No | Browser language |
 | [`showStatusScreen`](#showstatusscreen) | Bool | No | `false` |
 | [`autoContinuePayment`](#autocontinuepayment) | Bool | No | `true` |
+| [`elementSelector`](#elementselector-web-only) | String \| HTMLElement? | No |  |
 
 On Web there is no `controller` field — wire events (`onStatus`, `showLoading`, `createPayment`) directly as fields on the config. See [`controller`](#controller-ios-android).
 
@@ -114,6 +115,10 @@ Flag that controls whether the SDK presents its built-in result screen after the
 Controls whether the SDK automatically continues the payment flow after creating it. When `true` (default), the SDK handles 3DS and status polling internally. Set to `false` if you want to control the post-creation flow manually.
 
 With `false`, the SDK stops once the payment is created: it does not poll status, does not run 3DS, and `onStatus` is not invoked for the transaction.
+
+## `elementSelector` (Web only)
+
+CSS selector string (or an `HTMLElement`) for the DOM node the SDK renders the payment or enrollment form into. Optional and used only by form-based flows — headless flows ignore it, and wallet/list views take their own `elementSelector` on `.mount()`. When omitted, form-based flows fall back to the SDK's default container.
 
 ## `appearance` (iOS, Android)
 

--- a/docs/yuno-sdk/reference/transaction-config.mdx
+++ b/docs/yuno-sdk/reference/transaction-config.mdx
@@ -23,7 +23,7 @@ On web, `TransactionConfig` is a plain object passed directly to `sdkPayments.tr
 | [`language`](#language) | String? | No | Browser language |
 | [`showStatusScreen`](#showstatusscreen) | Bool | No | `false` |
 | [`autoContinuePayment`](#autocontinuepayment) | Bool | No | `true` |
-| [`elementSelector`](#elementselector-web-only) | String \| HTMLElement? | No |  |
+| [`elementSelector`](#elementselector-web-only) | String? | No |  |
 
 On Web there is no `controller` field — wire events (`onStatus`, `showLoading`, `createPayment`) directly as fields on the config. See [`controller`](#controller-ios-android).
 
@@ -118,7 +118,7 @@ With `false`, the SDK stops once the payment is created: it does not poll status
 
 ## `elementSelector` (Web only)
 
-CSS selector string (or an `HTMLElement`) for the DOM node the SDK renders the payment or enrollment form into. Optional and used only by form-based flows — headless flows ignore it, and wallet/list views take their own `elementSelector` on `.mount()`. When omitted, form-based flows fall back to the SDK's default container.
+CSS selector for the DOM node the SDK renders the payment or enrollment form into. Optional and used only by form-based flows — headless flows ignore it, and wallet/list views take their own `elementSelector` on `.mount()`. When omitted, form-based flows fall back to the SDK's default container.
 
 ## `appearance` (iOS, Android)
 


### PR DESCRIPTION
## Summary
Aligns the Web v2 Universal SDK docs with the SDK change that moves `elementSelector` off `start()` and back onto the **transaction config** as an **optional** field, consumed only by form-based payment/enrollment flows (headless and other flows ignore it).

Tracks sdk-web PR [#2348](https://github.com/yuno-payments/sdk-web/pull/2348).

### Files
- `get-started.mdx` — canonical example + prose note
- `migration/web/{lite,seamless-lite,seamless,full,enrollment}.mdx` — code samples, mapping tables, behavior-change notes, checklists
- `features/enrollment.mdx` — Web example + "skip the form" note
- `reference/transaction-config.mdx` — added `elementSelector` to the Web field table + a field section

### Unchanged (by design)
- Per-view `views.*.mount({ elementSelector })` (Apple Pay / Google Pay / payment list)
- iOS/Android `start(paymentSelected:)` samples
- v1 (old) sides of migration tables

## Verification
- `grep` confirms no Web `start({ ... elementSelector })` remains and no stale "moved to start()" / "not a config field" prose

> Note: docs land ahead of the shipped bundle — merge once sdk-web #2348 is in a released alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior in this repo; integrators should align code with the documented SDK once the linked sdk-web release ships.
> 
> **Overview**
> Aligns **Web v2 Universal SDK** documentation with sdk-web [#2348](https://github.com/yuno-payments/sdk-web/pull/2348): **`elementSelector` moves from `transaction.start()` to optional `TransactionConfig`** on `sdkPayments.transaction({ … })`.
> 
> **Get started**, **enrollment**, and **`transaction-config`** reference are updated so form-based payment/enrollment examples set `elementSelector` on the config and call `start({ paymentMethod })` without it. Prose clarifies the field is **optional**, used only for **form-based** flows; **headless** flows ignore it; **payment list / wallet** views still use `elementSelector` on `.mount()`.
> 
> **Migration guides** (lite, seamless, seamless-lite, full, enrollment) revise mapping tables, behavior notes, checklists, and side-by-side samples to match—replacing prior “moved to `start()`” / “not a config field” wording. iOS/Android samples are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e1e8d34e21b6956970de6a687d42b4bd27c45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->