### PR TITLE
docs: Increment Authorization endpoint

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -440,6 +440,7 @@
               "reference/payments/cancel-payment",
               "reference/payments/authorize-payment",
               "reference/payments/capture-authorization",
+              "reference/payments/increment-authorization",
               "reference/payments/disputes",
               "reference/payments/update-dispute",
               "reference/payments/retrieve-issuers",

--- a/openapi/payments/increment-authorization.json
+++ b/openapi/payments/increment-authorization.json
@@ -1,0 +1,505 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "payment-api-increment-authorization",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "x-default": "<Your public-api-key>",
+        "name": "public-api-key"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "x-default": "<Your private-secret-key>",
+        "name": "private-secret-key"
+      },
+      "sec2": {
+        "type": "apiKey",
+        "in": "header",
+        "x-default": "<Your X-Idempotency-Key>",
+        "name": "X-Idempotency-Key"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": [],
+      "sec2": []
+    }
+  ],
+  "paths": {
+    "/payments/{payment_id}/transactions/{transaction_id}/increment": {
+      "post": {
+        "summary": "Increment Authorization",
+        "description": "Raises an existing authorization hold by a delta amount. Each increment creates its own `AUTHORIZE_INCREMENT` transaction with a per-increment result.",
+        "operationId": "increment-authorization",
+        "parameters": [
+          {
+            "name": "payment_id",
+            "in": "path",
+            "description": "The unique identifier of the payment (UUID, 36 chars).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "description": "The unique identifier of the original AUTHORIZE transaction to increment (UUID, 36 chars).",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "amount",
+                  "merchant_reference"
+                ],
+                "properties": {
+                  "amount": {
+                    "type": "object",
+                    "description": "The amount to ADD to the current authorized amount (a delta, not the new total). The currency must match the original authorization.",
+                    "required": [
+                      "value",
+                      "currency"
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": "number",
+                        "description": "The delta to add to the current authorized amount.",
+                        "example": 50.0
+                      },
+                      "currency": {
+                        "type": "string",
+                        "description": "Three-letter ISO 4217 currency code. Must match the original authorization.",
+                        "example": "EUR"
+                      }
+                    }
+                  },
+                  "merchant_reference": {
+                    "type": "string",
+                    "description": "The reference for this increment."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Optional description of the increment."
+                  }
+                }
+              },
+              "examples": {
+                "Increment by 50": {
+                  "value": {
+                    "amount": {
+                      "value": 50.0,
+                      "currency": "EUR"
+                    },
+                    "merchant_reference": "session-8842-inc-2",
+                    "description": "EV charging session top-up"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier of the increment transaction (UUID)."
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Transaction type.",
+                      "example": "AUTHORIZE_INCREMENT"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "SUCCEEDED",
+                        "DECLINED",
+                        "PENDING",
+                        "ERROR"
+                      ],
+                      "description": "Per-increment result. `SUCCEEDED`: the hold was raised. `DECLINED`: the issuer or provider declined this increment; the previous authorized amount stands. `PENDING`: the provider processes increments asynchronously; the final result is delivered via webhook. `ERROR`: the increment could not be processed."
+                    },
+                    "amount": {
+                      "type": "object",
+                      "description": "The delta added by this increment.",
+                      "properties": {
+                        "value": {
+                          "type": "number",
+                          "example": 50.0
+                        },
+                        "currency": {
+                          "type": "string",
+                          "example": "EUR"
+                        }
+                      }
+                    },
+                    "merchant_reference": {
+                      "type": "string",
+                      "description": "The reference sent in the request."
+                    },
+                    "parent_transaction_id": {
+                      "type": "string",
+                      "description": "The `transaction_id` of the original AUTHORIZE transaction this increment belongs to."
+                    },
+                    "response_code": {
+                      "type": "string",
+                      "description": "Normalized response code for this increment. `AUTHORIZATION_NOT_INCREMENTABLE` indicates the original authorization was not created as `PRE_AUTHORIZATION` and the provider rejected the increment."
+                    },
+                    "response_message": {
+                      "type": "string",
+                      "description": "Human-readable detail of the result."
+                    },
+                    "provider_data": {
+                      "type": "object",
+                      "description": "Raw provider identifiers and status for this increment."
+                    },
+                    "payment": {
+                      "type": "object",
+                      "description": "The parent payment after this increment.",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique identifier of the payment (UUID)."
+                        },
+                        "status": {
+                          "type": "string",
+                          "example": "AUTHORIZED"
+                        },
+                        "amount": {
+                          "type": "object",
+                          "description": "The new total authorized amount after the increment.",
+                          "properties": {
+                            "value": {
+                              "type": "number",
+                              "example": 150.0
+                            },
+                            "currency": {
+                              "type": "string",
+                              "example": "EUR"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "Approved Increment": {
+                    "value": {
+                      "id": "8f2f4bce-1d2f-4f6e-9a3b-0c1e5d3a7b21",
+                      "type": "AUTHORIZE_INCREMENT",
+                      "status": "SUCCEEDED",
+                      "amount": {
+                        "value": 50.0,
+                        "currency": "EUR"
+                      },
+                      "merchant_reference": "session-8842-inc-2",
+                      "parent_transaction_id": "1a71c7b7-80c2-4ba5-b601-4d34d48c0e18",
+                      "response_code": "00",
+                      "response_message": "Approved",
+                      "provider_data": {
+                        "id": "prov-ref-001",
+                        "status": "..."
+                      },
+                      "payment": {
+                        "id": "d19205be-1a70-4c13-a4e6-8b7a9f3e2c11",
+                        "status": "AUTHORIZED",
+                        "amount": {
+                          "value": 150.0,
+                          "currency": "EUR"
+                        }
+                      }
+                    }
+                  },
+                  "Pending Increment (async provider)": {
+                    "value": {
+                      "id": "8f2f4bce-1d2f-4f6e-9a3b-0c1e5d3a7b21",
+                      "type": "AUTHORIZE_INCREMENT",
+                      "status": "PENDING",
+                      "amount": {
+                        "value": 50.0,
+                        "currency": "EUR"
+                      },
+                      "merchant_reference": "session-8842-inc-2",
+                      "parent_transaction_id": "1a71c7b7-80c2-4ba5-b601-4d34d48c0e18",
+                      "response_message": "Increment in progress; final result delivered via webhook",
+                      "provider_data": {
+                        "id": "prov-ref-001",
+                        "status": "..."
+                      },
+                      "payment": {
+                        "id": "d19205be-1a70-4c13-a4e6-8b7a9f3e2c11",
+                        "status": "AUTHORIZED",
+                        "amount": {
+                          "value": 100.0,
+                          "currency": "EUR"
+                        }
+                      }
+                    }
+                  },
+                  "Declined Increment": {
+                    "value": {
+                      "id": "8f2f4bce-1d2f-4f6e-9a3b-0c1e5d3a7b21",
+                      "type": "AUTHORIZE_INCREMENT",
+                      "status": "DECLINED",
+                      "amount": {
+                        "value": 50.0,
+                        "currency": "EUR"
+                      },
+                      "merchant_reference": "session-8842-inc-2",
+                      "parent_transaction_id": "1a71c7b7-80c2-4ba5-b601-4d34d48c0e18",
+                      "response_code": "51",
+                      "response_message": "Insufficient funds",
+                      "provider_data": {
+                        "id": "prov-ref-001",
+                        "status": "..."
+                      },
+                      "payment": {
+                        "id": "d19205be-1a70-4c13-a4e6-8b7a9f3e2c11",
+                        "status": "AUTHORIZED",
+                        "amount": {
+                          "value": 100.0,
+                          "currency": "EUR"
+                        }
+                      }
+                    }
+                  },
+                  "Not Incrementable": {
+                    "value": {
+                      "id": "8f2f4bce-1d2f-4f6e-9a3b-0c1e5d3a7b21",
+                      "type": "AUTHORIZE_INCREMENT",
+                      "status": "DECLINED",
+                      "amount": {
+                        "value": 50.0,
+                        "currency": "EUR"
+                      },
+                      "merchant_reference": "session-8842-inc-2",
+                      "parent_transaction_id": "1a71c7b7-80c2-4ba5-b601-4d34d48c0e18",
+                      "response_code": "AUTHORIZATION_NOT_INCREMENTABLE",
+                      "response_message": "The original authorization was not created as PRE_AUTHORIZATION",
+                      "provider_data": {
+                        "id": "prov-ref-001",
+                        "status": "..."
+                      },
+                      "payment": {
+                        "id": "d19205be-1a70-4c13-a4e6-8b7a9f3e2c11",
+                        "status": "AUTHORIZED",
+                        "amount": {
+                          "value": 100.0,
+                          "currency": "EUR"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Currency does not match the original authorization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "401",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "UNAUTHORIZED",
+                      "messages": [
+                        "Invalid credentials"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "PAYMENT_NOT_FOUND",
+                      "messages": [
+                        "Payment or transaction not found"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "409",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "INVALID_TRANSACTION_STATE",
+                      "messages": [
+                        "The target transaction is not an active authorization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "422",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "OPERATION_NOT_SUPPORTED",
+                      "messages": [
+                        "The provider does not support incremental authorizations"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "INVALID_REQUEST"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "example": "Invalid request"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "key": "charset",
+        "value": "utf-8"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  }
+}

--- a/openapi/payments/increment-authorization.json
+++ b/openapi/payments/increment-authorization.json
@@ -327,7 +327,31 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Result": {
+                  "Invalid request": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Invalid request"
+                      ]
+                    }
+                  },
+                  "Payment or transaction not found": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "Payment or transaction not found"
+                      ]
+                    }
+                  },
+                  "Transaction not an active authorization": {
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "The target transaction is not an active authorization (already captured, voided, or expired)"
+                      ]
+                    }
+                  },
+                  "Currency mismatch": {
                     "value": {
                       "code": "INVALID_REQUEST",
                       "messages": [
@@ -388,82 +412,16 @@
               }
             }
           },
-          "404": {
-            "description": "404",
+          "403": {
+            "description": "403",
             "content": {
               "application/json": {
                 "examples": {
                   "Result": {
                     "value": {
-                      "code": "PAYMENT_NOT_FOUND",
+                      "code": "FORBIDDEN",
                       "messages": [
-                        "Payment or transaction not found"
-                      ]
-                    }
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "example": "INVALID_REQUEST"
-                    },
-                    "messages": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "example": "Invalid request"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "409",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "Result": {
-                    "value": {
-                      "code": "INVALID_TRANSACTION_STATE",
-                      "messages": [
-                        "The target transaction is not an active authorization"
-                      ]
-                    }
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "example": "INVALID_REQUEST"
-                    },
-                    "messages": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "example": "Invalid request"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "422",
-            "content": {
-              "application/json": {
-                "examples": {
-                  "Result": {
-                    "value": {
-                      "code": "OPERATION_NOT_SUPPORTED",
-                      "messages": [
-                        "The provider does not support incremental authorizations"
+                        "Forbidden"
                       ]
                     }
                   }

--- a/reference/payments/capture-authorization.mdx
+++ b/reference/payments/capture-authorization.mdx
@@ -10,4 +10,6 @@ Do not execute a capture while another is in progress. Wait for the current oper
 
 This request captures a payment that was previously authorized. This action is required to finalize a payment when an authorization was created with the capture option set `false`. Depending on the payment provider, the capture could be partial (including multiple captures) or total.
 
+If the authorization was raised with [incremental authorizations](/reference/increment-authorization), an explicit `amount` can settle up to the raised total, and a capture without an `amount` settles the transaction's full current hold — the original authorized amount plus all succeeded increments on that transaction.
+
 Note that this request requires an `X-Idempotency-Key`. Check the [Authentication](/reference/authentication#idempotency) page for more information.

--- a/reference/payments/increment-authorization.mdx
+++ b/reference/payments/increment-authorization.mdx
@@ -20,7 +20,7 @@ Some providers only allow increments on authorizations created as pre-authorizat
 
 ## Provider support
 
-Support is provider-dependent. If the provider routed for the payment does not support incremental authorizations, the request returns a `422` error.
+Support is provider-dependent. If the provider routed for the payment does not support incremental authorizations, the request returns the standard `operation_not_supported_by_provider` error, the same way as any operation the provider does not support.
 
 | Provider | Result | Notes |
 | --- | --- | --- |

--- a/reference/payments/increment-authorization.mdx
+++ b/reference/payments/increment-authorization.mdx
@@ -1,0 +1,31 @@
+---
+title: "Increment Authorization"
+openapi: "/openapi/payments/increment-authorization.json POST /payments/{payment_id}/transactions/{transaction_id}/increment"
+description: "Raises an existing authorization hold by a delta amount, without creating a new authorization."
+---
+
+This request raises the amount of a previously authorized payment (an incremental authorization). It is designed for open-ended-amount scenarios — EV charging, fuel, hospitality, car rental — where you authorize a small amount first and grow the hold as the final amount becomes known, then capture once with the [capture API](/reference/capture-authorization).
+
+The `amount` you send is a **delta**: how much to add to the current authorized amount. Yuno translates it to each provider's expected semantics.
+
+Each increment creates its own `AUTHORIZE_INCREMENT` transaction with a per-increment result, visible in [Retrieve Payment](/reference/retrieve-payment-by-id-v2) and notified via webhook. A declined increment leaves the previously authorized amount untouched. Multiple increments can be performed on the same authorization.
+
+Note that this request requires an `X-Idempotency-Key`. Check the [Authentication](/reference/authentication#idempotency) page for more information.
+
+<Warning>
+**The original authorization must opt in**
+
+Some providers only allow increments on authorizations created as pre-authorization holds. Set `authorization_type: "PRE_AUTHORIZATION"` (together with `capture: false`) when [creating the payment](/reference/create-payment); see the [Cancel and Capture Flow](/docs/payment-features/Cancel-and-capture-flow#pre-authorization-holds-authorization_type) guide. If the original authorization did not opt in and the provider rejects the increment, the increment transaction is returned with the `AUTHORIZATION_NOT_INCREMENTABLE` response code.
+</Warning>
+
+## Provider support
+
+Support is provider-dependent. If the provider routed for the payment does not support incremental authorizations, the request returns a `422` error.
+
+| Provider | Result | Notes |
+| --- | --- | --- |
+| Stripe | Synchronous | Requires the original authorization created with `authorization_type: "PRE_AUTHORIZATION"` |
+| Adyen | Asynchronous | The transaction is returned as `PENDING`; the final result is delivered via webhook |
+| Checkout.com | Synchronous | |
+| CyberSource | Synchronous | |
+| Revolut | Asynchronous | The transaction is returned as `PENDING`; the final result is delivered via webhook. Increments require the original authorization created with `authorization_type: "PRE_AUTHORIZATION"`, are available on card, Apple Pay, and Google Pay only, can only be tested in Production (not available in sandbox), and are limited to 10 sequential increments with a total of up to 5× the initial amount |

--- a/reference/payments/increment-authorization.mdx
+++ b/reference/payments/increment-authorization.mdx
@@ -12,6 +12,10 @@ Each increment creates its own `AUTHORIZE_INCREMENT` transaction with a per-incr
 
 Note that this request requires an `X-Idempotency-Key`. Check the [Authentication](/reference/authentication#idempotency) page for more information.
 
+## Capturing after increments
+
+A [capture](/reference/capture-authorization) with an explicit `amount` can settle any amount up to the current total authorized (original authorization plus all succeeded increments). A capture **without an amount** settles the transaction's full current hold — the original authorized amount plus all `SUCCEEDED` increments on that transaction. Increments still `PENDING` at capture time are not included.
+
 <Warning>
 **The original authorization must opt in**
 


### PR DESCRIPTION
## What

Documents the new incremental authorization endpoint (C2-17705): `POST /v1/payments/{payment_id}/transactions/{transaction_id}/increment`.

- **OpenAPI** (`openapi/payments/increment-authorization.json`, new): request (`amount` as **delta**, `merchant_reference`, optional `description`), transaction-first 201 response (`AUTHORIZE_INCREMENT` tx with `SUCCEEDED` / `DECLINED` / `PENDING` / `ERROR`, `parent_transaction_id`, nested `payment` with the new total), examples incl. the `AUTHORIZATION_NOT_INCREMENTABLE` case, and error responses (400/401/404/409/422).
- **Reference page** (`reference/payments/increment-authorization.mdx`, new): usage, idempotency, the `authorization_type: PRE_AUTHORIZATION` prerequisite, provider support table, Revolut caveats (async via webhook, production-only testing, card/Apple Pay/Google Pay only, provider caps).
- **Navigation** (`docs.json`): page added after Capture Authorization.

## ⚠️ Do not merge yet

Draft on purpose: the feature ships this sprint (C2-17705, sprint 108). Merge only once it is released — Mintlify auto-deploys on merge. Pairs with the `authorization_type` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)