### PR TITLE
chore: web sdk changelog 2.0.0-alpha.2

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,24 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "2.0.0-alpha.2",
+      "release_date": "2026-07-23",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@2.0.0-alpha.2",
+        "language": "bash"
+      },
+      "entries": [],
+      "consumed_tickets": [
+        "CORECM-16454",
+        "CORECM-17854",
+        "CORECM-17910",
+        "CORECM-18152",
+        "CORECM-18216",
+        "CORECM-18230",
+        "CORECM-18234"
+      ]
+    },
+    {
       "version": "1.9.17",
       "release_date": "2026-07-20",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `2.0.0-alpha.2`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.0-alpha.2

0 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog JSON update with no application or SDK runtime code changes.
> 
> **Overview**
> Adds a new **web** SDK release block at the top of `changelog/source/web.json` for **`2.0.0-alpha.2`** (dated 2026-07-23), including the `npm install @yuno-payments/sdk-web@2.0.0-alpha.2` upgrade snippet.
> 
> The release is recorded with an **empty `entries` array** (no public changelog bullets yet) and **`consumed_tickets`** linking seven CORECM tickets for traceability to the upstream sdk-web release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ef70cf37a756bff028eee67be9cfa76eb0b697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->