### PR TITLE
fix: mark web sdk 1.10.0 design changes as breaking

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -74,7 +74,7 @@
           "links": []
         },
         {
-          "type": "CHANGED",
+          "type": "BREAKING",
           "title": "Click to Pay footers use the shared modal footer",
           "description": "The Click to Pay card form, enrolled card, and installment selection screens now render the shared modal footer instead of a Click to Pay-specific copy, matching the full-width button and centered \"Powered by Yuno\" tag redesign. The legacy CSS hooks (`sdk-payments-c2p-button-bottom__modal-bottom`, `__button-continue`, `__button-back`) are preserved and the shared classes are added alongside them; the internal wrapper classes `sdk-payments-c2p-button-bottom__buttons-content` and `__button-wrapper` no longer exist in the DOM. The Click to Pay footer badge now links the country-specific privacy policy URL instead of always the global fallback.",
           "group": "Checkout",
@@ -82,7 +82,7 @@
           "links": []
         },
         {
-          "type": "CHANGED",
+          "type": "BREAKING",
           "title": "Full-width action button in modal footers",
           "description": "The action button in the shared modal footer now spans the full width on every viewport, with the \"Powered by Yuno\" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.",
           "group": "Checkout",
@@ -90,7 +90,7 @@
           "links": []
         },
         {
-          "type": "FIXED",
+          "type": "BREAKING",
           "title": "Improved Enrolled Card Form Rendering",
           "description": "The enrolled card form no longer reserves empty space when it has no fields to display, and now renders the card holder name field when the payment method configuration requires it.",
           "group": "Card Payments",

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -18,7 +18,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="changed" /> **Streamlined Saved Card Display**  
   Removed the card image preview from the saved (tokenized) card flow and replaced it with a compact preview showing the card brand, last four digits, cardholder name and expiry date.
 
-- <ChangelogBadge type="fixed" /> **Improved Enrolled Card Form Rendering**  
+- <ChangelogBadge type="breaking" /> **Improved Enrolled Card Form Rendering**  
   The enrolled card form no longer reserves empty space when it has no fields to display, and now renders the card holder name field when the payment method configuration requires it.
 
 - <ChangelogBadge type="fixed" /> **onInstallmentSelected Callback for Enrolled Cards**  
@@ -50,10 +50,10 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="added" /> **Express-Only Payment Methods Callback**  
   Added an optional `onlyExpressPaymentMethods` callback to the full checkout configuration that reports `true` when every available payment method renders as an express button (Apple Pay, Google Pay, PayPal, PayPal enrollment, PayPal Braintree, Revolut Pay) and `false` otherwise. When only express methods are available, the "Or pay with" divider is no longer rendered below the express buttons.
 
-- <ChangelogBadge type="changed" /> **Click to Pay footers use the shared modal footer**  
+- <ChangelogBadge type="breaking" /> **Click to Pay footers use the shared modal footer**  
   The Click to Pay card form, enrolled card, and installment selection screens now render the shared modal footer instead of a Click to Pay-specific copy, matching the full-width button and centered "Powered by Yuno" tag redesign. The legacy CSS hooks (`sdk-payments-c2p-button-bottom__modal-bottom`, `__button-continue`, `__button-back`) are preserved and the shared classes are added alongside them; the internal wrapper classes `sdk-payments-c2p-button-bottom__buttons-content` and `__button-wrapper` no longer exist in the DOM. The Click to Pay footer badge now links the country-specific privacy policy URL instead of always the global fallback.
 
-- <ChangelogBadge type="changed" /> **Full-width action button in modal footers**  
+- <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
 ## v1.9.19


### PR DESCRIPTION
## Summary
- Reclassifies three **v1.10.0** entries of the Web SDK changelog as `breaking` in `changelog/source/web.json` and `changelog/web.mdx` (they shipped as `changed`/`fixed` in the auto-generated #674):
  - **Click to Pay footers use the shared modal footer** — removes internal DOM wrapper classes (`changed` → `breaking`)
  - **Full-width action button in modal footers** — visual redesign of the modal footer (`changed` → `breaking`)
  - **Improved Enrolled Card Form Rendering** — layout/rendering behavior change (`fixed` → `breaking`)
- Matches the corrected source changelog in sdk-web: yuno-payments/sdk-web#2377.

## Test plan
- [ ] `changelog/source/web.json` is valid JSON and the three v1.10.0 entries have `"type": "BREAKING"`
- [ ] `changelog/web.mdx` v1.10.0 section renders the three entries with the breaking badge
- [ ] Docs preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)