### PR TITLE
docs(payouts-and-disputes): simple copy and mechanical fixes across 2 pages

### DIFF
--- a/docs/payouts-and-disputes/chargeback-management.mdx
+++ b/docs/payouts-and-disputes/chargeback-management.mdx
@@ -3,13 +3,13 @@ title: "Chargeback Management"
 description: "Explains chargeback and dispute states, evidence submission, and predispute deflection handling across providers"
 ---
 
-Yuno offers a unified and automated solution for handling disputes, allowing you to manage chargebacks across all providers from a single dashboard. Our platform helps you automate workflows, recover revenue, and stay audit-ready, all without the back and forth.
+Yuno offers a unified and automated solution for handling disputes, allowing you to manage chargebacks across all providers from a single dashboard. Yuno's platform automates workflows, helps you recover revenue, and keeps you audit-ready.
 
 ## What is a chargeback?
 
-A chargeback is a claim initiated by a customer through their issuing bank due to a transaction they find problematic, such as unauthorized payments, incorrect amounts, or merchant disputes.
+A chargeback is a claim initiated by a customer through their issuing bank due to a transaction they find problematic. Common reasons include unauthorized payments, incorrect amounts, or merchant disputes.
 
-In Yuno, a **chargeback** and a **dispute** are technically the same—they both represent a contested transaction.\
+In Yuno, a **chargeback** and a **dispute** are technically the same: they both represent a contested transaction.\
 The conceptual difference lies in the merchant's response: when a merchant provides documentation to contest the chargeback, it becomes an **active dispute**. However, the transaction remains the same, and only its state evolves based on the actions taken.
 
 ## Chargeback workflow
@@ -116,7 +116,7 @@ Yuno simplifies and optimizes your chargeback management through several key adv
 
 ### All your disputes in one integrated workflow
 
-Consolidate chargeback data from all your payment providers into one dashboard. Whether it's Visa, Mastercard, or a local acquirer, you can track, respond, and manage disputes centrally—no API stitching required.
+Consolidate chargeback data from all your payment providers into one dashboard. Whether it's Visa, Mastercard, or a local acquirer, you can track, respond, and manage disputes centrally.
 
 ### Streamlined chargeback response
 
@@ -124,11 +124,11 @@ Automate chargeback responses with the right supporting documentation to ensure 
 
 ### Ensure compliance
 
-Every chargeback, every response, every update—logged and accessible. With built-in audit trails and exportable records, compliance and internal reviews are faster and easier.
+Every chargeback, every response, every update is logged and accessible. With built-in audit trails and exportable records, compliance and internal reviews are faster and easier.
 
 ## Understand the reason code
 
-Understanding the reason code behind each chargeback is crucial, as it explains why the customer initiated the dispute. Familiarity with these codes allows you to tailor your response more effectively and gather the necessary information for each case. In the [Chargeback Reason Codes section](/docs/reason-codes), you can find a comprehensive list of all possible codes provided by acquirers. In each chargeback transaction you'll be able to find the reason code in the `response_code` field.
+Understanding the reason code behind each chargeback is crucial, as it explains why the customer initiated the dispute. Familiarity with these codes allows you to tailor your response more effectively and gather the necessary information for each case. In the [Chargeback Response Codes section](/docs/reason-codes), you can find a comprehensive list of all possible codes provided by acquirers. In each chargeback transaction you'll be able to find the reason code in the `response_code` field.
 
 ## Evidence management
 
@@ -186,7 +186,7 @@ If you need to add additional evidence to an existing dispute, you can use the [
 
 * **Status unchanged**: Adding additional evidence does not change the chargeback status. The status remains the same regardless of updates.
 * **Provider support**: Not all providers support updating disputes. If a provider doesn't support updates, you'll receive a controlled error response, and the chargeback status will remain unchanged.
-* **Retrieving dispute information**: You can retrieve the current status and information about a chargeback/dispute by using the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) endpoint, which includes transaction details with chargeback information.
+* **Retrieving dispute information**: Use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) endpoint to check the current status of a chargeback/dispute. The response includes transaction details with chargeback information.
 </Info>
 
 Please refer to the [Disputes API](/reference/disputes) and [Update Dispute API](/reference/update-dispute) reference sections for more information.

--- a/docs/payouts-and-disputes/payouts.mdx
+++ b/docs/payouts-and-disputes/payouts.mdx
@@ -10,7 +10,7 @@ The Yuno Payout solution enables you to create payout requests without restricti
 ## Benefits of using Yuno Payouts
 
 * **Centralization**: The Payout service saves you time and costs by centralizing all your payment operations in one place. You no longer need to manage payments across multiple systems or interfaces.
-* **Information** : Stay informed about payment statuses with our customizable notifications. You can receive real-time updates on any changes in the payment order status tailored to your preferences.
+* **Information**: Stay informed about payment statuses with Yuno's customizable notifications. You can receive real-time updates on any changes in the payment order status tailored to your preferences.
 * **Localization**: By depositing funds directly into your partners' local bank accounts, you can pay them in their preferred currency, eliminating the need for foreign currency conversions and saving them from extra fees and taxes.
 
 ## How Payouts work
@@ -21,20 +21,20 @@ A payout in Yuno can go through a few different states, starting with its creati
 
 When the payout changes to the **PENDING** status, a series of actions are performed, defining if the payout will succeed, transfer the funds, or if it will be blocked. Below, you find the description for each of the possible ending states:
 
-* **SUCCEEDED**:  The provider validates the transaction, and the funds are successfully transferred to the beneficiary’s account. You'll receive a confirmation notification.
-* **REJECTED**:  The payout was not processed due to problems Yuno identified before attempting the transfer. Possible reasons for a rejected payout include insufficient funds or incorrect payout details, like a wrong account number. You'll need to create a new payout to perform the transaction.
-* **DECLINED**:  The payout was attempted, but the provider refused to accept it. Reasons for a declined payout include a frozen or closed beneficiary account or the transaction being flagged as a potential fraud. You'll need to create a new payout to perform the transaction.
+* **SUCCEEDED**: The provider validates the transaction, and the funds are successfully transferred to the beneficiary’s account. You'll receive a confirmation notification.
+* **REJECTED**: The payout was not processed due to problems Yuno identified before attempting the transfer. Possible reasons for a rejected payout include insufficient funds or incorrect payout details, like a wrong account number. You'll need to create a new payout to perform the transaction.
+* **DECLINED**: The payout was attempted, but the provider refused to accept it. Reasons for a declined payout include a frozen or closed beneficiary account or the transaction being flagged as a potential fraud. You'll need to create a new payout to perform the transaction.
 
 Learn more about the payout status on the [Payouts Status](/reference/payouts/payout-workflow) page.
 
 ## New Concepts
 
 * **Beneficiary**: This is equivalent to the customer for payins. It is the object that receives beneficiary information for the payout. Example: If the payout is for salary payments, the beneficiary would be the employee receiving their salary.
-* **Withdrawal Method**: Similar to Payins, where information for the corresponding payment method must be completed for the payment, in payouts, information for the withdrawal method to be used for the payout must be completed. Within this, the corresponding information must be sent depending on the category of the withdrawal method, which can be cards, bank transfers, or wallets.
+* **Withdrawal Method**: The payment method's counterpart for payouts. Just as payins require payment method information, payouts require withdrawal method information. Send the fields for the category you're using: cards, bank transfers, or wallets.
 
 ## Using Yuno Payouts
 
-The Yuno Payouts feature is available through Yuno API. You can use the API to create and retrieve payout information.  To use the Payouts solution, you need to fulfill the following requirements:
+The Yuno Payouts feature is available through Yuno API. You can use the API to create and retrieve payout information. To use the Payouts solution, you need to fulfill the following requirements:
 
 * You need a Yuno account.
 * You need to integrate with [Yuno API](/reference/payouts/create-payout).
@@ -43,7 +43,7 @@ The Yuno Payouts feature is available through Yuno API. You can use the API to c
 To use the Payouts solution, you'll need to follow the steps below:
 
 1. Configure the provider credentials in the [Connections section](/docs/using-yuno/dashboard-overview/connections) in your Yuno dashboard.
-   1. \[Optional] - And a [Webhook URL](/docs/webhooks/configure-webhooks) to get notifications about updates with the payout transactions.
+   * (Optional) Add a [Webhook URL](/docs/webhooks/configure-webhooks) to get notifications about updates to the payout transactions.
 2. Create the payout using the [Create Payout](/reference/payouts/create-payout) endpoint. You need to provide the beneficiary information, the amount, and the withdrawal method to make the payout.
 3. Yuno will verify the information and then send the payout request to the provider. The provider will analyze the available funds to authorize the payment.
 4. To check the current status of payouts, you can use one of the following options:
@@ -58,9 +58,9 @@ Yuno Payouts requires a security and risk analysis. To learn more about the Yuno
 
 ## Referenced Payouts
 
-Payouts could be made to different payment methods, such as bank accounts and even card, depending on the provider. For Payouts to a card payment method where the merchant does not have the credit card information (not being PCI compliant) Yuno lets them send the Payout if the card was previously used in a payment. This is called a "Referenced Payout".
+Payouts could be made to different payment methods, such as bank accounts and even card, depending on the provider. For Payouts to a card payment method where the merchant does not have the credit card information (not being PCI compliant) Yuno lets them send the Payout if the card was previously used in a payment. This is called a "Referenced Payout."
 
-In order to be able to use this, you'll need to first charge the customer using one of our PCI compliant solutions (Any [Yuno SDK](/docs/sdks/overview/quickstart)) and then make a Payout indicating the original transaction where we can find the credit card information.
+To use this, you'll need to first charge the customer using one of Yuno's PCI compliant solutions (any [Yuno SDK](/docs/sdks/overview/quickstart)) and then make a Payout indicating the original transaction where Yuno can find the credit card information.
 
 ```json
 "withdrawal_method": {


### PR DESCRIPTION
## Summary
- Standardizes voice ("our"/"we" to "Yuno's"/"Yuno") and fixes double spaces, a misplaced period inside quotes, and "In order to" to "To" on Payouts.
- Restructures a confusing numbered sub-step into a clean optional bullet, and splits an overlong Withdrawal Method definition into shorter sentences.
- Rewrites em dashes and an overlong sentence on Chargeback Management, corrects a mismatched link label ("Reason Codes" to "Response Codes"), and cuts unsupported promotional claims.