### PR TITLE
docs(subscriptions): first-charge semantics for monthly_billing_day

### DIFF
--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -121,7 +121,7 @@
                       },
                       "monthly_billing_day": {
                         "type": "integer",
-                        "description": "The day of the month when billing is processed. (MAX 31; MIN 1)"
+                        "description": "The day of the month when billing is processed. (MAX 31; MIN 1). Only valid for MONTH frequency. If the subscription has not started yet (availability.start_at is in the future), the first billing still occurs at availability.start_at and the billing day applies from the second cycle onward; the resulting first billing period may be shorter than a full cycle and is charged in full."
                       }
                     }
                   },


### PR DESCRIPTION
Documents the semantics pinned by [SUB-56](https://yunopayments.atlassian.net/browse/SUB-56) (subscription-ms [#293](https://github.com/yuno-payments/subscription-ms/pull/293), deployed to stg 2026-07-28): a subscription that has not started yet bills at `availability.start_at` regardless of `monthly_billing_day`; the billing day anchors the schedule from the second cycle onward; the resulting shorter first period is charged in full. Previously the field's description said only "the day of the month when billing is processed" — first-charge behaviour was unspecified (EC-DATE-04 in the team's edge-case catalogue).

Update endpoint only for now — the create endpoint gains the field once payment-api's pass-through fix deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbGkAkxe5sUEZyB2mu4WAm

[SUB-56]: https://yunopayments.atlassian.net/browse/SUB-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ