### PR TITLE
docs(ai-capabilities): use canonical path for building-ai-integrations link

### DIFF
--- a/docs/ai-capabilities/remote-yuno-mcp-server.mdx
+++ b/docs/ai-capabilities/remote-yuno-mcp-server.mdx
@@ -27,7 +27,7 @@ The Remote Yuno MCP Server implements the Model Context Protocol (MCP) to provid
 
 ## When to use the remote server
 
-Use the Remote MCP Server when you want centralized security, observability, and policy enforcement (IP binding, rate limits, TTLs). It's also useful when teams and tools should connect without distributing raw API credentials locally. For rapid prototyping on a developer machine, the [local MCP](/docs/building-ai-integrations-with-yunos-llms-and-mcp) (CLI-launched) may be sufficient.
+Use the Remote MCP Server when you want centralized security, observability, and policy enforcement (IP binding, rate limits, TTLs). It's also useful when teams and tools should connect without distributing raw API credentials locally. For rapid prototyping on a developer machine, the [local MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp) (CLI-launched) may be sufficient.
 
 ## Connecting from MCP-compatible clients
 
@@ -59,4 +59,4 @@ Replace the placeholder header values below with your `YUNO_PUBLIC_API_KEY`, `YU
 
 ## Related information
 
-* For local development and how MCP maps Yuno API endpoints into tools, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/building-ai-integrations-with-yunos-llms-and-mcp).
+* For local development and how MCP maps Yuno API endpoints into tools, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp).


### PR DESCRIPTION
## Summary
- Fixes two links in `remote-yuno-mcp-server.mdx` that pointed to `/docs/building-ai-integrations-with-yunos-llms-and-mcp`, which only resolves via a `docs.json` redirect, instead of the canonical `/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp` path.
- Opened as a test to check whether the Mintlify production deploy actually triggers on merge to `main` — PR #686 merged cleanly but the live site doesn't appear to reflect it, and the merge commit has zero CI checks/deployments recorded.
