### PR TITLE
[C2-17851] docs: stored credentials behavior with the Seamless SDK

### DIFF
--- a/docs/payment-features/stored-credentials.mdx
+++ b/docs/payment-features/stored-credentials.mdx
@@ -183,3 +183,22 @@ If you already have the `network_transaction_id` for the card, you can include i
 <Danger>
   Remember to specify the `usage` in the `stored_credentials` section, as we trigger the `network_transaction_id` logic based on those fields.
 </Danger>
+
+## Stored credentials with the Seamless SDK
+
+When you create payments through the [Seamless SDK](/docs/sdks/seamless-sdk) (`workflow: SDK_SEAMLESS`), Yuno manages the stored credential logic for you. You only need to provide the `stored_credentials.reason` — the `usage` is determined by Yuno based on the state of the payment method, and any value you send in that field is ignored.
+
+<div className="code-nowrap-table dense-table">
+
+| Your request                                     | Payment method state                             | What Yuno sends to the provider                                                                                        |
+| :----------------------------------------------- | :----------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| No `stored_credentials` object                   | —                                                | No stored credentials are sent.                                                                                        |
+| No `reason` provided                             | —                                                | No stored credentials are sent.                                                                                        |
+| `reason` + `vaulted_token`                       | Token has a `network_transaction_id` associated  | `usage = USED` with the `network_transaction_id` associated with the token.                                            |
+| `reason` + `vaulted_token`                       | Token has no `network_transaction_id` yet        | `usage = FIRST`, so the card network returns a `network_transaction_id` that Yuno associates with the `vaulted_token`. |
+| `reason` + new card with `vault_on_success: true` | Token is created after a successful payment      | `usage = FIRST`.                                                                                                       |
+| `reason` + new card without vault                | —                                                | No stored credentials are sent.                                                                                        |
+
+</div>
+
+Once a `network_transaction_id` is associated with the `vaulted_token`, subsequent payments with that token are automatically sent as `usage = USED` with the stored `network_transaction_id`, without any additional action on your side.

--- a/docs/sdks/seamless-sdk/web-payments.mdx
+++ b/docs/sdks/seamless-sdk/web-payments.mdx
@@ -173,6 +173,8 @@ Configure the seamless checkout with the following options:
 
 Payments can be initiated by the customer (CIT) or by the merchant (MIT). You find more information about their characteristics in [Stored credentials](/docs/payment-features/stored-credentials).
 
+When using stored credentials with the Seamless SDK, you only need to send `stored_credentials.reason` in the payment request — Yuno determines the `usage` automatically based on the state of the payment method. See [Stored credentials with the Seamless SDK](/docs/payment-features/stored-credentials#stored-credentials-with-the-seamless-sdk) for the detailed behavior.
+
 The step-by-step on this page refers to a customer-initiated transaction without the recurrence option. Typically, it's used in one-time online purchases, in-store purchases, ATM withdrawals, etc.
 </Note>
 


### PR DESCRIPTION
### Related ticket: [C2-17851](https://yunopayments.atlassian.net/browse/C2-17851)

### Description

Documents how stored credentials work in the Seamless SDK (`workflow: SDK_SEAMLESS`), where Yuno owns the stored credential logic — merchants only send `stored_credentials.reason` and `usage` is determined by Yuno from the state of the payment method.

- **`docs/payment-features/stored-credentials.mdx`**: new section "Stored credentials with the Seamless SDK" with the full behavior matrix (vaulted token with/without `network_transaction_id`, new card with/without `vault_on_success`, missing `reason`).
- **`docs/sdks/seamless-sdk/web-payments.mdx`**: note in the CIT/MIT section pointing to the new behavior section.

### Depends on

⚠️ The "vaulted token without `network_transaction_id` → `usage = FIRST`" row reflects [payment-rx-orc#1841](https://github.com/yuno-payments/payment-rx-orc/pull/1841), which is not merged yet. **Do not merge this PR before that one.** The rest of the matrix documents current behavior.

Generated with Claude Code

[C2-17851]: https://yunopayments.atlassian.net/browse/C2-17851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only; no runtime, auth, or payment logic changes.
> 
> **Overview**
> **Documentation-only** update for how **stored credentials** work when payments use the Seamless SDK (`workflow: SDK_SEAMLESS`).
> 
> **`stored-credentials.mdx`** adds **Stored credentials with the Seamless SDK**: merchants send only `stored_credentials.reason`; Yuno sets `usage` from payment-method state and ignores client `usage`. A table covers missing `stored_credentials`/`reason`, vaulted tokens with or without `network_transaction_id`, and new cards with or without `vault_on_success`, plus follow-on `USED` behavior. A minor fix closes the existing `<Danger>` block.
> 
> **`web-payments.mdx`** extends the CIT/MIT note with the same `reason`-only guidance and a deep link to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87471a5fdb96f06240e0a4cad54f5ee0f68e38f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->