### PR TITLE
[RELEASE] Subscriptions docs batch — SUB-48/28/31/56 → main

### DIFF
--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -41,7 +41,8 @@ Every business model is unique, so we allow merchants to define specific rules t
 | `retry_on_decline` | bool   | Indicates whether to retry a payment after a first decline. Defaults to false. This flag is the only switch that enables retries; there is no dashboard toggle. | TRUE |
 | `amount`           | number | Number of retries the subscription will attempt. The maximum equals your environment's configured retry schedule length — 5 in production. Values above the cap are clamped to it. This cap is set per environment and is not configurable per account via the API. | 4 |
 | `strategy`         | string | The retry strategy. Allowed values: DEFAULT and CUSTOM_SCHEDULE. DEFAULT uses the fixed schedule above (NOT ML-based timing). CUSTOM_SCHEDULE uses the per-attempt schedule you provide. | `CUSTOM_SCHEDULE` |
-| `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. The subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. | TRUE |
+| `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. On its own, the subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. If `cancel_on_exhausted_retries` is also true, the subscription is canceled instead — see [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
+| `cancel_on_exhausted_retries` | bool | When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of rolling forward to the next cycle. Defaults to false. Can only be set when the subscription is created. See [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
 | `schedule`         | object | Contains attempt and delay\_seconds fields                                                                                               | Attempt: 2, `delay_seconds`: 86400 |
 
 </div>
@@ -53,4 +54,45 @@ The maximum number of retries equals your environment's configured retry schedul
 
 <Note>
 `strategy`: `DEFAULT` applies the fixed schedule above, not ML-based timing. Use `CUSTOM_SCHEDULE` together with the `schedule` array to define custom delays.
+</Note>
+
+### Canceling a subscription when retries run out
+
+By default, when every retry for a billing cycle has been attempted and none succeeded, the subscription stays `ACTIVE` and billing rolls forward to the next cycle. A subscription backed by a permanently dead card therefore keeps generating failed charges indefinitely.
+
+Set `cancel_on_exhausted_retries` to `true` when creating the subscription to change that:
+
+```json
+{
+  "retries": {
+    "retry_on_decline": true,
+    "amount": 3,
+    "cancel_on_exhausted_retries": true
+  }
+}
+```
+
+When retries for a cycle end without a successful payment, Yuno then:
+
+1. Sets the subscription status to `CANCELED`.
+2. Sets `cancellation_source` to `RETRIES_EXHAUSTED`.
+3. Stops all future scheduled billing for the subscription.
+4. Sends one `SUBSCRIPTION.CANCEL` webhook.
+
+This applies whichever way the retries ended — the schedule running to its last attempt, or `stop_on_hard_decline` ending the cycle early after a hard decline. In both cases `cancellation_source` is `RETRIES_EXHAUSTED`.
+
+<Note>
+`cancel_on_exhausted_retries` defaults to `false`. If you omit it, subscriptions behave exactly as they do today. No existing subscription changes behavior.
+</Note>
+
+<Warning>
+**This cancellation is final.** A canceled subscription is no longer billable, so [Retry Subscription](/reference/subscriptions/retry-subscription) is rejected for it. Without this flag you can manually rescue a subscription whose retries were exhausted; with it enabled, that option is gone once the cancellation happens. Enable it only if an exhausted retry schedule should genuinely end the customer's subscription.
+</Warning>
+
+<Note>
+`cancel_on_exhausted_retries` can only be set when the subscription is created. [Update Subscription](/reference/subscriptions/update-subscription) rejects a request that changes it. Sending back the same value the subscription already has is accepted, so a read-modify-write of the full subscription object still works.
+</Note>
+
+<Note>
+This flag applies to renewal cycles. Subscriptions created with `initial_payment_validation: true` already cancel themselves when their first payment fails, and that path reports `cancellation_source` as `SYSTEM` rather than `RETRIES_EXHAUSTED`.
 </Note>

--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -9,7 +9,7 @@ Yuno's Smart Retries help recover declined recurring credit card payments by ret
 
 Yuno's Smart Retries offer several benefits that enhance payment processes and revenue recovery:
 
-* **Data-driven decision-making**: Uses a proven retry schedule, with machine-learning-based retry timing available on request through the `SMART` strategy.
+* **Data-driven decision-making**: Uses a proven retry schedule, or machine-learning-based retry timing via the `SMART` strategy.
 * **Enhanced revenue retrieval**: Increases the chances of successfully collecting payments.
 * **Decreased subscriber turnover**: Minimizes disruptions and involuntary subscriber departures.
 * **Flexible logic**: Allows customization of retry schedules to maximize success opportunities.
@@ -17,7 +17,7 @@ Yuno's Smart Retries offer several benefits that enhance payment processes and r
 
 ### Retry schedule
 
-By default, Yuno applies the fixed retry schedule below. Each delay is measured **from the previous attempt**, not cumulatively from the first attempt. You can also request machine-learning-based retry timing, which adapts the moment of each retry per transaction, by setting `strategy` to `SMART` — see [Machine-learning retry timing](#machine-learning-retry-timing).
+By default, Yuno applies the fixed retry schedule below. Each delay is measured **from the previous attempt**, not cumulatively from the first attempt. You can also switch to machine-learning-based retry timing, which adapts the moment of each retry per transaction, by setting `strategy` to `SMART` — see [Machine-learning retry timing](#machine-learning-retry-timing).
 
 | Attempt                    | Delay after the previous attempt | Total time after the first attempt |
 | :------------------------- | :------------------------------- | :--------------------------------- |
@@ -79,6 +79,6 @@ Machine-learning timing is applied **from the second retry onward**. The first r
 If a timing decision is not available in time, the retry falls back to the fixed schedule above. Retries are never skipped or dropped because of this — only their timing changes.
 </Note>
 
-<Warning>
-`SMART` is enabled per organization. If it is not yet enabled for yours, sending `strategy: SMART` returns a `400 INVALID_PARAMETERS` response. Contact your Yuno representative to request access.
-</Warning>
+<Note>
+`SMART` is available to all accounts — no enablement request is required. Set `strategy` to `SMART` on any subscription.
+</Note>

--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -9,7 +9,7 @@ Yuno's Smart Retries help recover declined recurring credit card payments by ret
 
 Yuno's Smart Retries offer several benefits that enhance payment processes and revenue recovery:
 
-* **Data-driven decision-making**: Uses a proven retry schedule, with machine-learning-based timing available for eligible organizations.
+* **Data-driven decision-making**: Uses a proven retry schedule, with machine-learning-based retry timing available on request through the `SMART` strategy.
 * **Enhanced revenue retrieval**: Increases the chances of successfully collecting payments.
 * **Decreased subscriber turnover**: Minimizes disruptions and involuntary subscriber departures.
 * **Flexible logic**: Allows customization of retry schedules to maximize success opportunities.
@@ -17,7 +17,7 @@ Yuno's Smart Retries offer several benefits that enhance payment processes and r
 
 ### Retry schedule
 
-By default, Yuno applies the fixed retry schedule below. Each delay is measured **from the previous attempt**, not cumulatively from the first attempt. Eligible organizations can also opt into machine-learning-based timing, which adapts the moment of each retry per transaction.
+By default, Yuno applies the fixed retry schedule below. Each delay is measured **from the previous attempt**, not cumulatively from the first attempt. You can also request machine-learning-based retry timing, which adapts the moment of each retry per transaction, by setting `strategy` to `SMART` — see [Machine-learning retry timing](#machine-learning-retry-timing).
 
 | Attempt                    | Delay after the previous attempt | Total time after the first attempt |
 | :------------------------- | :------------------------------- | :--------------------------------- |
@@ -40,7 +40,7 @@ Every business model is unique, so we allow merchants to define specific rules t
 | :----------------- | :----- | :--------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------- |
 | `retry_on_decline` | bool   | Indicates whether to retry a payment after a first decline. Defaults to false. This flag is the only switch that enables retries; there is no dashboard toggle. | TRUE |
 | `amount`           | number | Number of retries the subscription will attempt. The maximum equals your environment's configured retry schedule length — 5 in production. Values above the cap are clamped to it. This cap is set per environment and is not configurable per account via the API. | 4 |
-| `strategy`         | string | The retry strategy. Allowed values: DEFAULT and CUSTOM_SCHEDULE. DEFAULT uses the fixed schedule above (NOT ML-based timing). CUSTOM_SCHEDULE uses the per-attempt schedule you provide. | `CUSTOM_SCHEDULE` |
+| `strategy`         | string | The retry strategy. Allowed values: DEFAULT, SMART and CUSTOM_SCHEDULE. DEFAULT uses the fixed schedule above. SMART uses machine-learning-based retry timing — see [Machine-learning retry timing](#machine-learning-retry-timing). CUSTOM_SCHEDULE uses the per-attempt schedule you provide. | `CUSTOM_SCHEDULE` |
 | `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. The subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. | TRUE |
 | `schedule`         | object | Contains attempt and delay\_seconds fields                                                                                               | Attempt: 2, `delay_seconds`: 86400 |
 
@@ -52,5 +52,33 @@ The maximum number of retries equals your environment's configured retry schedul
 </Note>
 
 <Note>
-`strategy`: `DEFAULT` applies the fixed schedule above, not ML-based timing. Use `CUSTOM_SCHEDULE` together with the `schedule` array to define custom delays.
+`strategy`: `DEFAULT` applies the fixed schedule above. Use `SMART` for machine-learning-based retry timing, or `CUSTOM_SCHEDULE` together with the `schedule` array to define your own delays.
 </Note>
+
+### Machine-learning retry timing
+
+Set `strategy` to `SMART` to have Yuno's machine-learning model choose **when** each retry is attempted, instead of using the fixed schedule. The model weighs signals such as the decline reason, the country, the card issuer and the payment provider to pick the moment most likely to succeed.
+
+```json
+{
+  "retries": {
+    "retry_on_decline": true,
+    "amount": 4,
+    "strategy": "SMART"
+  }
+}
+```
+
+`SMART` changes retry **timing** only. It does not change how many retries you get: `amount` still controls that, and the same per-environment maximum applies. Any `schedule` array sent alongside `strategy: SMART` is ignored.
+
+<Note>
+Machine-learning timing is applied **from the second retry onward**. The first retry always uses the standard delay from the fixed schedule above.
+</Note>
+
+<Note>
+If a timing decision is not available in time, the retry falls back to the fixed schedule above. Retries are never skipped or dropped because of this — only their timing changes.
+</Note>
+
+<Warning>
+`SMART` is enabled per organization. If it is not yet enabled for yours, sending `strategy: SMART` returns a `400 INVALID_PARAMETERS` response. Contact your Yuno representative to request access.
+</Warning>

--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -42,7 +42,7 @@ Every business model is unique, so we allow merchants to define specific rules t
 | `amount`           | number | Number of retries the subscription will attempt. The maximum equals your environment's configured retry schedule length — 5 in production. Values above the cap are clamped to it. This cap is set per environment and is not configurable per account via the API. | 4 |
 | `strategy`         | string | The retry strategy. Allowed values: DEFAULT, SMART and CUSTOM_SCHEDULE. DEFAULT uses the fixed schedule above. SMART uses machine-learning-based retry timing — see [Machine-learning retry timing](#machine-learning-retry-timing). CUSTOM_SCHEDULE uses the per-attempt schedule you provide. | `CUSTOM_SCHEDULE` |
 | `stop_on_hard_decline` | bool | When true and a hard decline is detected, retries stop for the current cycle only. On its own, the subscription stays ACTIVE, billing advances to the next cycle, and no cancel/pause or subscription webhook is emitted. If `cancel_on_exhausted_retries` is also true, the subscription is canceled instead — see [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
-| `cancel_on_exhausted_retries` | bool | When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of rolling forward to the next cycle. Defaults to false. Can only be set when the subscription is created. See [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
+| `cancel_on_exhausted_retries` | bool | When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of rolling forward to the next cycle. Defaults to false. Can be set at creation or changed later with [Update Subscription](/reference/subscriptions/update-subscription). See [Canceling a subscription when retries run out](#canceling-a-subscription-when-retries-run-out). | TRUE |
 | `schedule`         | object | Contains attempt and delay\_seconds fields                                                                                               | Attempt: 2, `delay_seconds`: 86400 |
 
 </div>
@@ -88,7 +88,7 @@ If a timing decision is not available in time, the retry falls back to the fixed
 
 By default, when every retry for a billing cycle has been attempted and none succeeded, the subscription stays `ACTIVE` and billing rolls forward to the next cycle. A subscription backed by a permanently dead card therefore keeps generating failed charges indefinitely.
 
-Set `cancel_on_exhausted_retries` to `true` when creating the subscription to change that:
+Set `cancel_on_exhausted_retries` to `true` — at creation or via [Update Subscription](/reference/subscriptions/update-subscription) — to change that:
 
 ```json
 {
@@ -118,7 +118,7 @@ This applies whichever way the retries ended — the schedule running to its las
 </Warning>
 
 <Note>
-`cancel_on_exhausted_retries` can only be set when the subscription is created. [Update Subscription](/reference/subscriptions/update-subscription) rejects a request that changes it. Sending back the same value the subscription already has is accepted, so a read-modify-write of the full subscription object still works.
+`cancel_on_exhausted_retries` can be set at creation or changed afterward with [Update Subscription](/reference/subscriptions/update-subscription).
 </Note>
 
 <Note>

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1664,7 +1664,8 @@ Sent when a paused subscription is resumed and transitions back to the `ACTIVE` 
         "amount": 4,
         "strategy": "DEFAULT",
         "schedule": null,
-        "stop_on_hard_decline": null
+        "stop_on_hard_decline": null,
+        "cancel_on_exhausted_retries": null
       },
       "metadata": [
         {
@@ -1701,6 +1702,12 @@ Sent when a paused subscription is resumed and transitions back to the `ACTIVE` 
 ### subscription.cancel
 
 Sent when a subscription is canceled. Once canceled, the subscription is terminated and cannot be reactivated.
+
+The subscription object carries a `cancellation_source` field describing what triggered the cancellation — `MERCHANT`, `SYSTEM`, `PLAN_CHANGE`, or `RETRIES_EXHAUSTED`. See [the subscription object](/reference/subscriptions/the-subscription-object) for what each value means.
+
+<Note>
+Treat `cancellation_source` as open-ended. New values can be added as Yuno introduces new cancellation behaviors, so handle an unrecognized value gracefully rather than switching exhaustively over the current list. `RETRIES_EXHAUSTED` is the most recent addition — it is sent when retries for a billing cycle end without a successful payment on a subscription created with `retries.cancel_on_exhausted_retries` set to `true`.
+</Note>
 
 ```json JSON
 {
@@ -1814,7 +1821,8 @@ Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification
         "amount": 4,
         "strategy": "DEFAULT",
         "schedule": null,
-        "stop_on_hard_decline": null
+        "stop_on_hard_decline": null,
+        "cancel_on_exhausted_retries": null
       },
       "metadata": [
         {
@@ -1856,6 +1864,10 @@ There is **no `subscription.error` webhook**. Yuno does not emit a subscription 
 
 <Note>
 The renewal **charge** itself is always signaled by a `payment.purchase` webhook, never by a subscription webhook. The `payments` array inside the subscription object is currently always empty in webhook payloads. `subscription.active` is sent once (at `billing_cycles.current` = 2), not on every renewal.
+</Note>
+
+<Note>
+There is one case where a failed renewal does produce a subscription webhook. If the subscription was created with `retries.cancel_on_exhausted_retries` set to `true`, then once retries for that cycle end without a successful payment the subscription is canceled and a single [`subscription.cancel`](#subscriptioncancel) is emitted with `cancellation_source` set to `RETRIES_EXHAUSTED`. This is still not a `subscription.error` — the individual failed attempts remain `payment.purchase` webhooks. Only the final cancellation is signaled on the subscription.
 </Note>
 
 ## Onboardings

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1867,7 +1867,7 @@ The renewal **charge** itself is always signaled by a `payment.purchase` webhook
 </Note>
 
 <Note>
-There is one case where a failed renewal does produce a subscription webhook. If the subscription was created with `retries.cancel_on_exhausted_retries` set to `true`, then once retries for that cycle end without a successful payment the subscription is canceled and a single [`subscription.cancel`](#subscriptioncancel) is emitted with `cancellation_source` set to `RETRIES_EXHAUSTED`. This is still not a `subscription.error` — the individual failed attempts remain `payment.purchase` webhooks. Only the final cancellation is signaled on the subscription.
+There is one case where a failed renewal does produce a subscription webhook. If the subscription has `retries.cancel_on_exhausted_retries` set to `true`, then once retries for that cycle end without a successful payment the subscription is canceled and a single [`subscription.cancel`](#subscriptioncancel) is emitted with `cancellation_source` set to `RETRIES_EXHAUSTED`. This is still not a `subscription.error` — the individual failed attempts remain `payment.purchase` webhooks. Only the final cancellation is signaled on the subscription.
 </Note>
 
 ## Onboardings

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -386,7 +386,7 @@
                       },
                       "cancel_on_exhausted_retries": {
                         "type": "boolean",
-                        "description": "When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of remaining ACTIVE and advancing to the next cycle. The subscription status becomes CANCELED, cancellation_source is set to RETRIES_EXHAUSTED, future billing stops, and a single SUBSCRIPTION.CANCEL webhook is emitted. Applies both when the retry schedule runs out and when stop_on_hard_decline ends the cycle early. Defaults to false, which preserves the existing behavior. Can only be set at creation: an update that changes it is rejected, although resending the current value is accepted. The cancellation is final, so Retry Subscription is rejected afterwards."
+                        "description": "When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of remaining ACTIVE and advancing to the next cycle. The subscription status becomes CANCELED, cancellation_source is set to RETRIES_EXHAUSTED, future billing stops, and a single SUBSCRIPTION.CANCEL webhook is emitted. Applies both when the retry schedule runs out and when stop_on_hard_decline ends the cycle early. Defaults to false, which preserves the existing behavior. Can be set at creation or changed later via Update Subscription. The cancellation itself is final, so Retry Subscription is rejected afterwards."
                       }
                     }
                   },

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -351,7 +351,7 @@
                       },
                       "strategy": {
                         "type": "string",
-                        "description": "The retry strategy. Allowed values: DEFAULT (the fixed retry schedule), SMART (machine-learning-based retry timing, applied from the second retry onward; enabled per organization) or CUSTOM_SCHEDULE (uses the per-attempt schedule array you provide).",
+                        "description": "The retry strategy. Allowed values: DEFAULT (the fixed retry schedule), SMART (machine-learning-based retry timing, applied from the second retry onward) or CUSTOM_SCHEDULE (uses the per-attempt schedule array you provide).",
                         "enum": [
                           "DEFAULT",
                           "SMART",

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -381,7 +381,11 @@
                       },
                       "stop_on_hard_decline": {
                         "type": "boolean",
-                        "description": "When true, the retry schedule stops for the current billing cycle after a hard decline. The subscription remains ACTIVE and billing advances to the next cycle; no subscription is canceled or paused and no subscription webhook is emitted."
+                        "description": "When true, the retry schedule stops for the current billing cycle after a hard decline. On its own, the subscription remains ACTIVE and billing advances to the next cycle; no subscription is canceled or paused and no subscription webhook is emitted. If cancel_on_exhausted_retries is also true, the subscription is canceled instead."
+                      },
+                      "cancel_on_exhausted_retries": {
+                        "type": "boolean",
+                        "description": "When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of remaining ACTIVE and advancing to the next cycle. The subscription status becomes CANCELED, cancellation_source is set to RETRIES_EXHAUSTED, future billing stops, and a single SUBSCRIPTION.CANCEL webhook is emitted. Applies both when the retry schedule runs out and when stop_on_hard_decline ends the cycle early. Defaults to false, which preserves the existing behavior. Can only be set at creation: an update that changes it is rejected, although resending the current value is accepted. The cancellation is final, so Retry Subscription is rejected afterwards."
                       }
                     }
                   },

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -351,9 +351,10 @@
                       },
                       "strategy": {
                         "type": "string",
-                        "description": "The retry strategy. Allowed values: DEFAULT (the fixed retry schedule; not ML-based timing) or CUSTOM_SCHEDULE (uses the per-attempt schedule array you provide).",
+                        "description": "The retry strategy. Allowed values: DEFAULT (the fixed retry schedule), SMART (machine-learning-based retry timing, applied from the second retry onward; enabled per organization) or CUSTOM_SCHEDULE (uses the per-attempt schedule array you provide).",
                         "enum": [
                           "DEFAULT",
+                          "SMART",
                           "CUSTOM_SCHEDULE"
                         ]
                       },

--- a/openapi/subscriptions/list-subscription-payments.json
+++ b/openapi/subscriptions/list-subscription-payments.json
@@ -44,7 +44,7 @@
                 "examples": {
                   "Result": {
                     "value": {
-                      "items": [
+                      "data": [
                         {
                           "id": "00000000-0000-4000-8000-000000000010",
                           "payment_id": "00000000-0000-4000-8000-000000000011",
@@ -82,7 +82,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "items": {
+                    "data": {
                       "type": "array",
                       "description": "Every payment attempt for this subscription, most recent first.",
                       "items": {

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -121,7 +121,7 @@
                       },
                       "monthly_billing_day": {
                         "type": "integer",
-                        "description": "The day of the month when billing is processed. (MAX 31; MIN 1)"
+                        "description": "The day of the month when billing is processed. (MAX 31; MIN 1). Only valid for MONTH frequency. If the subscription has not started yet (availability.start_at is in the future), the first billing still occurs at availability.start_at and the billing day applies from the second cycle onward; the resulting first billing period may be shorter than a full cycle and is charged in full."
                       }
                     }
                   },

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -250,6 +250,10 @@
                         "type": "integer",
                         "description": "The number of retries that the subscription plan will have to completion. If not set, or higher than 7, 7 will be defined as default. Max: 7",
                         "format": "int32"
+                      },
+                      "cancel_on_exhausted_retries": {
+                        "type": "boolean",
+                        "description": "When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of remaining ACTIVE and advancing to the next cycle. cancellation_source is set to RETRIES_EXHAUSTED and a single SUBSCRIPTION.CANCEL webhook is emitted. Defaults to false. The cancellation itself is final, so Retry Subscription is rejected afterwards."
                       }
                     }
                   },

--- a/reference/subscriptions/list-subscription-payments.mdx
+++ b/reference/subscriptions/list-subscription-payments.mdx
@@ -7,7 +7,7 @@ description: "Returns the charge history for a subscription, including plan/phas
 <Note>
 **This is a net-new endpoint**
 
-There was no payments subresource before Plans — the `payments` array on [the subscription object](/reference/subscriptions/the-subscription-object) is a legacy, always-empty field. Since there's no prior merchant integration to preserve here, this endpoint ships as one clean `items[]` shape with full plan/phase context — no legacy fields.
+There was no payments subresource before Plans — the `payments` array on [the subscription object](/reference/subscriptions/the-subscription-object) is a legacy, always-empty field. Since there's no prior merchant integration to preserve here, this endpoint ships as one clean `data[]` shape with full plan/phase context — no legacy fields.
 </Note>
 
 <Warning>

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -284,6 +284,18 @@ This object represents a subscription that can be associated with a customer.
 
       Example: 4
     </ParamField>
+
+    <ParamField body="strategy" type="string">
+      How the timing of each retry is decided. One of:
+
+      - `DEFAULT` — the fixed retry schedule.
+      - `SMART` — machine-learning-based retry timing, applied from the second retry onward. Available to all accounts.
+      - `CUSTOM_SCHEDULE` — the per-attempt `schedule` array you provide.
+
+      Treat this field as open-ended. New values can be introduced as Yuno adds retry behaviors, so handle an unrecognized value gracefully rather than switching exhaustively over the list above. `SMART` is the most recent addition.
+
+      Example: `SMART`
+    </ParamField>
   </Expandable>
 </ParamField>
 

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -68,7 +68,7 @@ This object represents a subscription that can be associated with a customer.
   - `MERCHANT` = You canceled the subscription, through [Cancel Subscription](/reference/subscriptions/cancel-subscription) or the dashboard.
   - `SYSTEM` = Yuno canceled the subscription automatically. This includes a subscription created with `initial_payment_validation: true` whose first payment did not succeed.
   - `PLAN_CHANGE` = The subscription was replaced as part of a [plan change](/docs/payment-features/subscriptions/plans). A new subscription continues the customer's billing under the new plan.
-  - `RETRIES_EXHAUSTED` = Retries for a billing cycle ended without a successful payment and the subscription was created with `retries.cancel_on_exhausted_retries` set to `true`. See [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
+  - `RETRIES_EXHAUSTED` = Retries for a billing cycle ended without a successful payment while the subscription had `retries.cancel_on_exhausted_retries` set to `true`. See [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
 
   <Note>
   Treat this field as open-ended. New values can be introduced as Yuno adds cancellation behaviors, so handle an unrecognized value gracefully rather than switching exhaustively over the list above. `RETRIES_EXHAUSTED` is the most recent addition.
@@ -372,7 +372,7 @@ This object represents a subscription that can be associated with a customer.
     </ParamField>
 
     <ParamField body="cancel_on_exhausted_retries" type="bool">
-      When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of advancing to the next cycle. `cancellation_source` is set to `RETRIES_EXHAUSTED` and a single `SUBSCRIPTION.CANCEL` webhook is emitted. Defaults to false. Can only be set at creation, and the cancellation is final — see [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
+      When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of advancing to the next cycle. `cancellation_source` is set to `RETRIES_EXHAUSTED` and a single `SUBSCRIPTION.CANCEL` webhook is emitted. Defaults to false. Can be set at creation or changed later via [Update Subscription](/reference/subscriptions/update-subscription); the cancellation itself is final — see [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
 
       Example: TRUE
     </ParamField>

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -58,7 +58,21 @@ This object represents a subscription that can be associated with a customer.
   - `TRIALING` = The subscription is inside a plan's leading trial phase (see `plan_id`/`current_phase`). Transitions to `ACTIVE` automatically once the trial ends — this is webhooked like any other status change.
   - `PAUSED` = The subscription has been paused and can be reactivated.
   - `COMPLETED` = The subscription is completed because it reached the end date and time.
-  - `CANCELED` = Subscription canceled.
+  - `CANCELED` = Subscription canceled. See `cancellation_source` for what triggered it.
+</ParamField>
+
+<ParamField body="cancellation_source" type="enum">
+  What caused the subscription to be canceled. Only set once the subscription reaches `CANCELED`; `null` otherwise.
+
+  Possible values:
+  - `MERCHANT` = You canceled the subscription, through [Cancel Subscription](/reference/subscriptions/cancel-subscription) or the dashboard.
+  - `SYSTEM` = Yuno canceled the subscription automatically. This includes a subscription created with `initial_payment_validation: true` whose first payment did not succeed.
+  - `PLAN_CHANGE` = The subscription was replaced as part of a [plan change](/docs/payment-features/subscriptions/plans). A new subscription continues the customer's billing under the new plan.
+  - `RETRIES_EXHAUSTED` = Retries for a billing cycle ended without a successful payment and the subscription was created with `retries.cancel_on_exhausted_retries` set to `true`. See [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
+
+  <Note>
+  Treat this field as open-ended. New values can be introduced as Yuno adds cancellation behaviors, so handle an unrecognized value gracefully rather than switching exhaustively over the list above. `RETRIES_EXHAUSTED` is the most recent addition.
+  </Note>
 </ParamField>
 
 <ParamField body="plan_id" type="string">
@@ -337,6 +351,18 @@ This object represents a subscription that can be associated with a customer.
       The number of retries that the subscription plan will have to completion. The maximum equals your environment's configured retry schedule length (6 in production). Values above the cap are clamped to it. Max: 6
 
       Example: 4
+    </ParamField>
+
+    <ParamField body="stop_on_hard_decline" type="bool">
+      When true and a hard decline is detected, retries stop for the current billing cycle only. On its own, the subscription stays ACTIVE and billing advances to the next cycle. If `cancel_on_exhausted_retries` is also true, the subscription is canceled instead.
+
+      Example: TRUE
+    </ParamField>
+
+    <ParamField body="cancel_on_exhausted_retries" type="bool">
+      When true, the subscription is canceled once retries for a billing cycle end without a successful payment, instead of advancing to the next cycle. `cancellation_source` is set to `RETRIES_EXHAUSTED` and a single `SUBSCRIPTION.CANCEL` webhook is emitted. Defaults to false. Can only be set at creation, and the cancellation is final — see [Retries](/docs/payment-features/subscriptions/retries#canceling-a-subscription-when-retries-run-out).
+
+      Example: TRUE
     </ParamField>
   </Expandable>
 </ParamField>


### PR DESCRIPTION
Single consolidated merge per repo. Folded (marked merged into this branch):

| Folded PR | Ticket | What |
|---|---|---|
| #648 | SUB-48 | payments envelope `items` → `data` fix |
| #651 | SUB-28 | `cancel_on_exhausted_retries` flag + `RETRIES_EXHAUSTED` cancellation source |
| #655 | SUB-31 | `SMART` retry strategy documentation |
| #663 | SUB-56 | `monthly_billing_day` first-charge semantics |

One union conflict (SUB-28 × SUB-31 on `retries.mdx` + `the-subscription-object.mdx`) resolved keeping both features: SMART in the `strategy` enum AND the `cancel_on_exhausted_retries` field with its hard-decline interplay. OpenAPI JSON re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbGkAkxe5sUEZyB2mu4WAm