### PR TITLE
chore: web sdk changelog 1.9.22

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,28 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.22",
+      "release_date": "2026-07-30",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.22",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Enrolled Card Installment Notifications",
+          "description": "The onInstallmentSelected callback now fires only from the enrolled card the customer selected: it notifies the default installment on first selection, changes made while the card is active, and the last selection when returning to the card. Cards not selected no longer emit duplicate notifications when switching payment methods.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-14047",
+        "YSHUB-6227"
+      ]
+    },
+    {
       "version": "1.10.0",
       "release_date": "2026-07-29",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.22`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.22

1 entry.