### PR TITLE
chore: vtex sdk changelog 4.2.335

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.335
+*July 29, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="added" /> **Samsung Pay support**  
+  Shoppers can now pay with Samsung Pay at checkout, alongside the existing digital wallets. The connector routes Samsung Pay authorizations to the wallet flow so the payment app can render the Samsung Pay button and complete the payment through Yuno.
+
 ## v4.2.333
 *July 27, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.335",
+      "release_date": "2026-07-29",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.335",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Samsung Pay support",
+          "description": "Shoppers can now pay with Samsung Pay at checkout, alongside the existing digital wallets. The connector routes Samsung Pay authorizations to the wallet flow so the payment app can render the Samsung Pay button and complete the payment through Yuno.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.333",
       "release_date": "2026-07-27",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.335`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.335

1 entry.