### PR TITLE
docs(click-to-pay): document CTP Passkey mobile deeplink/OTT flow (iOS, Android, Flutter)

### DIFF
--- a/docs/wallets/click-to-pay.mdx
+++ b/docs/wallets/click-to-pay.mdx
@@ -110,4 +110,50 @@ Standard Click to Pay card flows use the existing SDK callbacks, but Passkey use
 For Passkey transactions, the one-time token (OTT) never reaches the usual SDK callbacks (including `callbackOTT` on Android). Always read it from the deeplink parameters before continuing the flow.
 </Info>
 
-For full implementation details, see [Android Full Checkout](/docs/sdks/full-checkout/android-payments) and [iOS Full Checkout](/docs/sdks/full-checkout/ios-payments).
+### Mobile: handling the response (OTT and deeplink)
+
+The integration flow for Click to Pay Passkey has a specific response handling that differs from the standard payment flow.
+
+When a shopper completes a payment using CTP Passkey, the one-time token (OTT) is **not** delivered through the usual delegate/listener methods. Instead, the transaction result — both success and failure — is communicated to your app through the **deeplink URL**.
+
+<Steps>
+  <Step title="Close the external browser">
+    As soon as your app receives the deeplink callback, immediately call `receiveDeeplink`. This lets the SDK properly close the external web browser used for Passkey authentication.
+    <CodeGroup>
+    ```swift iOS
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+
+        Yuno.receiveDeeplink(url: url)
+
+        // ...
+
+        return true
+    }
+    ```
+
+    ```dart Flutter
+    void _handleDeepLink(Uri uri) {
+
+        Yuno.receiveDeeplink(url: uri);
+
+        // ...
+    }
+    ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Read the transaction result from the deeplink URL">
+    The deeplink URL carries query-string parameters that indicate the transaction state:
+
+    - `has_error` — if this parameter is present, an error occurred during the transaction and you must handle the error scenario.
+    - `one_time_token` — if the transaction was successful, the URL contains this token.
+  </Step>
+
+  <Step title="Create the payment">
+    If a `one_time_token` is present in the URL:
+
+    1. Extract the `one_time_token` value.
+    2. Use this token to create the payment from your backend via the [Create payment](/reference/payments/create-payment) endpoint.
+    3. Once the payment is created, call `continuePayment` in the SDK to finalize the transaction.
+  </Step>
+</Steps>

--- a/docs/wallets/click-to-pay.mdx
+++ b/docs/wallets/click-to-pay.mdx
@@ -116,44 +116,69 @@ The integration flow for Click to Pay Passkey has a specific response handling t
 
 When a shopper completes a payment using CTP Passkey, the one-time token (OTT) is **not** delivered through the usual delegate/listener methods. Instead, the transaction result — both success and failure — is communicated to your app through the **deeplink URL**.
 
-<Steps>
-  <Step title="Close the external browser">
-    As soon as your app receives the deeplink callback, immediately call `receiveDeeplink`. This lets the SDK properly close the external web browser used for Passkey authentication.
-    <CodeGroup>
-    ```swift iOS
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+This is the same on **iOS, Android, and Flutter**: the merchant reads the result from the deeplink URL and acts on it. Only *where* the deeplink arrives changes per platform.
 
-        Yuno.receiveDeeplink(url: url)
+**Read two parameters from the deeplink URL**
 
-        // ...
+- `has_error` — an error occurred or the shopper canceled. Read the `message` parameter and show the error.
+- `one_time_token` — the transaction succeeded and the OTT is contained in the URL.
 
-        return true
+**Once you have the `one_time_token`**
+
+1. Send it to your backend to create the payment via the [Create payment](/reference/payments/create-payment) endpoint.
+2. Continue the flow in the SDK with `continuePayment` to finalize the transaction.
+
+**Where the deeplink arrives on each platform**
+
+- **iOS** — in `application(_:open:options:)`. Call `Yuno.receiveDeeplink(url)` to close the Passkey browser, then read the parameters from `url`.
+- **Flutter** — in your deeplink handler. `await Yuno.receiveDeeplink(url: uri)` to close the Passkey browser, then read the parameters from `uri`.
+- **Android** — the deeplink relaunches your `Activity` (there is no SDK close call). Read the parameters from `intent.data` in `onCreate`/`onNewIntent`. The receiving activity must declare an `intent-filter` in `AndroidManifest.xml` matching the scheme/host/path of your `callback_url`.
+
+<CodeGroup>
+```swift iOS
+func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    guard url.scheme == "myapp" else { return false }
+    Yuno.receiveDeeplink(url) // closes the Passkey browser
+
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+    if items?.contains(where: { $0.name == "has_error" }) == true {
+        // handle error (read the `message` parameter)
+    } else if let ott = items?.first(where: { $0.name == "one_time_token" })?.value {
+        // send `ott` to your backend, then continue the flow in the SDK
     }
-    ```
+    return true
+}
+```
 
-    ```dart Flutter
-    void _handleDeepLink(Uri uri) {
+```dart Flutter
+Future<void> _handleDeepLink(Uri uri) async {
+    await Yuno.receiveDeeplink(url: uri); // closes the Passkey browser
 
-        Yuno.receiveDeeplink(url: uri);
-
-        // ...
+    if (uri.queryParameters.containsKey('has_error')) {
+        // handle error (read the `message` parameter)
+    } else {
+        final ott = uri.queryParameters['one_time_token'];
+        if (ott != null) {
+            // send `ott` to your backend, then continue the flow in the SDK
+        }
     }
-    ```
-    </CodeGroup>
-  </Step>
+}
+```
 
-  <Step title="Read the transaction result from the deeplink URL">
-    The deeplink URL carries query-string parameters that indicate the transaction state:
+```kotlin Android
+override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    val uri = intent.data ?: return
 
-    - `has_error` — if this parameter is present, an error occurred during the transaction and you must handle the error scenario.
-    - `one_time_token` — if the transaction was successful, the URL contains this token.
-  </Step>
+    when {
+        uri.getBooleanQueryParameter("has_error", false) ->
+            showError(uri.getQueryParameter("message") ?: "Operation canceled")
 
-  <Step title="Create the payment">
-    If a `one_time_token` is present in the URL:
-
-    1. Extract the `one_time_token` value.
-    2. Use this token to create the payment from your backend via the [Create payment](/reference/payments/create-payment) endpoint.
-    3. Once the payment is created, call `continuePayment` in the SDK to finalize the transaction.
-  </Step>
-</Steps>
+        uri.getQueryParameter("one_time_token") != null -> {
+            val ott = uri.getQueryParameter("one_time_token")
+            // send `ott` to your backend, then continue the flow in the SDK
+        }
+    }
+}
+```
+</CodeGroup>


### PR DESCRIPTION
## Context
The **SDK integration (Click to Pay Passkey)** section in `docs/wallets/click-to-pay.mdx` ended by pointing to the generic Android/iOS Full Checkout guides — which never actually describe the Passkey-specific response handling.

## Change
Added a **Mobile: handling the response (OTT and deeplink)** subsection documenting the CTP Passkey flow, where the result is delivered through the **deeplink URL** instead of the usual delegate/listener callbacks. The handling is unified across **iOS, Android, and Flutter**:

- The merchant reads only two query params from the deeplink: `has_error` and `one_time_token`. The checkout session is **not** read from the deeplink.
- Once the `one_time_token` is present: create the payment in the backend via the Create payment endpoint, then call `continuePayment` to finalize.
- Per-platform "where the deeplink arrives" notes + a minimal `<CodeGroup>` (iOS / Flutter / Android):
  - **iOS** — in `application(_:open:options:)`; `Yuno.receiveDeeplink(url)` closes the Passkey browser, then read the params from `url`.
  - **Flutter** — `await Yuno.receiveDeeplink(url: uri)` closes the Passkey browser, then read the params from `uri`.
  - **Android** — the deeplink relaunches the `Activity` (no SDK close call); read the params from `intent.data` in `onCreate`/`onNewIntent`. Requires an `intent-filter` in `AndroidManifest.xml` matching the `callback_url`.

## Notes
- Docs-only change, single file.

## Testing
- [ ] Mintlify preview renders the `<CodeGroup>` (iOS / Flutter / Android tabs) correctly.
- [ ] No broken links (Create payment reference link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
