### PR TITLE
docs(webhooks): clarify HMAC secret is scoped to the webhook, not per PSP connection

### DIFF
--- a/reference/webhooks/index.mdx
+++ b/reference/webhooks/index.mdx
@@ -47,6 +47,8 @@ x-secret:  <secret>
 
 Configure `hmac_client_secret`. Yuno signs the payload with it and sends the signature as a header, so you can verify that the notification is authentic and was not tampered with.
 
+A webhook's authentication (including `hmac_client_secret`) is scoped to the webhook object itself, not to a specific payment provider connection. If your account routes payments through multiple PSP connections, a single webhook still delivers and signs events for all of them the same way — there's no separate secret per connection. Configure more than one webhook only if you need events split across different endpoints, not to segment by provider.
+
 ```
 x-hmac-signature: Base64(
   HMAC-SHA256(key = hmac_client_secret, msg = <raw request body>)


### PR DESCRIPTION
## Summary
- Clarifies that a webhook's `hmac_client_secret` is scoped to the webhook object, not to any specific PSP connection — one webhook signs deliveries the same way regardless of which provider processed the payment.

## Verification
- `manage-webhooks.json` schema: no `connection_id`/`psp`/`provider` field anywhere.
- `openapi/organizations/connections` schema: no `webhook`/`hmac`/`signature` field anywhere.
- The two resources are fully decoupled in the API — this is a documented fact of the existing schema.
