### PR TITLE
chore: web sdk changelog 1.9.18

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.18",
+      "release_date": "2026-07-28",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.18",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Express-Only Payment Methods Callback",
+          "description": "Added an optional `onlyExpressPaymentMethods` callback to the full checkout configuration that reports `true` when every available payment method renders as an express button (Apple Pay, Google Pay, PayPal, PayPal enrollment, PayPal Braintree, Revolut Pay) and `false` otherwise. When only express methods are available, the \"Or pay with\" divider is no longer rendered below the express buttons.",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18528"
+      ]
+    },
+    {
       "version": "1.9.17",
       "release_date": "2026-07-20",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.18
+*July 28, 2026*
+
+**Checkout**
+
+- <ChangelogBadge type="added" /> **Express-Only Payment Methods Callback**  
+  Added an optional `onlyExpressPaymentMethods` callback to the full checkout configuration that reports `true` when every available payment method renders as an express button (Apple Pay, Google Pay, PayPal, PayPal enrollment, PayPal Braintree, Revolut Pay) and `false` otherwise. When only express methods are available, the "Or pay with" divider is no longer rendered below the express buttons.
+
 ## v1.9.17
 *July 20, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.18`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.18

1 entry.