### PR TITLE
docs(C2-18018): wallet vault_on_success tokens are hidden from the customer listing — store the token from the CIT response

### DIFF
--- a/docs/payment-features/enrollment/enroll-payment-methods.mdx
+++ b/docs/payment-features/enrollment/enroll-payment-methods.mdx
@@ -74,7 +74,7 @@ The enrollment workflow varies by payment method type:
 * **Checkout workflow**: Requires customer session for most payment methods (Cards, Nupay, PayPal, Daviplata, dLocal methods, Astropay, Adyen PIX Biométrico)
 * **Direct workflow**: Available for Cards only (PCI compliant merchants). Proceed directly to Step 3 using the customer `id` generated in Step 1.
 * **SDK workflow**: Payment methods like Nequi and Bancolombia Tokenbox require SDK implementation. WALLET\_CONNECT (MercadoPago) supports both SDK and Checkout workflows. Consult the [SDK documentation](/docs/sdks/overview/quickstart) for details.
-* **SDK Seamless workflow**: You can enroll payment methods during the seamless payment flow by setting `vault_on_success: true` when creating the payment. The payment method will be automatically enrolled if the payment succeeds.
+* **SDK Seamless workflow**: You can enroll payment methods during the seamless payment flow by setting `vault_on_success: true` when creating the payment. The payment method will be automatically enrolled if the payment succeeds. For wallets (Apple Pay / Google Pay), the instrument is vaulted as a hidden record: the `vaulted_token` is returned in the payment response but does not appear in the customer's payment-methods listing — see the note in [Step 5](#step-5-retrieve-payment-methods).
 </Warning>
 
 Create a customer session to store the customer's payment preferences using the [Create Customer Session](/reference/create-customer-session) endpoint. Use the `id` from Step 1 as the `customer_id`.
@@ -115,6 +115,12 @@ The customer must provide authorization on the payment provider page. Retrieve t
 Redirect the user to complete authorization. Once enrollment is complete, proceed to the next step.
 
 To confirm enrollment, retrieve the enrolled payment methods and verify the `status` is `ENROLLED`.
+
+<Note>
+**Wallet-vaulted instruments are not listed**
+
+Instruments vaulted through a wallet payment (Apple Pay / Google Pay with `vault_on_success: true`) are stored as hidden records: they do not appear in the enrolled payment methods listing, even though their `vaulted_token` is valid and chargeable. Store that token from the payment response, and resolve it individually with [Retrieve Enrolled Payment Method by ID](/reference/retrieve-enrolled-payment-method-by-id-api) if needed. See [Stored Credentials](/docs/payment-features/stored-credentials#wallet-originated-tokens-apple-pay-and-google-pay).
+</Note>
 
 <Note>
 **Fingerprint**

--- a/docs/payment-features/stored-credentials.mdx
+++ b/docs/payment-features/stored-credentials.mdx
@@ -134,7 +134,7 @@ Charges on a stored wallet token always use `detail.card.stored_credentials` —
 | Later charges in the same recurring series (MIT)         | `SUBSCRIPTION` | `USED`  |
 | Customer-present one-click purchase on the stored token  | `CARD_ON_FILE` | `USED`  |
 
-Yuno attaches the `network_transaction_id` from the `usage: FIRST` payment automatically, exactly as for cards. Keep `reason` consistent within a series — see the "Critical: Complete All Required Fields" note under [Create a payment with processing type](#create-a-payment-with-processing-type).
+Yuno attaches the `network_transaction_id` from the `usage: FIRST` payment automatically, exactly as for cards. Keep `reason` consistent within a series. See the "Critical: Complete All Required Fields" note under [Create a payment with processing type](#create-a-payment-with-processing-type).
 
 ## Subscription agreement
 

--- a/docs/payment-features/stored-credentials.mdx
+++ b/docs/payment-features/stored-credentials.mdx
@@ -115,6 +115,26 @@ curl --request POST \
 '
 ```
 
+## Wallet-originated tokens (Apple Pay and Google Pay)
+
+A wallet CIT with `vault_on_success: true` also produces a `vaulted_token`: Apple Pay and Google Pay decrypt to a card network token, so the stored instrument is a `CARD` record with `parent_payment_method_type` set to the wallet type.
+
+<Warning>
+**Store the token from the payment response**
+
+The `vaulted_token` is returned only in the CIT payment response. Wallet-vaulted instruments are intentionally not included in [Retrieve Enrolled Payment Methods](/reference/retrieve-enrolled-payment-methods-api) — an empty `payment_methods` list for a wallet-only customer is expected, even though the token is valid and chargeable. Persist the `vaulted_token` (plus any display metadata you need, such as brand and last four digits) on your side when the CIT succeeds. A stored token can still be resolved individually with [Retrieve Enrolled Payment Method by ID](/reference/retrieve-enrolled-payment-method-by-id-api).
+</Warning>
+
+Charges on a stored wallet token always use `detail.card.stored_credentials` — not `detail.wallet`:
+
+| Scenario                                                 | `reason`       | `usage` |
+| :------------------------------------------------------- | :------------- | :------ |
+| First charge (wallet sheet shown, instrument vaulted)    | `SUBSCRIPTION` | `FIRST` |
+| Later charges in the same recurring series (MIT)         | `SUBSCRIPTION` | `USED`  |
+| Customer-present one-click purchase on the stored token  | `CARD_ON_FILE` | `USED`  |
+
+Yuno attaches the `network_transaction_id` from the `usage: FIRST` payment automatically, exactly as for cards. Keep `reason` consistent within a series (see the warning above).
+
 ## Subscription agreement
 
 For certain markets (MX for example) and payment processors, when a subscription-related payment is made, the ID of the agreement with the customer needs to be specified in the payment request to ensure correct processing. To facilitate this, Yuno has enabled the `subscription_agreement_id` field inside the `stored_credentials` struct, allowing you to share the agreement made with the customer.

--- a/docs/payment-features/stored-credentials.mdx
+++ b/docs/payment-features/stored-credentials.mdx
@@ -23,6 +23,7 @@ Think of who's in control of recurrence:
 * Create a payment
 * Subscription agreement ID
 * Network transaction ID
+* Wallet-originated tokens (Apple Pay and Google Pay)
 
 ## Categorization
 
@@ -133,7 +134,7 @@ Charges on a stored wallet token always use `detail.card.stored_credentials` —
 | Later charges in the same recurring series (MIT)         | `SUBSCRIPTION` | `USED`  |
 | Customer-present one-click purchase on the stored token  | `CARD_ON_FILE` | `USED`  |
 
-Yuno attaches the `network_transaction_id` from the `usage: FIRST` payment automatically, exactly as for cards. Keep `reason` consistent within a series (see the warning above).
+Yuno attaches the `network_transaction_id` from the `usage: FIRST` payment automatically, exactly as for cards. Keep `reason` consistent within a series — see the "Critical: Complete All Required Fields" note under [Create a payment with processing type](#create-a-payment-with-processing-type).
 
 ## Subscription agreement
 

--- a/docs/wallets/apple-pay/apple-pay-direct-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-direct-integration.mdx
@@ -150,6 +150,10 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
 
 When the CIT is successful, you'll receive a response containing the `vaulted_token`. It can be used for subsequent transactions. Store it encrypted at rest, and restrict access to only the systems that need it to create MIT charges.
 
+<Note>
+  The payment response is the only place the `vaulted_token` is returned. Wallet-vaulted instruments are intentionally not included in [Retrieve Enrolled Payment Methods](/reference/retrieve-enrolled-payment-methods-api), so don't rely on the customer's payment-methods list to rediscover the token — persist it (with any display metadata you need) when the CIT succeeds. A stored token can still be resolved individually with [Retrieve Enrolled Payment Method by ID](/reference/retrieve-enrolled-payment-method-by-id-api). See [Stored Credentials](/docs/payment-features/stored-credentials#wallet-originated-tokens-apple-pay-and-google-pay) for the tagging rules on stored wallet tokens.
+</Note>
+
 ```json
 {
   "id": "61533a3b-f971-422f-a839-9af61f8ec9ab",

--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -206,6 +206,10 @@ The key parameters for a CIT are:
   Set `verify: true` for free trial flows where `amount` is `0`. Omit the field for standard paid CITs.
 </Note>
 
+<Note>
+  The `vaulted_token` is returned only in the CIT payment response. Wallet-vaulted instruments are intentionally not included in [Retrieve Enrolled Payment Methods](/reference/retrieve-enrolled-payment-methods-api), so don't rely on the customer's payment-methods list to rediscover the token — store it (with any display metadata you need) when the CIT succeeds. A stored token can still be resolved individually with [Retrieve Enrolled Payment Method by ID](/reference/retrieve-enrolled-payment-method-by-id-api). See [Stored Credentials](/docs/payment-features/stored-credentials#wallet-originated-tokens-apple-pay-and-google-pay).
+</Note>
+
 ### Merchant Initiated Transaction (MIT)
 
 MIT transactions are processed automatically for subsequent billing cycles using the token generated during the CIT.


### PR DESCRIPTION
## Summary
- **stored-credentials.mdx** — new section "Wallet-originated tokens (Apple Pay and Google Pay)": wallet CITs vault a hidden `CARD` record (parent = wallet), the token is returned only in the payment response, and the stored-credentials tagging matrix for charges on stored wallet tokens (`SUBSCRIPTION`/`CARD_ON_FILE` × `FIRST`/`USED`, always `detail.card`).
- **apple-pay-direct-integration.mdx** — CIT response handling: note that the listing will not return the instrument; persist the token + display metadata; retrieve-by-id remains available.
- **apple-pay-sdk-integration.mdx** — same note in the SDK recurring (CIT) section.
- **enrollment/enroll-payment-methods.mdx** — seamless-workflow bullet + Step 5 note: wallet-vaulted instruments are hidden records and never appear in the enrolled payment methods listing.

## Contract source
Confirmed in YSHUB-6260 triage (closed as working-as-intended): listing filters `isHidden` (customer-payment-method-ms `FindByOrganizationCustomerCode.kt`), intent documented in migration V2.47; retrieve-by-id (`getPaymentMethod` → `findByCode`) intentionally returns hidden records — ratification tracked in the follow-up ticket. Behavior shipped with payment-rx-orc #1846 (rel-2026-07-28).

Not covered here: Google Pay direct/SDK pages have no recurring section today — the pattern is documented via the Apple Pay pages + Stored Credentials; adding GP recurring pages is separate content work.

Refs: C2-18018, YSHUB-6260, OR-1122. Merchant context: Municorn (yuno-x-municorn thread 1785489958.001709).

🤖 Generated with [Claude Code](https://claude.com/claude-code)