### PR TITLE
chore: web sdk changelog 1.9.19

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.19",
+      "release_date": "2026-07-29",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.19",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "onInstallmentSelected Callback for Enrolled Cards",
+          "description": "Added support for the onInstallmentSelected callback on enrolled cards.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6205"
+      ]
+    },
+    {
       "version": "1.9.18",
       "release_date": "2026-07-28",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.19
+*July 29, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **onInstallmentSelected Callback for Enrolled Cards**  
+  Added support for the onInstallmentSelected callback on enrolled cards.
+
 ## v1.9.18
 *July 28, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.19`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.19

1 entry.