### PR TITLE
docs(payment-features): simple copy and bug fixes across 15 pages

### DIFF
--- a/docs/payment-features/3ds-standalone.mdx
+++ b/docs/payment-features/3ds-standalone.mdx
@@ -3,49 +3,49 @@ title: "3DS Standalone"
 description: "Run 3D Secure authentication only, with no payment provider or authorization involved, via routing configuration"
 ---
 
-3DS Standalone runs only the 3D Secure authentication step — no payment provider is involved and no authorization happens. The response returns the authentication result (ECI + CAVV cryptogram and related data), which the merchant uses to decide what to do next (for example, forward it to their acquirer).
+3DS Standalone runs only the 3D Secure authentication step: no payment provider is involved and no authorization happens. The response returns the authentication result (ECI + CAVV cryptogram and related data). The merchant uses this result to decide what to do next, for example, forward it to their acquirer.
 
-The flow uses the standard `/payments` endpoint. What runs depends on how the route is configured: for standalone, the route must resolve **only** to the Yuno 3DS connection with no payment provider attached, so only the authentication runs.
+The flow uses the standard `/payments` endpoint. What runs depends on how the route is configured. For standalone, the route must resolve **only** to the Yuno 3DS connection with no payment provider attached, so only the authentication runs.
 
 ## Dashboard configuration
 
-### Step 1 — Create the Yuno 3DS connection
+### Step 1: Create the Yuno 3DS connection
 
 Go to **Dashboard → Connections → Add Connection** and select **Yuno 3DS**. Check the **"Yuno 3DS Standalone"** checkbox, fill in the acquirer data, and click **Next**.
 
 The **acquirer data** is the 3DS registration data your acquirer provides. For the default provider (Netcetera) the fields are:
 
-- **Acquirer BIN** — the Bank Identification Number used to clear and settle the transaction, together with the country where it is licensed.
-- **Merchant ID** — the affiliation number provided by the acquirer.
-- **Merchant Category Code (MCC)** — the code representing your merchant category, provided by the acquirer.
-- **Merchant Name** — the official business name conducting the transaction.
-- **Merchant URL** — the merchant's website / online platform.
-- **Country Code** — the country where the payment is processed ([ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1)).
+- **Acquirer BIN**: the Bank Identification Number used to clear and settle the transaction, together with the country where it is licensed.
+- **Merchant ID**: the affiliation number provided by the acquirer.
+- **Merchant Category Code (MCC)**: the code representing your merchant category, provided by the acquirer.
+- **Merchant Name**: the official business name conducting the transaction.
+- **Merchant URL**: the merchant's website / online platform.
+- **Country Code**: the country where the payment is processed ([ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1)).
 
 <Frame><img src="/images/reference/3ds-standalone/image1.png" /></Frame>
 <Frame><img src="/images/reference/3ds-standalone/image2.png" /></Frame>
 
-### Step 2 — Configure the route
+### Step 2: Configure the route
 
-Go to **Dashboard → Routing** and create a **CARD** route that points all transactions to the Yuno 3DS connection. The branch that handles standalone traffic must resolve **only** to the Yuno 3DS connection — no payment provider.
+Go to **Dashboard → Routing** and create a **CARD** route that points all transactions to the Yuno 3DS connection. The branch that handles standalone traffic must resolve **only** to the Yuno 3DS connection: no payment provider.
 
 <Note>
-If you already have a CARD route that points to a payment provider and want standalone authentication to coexist with it, you can isolate the standalone traffic with a condition group on metadata (for example `3ds_connection = standard`) that points only to the Yuno 3DS connection.
+You might already have a CARD route that points to a payment provider, and want standalone authentication to coexist with it. You can isolate the standalone traffic with a condition group on metadata (for example `3ds_connection = standard`) that points only to the Yuno 3DS connection.
 </Note>
 
 <Frame><img src="/images/reference/3ds-standalone/image3.png" /></Frame>
 
 #### Selecting a specific connection (more than one 3DS Standalone connection)
 
-If you have **more than one 3DS Standalone connection** configured — for example one set to **Data Only** and another with **no preference** (standard) — the router cannot decide on its own which one to use. In that case you must drive the selection explicitly with **metadata**.
+You might have **more than one 3DS Standalone connection** configured, for example, one set to **Data Only** and another with **no preference** (standard). In that case, the router cannot decide on its own which one to use, so drive the selection explicitly with **metadata**.
 
 The mechanism has two parts that must always work together:
 
-1. **In the route:** add a condition group per connection that matches on a metadata key (for example `3ds_connection = standard` for one connection and a different value for the other). Each value points the traffic to the connection you want.
-2. **In the requests:** add a `metadata` entry carrying that same key/value. It must be sent in **both** the 3DS Setup request and the `/payments` request — and it must be **identical in both**.
+1. **In the route:** add a condition group per connection that matches on a metadata key. For example, `3ds_connection = standard` for one connection and a different value for the other. Each value points the traffic to the connection you want.
+2. **In the requests:** add a `metadata` entry carrying that same key/value. It must be sent in **both** the 3DS Setup request and the `/payments` request, and it must be **identical in both**.
 
 <Warning>
-The 3DS Setup and the payment are routed independently. If the `metadata` sent in the 3DS Setup does not match the `metadata` sent in `/payments`, each call can resolve to a different connection — the Setup and the payment would then run against different connections and the authentication would not complete. Always send the **same** `metadata` in both calls so they select the **same** connection from the route.
+The 3DS Setup and the payment are routed independently. If the `metadata` sent in the 3DS Setup does not match the `metadata` sent in `/payments`, each call can resolve to a different connection. The Setup and the payment would then run against different connections, and the authentication would not complete. Always send the **same** `metadata` in both calls so they select the **same** connection from the route.
 </Warning>
 
 `metadata` is a JSON array of `{ "key", "value" }` entries. Send the same entry in both the Setup and the payment:
@@ -60,7 +60,9 @@ The 3DS Setup and the payment are routed independently. If the `metadata` sent i
 ```
 
 <Note>
-If you have a single 3DS Standalone connection **and the route has no other condition groups beyond it** (no other connections or conditionals), this metadata selection is not required — the route resolves to that connection automatically. If the route combines the 3DS Standalone connection with other conditionals (for example a second standalone connection), use the metadata mechanism above to isolate and select it.
+This applies when you have a single 3DS Standalone connection. If **the route has no other condition groups beyond it** (no other connections or conditionals), this metadata selection is not required. The route resolves to that connection automatically.
+
+The route may instead combine the 3DS Standalone connection with other conditionals, for example a second standalone connection. In that case, use the metadata mechanism above to isolate and select it.
 </Note>
 
 ## Standalone flow (using 3DS Setup)
@@ -75,13 +77,13 @@ The 3DS Setup has two possible values in the `type` field. The difference is **w
 
 | `type` | What it does | When to use |
 | :--- | :--- | :--- |
-| `STANDARD` (default) | Yuno (through the 3DS provider) handles the device-data collection. The response returns a `collect_url` and a `token`; the merchant must complete the collection by loading that `collect_url` with the `token`. | The standard flow — let Yuno / the 3DS provider drive the device-data collection. |
+| `STANDARD` (default) | Yuno (through the 3DS provider) handles the device-data collection. The response returns a `collect_url` and a `token`; the merchant must complete the collection by loading that `collect_url` with the `token`. | The standard flow: let Yuno / the 3DS provider drive the device-data collection. |
 | `MERCHANT_PROVIDED` | The merchant sends all the required data themselves (`browser_info` and `device_fingerprints`), so no device-data collection step is performed. | When a 3DS provider already collects this data on its own and hands it to you. |
 
 </div>
 
 <Note>
-If you have more than one 3DS Standalone connection, include the `metadata` in this request (as shown below) so the Setup is routed to the intended connection. Remember to send the **same** `metadata` later in the `/payments` request.
+If you have more than one 3DS Standalone connection, include the `metadata` in this request (as shown below). This routes the Setup to the intended connection. Remember to send the **same** `metadata` later in the `/payments` request.
 </Note>
 
 #### Type STANDARD
@@ -159,7 +161,7 @@ curl --location 'https://api-staging.y.uno/v1/three-d-secure/setups' \
 After you receive the `collect_url` and `token`, complete the device-data collection (the 3DS Method) **before** creating the payment.
 
 <Note>
-**Suggested implementation (reference only — not a fixed contract).** The exact field name and mechanics can vary by 3DS provider, so validate against the provider you use. The general idea: render a hidden iframe and auto-submit a form that POSTs the token to the `collect_url`, wait for the period indicated by `timeout_value`, then continue to create the payment.
+**Suggested implementation (reference only, not a fixed contract).** The exact field name and mechanics can vary by 3DS provider. Validate against the provider you use. The general idea: render a hidden iframe and auto-submit a form that POSTs the token to the `collect_url`. Wait for the period indicated by `timeout_value`, then continue to create the payment.
 
 ```html
 <!-- Hidden iframe that receives the collection POST -->
@@ -178,7 +180,7 @@ After you receive the `collect_url` and `token`, complete the device-data collec
 </Note>
 
 <Note>
-If the provider returns an **empty** `collect_url` and `token` (for example `CHECKOUT_COM_3DS` above), there is no collection step — skip it and go straight to creating the payment.
+If the provider returns an **empty** `collect_url` and `token` (for example `CHECKOUT_COM_3DS` above), there is no collection step. Skip it and go straight to creating the payment.
 </Note>
 
 #### Type MERCHANT_PROVIDED
@@ -186,7 +188,7 @@ If the provider returns an **empty** `collect_url` and `token` (for example `CHE
 The merchant sends all the required data themselves (`browser_info` and `device_fingerprints`), so no device-data collection step is performed.
 
 <Note>
-Use `device_fingerprints` only when a 3DS provider that collects this data on its own (i.e. does not use the `collect_url`) hands you the fingerprint `id` — forward that `id` here. The `provider_id` must match the 3DS provider configured on the connection.
+Use `device_fingerprints` only when a 3DS provider that collects this data on its own (i.e. does not use the `collect_url`) hands you the fingerprint `id`. Forward that `id` here. The `provider_id` must match the 3DS provider configured on the connection.
 </Note>
 
 **Request**
@@ -264,10 +266,10 @@ curl --location 'https://api-staging.y.uno/v1/three-d-secure/setups' \
 
 ### 2. Create the payment
 
-Create the payment using the `three_d_secure_setup_id` generated in the previous step. Since the route resolves only to the Yuno 3DS connection (no payment provider), only the authentication runs and the 3DS result is returned — no authorization takes place.
+Create the payment using the `three_d_secure_setup_id` generated in the previous step. Since the route resolves only to the Yuno 3DS connection (no payment provider), only the authentication runs and the 3DS result is returned. No authorization takes place.
 
 <Warning>
-**Payment method:** because this is a standalone 3DS authentication flow, the card must already be available to it — either send the `card_data` in the request, or reference a payment method that was **enrolled (vaulted) beforehand**. Do **not** send `vault_on_success: true` — this flow does not support it.
+**Payment method:** because this is a standalone 3DS authentication flow, the card must already be available to it. Either send the `card_data` in the request, or reference a payment method that was **enrolled (vaulted) beforehand**. Do **not** send `vault_on_success: true`: this flow does not support it.
 </Warning>
 
 <Warning>
@@ -324,16 +326,16 @@ curl --location 'https://api-staging.y.uno/v1/payments' \
 ```
 
 <Note>
-**Workflow:** a **frictionless** / **data-only** authentication resolves inline (the examples ran with `workflow: DIRECT`) and the result comes back on the payment response. A **challenge** needs the cardholder to act, so the payment returns `PENDING` with a `redirect_url` and `checkout.sdk_action_required: true` — handle it with a redirect-capable workflow (`REDIRECT`) or the Yuno SDK (see [Authentication outcomes → Challenge](#challenge)).
+**Workflow:** a **frictionless** / **data-only** authentication resolves inline (the examples ran with `workflow: DIRECT`) and the result comes back on the payment response. A **challenge** needs the cardholder to act, so the payment returns `PENDING` with a `redirect_url` and `checkout.sdk_action_required: true`. Handle it with a redirect-capable workflow (`REDIRECT`) or the Yuno SDK (see [Authentication outcomes → Challenge](#challenge)).
 </Note>
 
 The payment's top-level `status` / `sub_status` tell you the outcome, and the 3DS result lives in `payment_method.payment_method_detail.card.three_d_secure`:
 
 - **Frictionless / Data Only** → `status: SUCCEEDED`, `sub_status: THREE_D_SECURE_VERIFIED`.
-- **Challenge** → `status: PENDING`, `sub_status: WAITING_ADDITIONAL_STEP`, with `checkout.sdk_action_required: true` and a `redirect_url` (resolves later — see [Webhook notification](#webhook-notification)).
+- **Challenge** → `status: PENDING`, `sub_status: WAITING_ADDITIONAL_STEP`, with `checkout.sdk_action_required: true` and a `redirect_url` (resolves later; see [Webhook notification](#webhook-notification)).
 - **Failed / rejected authentication** → `status: DECLINED`.
 
-A standalone payment ultimately resolves to either `SUCCEEDED` / `THREE_D_SECURE_VERIFIED` (authentication completed) or `DECLINED` (authentication failed or rejected). The transaction-level status and 3DS response codes follow the standard Yuno reference — [Transaction statuses and response codes](/reference/payments/status-and-response-codes/transaction) (for example `SUCCEEDED_THREE_D_SECURE`, `CHALLENGE_REQUIRED`, `AUTHENTICATION_FAILED_THREE_D_SECURE`, `REJECTED_THREE_D_SECURE_REQUIRED`).
+A standalone payment ultimately resolves to either `SUCCEEDED` / `THREE_D_SECURE_VERIFIED` (authentication completed) or `DECLINED` (authentication failed or rejected). The transaction-level status and 3DS response codes follow the standard Yuno reference: [Transaction statuses and response codes](/reference/payments/status-and-response-codes/transaction). Example codes include `SUCCEEDED_THREE_D_SECURE`, `CHALLENGE_REQUIRED`, `AUTHENTICATION_FAILED_THREE_D_SECURE`, and `REJECTED_THREE_D_SECURE_REQUIRED`.
 
 ## Authentication outcomes
 
@@ -536,9 +538,9 @@ A standalone payment ultimately resolves to either `SUCCEEDED` / `THREE_D_SECURE
 </Accordion>
 
 **Flow summary:**
-1. Only browser/device data is shared with the issuer to feed their risk models — no real authentication occurs.
+1. Only browser/device data is shared with the issuer to feed their risk models: no real authentication occurs.
 2. The flow continues like frictionless and returns a result (`SUCCEEDED` / `THREE_D_SECURE_VERIFIED`, `pares_status = I`).
-3. Liability shift = **NO** — the merchant retains fraud liability. Typically ECI 04.
+3. Liability shift = **NO**: the merchant retains fraud liability. Typically ECI 04.
 
 ### Challenge
 
@@ -638,7 +640,7 @@ The payment comes back as `PENDING` with a `redirect_url` and `checkout.sdk_acti
 </Accordion>
 
 <Note>
-Once the cardholder completes the challenge, the **final** result is delivered through the payment webhook (see [Webhook notification](#webhook-notification) below): `status: SUCCEEDED` / `THREE_D_SECURE_VERIFIED` on success (populated `electronic_commerce_indicator` and `cryptogram` / CAVV, `pares_status: Y`, `has_challenge: true`), or `status: DECLINED` if the challenge fails.
+Once the cardholder completes the challenge, the **final** result is delivered through the payment webhook (see [Webhook notification](#webhook-notification) below). On success, the payment shows `status: SUCCEEDED` / `THREE_D_SECURE_VERIFIED`, with a populated `electronic_commerce_indicator` and `cryptogram` / CAVV, `pares_status: Y`, and `has_challenge: true`. If the challenge fails, the payment shows `status: DECLINED`.
 </Note>
 
 **Flow summary:**
@@ -647,28 +649,28 @@ Once the cardholder completes the challenge, the **final** result is delivered t
    - **With the Yuno SDK:** the SDK renders the challenge automatically.
    - **With a redirect-capable workflow (`REDIRECT`):** redirect the cardholder to the `redirect_url` returned in the payment response so they can complete the challenge.
 3. The cardholder completes the challenge (OTP, biometrics, Out-of-Band, Decoupled, Passkeys/FIDO-SPC). It is asynchronous.
-4. When finished, the cardholder is returned to your `callback_url`, and the final authentication result is delivered through the payment webhook (`payment.purchase`) — or read it via `GET /v1/payments/{id}`.
-5. On success (`pares_status = Y`) the payment is `SUCCEEDED` / `THREE_D_SECURE_VERIFIED` and liability shift = **yes**; if the challenge fails the payment is `DECLINED`. Until the result arrives, the merchant sees the payment as `PENDING`.
+4. When finished, the cardholder is returned to your `callback_url`. The final authentication result is delivered through the payment webhook (`payment.purchase`), or read it via `GET /v1/payments/{id}`.
+5. On success (`pares_status = Y`) the payment is `SUCCEEDED` / `THREE_D_SECURE_VERIFIED` and liability shift = **yes**. If the challenge fails, the payment is `DECLINED`. Until the result arrives, the merchant sees the payment as `PENDING`.
 
 ### Failed / rejected
 
 1. The ACS returns a non-authenticated result (`pares_status N` / `R`) or the authentication is rejected.
 2. The payment resolves to `DECLINED`; the transaction carries a failure response code such as `AUTHENTICATION_FAILED_THREE_D_SECURE` or `REJECTED_THREE_D_SECURE_REQUIRED`.
-3. No liability shift — there is no successful authentication.
+3. No liability shift: there is no successful authentication.
 
 ## Receiving the result
 
-For **frictionless** and **data-only**, the `three_d_secure` result is available on the payment response immediately (`status: SUCCEEDED`). For a **challenge**, the result is delivered asynchronously once the cardholder finishes — see [Webhook notification](#webhook-notification) — or poll `GET /v1/payments/{id}` to read the final `three_d_secure` result.
+For **frictionless** and **data-only**, the `three_d_secure` result is available on the payment response immediately (`status: SUCCEEDED`). For a **challenge**, the result is delivered asynchronously once the cardholder finishes (see [Webhook notification](#webhook-notification)). Alternatively, poll `GET /v1/payments/{id}` to read the final `three_d_secure` result.
 
 ## Webhook notification
 
-The authentication result is delivered through the standard Yuno payment notification — the **same webhook you already use for payment status updates**. There is no separate 3DS-specific webhook. The event is a `payment` notification with `type_event: "payment.purchase"`; the payment is under `data.payment`, and the 3DS result is in `data.payment.transactions.payment_method.payment_method_detail.card.three_d_secure`.
+The authentication result is delivered through the standard Yuno payment notification: the **same webhook you already use for payment status updates**. There is no separate 3DS-specific webhook. The event is a `payment` notification with `type_event: "payment.purchase"`. The payment is under `data.payment`, and the 3DS result is in `data.payment.transactions.payment_method.payment_method_detail.card.three_d_secure`.
 
 <Note>
-For a **declined** authentication the same webhook (`payment.purchase`) is delivered — only the status changes: the payment is `DECLINED` and the transaction carries a failure response code such as `AUTHENTICATION_FAILED_THREE_D_SECURE` or `REJECTED_THREE_D_SECURE_REQUIRED`.
+For a **declined** authentication the same webhook (`payment.purchase`) is delivered; only the status changes. The payment is `DECLINED` and the transaction carries a failure response code such as `AUTHENTICATION_FAILED_THREE_D_SECURE` or `REJECTED_THREE_D_SECURE_REQUIRED`.
 </Note>
 
-**Example — successful authentication (after a completed challenge)**
+**Example: successful authentication (after a completed challenge)**
 
 <Accordion title="View webhook payload">
 ```json
@@ -775,8 +777,8 @@ For a **declined** authentication the same webhook (`payment.purchase`) is deliv
 | :--- | :--- |
 | `version` | The 3D Secure protocol version used for the authentication (e.g. 2.1.0 / 2.2.0 / 2.3.1). Newer versions enable additional challenge methods (OOB, Passkeys/FIDO, etc.). |
 | `electronic_commerce_indicator` (ECI) | Indicates the authentication result and who bears fraud liability. Visa: 05 authenticated / 06 attempted / 07 not authenticated. Mastercard: 02 authenticated / 01 attempted / 00 not authenticated. Empty while a challenge is still pending. |
-| `cryptogram` | The CAVV/AAV — cryptographic proof generated by the issuer that authentication took place. Unique per transaction; sent to the acquirer in the authorization to validate the 3DS. While a challenge is pending, this field carries the encoded challenge request instead. |
-| `transaction_id` | The 3DS Server Transaction ID (`threeDSServerTransID`) — identifier of the 3DS transaction assigned by the 3DS Server in 3DS2. Correlates the AReq/ARes messages. (This is the 3DS2 value; the legacy 3DS1 "XID" is a different field.) |
+| `cryptogram` | The CAVV/AAV: cryptographic proof generated by the issuer that authentication took place. Unique per transaction; sent to the acquirer in the authorization to validate the 3DS. While a challenge is pending, this field carries the encoded challenge request instead. |
+| `transaction_id` | The 3DS Server Transaction ID (`threeDSServerTransID`): identifier of the 3DS transaction assigned by the 3DS Server in 3DS2. Correlates the AReq/ARes messages. (This is the 3DS2 value; the legacy 3DS1 "XID" is a different field.) |
 | `directory_server_transaction_id` (dsTransID) | Unique transaction identifier assigned by the Directory Server (Visa/Mastercard) in 3DS2. A mandatory value that must travel in the authorization alongside the cryptogram. |
 | `pares_status` | Authentication result (EMVCo transStatus): Y authenticated, N failed, A attempted, U unavailable, R rejected, C challenge required, I data only. |
 | `acs_id` | Identifier of the issuer's ACS (Access Control Server) that processed the authentication. Used for reference/traceability to the ACS that responded. |

--- a/docs/payment-features/Cancel-and-capture-flow.mdx
+++ b/docs/payment-features/Cancel-and-capture-flow.mdx
@@ -3,11 +3,9 @@ title: "Cancel and Capture Flow"
 description: "Configure real-time, manual, or delayed capture and cancel settings for authorized card payments"
 ---
 
-When integrating with Yuno, you have multiple options for implementing capture and cancel operations. This guide outlines all available approaches and explains how to interact with our APIs for each scenario.
+This guide outlines all available approaches for capture and cancel operations and explains how to interact with our APIs for each scenario.
 
-We provide simple real-time capture for fast transactions, as well as highly customizable delayed capture and cancel configurations to meet your business needs.
-
-## Overview
+## In this guide
 
 * [**Capture modes**](#capture-modes)
   * [Real-time capture](#real-time-capture)
@@ -73,7 +71,7 @@ Manual captures provide maximum flexibility since they give you full control of 
 ```
 
 <Warning>
-****Capturing Different Amounts****
+**Capturing Different Amounts**
 
 If you need to capture a different amount than originally authorized, you must use manual capture. The real-time and delayed capture modes will always capture the initially authorized amount.
 </Warning>
@@ -169,9 +167,9 @@ Setting `simplified_mode` to `true` will make Yuno retry the cancel operation in
 If you call the [capture API](/reference/capture-authorization) or [cancel API](/reference/cancel-or-refund-a-payment) before the scheduled time, your call will override the delay and execute the action immediately. **This action automatically cancels the scheduled Yuno trigger**. Alternatively, you can capture or cancel the payment manually through your Yuno dashboard.
 
 <Info>
-****Delayed Capture and Cancel Settings****
+**Delayed Capture and Cancel Settings**
 
-We recommend not using **both** `delayed_capture_settings` and `delayed_cancel_settings` simultaneously to avoid unexpected behaviors. Use only one at a time based on your needs.
+Yuno recommends not using **both** `delayed_capture_settings` and `delayed_cancel_settings` simultaneously to avoid unexpected behaviors. Use only one at a time based on your needs.
 </Info>
 
 ## Configuration requirements
@@ -394,7 +392,7 @@ This example shows a complete payment request with both delayed capture and canc
 <Info>
 **Note**
 
-While this example shows both `delayed_capture_settings` and `delayed_cancel_settings` configured together, we recommend using only one at a time to avoid unexpected behaviors.
+While this example shows both `delayed_capture_settings` and `delayed_cancel_settings` configured together, Yuno recommends using only one at a time to avoid unexpected behaviors.
 </Info>
 
 ## When to use each mode

--- a/docs/payment-features/account-funding-transactions-afts.mdx
+++ b/docs/payment-features/account-funding-transactions-afts.mdx
@@ -7,7 +7,7 @@ description: "Load funds into wallets or transfer between accounts using account
 
 **Account Funding Transactions (AFT)** are financial transactions that facilitate the transfer of funds between payment accounts. They are widely used to load or top up user accounts, digital wallets, perform internal fund transfers within a payment platform.
 
-AFTs are a core component of payment orchestration systems, enabling efficient and secure movement of money across accounts.
+AFTs enable efficient and secure movement of money across accounts.
 
 ## What is an AFT?
 
@@ -31,7 +31,7 @@ AFTs leverage traditional payment networks (e.g., Visa, Mastercard, ACH) to proc
 
 ## Integration
 
-To perform an AFT, you will need to send a request to our [Payments API](/reference/create-payment) with the `additional_data.order.account_funding` object specifying the `sender` and`beneficiary` data.
+To perform an AFT, you will need to send a request to our [Payments API](/reference/create-payment) with the `additional_data.order.account_funding` object specifying the `sender` and `beneficiary` data.
 
 Each credit card scheme might require different information about the recipient and the sender, depending on the operating region and transaction category.
 
@@ -64,5 +64,5 @@ For more details, refer to the create [payments API](/reference/create-payment) 
 <Note>
 **Additional Data**
 
-In case you need to define additional information about the seller, such as `merchant_category_code`for example, you can find extra fields in the seller\_details inside the [additional\_data struct](/reference/the-payment-object) in the payment.
+In case you need to define additional information about the seller, such as `merchant_category_code` for example, you can find extra fields in the `seller_details` inside the [`additional_data` struct](/reference/the-payment-object) in the payment.
 </Note>

--- a/docs/payment-features/card-verification-results.mdx
+++ b/docs/payment-features/card-verification-results.mdx
@@ -3,7 +3,7 @@ title: "Card verification results (AVS & CVV)"
 description: "Understand how Yuno surfaces issuer-side address (AVS), postal code, cardholder name, and CVV/CVC check results on every card payment."
 ---
 
-When a card payment is authorized, the issuer can return the result of several verification checks the network ran against the card data the customer provided — most importantly **AVS** (Address Verification Service) and the **CVV / CVC** match. Yuno relays those results back to you on every card transaction so you can use them in your own risk, reconciliation, or retry logic.
+When a card payment is authorized, the issuer can return the result of several verification checks the network ran against the card data the customer provided, most importantly **AVS** (Address Verification Service) and the **CVV / CVC** match. Yuno relays those results back to you on every card transaction so you can use them in your own risk, reconciliation, or retry logic.
 
 This guide covers:
 
@@ -39,8 +39,8 @@ payment.transactions_history[].payment_method.detail.card.verification_services
 
 It appears on the response of:
 
-- `POST /v1/payments` — Create payment
-- `GET /v1/payments/{id}` — Retrieve payment
+- `POST /v1/payments`: Create payment
+- `GET /v1/payments/{id}`: Retrieve payment
 - `POST /v1/payments/{id}/capture`, `/refund`, `/cancel`, etc.
 
 It is also included in **payment webhook events** (`payment.created`, `payment.updated`, …), inside the same `payment_method.detail.card` path.
@@ -85,24 +85,24 @@ Yuno normalizes the result of every check returned by the issuer / acquirer into
 |---|---|
 | `PASS` | The check ran and the value matched the issuer's record. |
 | `FAIL` | The check ran and the value did **not** match. |
-| `UNAVAILABLE` | The check could not be completed — the issuer is not certified, did not respond, or does not support the check in this region. |
+| `UNAVAILABLE` | The check could not be completed: the issuer is not certified, did not respond, or does not support the check in this region. |
 | `UNCHECKED` | The check was not performed for this transaction (e.g. the merchant did not send a CVV, or the provider does not run AVS). |
 
 ---
 
 ## How to use these results
 
-AVS and CVV results are **not** authorization decisions — the transaction can be approved even when the checks fail. They are advisory signals you can fold into your own risk strategy.
+AVS and CVV results are **not** authorization decisions: the transaction can be approved even when the checks fail. They are advisory signals you can fold into your own risk strategy.
 
 A simple decision matrix many merchants use:
 
 | AVS (address_line_1_check / zip_code_check) | CVV (card_security_code_check) | Suggested action |
 |---|---|---|
 | `PASS` | `PASS` | Accept. |
-| `PASS` | `FAIL` | Soft decline / step-up — billing data looks right but the security code is wrong. |
-| `FAIL` | `PASS` | Review — billing-data mismatch is a strong fraud signal even with a correct CVV. |
+| `PASS` | `FAIL` | Soft decline / step-up: billing data looks right but the security code is wrong. |
+| `FAIL` | `PASS` | Review: billing-data mismatch is a strong fraud signal even with a correct CVV. |
 | `FAIL` | `FAIL` | Decline. |
-| `UNAVAILABLE` / `UNCHECKED` | any | Treat as unknown — fall back to other risk signals (3DS result, fraud-screening score). |
+| `UNAVAILABLE` / `UNCHECKED` | any | Treat as unknown: fall back to other risk signals (3DS result, fraud-screening score). |
 
 Because verification coverage varies by issuer and region, any decisioning you build on top should:
 
@@ -114,7 +114,7 @@ Because verification coverage varies by issuer and region, any decisioning you b
 
 ## Sending verification data on the request
 
-You can also pass `verification_services` **into** Yuno on the create-payment request — for example, when relaying upstream auth results from a system of record. The same four fields are accepted under:
+You can also pass `verification_services` **into** Yuno on the create-payment request, for example, when relaying upstream auth results from a system of record. The same four fields are accepted under:
 
 ```
 payment_method.payment_method_detail.card.verification_services

--- a/docs/payment-features/enrollment/enroll-cards-with-payment-link.mdx
+++ b/docs/payment-features/enrollment/enroll-cards-with-payment-link.mdx
@@ -7,14 +7,6 @@ Yuno provides merchants with the ability to manage overdue or declined payments 
 
 This feature is tailored for merchants who operate their own subscription engine and need to update credit card details to continue processing payments with a new `vaulted_token` for their customers.
 
-## Benefits
-
-* **Speed and ease**: Users can resolve payment issues instantly without logging into their account or re-entering all their details
-* **Seamless update**: The new card used in the payment link is automatically saved when the previous card expires or is blocked, preventing future payment issues
-* **Enhanced security**: All payments made through the link are protected with advanced encryption technology
-
-This feature ensures a smoother payment experience, reducing friction and improving service continuity for users of your subscription product.
-
 ## How it works
 
 ### 1. Receiving the payment link

--- a/docs/payment-features/enrollment/enroll-payment-methods.mdx
+++ b/docs/payment-features/enrollment/enroll-payment-methods.mdx
@@ -59,7 +59,7 @@ Register customer info through the [Create Customer](/reference/create-customer)
 <Note>
 **Customer complementary information**
 
-Providing optional details like phone, billing address, and shipping address enhances the payment experience. If you include these fields, certain sub-fields become required.
+Optional details like phone, billing address, and shipping address are not required to enroll a payment method, but some providers use them for fraud checks. If you include these fields, certain sub-fields become required.
 </Note>
 
 After creating the customer, you'll receive an `id` that identifies them in Yuno. If your customer already has an `id`, skip this step.
@@ -103,7 +103,7 @@ Enroll the payment method using one of the following endpoints:
 * [**Direct workflow**](/reference/enroll-payment-method-api): Pass the payment method `type` to the `type` parameter. (Only available for `CARD` payment methods used by PCI compliant merchants)
 * [**SDK workflow**](/docs/sdks/overview/quickstart): Payment methods like `NEQUI` and `BANCOLOMBIA_TOKENBOX` require SDK implementation. `WALLET_CONNECT` (MercadoPago) supports both SDK and Checkout workflows.
 
-Redirect the user to the payment provider page to complete enrollment. You'll receive this URL in Step 5.
+The enrollment response includes a redirect URL to the payment provider page. Step 5 explains where to find it and how to complete enrollment.
 
 ### Step 5: Retrieve payment methods
 

--- a/docs/payment-features/installments/index.mdx
+++ b/docs/payment-features/installments/index.mdx
@@ -11,14 +11,6 @@ Yuno supports payments in installments, which allows you to spread out the cost 
 
 <Frame>![](/images/reference/installments/image1.png)</Frame>
 
-### Benefits of using payments in installments
-
-There are several benefits to using installment payments for your customers:
-
-* **Affordability**: Paying in installments can make a large purchase more affordable by spreading out the cost over a longer period of time. This can be especially helpful if the customer doesn't have the full amount of money available upfront.
-* **Flexibility**: With payments in installments, you can offer your customer a payment plan that best suits their need. They can usually choose the number of months to pay off the purchase, as well as the amount of each payment.
-* **Convenience**: Payments in installments can be a convenient way to make a purchase. Customers can usually make payments online or by phone, and they don't have to worry about writing checks or carrying cash.
-
 ### Merchant vs. Provider Installments
 
 Installment implementation varies depending on the origin and your commercial agreements. There are two options merchants can use, one defined by themselves and the other according to the providers' definition:

--- a/docs/payment-features/installments/merchant-installments.mdx
+++ b/docs/payment-features/installments/merchant-installments.mdx
@@ -25,7 +25,7 @@ When you use Yuno's SDK, Yuno is responsible for presenting to the customer the 
 
 <Frame><img src="/images/reference/merchant-installments/image1.png" /></Frame>
 
-2. After enabling the installments, you need to create an installment plan using the  [Create Installments Plan](/reference/create-installments-plan) endpoint. When creating a plan, you will specify the accepted currency, amounts, card brands, dates, etc. Once the plan is active, Yuno applies it automatically to matching payments and presents the corresponding installment options to the customer.
+2. After enabling the installments, you need to create an installment plan using the [Create Installments Plan](/reference/create-installments-plan) endpoint. When creating a plan, you will specify the accepted currency, amounts, card brands, dates, etc. Once the plan is active, Yuno applies it automatically to matching payments and presents the corresponding installment options to the customer.
 
 <Warning>
 **Secure Fields SDK Integration**

--- a/docs/payment-features/installments/merchant-installments.mdx
+++ b/docs/payment-features/installments/merchant-installments.mdx
@@ -15,7 +15,7 @@ Depending on the way you are connected to Yuno, the process of configuring the i
 
 ### Direct workflow
 
-When using a [Direct integration](/docs/direct-flow),  you manage the front-end checkout experience. In this case, you will inform Yuno about the number of installments when creating the payment using the [Create Payment](/reference/create-payment) endpoint. The number of installments will be defined through the  `payment_method.detail.card.installments` parameter.
+When using a [Direct integration](/docs/direct-flow), you manage the front-end checkout experience. In this case, you will inform Yuno about the number of installments when creating the payment using the [Create Payment](/reference/create-payment) endpoint. The number of installments will be defined through the `payment_method.detail.card.installments` parameter.
 
 ### SDK Integration
 
@@ -25,7 +25,7 @@ When you use Yuno's SDK, Yuno is responsible for presenting to the customer the 
 
 <Frame><img src="/images/reference/merchant-installments/image1.png" /></Frame>
 
-2. After enabling the installments, you need to create an installment plan using the  [Create Installments Plan](/reference/create-installments-plan) endpoint. When creating a plan, you will specify the accepted currency, amounts, card brands, dates, etc. After that, we will take care of the rest.
+2. After enabling the installments, you need to create an installment plan using the  [Create Installments Plan](/reference/create-installments-plan) endpoint. When creating a plan, you will specify the accepted currency, amounts, card brands, dates, etc. Once the plan is active, Yuno applies it automatically to matching payments and presents the corresponding installment options to the customer.
 
 <Warning>
 **Secure Fields SDK Integration**

--- a/docs/payment-features/installments/provider-installments.mdx
+++ b/docs/payment-features/installments/provider-installments.mdx
@@ -26,5 +26,5 @@ This option is not enabled for all providers, only the ones that have Installmen
 <Danger>
 **Routing Configuration Warning**
 
-While setting your [route](docs/using-yuno/dashboard-overview/routing) for the Card payment method, remember that having a fallback for a provider that has "Provider installments" is not supported, as different providers handle different types of installment plans. It can cause a processing error in the fallback.
+While setting your [route](/docs/using-yuno/dashboard-overview/routing) for the Card payment method, remember that having a fallback for a provider that has "Provider installments" is not supported, as different providers handle different types of installment plans. It can cause a processing error in the fallback.
 </Danger>

--- a/docs/payment-features/payment-amount-details.mdx
+++ b/docs/payment-features/payment-amount-details.mdx
@@ -3,7 +3,7 @@ title: "Payment Details"
 description: "Break down a payment's total into fee, shipping, tips, taxes, and discount components for transparency"
 ---
 
-Our API offers flexibility in structuring payment amounts, accommodating various factors that may contribute to the total transaction sum. Whether it's base charges, taxes, fees, or tips, our system is designed to handle diverse components seamlessly. You can easily integrate and manage payments with different elements contributing to the overall amount
+The API lets you break down a payment's total into individual components, such as base charges, taxes, fees, tips, and discounts.
 
 * [Fee](#fee-amount)
 * [Shipping](#shipping-amount)
@@ -12,11 +12,11 @@ Our API offers flexibility in structuring payment amounts, accommodating various
 * [Discounts](#discounts)
 * [Customer validations](#customer-validations)
 
-This feature enhances transparency and convenience for both merchants and customers, enabling seamless handling of payment details within the payment process.
+These fields are informational: each component is already included in the payment's total `amount.value` and isn't added on top of it.
 
 ## Fee amount
 
-A dedicated field (`additiona_datal.order.fee_amount`) allows you to specify the fee amount for your services that is included in the transaction.
+A dedicated field (`additional_data.order.fee_amount`) allows you to specify the fee amount for your services that is included in the transaction.
 
 In the following example you can see a request that clarifies that a 180 JPY fee amount is part of a 5000 JPY final transaction. This field is for informational purposes, the `fee_amount` is already included in the final transaction amount and is not added separately.
 
@@ -116,7 +116,7 @@ curl --request POST \
 
 ## Tips
 
-A dedicated field (`additiona_datal.order.tip_amount`) allows you to specify the tips amount that is included in the transaction.
+A dedicated field (`additional_data.order.tip_amount`) allows you to specify the tips amount that is included in the transaction.
 
 In the following example you can see a request that clarifies that a 50 JPY tip amount is part of a 5000 JPY final transaction. This field is for informational purposes, the `tip_amount` is already included in the final transaction amount and is not added separately.
 
@@ -185,7 +185,7 @@ A dedicated array of objects (`additional_data.order.taxes`) allows you to speci
 | VAT\_EXEMPTION   | COL, ECU     | Value Added Tax Exemption                                                                                                                                                                                                                                                                                                                                                                         |
 | ISV              | DOM          | Sales Tax. Also known as "Impuesto Sobre las Ventas". In the Dominican Republic, the ISV, commonly known as ITBIS (Impuesto a la Transferencia de Bienes Industrializados y Servicios), is a value-added tax applied to the transfer of goods and services. The ITBIS is similar to the VAT in other countries, where the tax is levied at each stage of the production and distribution process. |
 
-In the following example, you can see a request that clarifies what taxes are part of a 1000.00 USD final transaction. This field is for informational purposes; the `taxes`struct is already included in the final transaction amount and has not been added separately.
+In the following example, you can see a request that clarifies what taxes are part of a 1000.00 USD final transaction. This field is for informational purposes; the `taxes` struct is already included in the final transaction amount and has not been added separately.
 
 ```json
 curl --request POST \
@@ -245,7 +245,7 @@ curl --request POST \
 
 A dedicated array of objects (`additional_data.order.discounts`) allows you to specify the discounts that are included in the transaction.
 
-In the following example you can see a request that clarifies that a 500 USD tip amount is part of a 5000 USD final transaction. This field is for informational purposes, the `discounts` is already included in the final transaction amount and is not added separately.
+In the following example you can see a request that clarifies that a 500 USD discount amount is part of a 5000 USD final transaction. This field is for informational purposes, the `discounts` is already included in the final transaction amount and is not added separately.
 
 ```json Example
 curl --request POST \
@@ -335,7 +335,7 @@ In the following example you can see a request that clarifies that customer has 
         "merchant_customer_validations":{
           "phone_is_verified":true,
           "account_is_verified":true,
-          "email_is_verified:":true
+          "email_is_verified":true
         }
     },
 [...]

--- a/docs/payment-features/sca-exemptions.mdx
+++ b/docs/payment-features/sca-exemptions.mdx
@@ -3,11 +3,11 @@ title: "SCA Exemptions"
 description: "Request PSD2 exemptions from Strong Customer Authentication for eligible low-risk or recurring card transactions"
 ---
 
-# Understanding SCA Exemptions
+## Understanding SCA Exemptions
 
 Under the European Union's Payment Services Directive 2 (PSD2), Strong Customer Authentication (SCA) is mandated for electronic payments to enhance security and reduce fraud. However, PSD2 provides specific scenarios—known as SCA exemptions—where transactions can bypass the standard authentication requirements. These exemptions are designed to streamline the payment process for low-risk transactions, improving the user experience without compromising security.
 
-# Challenge Request Indicator
+## Challenge Request Indicator
 
 The `strong_customer_authentication_exemptions` array enables merchants to specify their preference regarding the application of Strong Customer Authentication (SCA) exemptions during a transaction. By utilizing this field, merchants can request that certain transactions be exempted from the standard authentication challenges, thereby enhancing the customer experience and reducing friction during the payment process.
 
@@ -16,24 +16,12 @@ The `strong_customer_authentication_exemptions` array enables merchants to speci
 The `strong_customer_authentication_exemptions` array accepts the following values, each corresponding to a specific SCA exemption:
 
 * **`LOW_VALUE`**: Indicates that the transaction amount is below the low-value threshold defined by PSD2 (typically under €30).
-  *Benefit*: Low-value transactions may be exempt from SCA, expediting the payment process for minor purchases.
-
 * **`TRANSACTION_RISK_ANALYSIS`**: Signifies that a Transaction Risk Analysis (TRA) has been conducted, and the transaction is deemed low-risk.
-  *Benefit*: Allows low-risk transactions to bypass SCA, improving conversion rates.
-
 * **`STRONG_CUSTOMER_AUTHENTICATION`**: Signifies that the authentication responsibility has been delegated to a trusted third party who has already performed SCA.
-  *Benefit*: Enables authorized third parties to manage authentication, reducing the need for additional challenges.
-
 * **`OUT_OF_SCOPE`**: Signifies that the authentication responsibility shouldn't be taken into account.
-
 * **`SECURE_CORPORATE`**: Indicates that the payment is made using a secure corporate card not assigned to an individual.
-  *Benefit*: Corporate payments may be exempt from SCA, facilitating seamless business transactions.
-
 * **`TRUSTED_BENEFICIARY`**: Denotes that the merchant has been added to the customer's list of trusted beneficiaries after an initial SCA.
-  *Benefit*: Subsequent payments to trusted merchants can be exempt from SCA, streamlining repeat purchases.
-
 * **`RECURRING_PAYMENT`**: Indicates that the transaction is a fixed-amount recurring payment to the same beneficiary.
-  *Benefit*: Recurring payments may be exempt from SCA after the initial authentication, enhancing the customer experience for subscription services.
 
 <Note>
 **Cartes Bancaires Safe'R (France)**
@@ -89,5 +77,3 @@ In this example, the `strong_customer_authentication_exemptions` is set to LOW\_
 * *Issuer's Final Decision*: While merchants can request an exemption using the `strong_customer_authentication_exemptions` field, the card issuer has the final authority to accept or decline the exemption based on their risk assessment and compliance policies.
 * *Liability Implications*: Requesting an exemption may impact liability in cases of fraudulent transactions. It's essential to understand that if an exemption is granted, the liability shift associated with SCA may not apply.
 * *Regulatory Compliance*: Ensure that the use of this field aligns with regional regulations, such as PSD2 in Europe, and that your implementation adheres to the specific requirements and thresholds defined for each exemption type.
-
-By effectively utilizing the `strong_customer_authentication_exemptions` field, merchants can optimize their payment processes, reduce friction for customers, and maintain compliance with regulatory standards.

--- a/docs/payment-features/split-payments-marketplace.mdx
+++ b/docs/payment-features/split-payments-marketplace.mdx
@@ -208,7 +208,7 @@ In this section, we explore how the `split_marketplace` object is used to divide
       </td>
 
       <td>
-        The unique identifier for the recipient within the
+        The unique identifier for the recipient within the marketplace.
 
         Use the ID of a recipient created in Step 1 (Onboarding) when `type` is `PURCHASE` or `MARKETPLACE`.
       </td>

--- a/docs/payment-features/stored-credentials.mdx
+++ b/docs/payment-features/stored-credentials.mdx
@@ -7,10 +7,10 @@ Depending on how and when a payment is processed, it can originate from either c
 
 To ensure the responsible storage and use of cardholder information, Visa and Mastercard have established guidelines and regulations for stored credentials.
 
-We have streamlined the process for you to comply with these scheme rules, enabling you to securely store card details in Yuno for future use while maintaining compliance.
+Yuno has streamlined the process for you to comply with these scheme rules, enabling you to securely store card details in Yuno for future use while maintaining compliance.
 
 <Info>
-****Important: This is not the same as Subscriptions****
+**Important: This is not the same as Subscriptions**
 
 Think of who's in control of recurrence:
 
@@ -32,7 +32,7 @@ Think of who's in control of recurrence:
 | **Examples**       | Includes online purchases, in-store purchases, and ATM withdrawals.                                | Includes recurring payments, automatic subscription renewals, and recurring billing.                                                                                             |
 | **Authentication** | Typically requires cardholder authentication to ensure security.                                   | Requires initial customer authentication to set up, with potential additional authentication based on security regulations and card issuer policies for subsequent transactions. |
 
-Determining whether a transaction is initiated by the merchant or the customer has significant implications for security, user experience, fraud prevention, and regulatory compliance. This ensures an efficient and secure payment process for all parties involved.
+Determining whether a transaction is initiated by the merchant or the customer has significant implications for security, user experience, fraud prevention, and regulatory compliance.
 
 ## General considerations
 
@@ -117,7 +117,7 @@ curl --request POST \
 
 ## Subscription agreement
 
-For certain markets (MX for example) and payment processors, when a subscription-related payment is made, the ID of the agreement with the customer needs to be specified in the payment request to ensure correct processing. To facilitate this, we have enabled the `subscription_agreement_id` field inside the `stored_credentials` struct, allowing you to share the agreement made with the customer.
+For certain markets (MX for example) and payment processors, when a subscription-related payment is made, the ID of the agreement with the customer needs to be specified in the payment request to ensure correct processing. To facilitate this, Yuno has enabled the `subscription_agreement_id` field inside the `stored_credentials` struct, allowing you to share the agreement made with the customer.
 
 <Note>
 **Note**
@@ -166,7 +166,7 @@ If the transaction is customer-initiated (CIT), the network transaction referenc
 
 ### Use
 
-We associate the `network_transaction_id` with the `vaulted_token` for future transactions, so you don't have to manage the logic for each case. We will perform the association when a payment is created with:
+Yuno associates the `network_transaction_id` with the `vaulted_token` for future transactions, so you don't have to manage the logic for each case. Yuno performs the association when a payment is created with:
 
 * *Payment method*:
   * A card `vaulted_token`, or
@@ -175,11 +175,11 @@ We associate the `network_transaction_id` with the `vaulted_token` for future tr
   * `usage` set to `FIRST`
 
 <Warning>
-  When using <code>vault\_on\_success = true</code> in a direct integration, you must create the customer first and pass its <code>customer\_payer.id</code> in the payment request. Sending customer details inline does not create the customer on Yuno's side, so the card cannot be stored and no <code>vaulted\_token</code> will be returned.
+  When using `vault_on_success = true` in a direct integration, you must create the customer first and pass its `customer_payer.id` in the payment request. Sending customer details inline does not create the customer on Yuno's side, so the card cannot be stored and no `vaulted_token` will be returned.
 </Warning>
 
-If you already have the `network_transaction_id` for the card, you can include it in the payment in the corresponding field. If not, for MIT payments (with `stored_credentials.usage=USED`), we will send the `network_transaction_id` associated with the `vaulted_token` to the provider.
+If you already have the `network_transaction_id` for the card, you can include it in the payment in the corresponding field. If not, for MIT payments (with `stored_credentials.usage=USED`), Yuno sends the `network_transaction_id` associated with the `vaulted_token` to the provider.
 
 <Danger>
-  Remember to specify the `usage` in the `stored_credentials` section, as we trigger the `network_transaction_id` logic based on those fields.
+  Remember to specify the `usage` in the `stored_credentials` section, as Yuno triggers the `network_transaction_id` logic based on those fields.
 </Danger>

--- a/docs/payment-features/subscriptions/index.mdx
+++ b/docs/payment-features/subscriptions/index.mdx
@@ -3,30 +3,24 @@ title: "Subscriptions"
 description: "Automate recurring billing by letting Yuno's engine create, pause, resume, and cancel subscriptions on schedule"
 ---
 
-Subscriptions are essential components of a business model that enable your company to offer its products or services to customers on a recurring basis. Yuno's subscription service allows you to easily manage recurring payments, automate subscription billing, and provide seamless subscription experiences for your users. Whether running a SaaS application, a content platform, or an e-commerce store, Yuno's service can help you handle subscription-related tasks efficiently.
+Yuno's subscription service lets you manage recurring payments and automate subscription billing for your customers.
 
 <Note>
-****Subscriptions vs Stored Credentials****
+**Subscriptions vs Stored Credentials**
 
 * **Subscriptions** (this page): Yuno's recurrence engine. You provide instructions and frequency once, then Yuno automatically sends transactions on your behalf.
 * **Stored Credentials**: You control the recurrence. You're responsible for sending each transaction according to your own schedule. See [Stored Credentials](/docs/stored-credentials).
 </Note>
 
-## Benefits of using Yuno subscriptions
-
-* **Recurring revenue**: Subscriptions provide a steady and predictable income stream, which can help stabilize cash flow and reduce financial uncertainties.
-* **Customer loyalty**: Subscribers tend to be more loyal, resulting in higher customer retention rates and reduced churn.
-* **Reduced acquisition costs**: Subscriptions reduce the need for constant customer acquisition efforts, allowing businesses to focus more on retaining and serving existing customers.
-
 ## Yuno subscriptions
 
-A subscription in Yuno's environment can go through several stages, starting with its creation status. When a subscription is created, it automatically receives the **CREATED** status. However, it is a transitory status that is active while the payment isn't processed. After that, the subscription will be **ACTIVE** or **CANCELLED**, depending on the payment confirmation.
+A subscription in Yuno's environment can go through several stages, starting with its creation status. When a subscription is created, it automatically receives the **CREATED** status. However, it is a transitory status that is active while the payment isn't processed. After that, the subscription will be **ACTIVE** or **CANCELED**, depending on the payment confirmation.
 
 When the payment related to the subscription is confirmed, the subscription status changes to **ACTIVE**. It remains with this status while the subscription is within its availability data range and the customer pays the bills. An active subscription can change to three different statuses:
 
 * **COMPLETED**: The subscription finish date was reached. In this case, the current subscription is terminated, and it is not possible to reactivate it. If your client wants to continue using your product/service using recurring payments, you need to create a new subscription.
 * **PAUSED**: At any moment, you can pause the subscription. Use this option in case your customer has delayed a payment, for example. You can always activate a paused subscription.
-* **CANCELLED**: If your customer decides to cancel the recurring payment, you can cancel the subscription. After canceling it, the subscription is terminated, and it is not possible to reactivate it.
+* **CANCELED**: If your customer decides to cancel the recurring payment, you can cancel the subscription. After canceling it, the subscription is terminated, and it is not possible to reactivate it.
 
 <Frame><img src="/images/reference/subscriptions/image1.png" /></Frame>
 
@@ -49,10 +43,10 @@ To start using the subscriptions feature, you need a Yuno account and integratio
   * **Enrolled**: Customers can pay with a previously enrolled payment method. Only the vaulted token is needed when creating the subscription to associate it with the charges.
 * **Capabilities**:
   * **Frequency**: Define the frequency at which subscription charges will occur, whether daily, weekly, or monthly, specifying the amount that needs to be charged for the next billing cycle.
-  * **Billing cycles**: The number of billing cycles (following the frequency criterion) that will be completed to fulfill the subscription. If neither an end\_date is sent nor defined, we will continue attempting charges until it is stopped.
-  * **Billing date**: By specifying the billing\_date object, the merchant can define the logic behind the exact date for the billing of the subscription. This is mutually exclusive with the frequency object.
+  * **Billing cycles**: The number of billing cycles (following the frequency criterion) that will be completed to fulfill the subscription. If neither an `end_date` is sent nor defined, we will continue attempting charges until it is stopped.
+  * **Billing date**: By specifying the `billing_date` object, the merchant can define the logic behind the exact date for the billing of the subscription. This is mutually exclusive with the frequency object.
   * **Availability**: The start and end dates of the subscription. If they are not defined, nor the billing cycles, charges will continue until it is stopped.
-    * The fields billing\_cycles and availability.finish\_at impact each other. If both are completed during the subscription creation, it will transition to the COMPLETED state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding finish\_at.
+    * The fields `billing_cycles` and `availability.finish_at` impact each other. If both are completed during the subscription creation, it will transition to the COMPLETED state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`.
   * **Trial periods**: This feature lets you define a period where your customers can benefit from a reduced amount. It could be partial or total (for example, a free trial). You need to determine the value to be reduced from the total amount of each subscription charge and the billing cycles it should apply to.
   * **Initial payment validation**: A flag to identify if the subscription should wait for the first payment to continue. False by default. If the field is set to true, the subscription should remain in the CREATED status while waiting for the first payment of the subscription.
     * If the first payment succeeds (SUCCEEDED), the subscription transitions to ACTIVE.
@@ -64,8 +58,8 @@ Yuno provides subscription management functionalities through its API. You can u
 
 To use the subscription solution, normally, you will follow the steps described below:
 
-1. To begin, [Create a Customer](/reference/create-customer). You will need to provide personal customer information and the **merchant\_customer\_id**, a unique identifier for the customer used in your system. Upon completing the customer creation process, you will receive an **id** that identifies the user within the Yuno system. This **id** will be used to create the subscription.
-2. After creating the customer, you will need to [enroll a credit card](/docs/enroll-payment-methods) to generate a **vaulted\_token** for use in the subscription creation.
+1. To begin, [Create a Customer](/reference/create-customer). You will need to provide personal customer information and the `merchant_customer_id`, a unique identifier for the customer used in your system. Upon completing the customer creation process, you will receive an `id` that identifies the user within the Yuno system. This `id` will be used to create the subscription.
+2. After creating the customer, you will need to [enroll a credit card](/docs/enroll-payment-methods) to generate a `vaulted_token` for use in the subscription creation.
 3. [Create a Subscription](/reference/create-subscription) for your customer and the enrolled card. At this step, you will configure the subscription and define the payment method. When creating the subscription, you can customize:
    * The amount the subscription charges.
    * The billing frequency (daily, monthly, or yearly).

--- a/docs/payment-features/transaction-retries.mdx
+++ b/docs/payment-features/transaction-retries.mdx
@@ -25,7 +25,7 @@ Refund transactions also have specific statuses during and after the retry proce
 
 This feature provides several advantages:
 
-* **Improved transaction success rates**: Automatic retries enhance the likelihood of successful transaction completions, leading to higher approval rates and increased revenue.
+* **Improved transaction success rates**: Automatic retries enhance the likelihood of successful transaction completions, leading to higher approval rates.
 * **Enhanced user experience**: By automatically retrying failed transactions, user friction is reduced, improving overall customer satisfaction and retention.
 * **Operational efficiency**: Automating retry attempts optimizes time and resources by minimizing manual intervention for failed transactions, allowing teams to focus on strategic tasks.
 


### PR DESCRIPTION
## Summary
- Fixes real bugs across Payment Features docs: malformed JSON key, wrong/typo'd field names, a broken (404) routing link, a truncated sentence, and extra H1s breaking heading hierarchy.
- Rewrites em dashes and overlong (>25 word) sentences for readability, heaviest on 3DS Standalone.
- Standardizes CANCELLED/CANCELED against the actual `cancel-subscription` API enum, fixes malformed markdown bold and escaped underscores, and normalizes "We" to "Yuno" voice.
- Cuts redundant/promotional copy (unsupported claims, repeated "Benefits" sections, filler phrasing).
