### PR TITLE
docs(webhooks): simple copy and mechanical fixes across 4 pages

### DIFF
--- a/docs/webhooks/configure-webhooks.mdx
+++ b/docs/webhooks/configure-webhooks.mdx
@@ -40,14 +40,14 @@ When you enable **Use HMAC Authentication** in the dashboard, you'll provide a c
 
 See the [Verify Webhook Signatures (HMAC)](/docs/verify-webhook-signatures-hmac) guide for implementation details.
 
-### oAuth2
+### OAuth2
 
 When you enable **Use OAuth2 Authentication** in the dashboard, you can configure the following parameters so Yuno can obtain the authorization token that will be sent in the webhook headers:
 
 * `Authentication_url`: url to use for authentication
-* `Credentials`: Necessary credentials to communicate with the authentication\_url.
-  * Client Secret\_key
-  * Cliente Client\_ID
+* `Credentials`: Necessary credentials to communicate with the authentication_url.
+  * Client Secret_key
+  * Client_ID
 * `Grant type`: Type of grant for the authentication.
 
 <Frame><img src="/images/reference/configure-webhooks/image2.png" /></Frame>
@@ -56,91 +56,15 @@ When you enable **Use OAuth2 Authentication** in the dashboard, you can configur
 
 Yuno webhooks expect to receive an HTTP 200 OK status as a response to indicate that the webhook was received. The merchant system response does not need to provide any information on the body request, only the HTTP 200 status. In case of not receiving a response at the specified time, Yuno webhooks will send the event notification up to seven times to avoid information loss. The table below presents the webhooks notification schedule and the confirmation waiting time.
 
-<table>
-  <thead>
-    <tr>
-      <th>
-        Event
-      </th>
-
-      <th>
-        Deadline after the first try
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        First try
-      </td>
-
-      <td>
-        * <br />
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Second try
-      </td>
-
-      <td>
-        5 minutes
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Third try
-      </td>
-
-      <td>
-        50 minutes
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Fourth try
-      </td>
-
-      <td>
-        6 hours
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Fifth try
-      </td>
-
-      <td>
-        24 hours
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Sixth try
-      </td>
-
-      <td>
-        48 hours
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Seventh try
-      </td>
-
-      <td>
-        96 hours
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Event       | Deadline after the first try |
+| :---------- | :---------------------------- |
+| First try   | -                             |
+| Second try  | 5 minutes                     |
+| Third try   | 50 minutes                    |
+| Fourth try  | 6 hours                       |
+| Fifth try   | 24 hours                      |
+| Sixth try   | 48 hours                      |
+| Seventh try | 96 hours                      |
 
 ## Webhooks event types
 
@@ -213,6 +137,6 @@ Depending on the type of event, you will receive a different type of webhook and
 
 ### Fraud Screening Webhook Behavior
 
-When a transaction is declined by the fraud screening and doesn't move forward to processing with any provider, no transactions are created — the `transactions` array comes back empty. In this case, the only elements that get created are within the `fraud_screening` object, and the webhook that's triggered is `payment.fraud_screening`.
+When a transaction is declined by the fraud screening and doesn't move forward to processing with any provider, no transactions are created: the `transactions` array comes back empty. In this case, the only elements that get created are within the `fraud_screening` object, and the webhook that's triggered is `payment.fraud_screening`.
 
 If due to the routing configuration the fraud screening declines but the transaction still proceeds to processing, the event sent to the client is `payment.purchase`.

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -5,15 +5,11 @@ description: "Summarizes webhook delivery, retry schedule, and event types acros
 
 ## What is a webhook
 
-Webhooks enable apps to provide real-time information whenever an event happens without needing constant requests. They are a passive method to receive data between two systems through an HTTP POST. After configuring the Yuno webhooks, you will receive event notifications every time an activity or a function is generated within the Yuno flow.
+Webhooks let your system receive real-time event notifications from Yuno through an HTTP POST, instead of polling for updates. After you configure your webhook endpoint, Yuno sends a notification every time a relevant event happens in the payment flow.
 
-## Why do we recommend you use webhooks?
+## Requirements
 
-Webhooks are the best way to ensure your system is up-to-date with payment progress and status. Since the event notifications trigger automatically, your system won't need to perform recurrent requests to Yuno. You will process the payment information on demand.
-
-## What do you need to know before start using webhooks?
-
-To start using Yuno’s webhooks, you need to build a public REST API to receive event notifications (POST request). That means the REST API you will build should not require any authentication or access restriction through a header. Despite using a public API, the communication system is very safe since Yuno event notifications will not be available to the public and will use a unique URL to communicate only to your REST API.
+To use Yuno's webhooks, build a public REST API endpoint to receive event notifications (POST requests). This endpoint should not require authentication or access restrictions through a header. Despite being public, the endpoint stays secure: Yuno's event notifications aren't discoverable by the public and are sent to a unique URL known only to your system.
 
 ## Webhooks delivery and response requirements
 
@@ -23,7 +19,7 @@ If no response is received within the specified time, Yuno will retry sending th
 
 ## De-duplication
 
-Because Yuno retries delivery when it doesn't receive a confirmation, your endpoint can receive the same event more than once. This is expected behavior, not a bug — your integration should be able to identify and skip duplicates.
+Because Yuno retries delivery when it doesn't receive a confirmation, your endpoint can receive the same event more than once. This is expected behavior, not a bug: your integration should be able to identify and skip duplicates.
 
 ### The identifier
 
@@ -38,12 +34,12 @@ Every event payload includes `data.idempotency_key`, a unique identifier for tha
 - `chargeback` events
 
 <Note>
-Support for `enrollment` events is landing on July 11, 2026. Until then, enrollment payloads do not include `data.idempotency_key`.
+Support for `enrollment` events is planned but not yet available. Until then, enrollment payloads do not include `data.idempotency_key`.
 </Note>
 
 ### Why you might see the same event twice
 
-Each payload also includes a top-level `retry` field with the number of delivery attempts made for that event (`0` on the first attempt). If your endpoint doesn't return an HTTP 200 OK in time, Yuno resends the same event — same `data.idempotency_key`, incremented `retry` — following the schedule described in [Webhooks delivery and response requirements](#webhooks-delivery-and-response-requirements) above. Treat any event carrying an idempotency key you've already processed as a duplicate, regardless of its `retry` value.
+Each payload also includes a top-level `retry` field with the number of delivery attempts made for that event (`0` on the first attempt). If your endpoint doesn't return an HTTP 200 OK in time, Yuno resends the same event (same `data.idempotency_key`, incremented `retry`) following the schedule described in [Webhooks delivery and response requirements](#webhooks-delivery-and-response-requirements) above. Treat any event carrying an idempotency key you've already processed as a duplicate, regardless of its `retry` value.
 
 ### Recommended handling
 
@@ -54,7 +50,7 @@ async function handleWebhookEvent(event) {
   const key = event.data.idempotency_key;
 
   if (await store.has(key)) {
-    // Already processed — acknowledge and skip.
+    // Already processed, acknowledge and skip.
     return;
   }
 
@@ -63,7 +59,7 @@ async function handleWebhookEvent(event) {
 }
 ```
 
-Keep in mind that not every event type carries `data.idempotency_key` yet (see Coverage above) — for event types without it, fall back to your own de-duplication key, such as the combination of resource ID and event type.
+Keep in mind that not every event type carries `data.idempotency_key` yet (see Coverage above). For event types without it, fall back to your own de-duplication key, such as the combination of resource ID and event type.
 
 ## Common Webhook Events
 

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -3,7 +3,7 @@ title: "Object and Examples"
 description: "Documents webhook payload attributes with example JSON for payments, chargebacks, enrollments, payouts, and subscriptions"
 ---
 
-# Webhook attributes
+## Webhook attributes
 
 The JSON attributes for Yuno webhooks are listed below:
 
@@ -27,15 +27,21 @@ The JSON attributes for Yuno webhooks are listed below:
   Specifies the number of retries for that notification.
 </ParamField>
 
-<ParamField body="data" type="string">
+<ParamField body="data" type="object">
   Specifies the [payment](/reference/the-payment-object) (for payment type) or [payment method object](/reference/the-payment-method-object-api) (for enrollment and other objects).
+
+  <Expandable title="properties">
+    <ParamField body="idempotency_key" type="string">
+      Unique identifier for the event. It stays stable across every retry of the same event, so you can use it to identify and skip duplicate deliveries. See [De-duplication](/docs/webhooks/webhooks#de-duplication) for coverage details.
+    </ParamField>
+  </Expandable>
 </ParamField>
 
 <ParamField body="x-hmac-signature" type="string">
   Optional. The HMAC-SHA256 signature sent in the HTTP header for webhook verification when HMAC authentication is enabled.
 </ParamField>
 
-# Examples
+## Examples
 
 Yuno provides several webhooks related to enrollment and payment notifications. Here you will find some examples of data structures related to each event.
 
@@ -67,7 +73,7 @@ Yuno provides several webhooks related to enrollment and payment notifications. 
 
 ### Payment Webhook V2
 
-The next JSON object presents an example of a data structure related to a payment event from Webhook V2.
+Example payload:
 
 <Info>
   Webhook payloads for events corresponding to a bank transfer payment method include `payment.payment_method.payment_method_detail.bank_transfer.bank_id`. The field mirrors the `bank_id` sent in the original payment request and is omitted when no bank was selected.
@@ -390,7 +396,7 @@ The next JSON object presents an example of a data structure related to a paymen
 
 ### Payment Webhook V1
 
-The next JSON object presents an example of a data structure related to a payment event from Webhook V1.
+Example payload:
 
 ```json JSON
 {
@@ -593,7 +599,7 @@ The next JSON object presents an example of a data structure related to a paymen
 
 ### Chargeback Webhook V2
 
-The next JSON object presents an example of a data structure related to a payment event from Webhook V2.
+Example payload:
 
 ```json
 {
@@ -1123,7 +1129,7 @@ The next JSON object presents an example of a data structure related to a paymen
 
 ### Chargeback Webhook V1
 
-The next JSON object presents an example of a data structure related to a payment event from Webhook V1.
+Example payload:
 
 ```json JSON
 {

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -32,7 +32,7 @@ The JSON attributes for Yuno webhooks are listed below:
 
   <Expandable title="properties">
     <ParamField body="idempotency_key" type="string">
-      Unique identifier for the event. It stays stable across every retry of the same event, so you can use it to identify and skip duplicate deliveries. See [De-duplication](/docs/webhooks/webhooks#de-duplication) for coverage details.
+      Unique identifier for the event. It stays stable across every retry of the same event, so you can use it to identify and skip duplicate deliveries. See [De-duplication](/docs/webhooks#de-duplication) for coverage details.
     </ParamField>
   </Expandable>
 </ParamField>

--- a/docs/webhooks/verify-webhook-signatures-hmac.mdx
+++ b/docs/webhooks/verify-webhook-signatures-hmac.mdx
@@ -3,8 +3,6 @@ title: "Verify Webhook Signatures (HMAC)"
 description: "Verifies webhook authenticity by validating the HMAC SHA256 signature sent in the request header"
 ---
 
-Learn how to verify webhook signatures using HMAC to ensure webhooks from Yuno are authentic and haven't been tampered with during transmission.
-
 Webhook signature verification using HMAC (Hash-based Message Authentication Code) ensures that webhooks sent to your server actually originate from Yuno and haven't been intercepted or modified during transmission. This adds an extra layer of security beyond authentication methods like OAuth.
 
 While OAuth provides authentication (verifying who is sending the request), HMAC signatures provide:
@@ -12,7 +10,7 @@ While OAuth provides authentication (verifying who is sending the request), HMAC
 * **Data integrity**: Confirms the webhook payload hasn't been tampered with
 * **Authenticity**: Verifies the webhook genuinely comes from Yuno
 * **Protection**: Guards against man-in-the-middle attacks and replay attacks
-* **Compliance**: Meets security requirements for handling sensitive payment data
+* **Compliance**: Helps meet PCI DSS requirements for handling sensitive payment data
 
 ## How HMAC signatures work
 
@@ -62,7 +60,7 @@ x-hmac-signature: K7gNU3sdo+OL0wNhqoVWhr3g6s1xYv72ol/pe/Unols=
 
 Verify the `x-hmac-signature` header using the **raw request body** (before parsing JSON) and the same secret configured for the webhook in the Yuno dashboard.
 
-**Node.js (Express):** use a body parser that keeps the raw body for the webhook route (e.g. `express.raw()` for that path), then:
+**Node.js (Express):** use a body parser that keeps the raw body for the webhook route (for example, `express.raw()` for that path), then:
 
 ```javascript
 const crypto = require('crypto');
@@ -95,7 +93,7 @@ def verify_webhook_signature(raw_body: bytes, signature_header: str, secret: str
     return hmac.compare_digest(signature_header, expected)
 ```
 
-If the computed signature does not match the header, reject the webhook (e.g. return 401).
+If the computed signature does not match the header, reject the webhook (for example, return 401).
 
 ## Related documentation
 


### PR DESCRIPTION
## Summary
- Rewrites em dashes and condenses a 3-way repeated intro on Webhooks Overview, and updates a stale forward-looking note.
- Fixes a typo'd field name, converts a raw HTML retry table to markdown (correcting a broken deadline cell), and capitalizes the OAuth2 heading on Configure Webhooks.
- Demotes two extra H1s to H2 on Object and Examples, documents the `data.idempotency_key` attribute (nested under `data` to match the Expandable convention used elsewhere in the reference docs), and replaces a 4x-repeated intro sentence with a short label.
- Expands two Latin abbreviations, names PCI DSS explicitly instead of a vague "compliance" claim, and trims a redundant authenticity statement on Verify Webhook Signatures (HMAC).