### PR TITLE
docs(wallets): correct Apple Pay device/browser support, add support matrix

### DIFF
--- a/docs/wallets/apple-pay.mdx
+++ b/docs/wallets/apple-pay.mdx
@@ -32,7 +32,7 @@ In browsers without built-in Apple Pay support (for example, Chrome on macOS, or
 This flow is delivered by Apple's official Apple Pay JS SDK, which the Yuno Web SDK loads and manages automatically:
 
 - The Yuno Web SDK checks Apple Pay availability at runtime using Apple's APIs and displays the Apple Pay button whenever the customer's browser and device can complete a payment — including in third-party browsers. You do not need to implement browser detection or hide the button yourself.
-- No additional integration work is required for third-party browser support: the prerequisites are exactly the same as for Safari. Every domain where the Apple Pay button appears must be registered, as described in the [Prerequisites](/docs/prerequisites-apple-pay) guide.
+- No additional integration work is required for third-party browser support: the prerequisites are exactly the same as for Safari. Every domain where the Apple Pay button appears must be registered, as described in the [Prerequisites](/docs/wallets/apple-pay/prerequisites-apple-pay) guide.
 
 <Note>
   The cross-device payment flow requires the customer to have an iPhone running iOS 18 or later. On iPhone and iPad, Apple Pay works natively in all major browsers (Chrome, Edge, Firefox, and others), since they are based on the system's WebKit engine.
@@ -40,7 +40,7 @@ This flow is delivered by Apple's official Apple Pay JS SDK, which the Yuno Web 
 
 ## Integration
 
-To integrate Apple Pay using Yuno, you must first complete the [Prerequisites ](/docs/prerequisites-apple-pay) process. After, choose the integration option that best fits you and access the respective integration documentation:
+To integrate Apple Pay using Yuno, you must first complete the [Prerequisites ](/docs/wallets/apple-pay/prerequisites-apple-pay) process. After, choose the integration option that best fits you and access the respective integration documentation:
 
 * [SDK Integration](/docs/apple-pay-sdk-integration)
 * [Direct Integration](/docs/apple-pay-direct-integration)

--- a/docs/wallets/apple-pay.mdx
+++ b/docs/wallets/apple-pay.mdx
@@ -1,16 +1,42 @@
 ---
 title: "Apple Pay"
-description: "Introduces Apple Pay integration options with Yuno through the SDK or Direct API."
+description: "Introduces Apple Pay integration options with Yuno through the SDK or Direct API, and lists the devices and browsers where Apple Pay is available."
 ---
 
-Apple Pay is a cutting-edge mobile payment solution designed exclusively for iOS devices. With its proprietary technologies, Apple Pay offers a seamless, end-to-end payment experience that differentiates it from traditional payment methods. Before integrating with Yuno, it's crucial to grasp the workflow of this innovative system.
+Apple Pay is Apple's digital wallet, which lets customers pay quickly and securely with the cards saved on their Apple devices, confirming each payment with Face ID, Touch ID, or their device passcode. Apple Pay works in native iOS apps and on the web — and web support is not limited to Safari or Apple hardware: customers can also pay from third-party browsers on macOS and from any browser on Windows. See [Supported devices and browsers](#supported-devices-and-browsers) for the full matrix.
 
-Yuno presents an effortless way to incorporate Apple Pay as a payment method in your app. You have two integration options:
+Yuno presents an effortless way to incorporate Apple Pay as a payment method in your app or website. You have two integration options:
 
 * Utilize our user-friendly SDK
 * Directly integrate with our API
 
-Yuno streamlines the process of accepting Apple Pay payments and provides the flexibility to route payments to any payment service provider. By incorporating Apple Pay, you can elevate the customer experience and boost conversions within your app.
+Yuno streamlines the process of accepting Apple Pay payments and provides the flexibility to route payments to any payment service provider. By incorporating Apple Pay, you can elevate the customer experience and boost conversions in your app and on your website.
+
+## Supported devices and browsers
+
+Apple Pay is available in two contexts: **in-app**, for native iOS applications integrating the Yuno mobile SDK, and **on the web**, through the Yuno Web SDK or a direct API integration.
+
+On the web, Apple Pay is available across all major platforms and browsers:
+
+| Customer device | Browser | Payment experience |
+|-----------------|---------|--------------------|
+| iPhone / iPad (iOS, iPadOS) | Any browser — Safari, Chrome, Edge, Firefox, and others | Native Apple Pay payment sheet on the device |
+| Mac (macOS) | Safari | Native Apple Pay payment sheet |
+| Mac (macOS) | Chrome, Edge, Firefox, and other third-party browsers | Cross-device payment: the customer scans a code with their iPhone and confirms the payment on the phone |
+| Windows PC | Any browser | Cross-device payment: the customer scans a code with their iPhone and confirms the payment on the phone |
+
+### How Apple Pay works in third-party browsers
+
+In browsers without built-in Apple Pay support (for example, Chrome on macOS, or any browser on Windows), Apple provides a cross-device payment flow: when the customer selects Apple Pay at checkout, a code appears on the screen. The customer scans it with their iPhone and approves the payment on the phone, using the cards in their Apple Wallet.
+
+This flow is delivered by Apple's official Apple Pay JS SDK, which the Yuno Web SDK loads and manages automatically:
+
+- The Yuno Web SDK checks Apple Pay availability at runtime using Apple's APIs and displays the Apple Pay button whenever the customer's browser and device can complete a payment — including in third-party browsers. You do not need to implement browser detection or hide the button yourself.
+- No additional integration work is required for third-party browser support: the prerequisites are exactly the same as for Safari. Every domain where the Apple Pay button appears must be registered, as described in the [Prerequisites](/docs/prerequisites-apple-pay) guide.
+
+<Note>
+  The cross-device payment flow requires the customer to have an iPhone running iOS 18 or later. On iPhone and iPad, Apple Pay works natively in all major browsers (Chrome, Edge, Firefox, and others), since they are based on the system's WebKit engine.
+</Note>
 
 ## Integration
 

--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -18,7 +18,7 @@ This guide provides a comprehensive process to integrate Apple Pay with Yuno SDK
 </Note>
 
 <Note>
-  Apple Pay supports third-party browsers such as Google Chrome for users with iOS 18 or higher.
+  Apple Pay on the web is not limited to Safari or Apple devices. It also works in third-party browsers on iPhone, iPad, and macOS, and in any browser on Windows through Apple's cross-device payment flow. See [Supported devices and browsers](/docs/apple-pay#supported-devices-and-browsers) for the full matrix.
 </Note>
 
 ## Apple Pay overview

--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -8,7 +8,7 @@ This guide provides a comprehensive process to integrate Apple Pay with Yuno SDK
 <Note>
   **Setup Required**
 
-  Before implementing Apple Pay payments, ensure you have completed the [prerequisites](/docs/prerequisites-apple-pay).
+  Before implementing Apple Pay payments, ensure you have completed the [prerequisites](/docs/wallets/apple-pay/prerequisites-apple-pay).
 </Note>
 
 <Note>
@@ -305,7 +305,7 @@ For SDK recurring payments, you must provide a subscription management URL where
 
 ## Related documentation
 
-- [Prerequisites for Apple Pay](/docs/prerequisites-apple-pay)
+- [Prerequisites for Apple Pay](/docs/wallets/apple-pay/prerequisites-apple-pay)
 - [Apple Pay Direct integration](/docs/apple-pay-direct-integration)
 - [Subscription management](/docs/subscriptions)
 - [Webhooks](/docs/webhooks)


### PR DESCRIPTION
## Why

The [Apple Pay overview page](https://docs.y.uno/docs/apple-pay) currently says Apple Pay is *"designed exclusively for iOS devices"* and has no browser/device support information. That is incorrect, and it has repeatedly led readers (merchants and internal teams) to assume Apple Pay via Yuno is Safari/iOS-only and to treat the button appearing in other browsers as a bug.

Actual behavior, verified against the Web SDK implementation and confirmed with the Web SDK product team:

- The Yuno Web SDK loads Apple's official **Apple Pay JS SDK** automatically — merchants add nothing.
- Button visibility is decided at runtime via `ApplePaySession.applePayCapabilities()` (with `canMakePayments()` fallback), so the button is **not** hidden in non-Safari browsers.
- Supported web surfaces: Safari on macOS; **all** browsers on iOS/iPadOS; third-party browsers on macOS and any browser on Windows via Apple's cross-device flow (customer scans a code with their iPhone, iOS 18+, and completes the payment on the phone).
- Prerequisites are identical everywhere: register the payment-page domain (Apple Pay domain registration in the dashboard). No extra merchant-side work.

## What changed

- `docs/wallets/apple-pay.mdx`
  - Rewrote the intro paragraph (removed the *"exclusively for iOS devices"* claim).
  - Added a **Supported devices and browsers** section: platform/browser matrix, how the cross-device (scan-code) flow works in third-party browsers, runtime button availability, and a note that prerequisites are the same as for Safari.
- `docs/wallets/apple-pay/apple-pay-sdk-integration.mdx`
  - Replaced the incomplete note (*"supports third-party browsers such as Google Chrome for users with iOS 18 or higher"*) with a link to the new section, so there is a single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or payment logic impact.
> 
> **Overview**
> Corrects misleading Apple Pay docs that implied **iOS/Safari-only** support and adds a single source of truth for where web Apple Pay works with Yuno.
> 
> The **Apple Pay overview** (`apple-pay.mdx`) rewrites the intro (web + app, not “exclusively iOS”), extends copy to **websites** as well as apps, and adds **Supported devices and browsers**: a platform/browser matrix, explanation of Apple’s **cross-device (scan-code)** flow on macOS third-party browsers and Windows, and notes that the **Web SDK** handles availability via Apple’s APIs with **no extra merchant integration** beyond domain registration. Prerequisites links are updated to `/docs/wallets/apple-pay/prerequisites-apple-pay`, and the page description mentions the device/browser list.
> 
> The **SDK integration** guide replaces the narrow iOS 18 / Chrome note with a pointer to the new matrix and aligns prerequisite/related-doc links to the wallets path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69f3e88c7dec49ed20bc894931fd1dfc3098bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->