### PR TITLE
docs(reference): add EMEA production base URL to the environments table

### DIFF
--- a/reference/getting-started/api-environments.mdx
+++ b/reference/getting-started/api-environments.mdx
@@ -13,10 +13,11 @@ For how to switch between Test Mode and Live Mode in the Yuno dashboard, see [En
 
 ## Overview: Sandbox vs Production
 
-| Environment    | Purpose                                                      | Base URL                                       |
-| -------------- | ------------------------------------------------------------ | ---------------------------------------------- |
-| **Sandbox**    | Testing and development. No live data or real transactions. | <CopyChip value="https://api-sandbox.y.uno" /> |
-| **Production** | Live environment. Real transactions and accounting.         | <CopyChip value="https://api.y.uno" />         |
+| Environment           | Purpose                                                      | Base URL                                       |
+| --------------------- | ------------------------------------------------------------ | ---------------------------------------------- |
+| **Sandbox**           | Testing and development. No live data or real transactions. | <CopyChip value="https://api-sandbox.y.uno" /> |
+| **Production (US)**   | Live environment based in the US. Real transactions and accounting. | <CopyChip value="https://api.y.uno" />         |
+| **Production (EMEA)** | Live environment based in EMEA. Real transactions and accounting.   | <CopyChip value="https://api.eu.y.uno" />      |
 
 In the dashboard, Sandbox is referred to as **Test Mode** and Production as **Live Mode**. You use the same account for both; the dashboard toggle switches which environment you are using.
 


### PR DESCRIPTION
## Summary

On [/reference/getting-started/api-environments](https://docs.y.uno/reference/getting-started/api-environments), the **Overview: Sandbox vs Production** table now distinguishes the two production regions:

- **Production (US)** — `https://api.y.uno` (existing row, now labeled as US-based)
- **Production (EMEA)** — `https://api.eu.y.uno` (new row)

Both URLs keep the one-click `CopyChip` behavior.

## Note for reviewer

Scope kept to the Overview table as requested. The **Base URLs** section further down this page (and `auth.md`'s base-URL table) still list only `https://api.y.uno` for production — happy to extend those in this PR or a follow-up if the EMEA endpoint should appear there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)