### PR TITLE
docs(SUB-48): document cancel_on_exhausted_retries and RETRIES_EXHAUSTED

### DIFF
--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -41,7 +41,8 @@ Every business model is unique, so we allow merchants to define specific rules t
 | `retry_on_decline` | bool   | Indicates whether to retry a payment after a first decline. Defaults to false. This flag is the only switch that enables retries; there is no dashboard toggle. | TRUE |
 | `amount`           | number | Number of retries the subscription will attempt. The maximum equals your environment's configured retry schedule length — 5 in production. Values above the cap are clamped to it. This cap is set per environment and is not configurable per account via the API. | 4 |
 | `strategy`         | string | The retry strategy. Allowed values: DEFAULT and CUSTOM_SCHEDULE. DEFAULT uses the fixed schedule above (NOT ML-based timing). CUSTOM_SCHEDULE uses the per-attempt schedule you provide. | `CUSTOM_SCHEDULE` |
-| `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. The subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. | TRUE |
+| `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. On its own, the subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. If `cancel_on_exhausted_retries` is also true, the subscription is canceled instead — see [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
+| `cancel_on_exhausted_retries` | bool | When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of rolling forward to the next cycle. Defaults to false. Can only be set when the subscription is created. See [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
 | `schedule`         | object | Contains attempt and delay\_seconds fields                                                                                               | Attempt: 2, `delay_seconds`: 86400 |
 
 </div>
@@ -53,4 +54,45 @@ The maximum number of retries equals your environment's configured retry schedul
 
 <Note>
 `strategy`: `DEFAULT` applies the fixed schedule above, not ML-based timing. Use `CUSTOM_SCHEDULE` together with the `schedule` array to define custom delays.
+</Note>
+
+### Canceling a subscription when retries run out
+
+By default, when every retry for a billing cycle has been attempted and none succeeded, the subscription stays `ACTIVE` and billing rolls forward to the next cycle. A subscription backed by a permanently dead card therefore keeps generating failed charges indefinitely.
+
+Set `cancel_on_exhausted_retries` to `true` when creating the subscription to change that:
+
+```json
+{
+  "retries": {
+    "retry_on_decline": true,
+    "amount": 3,
+    "cancel_on_exhausted_retries": true
+  }
+}
+```
+
+When retries for a cycle end without a successful payment, Yuno then:
+
+1. Sets the subscription status to `CANCELED`.
+2. Sets `cancellation_source` to `RETRIES_EXHAUSTED`.
+3. Stops all future scheduled billing for the subscription.
+4. Sends one `SUBSCRIPTION.CANCEL` webhook.
+
+This applies whichever way the retries ended — the schedule running to its last attempt, or `stop_on_hard_decline` ending the cycle early after a hard decline. In both cases `cancellation_source` is `RETRIES_EXHAUSTED`.
+
+<Note>
+`cancel_on_exhausted_retries` defaults to `false`. If you omit it, subscriptions behave exactly as they do today. No existing subscription changes behavior.
+</Note>
+
+<Warning>
+**This cancellation is final.** A canceled subscription is no longer billable, so [Retry Subscription](/reference/subscriptions/retry-subscription) is rejected for it. Without this flag you can manually rescue a subscription whose retries were exhausted; with it enabled, that option is gone once the cancellation happens. Enable it only if an exhausted retry schedule should genuinely end the customer's subscription.
+</Warning>
+
+<Note>
+`cancel_on_exhausted_retries` can only be set when the subscription is created. [Update Subscription](/reference/subscriptions/update-subscription) rejects a request that changes it. Sending back the same value the subscription already has is accepted, so a read-modify-write of the full subscription object still works.
+</Note>
+
+<Note>
+This flag applies to renewal cycles. Subscriptions created with `initial_payment_validation: true` already cancel themselves when their first payment fails, and that path reports `cancellation_source` as `SYSTEM` rather than `RETRIES_EXHAUSTED`.
 </Note>

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1664,7 +1664,8 @@ Sent when a paused subscription is resumed and transitions back to the `ACTIVE` 
         "amount": 4,
         "strategy": "DEFAULT",
         "schedule": null,
-        "stop_on_hard_decline": null
+        "stop_on_hard_decline": null,
+        "cancel_on_exhausted_retries": null
       },
       "metadata": [
         {
@@ -1701,6 +1702,12 @@ Sent when a paused subscription is resumed and transitions back to the `ACTIVE` 
 ### subscription.cancel
 
 Sent when a subscription is canceled. Once canceled, the subscription is terminated and cannot be reactivated.
+
+The subscription object carries a `cancellation_source` field describing what triggered the cancellation — `MERCHANT`, `SYSTEM`, `PLAN_CHANGE`, or `RETRIES_EXHAUSTED`. See [the subscription object](/reference/subscriptions/the-subscription-object) for what each value means.
+
+<Note>
+Treat `cancellation_source` as open-ended. New values can be added as Yuno introduces new cancellation behaviors, so handle an unrecognized value gracefully rather than switching exhaustively over the current list. `RETRIES_EXHAUSTED` is the most recent addition — it is sent when retries for a billing cycle end without a successful payment on a subscription created with `retries.cancel_on_exhausted_retries` set to `true`.
+</Note>
 
 ```json JSON
 {
@@ -1814,7 +1821,8 @@ Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification
         "amount": 4,
         "strategy": "DEFAULT",
         "schedule": null,
-        "stop_on_hard_decline": null
+        "stop_on_hard_decline": null,
+        "cancel_on_exhausted_retries": null
       },
       "metadata": [
         {
@@ -1856,6 +1864,10 @@ There is **no `subscription.error` webhook**. Yuno does not emit a subscription 
 
 <Note>
 The renewal **charge** itself is always signaled by a `payment.purchase` webhook, never by a subscription webhook. The `payments` array inside the subscription object is currently always empty in webhook payloads. `subscription.active` is sent once (at `billing_cycles.current` = 2), not on every renewal.
+</Note>
+
+<Note>
+There is one case where a failed renewal does produce a subscription webhook. If the subscription was created with `retries.cancel_on_exhausted_retries` set to `true`, then once retries for that cycle end without a successful payment the subscription is canceled and a single [`subscription.cancel`](#subscriptioncancel) is emitted with `cancellation_source` set to `RETRIES_EXHAUSTED`. This is still not a `subscription.error` — the individual failed attempts remain `payment.purchase` webhooks. Only the final cancellation is signaled on the subscription.
 </Note>
 
 ## Onboardings

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -381,7 +381,11 @@
                       },
                       "stop_on_hard_decline": {
                         "type": "boolean",
-                        "description": "When true, the retry schedule stops for the current billing cycle after a hard decline. The subscription remains ACTIVE and billing advances to the next cycle; no subscription is canceled or paused and no subscription webhook is emitted."
+                        "description": "When true, the retry schedule stops for the current billing cycle after a hard decline. On its own, the subscription remains ACTIVE and billing advances to the next cycle; no subscription is canceled or paused and no subscription webhook is emitted. If cancel_on_exhausted_retries is also true, the subscription is canceled instead."
+                      },
+                      "cancel_on_exhausted_retries": {
+                        "type": "boolean",
+                        "description": "When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of remaining ACTIVE and advancing to the next cycle. The subscription status becomes CANCELED, cancellation_source is set to RETRIES_EXHAUSTED, future billing stops, and a single SUBSCRIPTION.CANCEL webhook is emitted. Applies both when the retry schedule runs out and when stop_on_hard_decline ends the cycle early. Defaults to false, which preserves the existing behavior. Can only be set at creation: an update that changes it is rejected, although resending the current value is accepted. The cancellation is final, so Retry Subscription is rejected afterwards."
                       }
                     }
                   },

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -58,7 +58,21 @@ This object represents a subscription that can be associated with a customer.
   - `TRIALING` = The subscription is inside a plan's leading trial phase (see `plan_id`/`current_phase`). Transitions to `ACTIVE` automatically once the trial ends — this is webhooked like any other status change.
   - `PAUSED` = The subscription has been paused and can be reactivated.
   - `COMPLETED` = The subscription is completed because it reached the end date and time.
-  - `CANCELED` = Subscription canceled.
+  - `CANCELED` = Subscription canceled. See `cancellation_source` for what triggered it.
+</ParamField>
+
+<ParamField body="cancellation_source" type="enum">
+  What caused the subscription to be canceled. Only set once the subscription reaches `CANCELED`; `null` otherwise.
+
+  Possible values:
+  - `MERCHANT` = You canceled the subscription, through [Cancel Subscription](/reference/subscriptions/cancel-subscription) or the dashboard.
+  - `SYSTEM` = Yuno canceled the subscription automatically. This includes a subscription created with `initial_payment_validation: true` whose first payment did not succeed.
+  - `PLAN_CHANGE` = The subscription was replaced as part of a [plan change](/docs/payment-features/subscriptions/plans). A new subscription continues the customer's billing under the new plan.
+  - `RETRIES_EXHAUSTED` = Retries for a billing cycle ended without a successful payment and the subscription was created with `retries.cancel_on_exhausted_retries` set to `true`. See [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
+
+  <Note>
+  Treat this field as open-ended. New values can be introduced as Yuno adds cancellation behaviors, so handle an unrecognized value gracefully rather than switching exhaustively over the list above. `RETRIES_EXHAUSTED` is the most recent addition.
+  </Note>
 </ParamField>
 
 <ParamField body="plan_id" type="string">
@@ -337,6 +351,18 @@ This object represents a subscription that can be associated with a customer.
       The number of retries that the subscription plan will have to completion. The maximum equals your environment's configured retry schedule length (6 in production). Values above the cap are clamped to it. Max: 6
 
       Example: 4
+    </ParamField>
+
+    <ParamField body="stop_on_hard_decline" type="bool">
+      When true and a hard decline is detected, retries stop for the current billing cycle only. On its own, the subscription stays ACTIVE and billing advances to the next cycle. If `cancel_on_exhausted_retries` is also true, the subscription is canceled instead.
+
+      Example: TRUE
+    </ParamField>
+
+    <ParamField body="cancel_on_exhausted_retries" type="bool">
+      When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of advancing to the next cycle. `cancellation_source` is set to `RETRIES_EXHAUSTED` and a single `SUBSCRIPTION.CANCEL` webhook is emitted. Defaults to false. Can only be set at creation, and the cancellation is final — see [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
+
+      Example: TRUE
     </ParamField>
   </Expandable>
 </ParamField>


### PR DESCRIPTION
## Why now

The [SUB-28](https://yunopayments.atlassian.net/browse/SUB-28) engine is on `share/28-07-26` and both gateway hops are open (payment-api#801, public-api#2037). Once those land the behaviour is reachable by merchants — and right now it is documented **nowhere**. This closes that before it ships.

## What the flag does

`retries.cancel_on_exhausted_retries` — when retries for a billing cycle end without a successful payment, the subscription is CANCELED with `cancellation_source: RETRIES_EXHAUSTED` instead of rolling forward still ACTIVE. Defaults to `false`, so nothing changes for anyone who omits it.

## Changes

| File | What |
|---|---|
| `docs/payment-features/subscriptions/retries.mdx` | Parameter row + a section on the behaviour |
| `openapi/subscriptions/create-subscription.json` | The property, beside its `stop_on_hard_decline` sibling |
| `reference/subscriptions/the-subscription-object.mdx` | The flag, `stop_on_hard_decline`, and `cancellation_source` |
| `docs/webhooks/object-and-examples.mdx` | `RETRIES_EXHAUSTED` on `subscription.cancel` + both examples |

## Three things worth a reviewer's attention

**1. `cancellation_source` was documented nowhere at all.** Not just the new value — `MERCHANT`, `SYSTEM` and `PLAN_CHANGE` have shipped for a long time and appear in the docs only as `"cancellation_source": null` inside webhook examples. Since SUB-28 widens exactly this field, this PR adds the enumeration rather than appending one value to a list that didn't exist. It also tells consumers to treat the field as open-ended, so the next value we add doesn't break anyone switching exhaustively.

**2. Two existing statements became conditionally false** and are now qualified rather than left to contradict the engine:
- `stop_on_hard_decline`'s "no cancel/pause or subscription webhook is emitted" — true on its own, false when the new flag is also set, because the two compose.
- the webhooks page's "Yuno does not emit a subscription event when a renewal charge fails" — still true for individual attempts, but the *exhaustion* now emits `subscription.cancel` when the flag is on.

**3. The irreversibility is called out in a `<Warning>`, deliberately.** After an auto-cancel the subscription is no longer billable, so [Retry Subscription](/reference/subscriptions/retry-subscription) is rejected. Today a merchant can manually rescue a subscription whose retries were exhausted; with this flag on, they cannot. That is a genuine merchant-facing semantics change and needs prose, not just a schema line.

## Verification

- Both edited JSON artefacts parse; the new OpenAPI property was confirmed to land in the `retries` schema of the `POST /subscriptions` request body, with the expected siblings.
- Every `json` code block in the edited MDX files was parsed. One block in `object-and-examples.mdx` is invalid — verified **pre-existing on `main`** (same block, same index), untouched here.
- All six internal links checked against the exact page paths in `docs.json`, not by substring.
- The `#subscriptioncancel` anchor follows the repo's existing slug convention (punctuation stripped).
- Markdown table column counts verified consistent.

Mintlify CLI isn't available locally, so the build itself is unverified — worth a preview check before merging.

## Noted, not fixed

`retries.mdx` says the production retry cap is **5**; `the-subscription-object.mdx` says **6**. Pre-existing contradiction, unrelated to this change, and I'd be guessing which is right — flagging rather than silently picking one.

## Related

- Engine: subscription-ms#285
- Gateways: payment-api#801, public-api#2037
- Also open on SUB-48: #648 (subscription-payments envelope `items` → `data`) — still needs a reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3YNcsvHj1XYzoB9oAb7Mj

[SUB-28]: https://yunopayments.atlassian.net/browse/SUB-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and OpenAPI schema text only; no runtime code. Merchant-facing semantics are clearly flagged (irreversible cancel, create-only flag).
> 
> **Overview**
> **Documentation-only** update for subscription retry exhaustion behavior (SUB-28): merchants can opt in at creation with `retries.cancel_on_exhausted_retries` so a billing cycle that ends without a successful payment **cancels** the subscription (`cancellation_source: RETRIES_EXHAUSTED`, one `subscription.cancel` webhook) instead of staying `ACTIVE` and rolling to the next cycle.
> 
> Adds a retries guide section (defaults, interaction with `stop_on_hard_decline`, create-only immutability, finality vs manual Retry Subscription), documents **`cancellation_source`** on the subscription object (`MERCHANT`, `SYSTEM`, `PLAN_CHANGE`, `RETRIES_EXHAUSTED`) with open-ended handling guidance, extends **Create Subscription** OpenAPI, and updates webhook examples/notes—including that failed renewals can still emit `subscription.cancel` when this flag is on, while individual declines remain `payment.purchase`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027b06a04f3056bab22a6448a60ef93b5a887bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->