### PR TITLE
chore: web sdk changelog 1.10.0

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,126 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.0",
+      "release_date": "2026-07-29",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Samsung Pay support in the Web SDK",
+          "description": "Adds Samsung Pay as an external wallet button. The SDK loads Samsung's Web Checkout SDK, reads the sdk_provider configuration returned by the backend, opens the Samsung payment sheet and forwards the tokenized payment credential to Yuno for authorization.",
+          "group": "Samsung Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Streamlined Saved Card Display",
+          "description": "Removed the card image preview from the saved (tokenized) card flow and replaced it with a compact preview showing the card brand, last four digits, cardholder name and expiry date.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed Google Pay Button Colors",
+          "description": "The Google Pay button now always honors an explicitly configured buttonColor (white or black), even when the page runs in dark mode. The default setting keeps adapting to the page color scheme automatically.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Improved Express Buttons Layout",
+          "description": "The full checkout now renders up to three express payment buttons side by side with unified default styles. Express buttons that do not fit in the row are shown inside the payment method list and render their native button when selected.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "PayPal Billing Agreement Enrollment Support",
+          "description": "The SDK now supports enrolling customers with PayPal billing agreements (PAYPAL_BA_ENROLLMENT) and sends the PayPal partner attribution ID when loading the PayPal SDK.",
+          "group": "PayPal",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "EU Region Initialization Support",
+          "description": "The Web SDK can now be initialized against the EU region, routing all SDK network calls to the EU checkout API. Existing integrations without a region set continue to use the current endpoint unchanged.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Checkout Lifecycle Analytics Events",
+          "description": "Adds `checkoutSdk_started` and `payment_resolved`, and enriches the existing `checkoutSdk_completed` with UX attributes (clicks, taps, keystrokes, scroll), so a checkout can be measured end to end: when it starts, how the payment resolved, and — from the presence of `checkoutSdk_completed` — whether it was completed or abandoned. Both new events flush on emission so they are not lost to the batch debounce.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Express-Only Payment Methods Callback",
+          "description": "Added an optional `onlyExpressPaymentMethods` callback to the full checkout configuration that reports `true` when every available payment method renders as an express button (Apple Pay, Google Pay, PayPal, PayPal enrollment, PayPal Braintree, Revolut Pay) and `false` otherwise. When only express methods are available, the \"Or pay with\" divider is no longer rendered below the express buttons.",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Click to Pay footers use the shared modal footer",
+          "description": "The Click to Pay card form, enrolled card, and installment selection screens now render the shared modal footer instead of a Click to Pay-specific copy, matching the full-width button and centered \"Powered by Yuno\" tag redesign. The legacy CSS hooks (`sdk-payments-c2p-button-bottom__modal-bottom`, `__button-continue`, `__button-back`) are preserved and the shared classes are added alongside them; the internal wrapper classes `sdk-payments-c2p-button-bottom__buttons-content` and `__button-wrapper` no longer exist in the DOM. The Click to Pay footer badge now links the country-specific privacy policy URL instead of always the global fallback.",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Full-width action button in modal footers",
+          "description": "The action button in the shared modal footer now spans the full width on every viewport, with the \"Powered by Yuno\" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.",
+          "group": "Checkout",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Improved Enrolled Card Form Rendering",
+          "description": "The enrolled card form no longer reserves empty space when it has no fields to display, and now renders the card holder name field when the payment method configuration requires it.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "onInstallmentSelected Callback for Enrolled Cards",
+          "description": "Added support for the onInstallmentSelected callback on enrolled cards.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-14047",
+        "CORECM-17675",
+        "CORECM-17715",
+        "CORECM-17796",
+        "CORECM-17970",
+        "CORECM-18240",
+        "CORECM-18373",
+        "CORECM-18405",
+        "CORECM-18528",
+        "CORECM-18597",
+        "CORECM-18627",
+        "YSHUB-6205"
+      ]
+    },
+    {
       "version": "1.9.19",
       "release_date": "2026-07-29",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,57 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.0
+*July 29, 2026*
+
+**Samsung Pay**
+
+- <ChangelogBadge type="added" /> **Samsung Pay support in the Web SDK**  
+  Adds Samsung Pay as an external wallet button. The SDK loads Samsung's Web Checkout SDK, reads the sdk_provider configuration returned by the backend, opens the Samsung payment sheet and forwards the tokenized payment credential to Yuno for authorization.
+
+**Card Payments**
+
+- <ChangelogBadge type="changed" /> **Streamlined Saved Card Display**  
+  Removed the card image preview from the saved (tokenized) card flow and replaced it with a compact preview showing the card brand, last four digits, cardholder name and expiry date.
+
+- <ChangelogBadge type="fixed" /> **Improved Enrolled Card Form Rendering**  
+  The enrolled card form no longer reserves empty space when it has no fields to display, and now renders the card holder name field when the payment method configuration requires it.
+
+- <ChangelogBadge type="fixed" /> **onInstallmentSelected Callback for Enrolled Cards**  
+  Added support for the onInstallmentSelected callback on enrolled cards.
+
+**Google Pay**
+
+- <ChangelogBadge type="fixed" /> **Fixed Google Pay Button Colors**  
+  The Google Pay button now always honors an explicitly configured buttonColor (white or black), even when the page runs in dark mode. The default setting keeps adapting to the page color scheme automatically.
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Improved Express Buttons Layout**  
+  The full checkout now renders up to three express payment buttons side by side with unified default styles. Express buttons that do not fit in the row are shown inside the payment method list and render their native button when selected.
+
+- <ChangelogBadge type="added" /> **EU Region Initialization Support**  
+  The Web SDK can now be initialized against the EU region, routing all SDK network calls to the EU checkout API. Existing integrations without a region set continue to use the current endpoint unchanged.
+
+- <ChangelogBadge type="added" /> **Checkout Lifecycle Analytics Events**  
+  Adds `checkoutSdk_started` and `payment_resolved`, and enriches the existing `checkoutSdk_completed` with UX attributes (clicks, taps, keystrokes, scroll), so a checkout can be measured end to end: when it starts, how the payment resolved, and — from the presence of `checkoutSdk_completed` — whether it was completed or abandoned. Both new events flush on emission so they are not lost to the batch debounce.
+
+**PayPal**
+
+- <ChangelogBadge type="added" /> **PayPal Billing Agreement Enrollment Support**  
+  The SDK now supports enrolling customers with PayPal billing agreements (PAYPAL_BA_ENROLLMENT) and sends the PayPal partner attribution ID when loading the PayPal SDK.
+
+**Checkout**
+
+- <ChangelogBadge type="added" /> **Express-Only Payment Methods Callback**  
+  Added an optional `onlyExpressPaymentMethods` callback to the full checkout configuration that reports `true` when every available payment method renders as an express button (Apple Pay, Google Pay, PayPal, PayPal enrollment, PayPal Braintree, Revolut Pay) and `false` otherwise. When only express methods are available, the "Or pay with" divider is no longer rendered below the express buttons.
+
+- <ChangelogBadge type="changed" /> **Click to Pay footers use the shared modal footer**  
+  The Click to Pay card form, enrolled card, and installment selection screens now render the shared modal footer instead of a Click to Pay-specific copy, matching the full-width button and centered "Powered by Yuno" tag redesign. The legacy CSS hooks (`sdk-payments-c2p-button-bottom__modal-bottom`, `__button-continue`, `__button-back`) are preserved and the shared classes are added alongside them; the internal wrapper classes `sdk-payments-c2p-button-bottom__buttons-content` and `__button-wrapper` no longer exist in the DOM. The Click to Pay footer badge now links the country-specific privacy policy URL instead of always the global fallback.
+
+- <ChangelogBadge type="changed" /> **Full-width action button in modal footers**  
+  The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
+
 ## v1.9.19
 *July 29, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.0`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.0

12 entries.