### PR TITLE
chore(changelog): add Android 2.19.1 and 2.20.1 Google Pay Pix crash fix

### DIFF
--- a/changelog/android.mdx
+++ b/changelog/android.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Android SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v2.20.1
+*July 28, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Google Pay Pix late-callback crash**  
+  Fixed a host-app crash when a Google Pay Pix result arrived after the checkout screen was closed — late callbacks are now safely ignored.
+
 ## v2.20.0
 *July 22, 2026*
 
@@ -13,6 +21,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="added" /> **onInstallmentSelected card callback (Web parity)**  
   `startCheckout` now accepts an optional `onInstallmentSelected` callback that fires every time the shopper selects or changes an installment option in the card form — including the default pre-selection at render and recalculations after a BIN change — so merchants can keep the cart total in sync with the selected installment. The payload mirrors the Web SDK's `OnInstallmentSelectedArgs`: `installment` (Int), `label` (String), `amount` { `currency`, `value`, `totalValue` } as strings, `additionalData` (reserved), and `isMerchantInstallment` (nullable, reserved for the merchant-installments feature). When installments stop being available after a selection was reported (e.g. the shopper switches to a card without installments), the callback fires once with null so the merchant knows the previous installment information is no longer valid. Fully backwards compatible: with no callback registered there is no behavior change, and an exception inside the merchant's callback never affects the payment flow.
   *See also: [CORECM-18470](https://yunopayments.atlassian.net/browse/CORECM-18470)*
+
+## v2.19.1
+*July 28, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Google Pay Pix late-callback crash**  
+  Fixed a host-app crash when a Google Pay Pix result arrived after the checkout screen was closed — late callbacks are now safely ignored.
 
 ## v2.19.0
 *July 9, 2026*

--- a/changelog/source/android.json
+++ b/changelog/source/android.json
@@ -2,6 +2,24 @@
   "sdk": "android",
   "releases": [
     {
+      "version": "2.20.1",
+      "release_date": "2026-07-28",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.20.1'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Google Pay Pix late-callback crash",
+          "description": "Fixed a host-app crash when a Google Pay Pix result arrived after the checkout screen was closed — late callbacks are now safely ignored.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "2.20.0",
       "release_date": "2026-07-22",
       "upgrade": {
@@ -21,6 +39,24 @@
               "url": "https://yunopayments.atlassian.net/browse/CORECM-18470"
             }
           ]
+        }
+      ]
+    },
+    {
+      "version": "2.19.1",
+      "release_date": "2026-07-28",
+      "upgrade": {
+        "snippet": "implementation 'com.yuno.payments:android-sdk:2.19.1'",
+        "language": "groovy"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Google Pay Pix late-callback crash",
+          "description": "Fixed a host-app crash when a Google Pay Pix result arrived after the checkout screen was closed — late callbacks are now safely ignored.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
         }
       ]
     },


### PR DESCRIPTION
Fixes a host-app crash when a Google Pay Pix result arrived after the checkout screen was closed, late callbacks are now safely ignored. Requested by Vlass.