### PR TITLE
docs(SUB-48): correct the subscription-payments envelope to `data`

### DIFF
--- a/openapi/subscriptions/list-subscription-payments.json
+++ b/openapi/subscriptions/list-subscription-payments.json
@@ -44,7 +44,7 @@
                 "examples": {
                   "Result": {
                     "value": {
-                      "items": [
+                      "data": [
                         {
                           "id": "00000000-0000-4000-8000-000000000010",
                           "payment_id": "00000000-0000-4000-8000-000000000011",
@@ -82,7 +82,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "items": {
+                    "data": {
                       "type": "array",
                       "description": "Every payment attempt for this subscription, most recent first.",
                       "items": {

--- a/reference/subscriptions/list-subscription-payments.mdx
+++ b/reference/subscriptions/list-subscription-payments.mdx
@@ -7,7 +7,7 @@ description: "Returns the charge history for a subscription, including plan/phas
 <Note>
 **This is a net-new endpoint**
 
-There was no payments subresource before Plans — the `payments` array on [the subscription object](/reference/subscriptions/the-subscription-object) is a legacy, always-empty field. Since there's no prior merchant integration to preserve here, this endpoint ships as one clean `items[]` shape with full plan/phase context — no legacy fields.
+There was no payments subresource before Plans — the `payments` array on [the subscription object](/reference/subscriptions/the-subscription-object) is a legacy, always-empty field. Since there's no prior merchant integration to preserve here, this endpoint ships as one clean `data[]` shape with full plan/phase context — no legacy fields.
 </Note>
 
 <Warning>


### PR DESCRIPTION
## The problem

PR #636 (merged 2026-07-23 15:04Z, Mintlify published 15:07Z) documents the **List Subscription Payments** merchant response envelope as `items`. public-api actually serves **`data`**.

A merchant integrating straight from the published reference decodes `items`, finds the key absent, and gets an empty list.

## Evidence

Upstream `public-api` master, `response/subscriptionPayments.go`:

```go
type SubscriptionPaymentsResponse struct {
    Data       []SubscriptionPaymentItem `json:"data"`
    Pagination PublicPagination          `json:"pagination"`
}
```

`ToPublic()` sets `Data: data`. There is no `items` key anywhere in that file. The same blob (`f847985e…`) is on `master`, `release/candidate` and the running stg image; it landed in public-api #2025 and has been in prod since rel-2026-07-22 (v2.210.0).

The documented `pagination` shape (`total` / `limit` / `offset` / `has_more`) was already correct — it matches `PublicPagination`.

## Why fix the docs and not the gateway

The alternative was adding `items` alongside `data` at the gateway. Rejected because:

- **Zero payload change.** Contract law ("the public payload never changes, additive only") is trivially satisfied — nothing is renamed or removed on a live merchant surface.
- **The `items` envelope has no merchant consumer.** It exists for internal/QA back-compat between the engine and payment-api. The public payments surface is net-new in rel-2026-07-22, so nothing at the edge has ever been served `items`.
- Emitting both would permanently double the size of every payments response for no product reason.

## Scope

Two envelope occurrences only:

| File | Change |
|---|---|
| `openapi/subscriptions/list-subscription-payments.json` | 200 example envelope key, and the 200 schema top-level property |
| `reference/subscriptions/list-subscription-payments.mdx` | "ships as one clean `items[]` shape" → `` `data[]` `` |

The two remaining `"items"` keys in the JSON are **JSON Schema array keywords** (inside the payments array and inside `line_items`) and are deliberately untouched. JSON revalidated after the edit — top-level keys are now `['data', 'pagination']` in both the example and the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVVyjuh3wfPt8H7xMCFpyn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime, auth, or data-path changes.
> 
> **Overview**
> **Aligns published API reference with production** for `GET /subscriptions/{subscription_id}/payments`.
> 
> The 200 response envelope is documented as **`data`** (plus `pagination`), not **`items`**. Merchants following the old docs would decode `items`, get nothing, and see an empty payment history even when charges exist.
> 
> Updates are limited to the OpenAPI example and schema top-level property in `list-subscription-payments.json`, and the MDX note that describes the response shape. Nested JSON Schema `items` keys for array element types are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d977cc7738875bcf7a81ec2425de6b511282558d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->