### PR TITLE
docs(ai-capabilities): simple copy and mechanical fixes across 6 pages

### DIFF
--- a/docs/ai-capabilities/agent-toolkit.mdx
+++ b/docs/ai-capabilities/agent-toolkit.mdx
@@ -3,16 +3,16 @@ title: "Agent Toolkit"
 description: "Build AI-powered payment experiences with Yuno's multi-framework toolkit."
 ---
 
-Yuno's Agent Toolkit enables AI agents to interact with Yuno's payment orchestration platform through function calling. Built for TypeScript, it connects to Yuno's remote MCP server and exposes payment tools that work across five AI frameworks — use one integration to access 300+ payment providers globally.
+Yuno's Agent Toolkit enables AI agents to interact with Yuno's payment orchestration platform through function calling. Built for TypeScript, it connects to Yuno's remote MCP server and exposes payment tools that work across five AI frameworks: use one integration to access 300+ payment providers globally.
 
-## Overview
+## What's included
 
 The Yuno Agent Toolkit is available as an npm package (`@yuno-payments/agent-toolkit`) and provides:
 
-*   **Framework Integrations** — Vercel AI SDK, Google Genkit, LangChain, OpenAI Chat, and OpenAI Agents SDK. Import only the adapter you need.
-*   **Multi-provider Orchestration** — Access 300+ payment providers globally through a single integration. Your AI agent inherits Yuno's smart routing, multi-provider failover, and market-specific payment methods.
-*   **Type-Safe** — Full TypeScript with comprehensive types and Zod-validated schemas.
-*   **Modular** — Import only the tool categories you need (customers, payments, subscriptions, etc.) and filter actions granularly.
+*   **Framework Integrations**: Vercel AI SDK, Google Genkit, LangChain, OpenAI Chat, and OpenAI Agents SDK. Import only the adapter you need.
+*   **Multi-provider Orchestration**: Access 300+ payment providers globally through a single integration. Your AI agent inherits Yuno's smart routing, multi-provider failover, and market-specific payment methods.
+*   **Type-Safe**: Full TypeScript with comprehensive types and Zod-validated schemas.
+*   **Modular**: Import only the tool categories you need (customers, payments, subscriptions, etc.) and filter actions granularly.
 
 ## Quick Start
 

--- a/docs/ai-capabilities/aida-ai-agent.mdx
+++ b/docs/ai-capabilities/aida-ai-agent.mdx
@@ -3,11 +3,11 @@ title: "Aida AI Agent"
 description: "Retrieves payment, payout, subscription, and webhook details through a conversational AI agent across Slack, email, and Dashboard"
 ---
 
-## Introduction
+## What Aida does
 
-Yuno is introducing **Aida**, an AI-powered agent designed to simplify data retrieval for support and operations teams. Aida allows you to instantly access detailed information about payments, payouts, subscriptions, and payment links, making it easier to troubleshoot incidents efficiently. It can also provide webhook data and surface the status of each actor involved in the payment flow: the provider, Yuno, and the merchant. Beyond transactional insights, Aida can answer technical questions about SDK integration, API usage, and how Yuno’s platform works. It also offers details about Yuno’s technical integrations and features with supported payment providers.
+**Aida** is Yuno's AI-powered agent for support and operations teams. It retrieves detailed information about payments, payouts, subscriptions, payment links, and webhooks, including the status of each actor in the payment flow: the provider, Yuno, and the merchant. Beyond transactional data, Aida answers technical questions about SDK integration, API usage, supported payment providers, and how Yuno's platform works.
 
-To use **Aida**, simply include “Aida” in your first message and follow up with your question. If at any point the agent is unable to resolve your request, you just need to send a message that includes **“human”** and we’ll automatically notify your key account manager and technical account manager to support you directly. If you do not include "Aida" in your messages you will be directly communicated to your Technical Account Manager.
+To use **Aida**, include "Aida" in your first message and follow up with your question. If the agent can't resolve your request, send a message that includes **"human"**, and Yuno will automatically notify your key account manager and technical account manager to support you directly. If you do not include "Aida" in your messages, you will be directly connected to your Technical Account Manager.
 
 Aida is available across multiple channels:
 
@@ -242,11 +242,11 @@ Simply provide Aida with the following information:
 
 ## From integration to features, Aida has you covered
 
-Instead of digging through pages to find what you need, you can just ask Aida using natural language. Aida is your conversational agent, designed to help support, operations, and technical teams get clear, immediate answers about Yuno's platform and features.
+Instead of digging through pages to find what you need, you can ask Aida using natural language. Aida is your conversational agent, designed to help support, operations, and technical teams get clear, immediate answers about Yuno's platform and features.
 
 You can ask Aida what payment methods are supported in a specific country, get a list of providers available in a particular region, or explore what features are enabled for each integration, such as refunds, recurring payments, or real-time notifications. You can also ask for guidance on how to integrate Yuno’s SDKs on web or mobile, understand which payment method types support 3DS or tokenization, or confirm if a certain provider allows installment payments.
 
-Whether you’re launching a new market, debugging a payment flow, or just exploring what’s possible with Yuno, Aida helps you get answers fast, just by asking!
+Whether you're launching a new market, debugging a payment flow, or exploring what's possible with Yuno, you can ask Aida directly.
 
 > “Aida, I want to understand how Yuno's subscriptions engine works, the key features it supports and how it adds value to my business.”
 

--- a/docs/ai-capabilities/aida-ai-dashboard.mdx
+++ b/docs/ai-capabilities/aida-ai-dashboard.mdx
@@ -13,31 +13,31 @@ Aida AI lives in one chatbot widget (bottom right). Open it on any screen, choos
 
 The Aida AI widget is always available in the bottom-right corner of every dashboard screen, so you can access help wherever you are.
 
-<Frame><img src="/images/reference/aida-ai-dashboard/image1.png" /></Frame>
+<Frame><img src="/images/reference/aida-ai-dashboard/image1.png" alt="Yuno Dashboard showing the Aida AI chatbot widget icon in the bottom-right corner of the screen" /></Frame>
 
 ### Start a new chat
 
 When you open the widget, you'll be prompted to start a new chat with Aida AI.
 
-<Frame><img src="/images/reference/aida-ai-dashboard/image2.png" /></Frame>
+<Frame><img src="/images/reference/aida-ai-dashboard/image2.png" alt="Aida AI chat widget open, showing options to start a new chat with Aida AI or customer support" /></Frame>
 
 ### Payments
 
 On the Payments section, use the chat to ask about payment IDs, status, or recent failures.
 
-<Frame><img src="/images/reference/aida-ai-dashboard/image3.png" /></Frame>
+<Frame><img src="/images/reference/aida-ai-dashboard/image3.png" alt="Aida AI chat widget open on the Payments section of the Yuno Dashboard, answering a question about a payment" /></Frame>
 
 ### Insights
 
 In the Insights section, ask Aida AI for metric explanations or quick charts.
 
-<Frame><img src="/images/reference/aida-ai-dashboard/image4.png" /></Frame>
+<Frame><img src="/images/reference/aida-ai-dashboard/image4.png" alt="Aida AI chat widget open on the Insights section of the Yuno Dashboard, explaining a metric" /></Frame>
 
 ### Routing
 
-Within Routing, ask Aida AI to create, optimise, or troubleshoot routing rules.
+Within Routing, ask Aida AI to create, optimize, or troubleshoot routing rules.
 
-<Frame><img src="/images/reference/aida-ai-dashboard/image5.png" /></Frame>
+<Frame><img src="/images/reference/aida-ai-dashboard/image5.png" alt="Aida AI chat widget open on the Routing section of the Yuno Dashboard, helping configure a routing rule" /></Frame>
 
 How to use:
 
@@ -56,4 +56,4 @@ Aida AI can help you with:
 * Troubleshooting: resolve issues and understand error messages
 * Technical questions: ask about SDK integration, API usage, and platform functionality
 
-For more information about Aida AI's capabilities, see the [Aida AI Agent documentation](/docs/aida-ai-agent).
+For more information about Aida AI's capabilities, see the [Aida AI Agent documentation](/docs/ai-capabilities/aida-ai-agent).

--- a/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx
+++ b/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx
@@ -3,20 +3,20 @@ title: "Building AI Integrations with Yuno's LLMs and MCP"
 description: "Exposes Yuno API endpoints as MCP tools and machine readable docs for LLM powered integrations"
 ---
 
-Yuno offers tools to help you build AI-aware and merchant-friendly payment experiences. Our machine-ready documentation makes it easier for large language models (LLMs) to understand Yuno’s APIs and documentation, while our Model Context Protocol (MCP) provides a seamless way to integrate Yuno's capabilities into your product.
+Yuno offers tools to help you build AI-aware and merchant-friendly payment experiences. Yuno's machine-ready documentation makes it easier for large language models (LLMs) to understand Yuno's APIs and documentation, while Yuno's Model Context Protocol (MCP) lets you integrate Yuno's capabilities directly into your product.
 
-This guide introduces how to work with both components. You’ll learn how the LLM layer empowers AI tools to deliver more accurate and contextual integration support, and how the MCP can embed key payment and merchant functionality directly into your environment, enabling faster builds with less friction.
+This guide introduces how to work with both components: how the LLM layer helps AI tools deliver more accurate and contextual integration support, and how the MCP embeds key payment and merchant functionality directly into your environment.
 
 ## Machine-ready content in plain text
 
-To help large language models understand and support Yuno integrations, we provide a dedicated set of Markdown (.md) files designed specifically for machine readability. These files describe Yuno’s APIs, product behavior, and implementation details in a format that’s easy for LLMs to parse and analyze.
+To help large language models understand and support Yuno integrations, Yuno provides a dedicated set of Markdown (.md) files designed specifically for machine readability. These files describe Yuno’s APIs, product behavior, and implementation details in a format that’s easy for LLMs to parse and analyze.
 
 The .md files are part of [Yuno Docs](/). You can access them by adding .md to the end of any Yuno Docs URL (this works for both Guides and API Reference pages). The content is served in plain text, making it easier for machines to extract and process the underlying knowledge without requiring human interpretation.
 
-This setup enables AI assistants, developer tools, and chat-based agents to answer questions, explain features, and guide integrations automatically. It’s a lightweight but powerful way to open up Yuno’s documentation to a wide range of intelligent applications.
+This setup enables AI assistants, developer tools, and chat-based agents to answer questions, explain features, and guide integrations automatically.
 
 <Note>
-  Looking for a managed, network-accessible MCP endpoint with IP binding, rate limits, and session TTLs? See the [remote Yuno MCP server](/docs/remote-yuno-mcp-server).
+  Looking for a managed, network-accessible MCP endpoint with IP binding, rate limits, and session TTLs? See the [remote Yuno MCP server](/docs/ai-capabilities/remote-yuno-mcp-server).
 </Note>
 
 ## Yuno's Model Context Protocol (MCP)

--- a/docs/ai-capabilities/remote-yuno-mcp-server.mdx
+++ b/docs/ai-capabilities/remote-yuno-mcp-server.mdx
@@ -3,7 +3,7 @@ title: "Remote Yuno MCP Server"
 description: "Provides a hosted MCP endpoint with API key auth, IP binding, rate limits, and session TTLs"
 ---
 
-The Remote Yuno MCP Server implements the Model Context Protocol (MCP) to provide secure, remote access to Yuno services. It acts as a hardened proxy so AI agents and automation clients can call Yuno APIs over MCP with enterprise‑grade security and session controls.
+The Remote Yuno MCP Server implements the Model Context Protocol (MCP) to provide secure, remote access to Yuno services. It acts as a hardened proxy so AI agents and automation clients can call Yuno APIs over MCP with enterprise-grade security and session controls.
 
 ## Key capabilities
 
@@ -17,19 +17,19 @@ The Remote Yuno MCP Server implements the Model Context Protocol (MCP) to provid
 ### Protocols
 
 * Streamable HTTP transport for bidirectional communication
-* JSON‑RPC 2.0 for standardized request/response
+* JSON-RPC 2.0 for standardized request/response
 
 ### Session management
 
 * Automatic creation, refresh, and cleanup
 * Scheduled cleanup every 5 minutes
-* Redis backend for persistent session and rate‑limit storage
+* Redis backend for persistent session and rate-limit storage
 
 ## When to use the remote server
 
-Use the Remote MCP Server when you want centralized security, observability, and policy enforcement (IP binding, rate limits, TTLs), or when teams and tools should connect without distributing raw API credentials locally. For rapid prototyping on a developer machine, the [local MCP](/docs/building-ai-integrations-with-yunos-llms-and-mcp) (CLI‑launched) may be sufficient.
+Use the Remote MCP Server when you want centralized security, observability, and policy enforcement (IP binding, rate limits, TTLs). It's also useful when teams and tools should connect without distributing raw API credentials locally. For rapid prototyping on a developer machine, the [local MCP](/docs/building-ai-integrations-with-yunos-llms-and-mcp) (CLI-launched) may be sufficient.
 
-## Connecting from MCP‑compatible clients
+## Connecting from MCP-compatible clients
 
 The Remote MCP Server exposes an HTTP transport endpoint. Configure your MCP client to connect to your provisioned URL and pass the required headers.
 

--- a/setup-mcp.mdx
+++ b/setup-mcp.mdx
@@ -3,7 +3,7 @@ title: "Model Context Protocol (MCP)"
 description: "Connect your AI coding agents directly to Yuno's documentation."
 ---
 
-The Model Context Protocol (MCP) allows AI tools like **Cursor**, **Windsurf**, and **Claude** to browse, search, and read Yuno's documentation in real-time. This ensures your AI assistant always has the latest context when helping you integrate Yuno.
+The Model Context Protocol (MCP) allows AI tools like **Cursor**, **Windsurf**, and **Claude** to browse, search, and read Yuno's documentation in real-time. This gives your AI assistant access to up-to-date context when helping you integrate Yuno.
 
 ## Documentation MCP URL
 Use the following URL to connect your tools to the Yuno documentation:


### PR DESCRIPTION
## Summary
- Softens the absolute "always has the latest context" claim on MCP Setup.
- Renames the generic "Introduction" heading, cuts filler/voice inconsistencies and a marketing-style closing line, and condenses a 5-sentence intro into 3 on Aida AI Agent.
- Standardizes voice and cuts promotional language on Building AI Integrations with Yuno's LLMs and MCP, and fixes its short-form link to the canonical path.
- Replaces non-breaking Unicode hyphens with regular ones and splits an overlong sentence on Remote Yuno MCP Server.
- Rewrites 5 em dashes and renames the generic "Overview" heading on Agent Toolkit.
- Adds alt text to all 5 dashboard screenshots, fixes "optimise" to "optimize", and corrects a short-form link to the canonical path on Aida AI Dashboard.
