### PR TITLE
chore: vtex sdk changelog 4.2.333

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,17 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.333
+*July 27, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="added" /> **Per-storefront seller website in payment metadata**  
+  Payments now report the storefront the order actually came from instead of the store's default host, improving reporting and reconciliation for merchants running multiple storefronts on one account. A new "Sales Channel Domains" affiliation setting optionally maps each sales channel to its public domain (for example `2:b2b.example.com;18:members.example.com`); unmapped channels fall back to the order's storefront host, and stores without the setting keep working with no configuration changes.
+
+- <ChangelogBadge type="added" /> **VTEX order sequence as processor transaction reference**  
+  A new affiliation setting, Send Order Sequence as Merchant Reference, makes payments carry the VTEX order sequence as the merchant reference, so payment providers configured with a custom transaction identification (such as Mercado Pago) receive the sequence as the external reference shown in their panel, matching pre-migration VTEX behavior. The setting is off by default; when it is disabled or the sequence is unavailable the reference falls back to the VTEX Order ID, and connections without the custom identification option are unaffected.
+
 ## v4.2.331
 *July 22, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,32 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.333",
+      "release_date": "2026-07-27",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.333",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Per-storefront seller website in payment metadata",
+          "description": "Payments now report the storefront the order actually came from instead of the store's default host, improving reporting and reconciliation for merchants running multiple storefronts on one account. A new \"Sales Channel Domains\" affiliation setting optionally maps each sales channel to its public domain (for example `2:b2b.example.com;18:members.example.com`); unmapped channels fall back to the order's storefront host, and stores without the setting keep working with no configuration changes.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "VTEX order sequence as processor transaction reference",
+          "description": "A new affiliation setting, Send Order Sequence as Merchant Reference, makes payments carry the VTEX order sequence as the merchant reference, so payment providers configured with a custom transaction identification (such as Mercado Pago) receive the sequence as the external reference shown in their panel, matching pre-migration VTEX behavior. The setting is off by default; when it is disabled or the sequence is unavailable the reference falls back to the VTEX Order ID, and connections without the custom identification option are unaffected.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.331",
       "release_date": "2026-07-22",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.333`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.333

2 entries.