### PR TITLE
docs(wallets): add Web SDK version requirements for Apple Pay in third-party browsers

### DIFF
--- a/docs/wallets/apple-pay.mdx
+++ b/docs/wallets/apple-pay.mdx
@@ -35,6 +35,12 @@ This flow is delivered by Apple's official Apple Pay JS SDK, which the Yuno Web 
 - No additional integration work is required for third-party browser support: the prerequisites are exactly the same as for Safari. Every domain where the Apple Pay button appears must be registered, as described in the [Prerequisites](/docs/wallets/apple-pay/prerequisites-apple-pay) guide.
 
 <Note>
+  **Web SDK version requirements**
+
+  Third-party browser support is available from Web SDK version **1.3**. We strongly recommend using version **1.8.0 or later**: starting with 1.8.0, the entire Apple Pay interaction completes before the One-Time Token (OTT) is created, so the flow no longer depends on the payment-creation and `continuePayment()` steps that earlier versions required. If you are on an older version, see the [Web SDK changelog](/changelog/web) for upgrade guidance.
+</Note>
+
+<Note>
   The cross-device payment flow requires the customer to have an iPhone running iOS 18 or later. On iPhone and iPad, Apple Pay works natively in all major browsers (Chrome, Edge, Firefox, and others), since they are based on the system's WebKit engine.
 </Note>
 


### PR DESCRIPTION
## Why

Follow-up to #654. The new **Supported devices and browsers** section documents that Apple Pay works in third-party desktop browsers, but not which Web SDK versions provide it. The Web SDK product team clarified the version line: support exists since **1.3**, and **1.8.0 or later is strongly recommended** — starting with 1.8.0 the entire Apple Pay interaction completes before the One-Time Token (OTT) is created, so the flow no longer depends on the payment-creation + `continuePayment()` sequence that earlier versions required.

Without this note, merchants on older SDK versions can read the new section and expect the cross-device flow to work as described.

## What changed

- `docs/wallets/apple-pay.mdx` — added a **Web SDK version requirements** note to the *How Apple Pay works in third-party browsers* section (minimum 1.3, recommended 1.8.0+, link to the Web SDK changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)