### PR TITLE
docs(how-yuno-works): fix em dashes, absolute links, wording, and broken link

### DIFF
--- a/docs/how-yuno-works/step-1-set-up-your-account.mdx
+++ b/docs/how-yuno-works/step-1-set-up-your-account.mdx
@@ -38,7 +38,7 @@ The dashboard will display a confirmation message when your connection is succes
 <Video src="https://github.com/writechoiceorg/yuno-images/raw/main/doc/set_up_you_account/connection_setup_V4_v2.mp4" />
 ### Step 3: Set up routing for your new connection
 
-After adding a connection, you need to assign it to a route. Routes determine which provider processes payments. While you can configure multiple routes and processors for each payment method, this guide covers a basic setup where all payments are processed through the Yuno Test Payment Gateway connection.
+After adding a connection, you need to assign it to a route. Routes determine which provider processes payments. You can configure multiple routes and processors for each payment method. This guide covers a basic setup where all payments are processed through the Yuno Test Payment Gateway connection.
 
 To set up routing:
 
@@ -66,7 +66,7 @@ After configuring your connection and routing, enable the Card payment method to
 <Video src="https://github.com/writechoiceorg/yuno-images/raw/main/doc/set_up_you_account/checkoutbuilder.mp4" />
 ### Step 5: Get your API credentials
 
-To complete the setup, you'll need to obtain your API credentials from the Yuno dashboard. These credentials are required for integrating Yuno into your application and are specific to the Sandbox environment.
+To complete the setup, you'll need to obtain your API credentials from the Yuno dashboard. These credentials are required for integrating Yuno into your app and are specific to the Sandbox environment.
 
 1. Navigate to the [Developers](https://dashboard.y.uno/developers) section in the dashboard sidebar
 2. Locate your API credentials in the Developer Tools section:

--- a/docs/how-yuno-works/step-2-your-first-payment.mdx
+++ b/docs/how-yuno-works/step-2-your-first-payment.mdx
@@ -3,12 +3,12 @@ title: "Create Your First Payment With SDK"
 description: "Walks through installing the Yuno SDK sample project and submitting a test card payment in sandbox"
 ---
 
-This guide shows you how to create your first payment using the Yuno SDK. You'll learn how to:
+This guide shows you how to create your first payment using the Yuno SDK in under 5 minutes. You'll learn how to:
 
 * Set up and run the example project
 * Make a test payment using the SDK
 
-The Yuno SDK enables you to integrate payment methods into your web application and process payments securely. By following this guide, you'll have your first payment up and running in under 5 minutes.
+The Yuno SDK integrates payment methods into your web app and processes payments securely.
 
 ### Step 1: Install prerequisites
 
@@ -29,7 +29,7 @@ cd yuno-sdk-web
 <Note>
 **SDK Integration Example**
 
-Yuno provides a ready-to-use application built with the Web SDK. Explore [this project](https://github.com/yuno-payments/yuno-sdk-web) to see how fast and easy it is to integrate with Yuno.
+Yuno provides a ready-to-use app built with the Web SDK. Explore [this project](https://github.com/yuno-payments/yuno-sdk-web) to see how fast and easy it is to integrate with Yuno.
 </Note>
 
 ### Step 3: Set up environment variables
@@ -63,7 +63,7 @@ Then, run the project with the following command:
 npm start
 ```
 
-To access the running application, open your browser and go to:
+To access the running app, open your browser and go to:
 
 ```shell
 http://localhost:8080
@@ -90,4 +90,4 @@ After accessing the running project in your browser, you'll see a basic checkout
 3. Find your test payment in the list
 4. Click the eye icon to view the full payment details
 
-Congratulations! You've successfully created your first payment with Yuno. Check out our other guides to learn more about integrating additional features.
+Congratulations! You've successfully created your first payment with Yuno. Check out [the Core Concepts guides](/docs/basic-concepts) to learn more about integrating additional features.

--- a/docs/how-yuno-works/what-is-yuno.mdx
+++ b/docs/how-yuno-works/what-is-yuno.mdx
@@ -33,7 +33,7 @@ Yuno is the intelligent control plane between your app and the global payments e
 
 ## How Yuno solves it
 
-You connect once. Yuno orchestrates everything else — routing, fraud, tokenization, retries, and operations — in real time.
+You connect once, and Yuno orchestrates everything else (routing, fraud, tokenization, retries, and operations) in real time.
 
 <Frame>
   <img src="/images/how-yuno-works/illustration-with-yuno.png" alt="A merchant connects once to Yuno and unlocks payouts, network tokens, account updater, 1,000+ global integrations, risk conditions, and insights." />
@@ -113,10 +113,10 @@ You connect once. Yuno orchestrates everything else — routing, fraud, tokeniza
   <Card title="SDKs" icon="code" href="/docs/sdks/overview/choose-integration">
     **Recommended.** Web, iOS, Android, Flutter, React Native.
   </Card>
-  <Card title="Direct API" icon="server" href="https://docs.y.uno/docs/direct-integration-use-cases/direct-flow">
+  <Card title="Direct API" icon="server" href="/docs/direct-integration-use-cases/direct-flow">
     Server-to-server for maximum control.
   </Card>
-  <Card title="Payment Links" icon="link" href="https://docs.y.uno/docs/using-yuno/dashboard-overview/payment-links#payment-links">
+  <Card title="Payment Links" icon="link" href="/docs/using-yuno/dashboard-overview/payment-links#payment-links">
     Hosted checkout via URL, minimal dev work.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## PR Description
Handoff list of simple copy-editing fixes across the three Getting Started pages in `docs/how-yuno-works/`: removing em dashes, converting absolute internal links to relative paths, applying the "application" → "app" termbase preference, correcting first-person voice, fixing a dead-end link, and trimming a 3x-repeated purpose statement.

## Changes
- `docs/how-yuno-works/what-is-yuno.mdx` — rewrote the double em-dash sentence ("Yuno orchestrates everything else...") using parentheses instead; changed the "Direct API" and "Payment Links" Integration options cards from absolute `https://docs.y.uno/...` hrefs to relative `/docs/...` paths for consistency with the rest of the page.
- `docs/how-yuno-works/step-1-set-up-your-account.mdx` — split the over-25-word routing sentence into two shorter sentences; replaced "application" with "app" in the API credentials sentence.
- `docs/how-yuno-works/step-2-your-first-payment.mdx` — replaced "application" with "app" in three places (intro, SDK Integration Example note, running-app instruction); replaced first-person "our other guides" with "the Core Concepts guides" and linked it to `/docs/basic-concepts` (previously pointed nowhere); removed the redundant third restatement of the guide's purpose before Step 1, keeping the opening sentence (with the "under 5 minutes" detail folded in) and the SDK description sentence.