### PR TITLE
docs(customers): add Operations links and shipping_address required fields

### DIFF
--- a/openapi/customers/create-customer.json
+++ b/openapi/customers/create-customer.json
@@ -1193,7 +1193,12 @@
                         "type": "string",
                         "description": "The neighborhood of the address line of the customer(MAX 255; MIN 1)."
                       }
-                    }
+                    },
+                    "required": [
+                      "address_line_1",
+                      "city",
+                      "country"
+                    ]
                   },
                   "metadata": {
                     "type": "array",

--- a/reference/customers/the-customer-object.mdx
+++ b/reference/customers/the-customer-object.mdx
@@ -251,3 +251,11 @@ This object represents a customer who will make payments using your service.
   Example: 2022-05-09T20:46:54.786342Z
 </ParamField>
 
+## Operations
+
+- [Create a Customer](/reference/customers/create-customer)
+- [Retrieve a Customer](/reference/customers/retrieve-customer)
+- [Retrieve by External ID](/reference/customers/retrieve-customer-by-external-id)
+- [Update a Customer](/reference/customers/update-customer)
+- [Delete a Customer](/reference/customers/delete-customer)
+


### PR DESCRIPTION
Adds an Operations section linking all 5 customer endpoints to the Customer Object page, and marks address_line_1, city, and country as required on shipping_address in the create-customer spec, matching API behavior confirmed by Andrea.