### PR TITLE
chore: web sdk changelog 1.10.1

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,46 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.1",
+      "release_date": "2026-07-30",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Faster Full Checkout Loading",
+          "description": "The Full and Seamless Full checkouts now load faster: SDK resources and express button scripts download in parallel with the initial API calls, reducing the time to show the payment method list and express buttons.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Samsung Pay Sheet Close Reports Cancellation",
+          "description": "Closing the Samsung Pay payment sheet now reports a user cancellation instead of showing a \"Transaction failed\" screen, and no longer leaves the merchant loading state stuck.",
+          "group": "Samsung Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed Enrolled Card Installment Notifications",
+          "description": "The onInstallmentSelected callback now fires only from the enrolled card the customer selected: it notifies the default installment on first selection, changes made while the card is active, and the last selection when returning to the card. Cards not selected no longer emit duplicate notifications when switching payment methods.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17218",
+        "CORECM-18728",
+        "CORECM-14047",
+        "YSHUB-6227"
+      ]
+    },
+    {
       "version": "1.10.0",
       "release_date": "2026-07-29",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,24 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.1
+*July 30, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Faster Full Checkout Loading**  
+  The Full and Seamless Full checkouts now load faster: SDK resources and express button scripts download in parallel with the initial API calls, reducing the time to show the payment method list and express buttons.
+
+**Samsung Pay**
+
+- <ChangelogBadge type="fixed" /> **Samsung Pay Sheet Close Reports Cancellation**  
+  Closing the Samsung Pay payment sheet now reports a user cancellation instead of showing a "Transaction failed" screen, and no longer leaves the merchant loading state stuck.
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Fixed Enrolled Card Installment Notifications**  
+  The onInstallmentSelected callback now fires only from the enrolled card the customer selected: it notifies the default installment on first selection, changes made while the card is active, and the last selection when returning to the card. Cards not selected no longer emit duplicate notifications when switching payment methods.
+
 ## v1.10.0
 *July 29, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.1`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.2

3 entries.