### PR TITLE
docs(core-concepts): simple copy and accessibility fixes across 8 pages

### DIFF
--- a/docs/basic-concepts/customers.mdx
+++ b/docs/basic-concepts/customers.mdx
@@ -7,8 +7,8 @@ The term **customer** refers to an individual who is part of a merchant's paymen
 
 ## Customer functionalities
 
-* **Registration and management of payment methods**: Customers can register and manage various payment methods, such as credit cards, debit cards, or other alternative methods, enabling a flexible and convenient payment experience.
-* **Payment processing**: Customers can securely and efficiently make payments using the payment methods registered in their account.
+* **Registration and management of payment methods**: Customers can register and manage various payment methods, such as credit cards, debit cards, or other alternative methods.
+* **Payment processing**: Customers can make payments using the payment methods registered in their account.
 * **Personal information storage**: Yuno allows customers to securely store their personal information associated with payment methods and other payment preferences, facilitating future transactions.
 
 For more detailed information on how to use the customer object, refer to the [API reference](/reference/the-customer-object).

--- a/docs/basic-concepts/payment-methods.mdx
+++ b/docs/basic-concepts/payment-methods.mdx
@@ -3,7 +3,7 @@ title: "Payment methods"
 description: "Explains payment methods versus processors and how enrollment and synchronous flows differ in Yuno."
 ---
 
-Yuno offers a wide range of connections with various processors and payment methods, continuously expanding each month. This page explains the available payment methods, their capabilities, and how they are organized within Yuno's platform.
+Yuno offers a wide range of connections with various processors and payment methods, continuously expanding this coverage. This page explains the available payment methods, their capabilities, and how they are organized within Yuno's platform.
 
 ## What is a payment method?
 
@@ -15,7 +15,7 @@ To better understand the payment process, it's essential to differentiate betwee
   * Bank transfers (iDeal)
   * Buy now, pay later services (Klarna)
   * Regional payment methods (UPI, Pix)
-* **Processors**: Processors act as intermediaries between the merchant's and customer's banks, managing refunds, cancellations, and facilitating payment processing. They handle the actual processing of the information obtained by the payment method.
+* **Processors**: Processors act as intermediaries between the merchant's and customer's banks: they manage refunds and cancellations, and handle the actual processing of the information obtained by the payment method.
 
 ## Differences between payment methods
 
@@ -30,9 +30,9 @@ The workflow for payment methods can vary depending on the capabilities of each 
 
 ### Enrollment
 
-In Yuno, **enrollment** refers to the process of storing a customer's payment method information for future purchases. This allows for seamless transactions initiated either by the customer or the merchant without requiring additional input from the customer.
+In Yuno, **enrollment** refers to the process of storing a customer's payment method information for future purchases. This allows the customer or the merchant to initiate transactions without requiring additional input from the customer.
 
-* **Enrollable payment methods**: Yuno offers various payment methods for enrollment. The most popular option is **Credit/Debit cards**, but we also offer alternative payment methods, mainly wallets, which allow customers to provide their account information for future payments.
+* **Enrollable payment methods**: Yuno offers various payment methods for enrollment, including **Credit/Debit cards** and alternative methods, mainly wallets, which allow customers to provide their account information for future payments.
 * **Non-enrollable payment methods**: Payment methods that cannot be enrolled are typically alternative methods, such as those relying on bank transfers or cash payments, which may require the customer to take action for each payment.
 
-<Frame><img src="/images/reference/payment-methods/image1.png" /></Frame>
+<Frame><img src="/images/reference/payment-methods/image1.png" alt="Diagram comparing enrollable and non-enrollable payment methods and synchronous versus asynchronous payment flows" /></Frame>

--- a/docs/basic-concepts/payments-1.mdx
+++ b/docs/basic-concepts/payments-1.mdx
@@ -11,15 +11,15 @@ Payments collect essential order details, including customer information, total 
 
 ## Payment workflow
 
-The following workflow illustrates the possible payment statuses and their connections. Every payment has a status that follows a standardized lifecycle, ensuring consistent functionality across all payment methods. A payment moves through a sequence of statuses until completion. The diagram below explains the potential outcomes based on transaction statuses.
+The following workflow illustrates the possible payment statuses and their connections. Every payment has a status that follows a standardized lifecycle, ensuring consistent capability across all payment methods. A payment moves through a sequence of statuses until completion. The diagram below explains the potential outcomes based on transaction statuses.
 
-<Frame>![](/images/reference/payments-1/image1.png)</Frame>
+<Frame>![Diagram of the payment status lifecycle, showing the possible statuses a payment can move through and the transitions between them](/images/reference/payments-1/image1.png)</Frame>
 
 For more details on status codes and messages, refer to the [Payments API reference](/reference/payment).
 
 ## Payments and transactions
 
-A payment consists of multiple transactions that determine its final outcome. If you enable different connections for your payment method route, such as fraud prevention, 3D Secure, or provider fallbacks, these transactions become part of the payment lifecycle.
+A payment consists of multiple transactions that determine its final outcome. If you enable different connections for your payment method route, such as fraud prevention, 3D Secure, or provider fallbacks, Yuno adds the corresponding transactions to the payment. These transactions become part of the payment lifecycle.
 
 In the [Payments](/docs/payments) section of your Yuno dashboard, you can view and export all payment and transaction details.
 

--- a/docs/basic-concepts/sessions.mdx
+++ b/docs/basic-concepts/sessions.mdx
@@ -12,10 +12,10 @@ Use customer sessions to enroll and store a customer's payment methods. Create a
 <Note>
 **Available payment methods**
 
-When creating both sessions, customer and checkout, the Yuno system will provide you with a list of all enabled payment methods in your Yuno dashboard within the Connections and Checkout builder section.
+When creating either session type, customer or checkout, the Yuno system returns a list of all enabled payment methods. These are the payment methods configured in your Yuno dashboard, under the Connections and Checkout builder section.
 </Note>
 
-For more detailed information on how to use the Create customer session endpoint, see [API reference](/reference/the-customer-session-object).
+For more detailed information on how to use the **Create customer session** endpoint, see [API reference](/reference/the-customer-session-object).
 
 ## Checkout session
 
@@ -24,7 +24,7 @@ Use checkout sessions to create payments or initiate the payment flow. Each time
 <Note>
 **Create a payment without a checkout session**
 
-By utilizing Direct integration, which doesn't require Yuno's SDK, you can create a payment without the need for a checkout session.
+Direct integration doesn't require Yuno's SDK, so you can create a payment without a checkout session.
 </Note>
 
-For more detailed information on how to use the **Create checkout session** endpoint, refer to the [API reference](/reference/the-checkout-session-object).
+For more detailed information on how to use the **Create checkout session** endpoint, see [API reference](/reference/the-checkout-session-object).

--- a/docs/basic-concepts/tokens.mdx
+++ b/docs/basic-concepts/tokens.mdx
@@ -3,9 +3,9 @@ title: "Tokens"
 description: "Compares one-time, vaulted, and network tokens and how Yuno's tokenization reduces PCI scope."
 ---
 
-Yuno provides a fully managed, PCI DSS Level 1 tokenization service. When a customer provides their payment details, Yuno replaces the sensitive data with a token — a non-sensitive string that represents the original credentials. Your systems only ever store and transmit tokens, never raw card data.
+Yuno provides a fully managed, PCI DSS Level 1 tokenization service. When a customer provides their payment details, Yuno replaces the sensitive data with a token, a non-sensitive string that represents the original credentials. Your systems only ever store and transmit tokens, never raw card data.
 
-This approach reduces your PCI compliance scope significantly: instead of a full audit, most merchants using Yuno's SDK only need to complete a short self-assessment questionnaire (SAQ A). For more details, see [PCI Compliance](/docs/pci-compliance).
+This approach reduces your PCI compliance scope significantly. Instead of a full audit, most merchants using Yuno's SDK only need to complete a short self-assessment questionnaire (SAQ A). For more details, see [PCI Compliance](/docs/pci-compliance).
 
 ## Yuno tokenization coverage
 
@@ -47,18 +47,18 @@ Vaulted tokens are the right choice for:
 * Subscriptions and recurring billing
 * One-click checkout flows
 
-Vaulted tokens persist until the customer unenrolls the payment method or the token is explicitly removed. Because they live in a centralized vault, vaulted tokens work across all processors connected to your Yuno account — no re-tokenization needed when switching or adding providers.
+Vaulted tokens persist until the customer unenrolls the payment method or the token is explicitly removed. Because they live in a centralized vault, vaulted tokens work across all processors connected to your Yuno account. No re-tokenization is needed when switching or adding providers.
 
 ### Network token
 
-A network token is a digitized representation of a card's Primary Account Number (PAN), issued directly by card networks such as Visa, Mastercard, or American Express. When network tokenization is enabled, Yuno automatically provisions and manages network tokens for all enrolled cards and substitutes them for the actual card data during authorization.
+A network token is a digitized representation of a card's Primary Account Number (PAN). It's issued directly by card networks such as Visa, Mastercard, or American Express. When network tokenization is enabled, Yuno automatically provisions and manages network tokens for all enrolled cards. These tokens replace the actual card data during authorization.
 
 Network tokens are the right choice for:
 
 * High-value recurring transactions where maximizing authorization rates matters
 * Scenarios requiring enhanced fraud protection at the network level
 
-Unlike vaulted tokens, network tokens are managed by the card network and **automatically updated** when a card is renewed or reissued — reducing involuntary declines without any action required from the merchant or cardholder.
+Unlike vaulted tokens, network tokens are managed by the card network and **automatically updated** when a card is renewed or reissued. This reduces involuntary declines without any action required from the merchant or cardholder.
 
 <Note>
 **Learn more**
@@ -80,7 +80,7 @@ For a full overview of network tokens, lifecycle statuses, and integration optio
 
 ### Card fingerprinting
 
-Every card enrolled through Yuno receives a `fingerprint` — a stable, cryptographic identifier derived from the PAN. Fingerprints remain consistent across multiple enrollments of the same card, allowing you to detect duplicates and deduplicate your vault without ever accessing or storing raw card numbers. See [Card Fingerprint](/docs/fingerprint).
+Every card enrolled through Yuno receives a `fingerprint`, a stable, cryptographic identifier derived from the PAN. Fingerprints remain consistent across multiple enrollments of the same card. This lets you detect duplicates and deduplicate your vault without ever accessing or storing raw card numbers. See [Card Fingerprint](/docs/fingerprint).
 
 ### Automatic card updates
 
@@ -88,6 +88,6 @@ Yuno's Card Account Updater automatically refreshes vaulted cards when issuers u
 
 ### Token migration
 
-If you are moving to Yuno from another provider, Yuno supports importing your existing tokenized cards directly into the Yuno vault. Your customers keep their saved payment methods, and you keep their full history — no re-enrollment required. See [Token Migration Process](/docs/token-migration-process).
+If you are moving to Yuno from another provider, Yuno supports importing your existing tokenized cards directly into the Yuno vault. Your customers keep their saved payment methods, and you keep their full history, with no re-enrollment required. See [Token Migration Process](/docs/token-migration-process).
 
 Yuno also supports exporting tokens if you ever need to move your vault data to another provider. See [Exporting Tokens from Yuno](/docs/exporting-tokens-from-yuno).

--- a/docs/basic-concepts/transactions.mdx
+++ b/docs/basic-concepts/transactions.mdx
@@ -5,7 +5,7 @@ description: "Explains primary and secondary transaction types and their statuse
 
 ## What is a transaction?
 
-Each payment has one or more associated transactions. A payment on Yuno can go through multiple processors via fallbacks, retries, or split routing, containing multiple transactions. You can check all transactions related to a payment in the [payment timeline](/docs/payments) on your Yuno dashboard.
+Each payment has one or more associated transactions. A payment on Yuno can go through multiple processors via fallbacks, retries, or split routing. Each of these paths can add multiple transactions to the payment. You can check all transactions related to a payment in the [payment timeline](/docs/payments) on your Yuno dashboard.
 
 On Yuno, transactions are divided into **primary** and **secondary** transactions. In addition, each transaction can have a different status depending on its processing stage.
 
@@ -13,7 +13,7 @@ On Yuno, transactions are divided into **primary** and **secondary** transaction
 
 ### Primary transactions
 
-Primary transactions are related to an initiating transaction and can be one of three types:
+Primary transactions initiate a payment and can be one of three types:
 
 * **Purchase**: A standard sale transaction.
 * **Authorize**: A transaction used to authorize a payment amount to be captured at a later time.
@@ -33,8 +33,8 @@ Secondary transactions refer to additional transactions that affect the final ou
 
 All possible statuses for each transaction type are presented below.
 
-<Frame>![](/images/reference/transactions/image1.png)</Frame>
+<Frame>![Diagram of all possible statuses for each transaction type](/images/reference/transactions/image1.png)</Frame>
 
 Refer to the [Transactions API reference](/reference/transaction) for more detailed information on transaction status codes and messages.
 
-In the [Payments](/docs/payments) section of your Yuno dashboard, you will be able to view and export all the information regarding your payments and transactions with Yuno.
+The [Payments](/docs/payments) section of your Yuno dashboard lets you view your payments and transactions. From there, you can also export this information.

--- a/docs/basic-concepts/webhooks-1.mdx
+++ b/docs/basic-concepts/webhooks-1.mdx
@@ -3,14 +3,19 @@ title: "Webhooks"
 description: "Explains how Yuno webhooks notify your system of payment and event status changes."
 ---
 
-Webhooks allow apps to receive real-time updates whenever an event occurs, eliminating the need for constant requests. They provide a passive way to transfer data between systems using an HTTP POST request. Once you configure Yuno webhooks, your system will receive event notifications whenever an activity or function occurs within the Yuno flow.
+Webhooks let your system receive real-time event notifications via an HTTP POST request, without needing to send constant requests to Yuno. Once you configure Yuno webhooks, your system receives a notification whenever an activity or function occurs within the Yuno flow.
 
-<Frame>![](/images/reference/webhooks-1/image1.png)</Frame>
+<Frame>![Diagram of the webhook notification flow between Yuno and your system](/images/reference/webhooks-1/image1.png)</Frame>
 
 ## Why use webhooks?
 
-Webhooks keep your system up to date with payment progress and status changes. Since event notifications trigger automatically, your system does not need to send repeated requests to Yuno. This allows you to process payment information only when needed, improving efficiency.
+Webhooks keep your system up to date with payment progress and status changes. Since event notifications trigger automatically, your system does not need to send repeated requests to Yuno. This allows you to process payment information only when needed.
 
 ## Getting started with webhooks
 
-To use Yuno's webhooks, you must build a public REST API to receive event notifications via POST requests. Your API should not require authentication or access restrictions through headers. Despite being a public API, the system remains secure since Yuno event notifications are not publicly accessible and use a unique URL for communication with your REST API.
+To use Yuno's webhooks, you must build a public REST API to receive event notifications via POST requests. Your API should not require authentication or access restrictions through headers. Despite being a public API, the system remains secure, since Yuno event notifications are not publicly accessible. They also use a unique URL for communication with your REST API.
+
+## See Also
+
+- [Webhooks Overview](/docs/webhooks): event types across payments, subscriptions, payouts, and banking connectivity
+- [Verify Webhook Signatures (HMAC)](/docs/webhooks/verify-webhook-signatures-hmac): confirm notifications genuinely come from Yuno

--- a/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
+++ b/docs/how-yuno-works/how-yuno-payment-flow-works.mdx
@@ -7,7 +7,7 @@ While Yuno provides diverse payment options, the basic payment process always fo
 
 ## The Yuno payment process
 
-The payment process consisting of the following steps:
+The payment process consists of the following steps:
 
 
 <Steps>
@@ -30,7 +30,7 @@ The payment process consisting of the following steps:
     * **SDK Integration**: Yuno's SDKs securely capture sensitive data and generate a one-time token (OTT).
     * **Direct Integration**: You collect the payment details directly on your servers (requiring PCI compliance) and send them to the payment endpoint.
     <Note>
-      An OTT is a temporary, single-use code used by Yuno SDKs to enhance security and simplify the integration for merchants.
+      An OTT is a temporary, single-use code used by Yuno SDKs to enhance security for merchants.
     </Note>
   </Step>
 


### PR DESCRIPTION
Applies fixes for Core Concepts: grammar corrections, trimmed marketing/unsupported claims, split overly long sentences, added diagram alt text, condensed redundant definitions, standardized cross-reference phrasing, and removed em dashes in Tokens.