### PR TITLE
docs(C2-17837): merchant-provided card last four for Google Pay device tokens

### DIFF
--- a/docs/wallets/google-pay/google-pay-direct-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-direct-integration.mdx
@@ -196,7 +196,7 @@ The field is optional and backward compatible. If you do not send it, behavior i
 * The value is ignored for other wallets, such as Apple Pay.
 
 <Warning>
-  `lfd` is applied on `POST /v1/payments`. It is accepted and validated on `POST /v1/payments/rx` and `POST /v2/payments`, but not applied on those endpoints — the payment succeeds and returns the DPAN-derived last four.
+  `lfd` is applied on `POST /v1/payments`. It is accepted and validated on `POST /v1/payments/rx` and `POST /v2/payments`, but not applied on those endpoints — the payment succeeds and the last four digits come back empty or DPAN-derived, exactly as before.
 </Warning>
 
 Once applied, the value appears in the create payment response, in the Get payment by ID response, and in payment webhooks, under `payment_method.detail.card.card_data.lfd`. Webhook payloads nest it under `payment_method_detail` instead of `detail`.

--- a/docs/wallets/google-pay/google-pay-direct-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-direct-integration.mdx
@@ -77,7 +77,7 @@ Key details for your Google Pay integration with Yuno:
 Yuno supports both Google Pay API authorization methods:
 
 * **`PAN_ONLY`**: Card credentials stored in the user's Google account. When used, Yuno automatically handles 3D Secure authentication if enabled.
-* **`CRYPTOGRAM_3DS`**: Device-based card credentials with built-in authentication. These credentials include cryptographic authentication and don't require additional 3DS processing.
+* **`CRYPTOGRAM_3DS`**: Device-based card credentials with built-in authentication. These credentials include cryptographic authentication and don't require additional 3DS processing. These credentials decrypt to a device-specific number (DPAN), so see [Card last four digits for device tokens](#card-last-four-digits-for-device-tokens) if you display the card's last four digits to the shopper.
 
 Both methods are supported globally across all countries where Yuno operates. On the frontend, include both `PAN_ONLY` and `CRYPTOGRAM_3DS` in your `allowedAuthMethods` array for maximum payment success rates.
 
@@ -143,6 +143,72 @@ The Google Pay SDK returns the following object structure, which must be passed 
     },
     "type": "GOOGLE_PAY"
   }
+}
+```
+
+## Card last four digits for device tokens
+
+When Google Pay returns a `CRYPTOGRAM_3DS` credential, the encrypted token decrypts to the **DPAN** — a device-specific number, not the card stored by the shopper. Its last four digits are not the ones the shopper recognizes, so `card_data.lfd` in the payment response is empty or shows the DPAN's last four.
+
+The real card's last four digits are available to you in Google's response, outside the encrypted token:
+
+```json
+{
+  "paymentMethodData": {
+    "info": {
+      "cardDetails": "1515",
+      "cardNetwork": "VISA"
+    },
+    "tokenizationData": {
+      "token": "..."
+    }
+  }
+}
+```
+
+Send `paymentMethodData.info.cardDetails` as `payment_method.detail.wallet.card_data.lfd` and Yuno uses it in place of the DPAN-derived value.
+
+```json
+{
+  "payment_method": {
+    "type": "GOOGLE_PAY",
+    "detail": {
+      "wallet": {
+        "payment_token": "{\"protocolVersion\":\"ECv2\", ...}",
+        "card_data": {
+          "lfd": "1515"
+        }
+      }
+    }
+  }
+}
+```
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `lfd` | string | No | Last four digits of the shopper's real card, taken from `paymentMethodData.info.cardDetails`. Must be exactly 4 numeric digits. |
+
+The field is optional and backward compatible. If you do not send it, behavior is unchanged.
+
+* Yuno applies the value only when the token is a device token — `auth_method` is `CRYPTOGRAM_3DS`, or `pan_type` is `DPAN` when `auth_method` is absent.
+* `PAN_ONLY` credentials ignore the value. Those decrypt to the real card, so Yuno keeps the decrypted last four.
+* Only `lfd` is accepted. `brand` and the remaining card fields keep their decrypted values, because the DPAN's BIN already identifies the card network correctly.
+* The value is ignored for other wallets, such as Apple Pay.
+
+<Warning>
+  `lfd` is applied on `POST /v1/payments`. It is accepted and validated on `POST /v1/payments/rx` and `POST /v2/payments`, but not applied on those endpoints — the payment succeeds and returns the DPAN-derived last four.
+</Warning>
+
+Once applied, the value appears in the create payment response, in the Get payment by ID response, and in payment webhooks, under `payment_method.detail.card.card_data.lfd`. Webhook payloads nest it under `payment_method_detail` instead of `detail`.
+
+If `lfd` is present but is not exactly 4 numeric digits, the request is rejected:
+
+```json
+{
+  "code": "INVALID_REQUEST",
+  "messages": [
+    "Invalid Request. payment_method.detail.wallet.card_data.lfd must be exactly 4 numeric digits."
+  ]
 }
 ```
 


### PR DESCRIPTION
Jira: [C2-17837](https://yunopayments.atlassian.net/browse/C2-17837) · FR: [OR-1074](https://yunopayments.atlassian.net/browse/OR-1074) · Merchant: **Whop**

Documents the new optional `payment_method.detail.wallet.card_data.lfd` field on the Google Pay **Direct integration** (server-to-server) page.

API change: yuno-payments/public-api#2030

### Why

Google Pay `CRYPTOGRAM_3DS` credentials decrypt to the DPAN only, so the last four digits Yuno returns are empty or the DPAN's — not the card the shopper recognizes. The real value exists only on the merchant side, in Google's `paymentMethodData.info.cardDetails`. The new field lets them send it.

The field is **opt-in**, so this page is what actually makes it usable — shipping the API change alone changes nothing for merchants.

### What the section covers

- Where to get the value from Google's response, with an example of the `paymentMethodData` shape
- Request example with `card_data.lfd`
- Field table (optional, exactly 4 numeric digits)
- Behavior: applied for device tokens only; `PAN_ONLY` keeps the decrypted value; `brand` and other card fields unchanged; ignored for other wallets; backward compatible when omitted
- Where the value surfaces afterwards (create response, get payment, webhooks — noting webhooks nest under `payment_method_detail` rather than `detail`)
- The `400 INVALID_REQUEST` error with its exact message

Also adds a pointer from the existing `CRYPTOGRAM_3DS` bullet in **Google Pay API authorization methods** to the new section.

### Reviewer note

The `<Warning>` about endpoint scope is deliberate and worth keeping: `lfd` is validated on `/v1/payments/rx` and `/v2/payments` but only **applied** on `POST /v1/payments`. Without that note a merchant can integrate on `rx`, get a clean `201`, and still see blank last four digits — indistinguishable from the bug they reported.

All behavior described here is verified on staging against the API change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Google Pay direct integration guide; no runtime or API code in this PR.
> 
> **Overview**
> Documents the optional **`payment_method.detail.wallet.card_data.lfd`** field on the Google Pay **Direct integration** page so merchants can show the shopper’s real card last four when **`CRYPTOGRAM_3DS`** tokens decrypt to a DPAN.
> 
> Adds a **Card last four digits for device tokens** section: source the value from Google’s `paymentMethodData.info.cardDetails`, request/field table, when Yuno applies it (device tokens only; **`PAN_ONLY`** and other wallets unchanged), where it appears in responses/webhooks, validation error, and a **Warning** that **`lfd` is only applied on `POST /v1/payments`** (accepted but not applied on `/v1/payments/rx` and `/v2/payments`).
> 
> The **`CRYPTOGRAM_3DS`** bullet under authorization methods now links to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a01730638aa3553d9eebc0aacd5d195a5e74b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[C2-17837]: https://yunopayments.atlassian.net/browse/C2-17837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OR-1074]: https://yunopayments.atlassian.net/browse/OR-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ