### PR TITLE
docs(dry-run): fix companion header name — X-Dry-Run, not Dry-run

### DIFF
--- a/reference/dry-run/register-dry-run-provider-event.mdx
+++ b/reference/dry-run/register-dry-run-provider-event.mdx
@@ -4,14 +4,14 @@ description: "Register provider request, response, or webhook payloads for pre-p
 openapi: "/openapi/dry-run/register-dry-run-provider-event.json POST /dry-run/provider-events"
 ---
 
-Dry-run is a pre-production validation surface. It receives the API calls your integration sends to a payment provider — request, response, and webhook payloads — and correlates them with the equivalent Yuno public-API call you make **in parallel** with the `Dry-run: true` header set.
+Dry-run is a pre-production validation surface. It receives the API calls your integration sends to a payment provider — request, response, and webhook payloads — and correlates them with the equivalent Yuno public-API call you make **in parallel** with the `X-Dry-Run: true` header set.
 
 Yuno then executes an automated validation pipeline that grades the quality of the public-API request against the provider payload: missing fields, shape mismatches, wrong enum values, unmapped metadata, and any other inconsistency that would cause the real payment to fail or behave differently once you go live.
 
 ### How the pair works
 
 1. Your integration makes its normal call to the provider (e.g. Stripe, Adyen, dlocal).
-2. Your integration also calls the relevant Yuno public-API endpoint (e.g. `POST /v1/payments`) with the header **`Dry-run: true`**. Yuno accepts the request, does not route it to any provider, and stores it for comparison.
+2. Your integration also calls the relevant Yuno public-API endpoint (e.g. `POST /v1/payments`) with the header **`X-Dry-Run: true`**. Yuno accepts the request, does not route it to any provider, and stores it for comparison.
 3. Your integration calls `POST /v1/dry-run/provider-events` with the raw provider exchange (request, response, webhook) it just performed, correlated to the same `merchant_reference`.
 4. Yuno pairs the two records by `merchant_reference` + `account_id` and runs the validation pipeline. Results are available through the dashboard and via `GET /v1/dry-run/provider-events/{id}` (read API, separate reference).
 
@@ -28,7 +28,7 @@ One call can carry up to **10** event entries (REQUEST, RESPONSE, and/or WEBHOOK
 </Note>
 
 <Note>
-This endpoint has a companion: `POST /v1/payments` accepts a `Dry-run: true` request header that tells Yuno to validate instead of routing. Both legs must share the same `merchant_reference` so validation can pair them.
+This endpoint has a companion: `POST /v1/payments` accepts an `X-Dry-Run: true` request header that tells Yuno to validate instead of routing. Both legs must share the same `merchant_reference` so validation can pair them.
 </Note>
 
 <Note>

--- a/reference/dry-run/register-dry-run-provider-event.mdx
+++ b/reference/dry-run/register-dry-run-provider-event.mdx
@@ -47,4 +47,4 @@ Use `X-Idempotency-Key` for safe retries. Same key + same payload returns the or
 
 - `merchant_reference` is always required and uniquely identifies the order on your side. Yuno uses it to resolve the event to a payment asynchronously when `payment_id` is not supplied.
 - `payment_id`, if supplied, is resolved immediately. If the id is unknown for your account the request returns `404 PAYMENT_NOT_FOUND`.
-- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (e.g. `stripe` + `CREDIT_CARD`). if omitted, Yuno uses the information from the associated payment.
+- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (e.g. `stripe` + `CREDIT_CARD`). If omitted, Yuno uses the information from the associated payment.


### PR DESCRIPTION
## What

The [Register a Dry-Run Provider Event](https://docs.y.uno/reference/dry-run/register-dry-run-provider-event) page documents the companion header on `POST /v1/payments` as **`Dry-run: true`**. The real header is **`X-Dry-Run`**.

Fixed in the 3 places the page mentions it (intro, "How the pair works" step 2, and the companion note).

## Why

`public-api` defines and reads the header as `X-Dry-Run`:

- `common/constants/headers.go:23` → `const HeaderDryRun = "X-Dry-Run"`
- `middleware/middlewareAuth.go:82,167-168` → reads and forwards `constants.HeaderDryRun`
- `controllers/paymentsController.go` → `@Param X-Dry-Run header ...` on create/refund/cancel/capture, which is what `docs/swagger.yaml` publishes

A merchant following the docs literally would send `Dry-run: true`, the API would ignore it, and the payment would be routed to the real provider instead of being validated — the opposite of the intended behavior.

## Scope

Docs only; no OpenAPI spec change is needed — `openapi/dry-run/register-dry-run-provider-event.json` describes `POST /v1/dry-run/provider-events`, which does not take this header.

Generated with Claude Code