### PR TITLE
docs(plugins/vtex): simple copy and mechanical fixes across 5 pages

### DIFF
--- a/docs/plugins/vtex/apple-pay-google-pay-enhanced-experience.mdx
+++ b/docs/plugins/vtex/apple-pay-google-pay-enhanced-experience.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Apple Pay & Google Pay enhanced experience"
-description: "Enable a seamless wallet experience on VTEX checkout and unlock Apple Pay installments."
+description: "Enable a direct wallet experience on VTEX checkout and unlock Apple Pay installments."
 ---
 
 The Apple Pay & Google Pay enhanced experience is an optional add-on for stores already using the Yuno VTEX plugin. It improves the checkout experience for shoppers by removing an intermediate screen between the VTEX checkout and the device's native wallet sheet, which is known to reduce conversion on wallet payments.
@@ -81,7 +81,7 @@ Setting up the enhanced experience involves adding a small JavaScript snippet to
     ```
 
     <Note>
-      Replace `YOUR_AFFILIATION_NAME` with the affiliation name from your Yuno provider configuration. In `paymentMethods`, list the wallets you want to enable — `'Apple Pay'`, `'Google Pay'`, or both.
+      Replace `YOUR_AFFILIATION_NAME` with the affiliation name from your Yuno provider configuration. In `paymentMethods`, list the wallets you want to enable: `'Apple Pay'`, `'Google Pay'`, or both.
     </Note>
   </Step>
 

--- a/docs/plugins/vtex/direct-sdk-integration.mdx
+++ b/docs/plugins/vtex/direct-sdk-integration.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Headless SDK integration"
-description: "Render the Yuno checkout experience directly on your own front-end — including headless and mobile WebView setups — using the SDK Web for VTEX."
+description: "Render the Yuno checkout experience directly on your own front-end, including headless and mobile WebView setups, using the SDK Web for VTEX."
 ---
 
-Most stores integrate Yuno through the standard plugin flow described in [Set up Yuno on VTEX](/docs/plugins/vtex/set-up-yuno-on-vtex). For stores that need to render the Yuno checkout experience directly on their own front-end instead, Yuno provides the **Yuno SDK Web for VTEX** as an npm package.
+Most stores integrate Yuno through the standard plugin flow described in [Set up Yuno on VTEX](/docs/plugins/vtex/set-up-yuno-on-vtex). For stores that need to render the Yuno checkout experience directly on their own front-end instead, Yuno provides the **Yuno SDK Web for VTEX** npm package.
 
 ## When this applies
 
-If your store has standard requirements, you do not need this page — the standard plugin flow already handles everything. Use the headless SDK integration only when your store has specific needs that require the Yuno checkout experience to be rendered directly by your front-end (for example, in headless or highly customized checkouts).
+If your store has standard requirements, you do not need this page. The standard plugin flow already handles everything. Use the headless SDK integration only when your store has specific needs that require the Yuno checkout experience to be rendered directly by your front-end. This applies, for example, to headless or highly customized checkouts.
 
-A **headless** store in VTEX is one where the merchant runs its own front-end outside VTEX's native storefront, while still using VTEX's commerce capabilities (catalog, cart, checkout, orders) through APIs. Because the front-end is fully under your control, the Yuno checkout experience is no longer rendered for you by the standard plugin — your front-end mounts the **Yuno SDK Web for VTEX** itself. For background on this architecture, see VTEX's [Headless commerce guide](https://developers.vtex.com/docs/guides/headless-commerce).
+A **headless** store in VTEX is one where the merchant runs its own front-end outside VTEX's native storefront. It still uses VTEX's commerce capabilities (catalog, cart, checkout, orders) through APIs. Because the front-end is fully under your control, the Yuno checkout experience is no longer rendered for you by the standard plugin. Instead, your front-end mounts the **Yuno SDK Web for VTEX** itself. For background on this architecture, see VTEX's [Headless commerce guide](https://developers.vtex.com/docs/guides/headless-commerce).
 
 ## What stays the same
 
@@ -17,7 +17,7 @@ The setup in your **VTEX dashboard** and **Yuno dashboard** does not change:
 
 *   You still configure Yuno as a payment provider in VTEX.
 *   You still configure the webhook in your Yuno dashboard.
-*   The **Yuno Payment Connector** remains the backbone of the integration — every payment continues to flow through it.
+*   The **Yuno Payment Connector** remains the backbone of the integration. Every payment continues to flow through it.
 
 ## What's different
 
@@ -25,9 +25,9 @@ Instead of letting the standard flow render the Yuno checkout for you, your fron
 
 ## Before you mount: run the authorization first
 
-The SDK does not generate its own payment context — it renders the checkout from a `payload` produced by the **Yuno Payment Connector**. That `payload` only exists once the **authorization step** of the transaction has run.
+The SDK does not generate its own payment context. It renders the checkout from a `payload` produced by the **Yuno Payment Connector**. That `payload` only exists once the **authorization step** of the transaction has run.
 
-Authorization is **step 1** of the VTEX [payment transaction flow](https://help.vtex.com/docs/tutorials/transaction-flow-in-payments). When the shopper places the order, VTEX calls the Payment Connector with the order details (items, amounts, shopper, shipping). The Connector processes that request and returns a response that includes the `payload` the SDK needs to configure and mount itself for that specific order.
+Authorization is **step 1** of the VTEX [payment transaction flow](https://help.vtex.com/docs/tutorials/transaction-flow-in-payments). When the shopper places the order, VTEX calls the Payment Connector with the order details (items, amounts, shopper, shipping). The Connector processes that request and returns a response that includes the `payload`. The SDK needs this payload to configure and mount itself for that specific order.
 
 <Warning>
   Always trigger the authorization step **before** mounting the SDK. If you mount it without the `payload` returned by the Connector, the SDK has no payment context to render and the checkout will not load.
@@ -110,7 +110,7 @@ Authorization is **step 1** of the VTEX [payment transaction flow](https://help.
     ```
 
     <Note>
-      Keep the SDK mounted while the shopper is paying. Call `unmount` **only when you tear the checkout down** — for example, when the component is destroyed or the shopper navigates away:
+      Keep the SDK mounted while the shopper is paying. Call `unmount` **only when you tear the checkout down**, for example, when the component is destroyed or the shopper navigates away:
 
       ```javascript
       // Later, when the checkout is no longer needed:
@@ -122,7 +122,7 @@ Authorization is **step 1** of the VTEX [payment transaction flow](https://help.
       | Field | Description |
       | :--- | :--- |
       | `elementRoot` | **Required.** ID of the DOM element where the SDK renders the checkout UI (for example, `yuno-sdk-root`). |
-      | `payload` | **Required.** The payment context for the current shopper, returned by the Yuno Payment Connector during authorization. It is a serialized JSON string — pass it as received, without parsing it. |
+      | `payload` | **Required.** The payment context for the current shopper, returned by the Yuno Payment Connector during authorization. It is a serialized JSON string. Pass it as received, without parsing it. |
       | `language` | **Required.** Language the SDK is displayed in (for example, `en`, `es`, `pt-BR`). |
       | `domainVTEX` | Optional (recommended). Your VTEX store domain (for example, `https://mystore.myvtex.com`). |
       | `proxyUrlVTEX` | Optional. URL of a proxy to VTEX, if your setup routes VTEX calls through one. |
@@ -138,19 +138,19 @@ Authorization is **step 1** of the VTEX [payment transaction flow](https://help.
 
 ## Using the Headless SDK inside a mobile app
 
-The Yuno SDK Web for VTEX is a **web** library. To use it inside a mobile app, you load your front-end page — the one that mounts the SDK — inside a **WebView**, since the SDK needs a browser environment to run.
+The Yuno SDK Web for VTEX is a **web** library. To use it inside a mobile app, you load your front-end page (the one that mounts the SDK) inside a **WebView**. The WebView is what gives the SDK the browser environment it needs to run.
 
 ### What a WebView is and why you need one
 
-A **WebView** is an embeddable browser component that renders web content inside a native app (`WebView` on Android, `WKWebView` on iOS, and wrappers such as `react-native-webview`). Because the SDK runs in the browser, the WebView is what gives it that browser environment: your app loads the URL that mounts the SDK, and the SDK renders the checkout inside the WebView.
+A **WebView** is an embeddable browser component that renders web content inside a native app (`WebView` on Android, `WKWebView` on iOS, and wrappers such as `react-native-webview`). Because the SDK runs in the browser, the WebView is what gives it that browser environment. Your app loads the URL that mounts the SDK, and the SDK renders the checkout inside the WebView.
 
-The implementation details below are **suggestions** — how you build the WebView and the bridge is entirely up to you. The goal is only to show what needs to be in place for the SDK to work.
+The implementation details below are **suggestions**. How you build the WebView and the bridge is entirely up to you. The goal is only to show what needs to be in place for the SDK to work.
 
 ### The bridge between your app and the WebView
 
 Your app and the page inside the WebView need to communicate in both directions:
 
-*   **Web → App:** the page reports results back to the native app (for example, payment completed, error, or loading state). Every WebView platform exposes a message channel for this — `window.ReactNativeWebView.postMessage(...)`, a JavaScript interface on Android, or a `WKScriptMessageHandler` on iOS.
+*   **Web → App:** the page reports results back to the native app (for example, payment completed, error, or loading state). Every WebView platform exposes a message channel for this: `window.ReactNativeWebView.postMessage(...)`, a JavaScript interface on Android, or a `WKScriptMessageHandler` on iOS.
 *   **App → Web:** the app injects/evaluates JavaScript in the page (for example, to deliver the `payload` after the page loads).
 
 We recommend defining a small **message contract** that the page emits and the app listens for. For example:
@@ -161,7 +161,7 @@ We recommend defining a small **message contract** that the page emits and the a
 { "type": "loading", "loading": true }
 ```
 
-When the SDK calls `onPaymentDone`, `onError`, or `onLoading`, your page forwards a message in this shape through the bridge, and the app reacts (close the WebView, show the result, toggle a spinner). The exact field names are yours to define.
+When the SDK calls `onPaymentDone`, `onError`, or `onLoading`, your page forwards a message in this shape through the bridge. The app then reacts by closing the WebView, showing the result, or toggling a spinner. The exact field names are yours to define.
 
 ### Technical considerations
 
@@ -198,15 +198,15 @@ Google Pay inside an Android WebView relies on the Chromium **Payment Request AP
     </queries>
     ```
 
-Some conditions are not about your app's code but about the **device where the payment is made** — they apply both to a shopper's device and to any device you use to test the flow. The device needs an up-to-date **Android System WebView** and **Google Play services**, and a **Google account with a valid payment method** added. For full details, see Google's [Using Google Pay with an Android WebView](https://developers.google.com/pay/api/android/guides/recipes/using-android-webview) guide.
+Some conditions are not about your app's code but about the **device where the payment is made**. They apply both to a shopper's device and to any device you use to test the flow. The device needs an up-to-date **Android System WebView** and **Google Play services**, and a **Google account with a valid payment method** added. For full details, see Google's [Using Google Pay with an Android WebView](https://developers.google.com/pay/api/android/guides/recipes/using-android-webview) guide.
 
 #### Apple Pay (iOS WebView)
 
-Apple Pay has a hard requirement on **where the page is served from**: it cannot run from a **static local HTML file** loaded into the WebView. The page that mounts the SDK must be served from a **hosted URL whose domain is registered and verified in your Apple Developer account**, and that domain must be configured in your **Yuno dashboard** so that every domain involved matches. If the domains do not match, Apple Pay will not become available.
+Apple Pay has a hard requirement on **where the page is served from**: it cannot run from a **static local HTML file** loaded into the WebView. The page that mounts the SDK must be served from a **hosted URL whose domain is registered and verified in your Apple Developer account**. That domain must also be configured in your **Yuno dashboard** so that every domain involved matches. If the domains do not match, Apple Pay will not become available.
 
 ### Examples
 
-The snippets below are **reference examples only** — they show one possible way to wire the WebView and the bridge in each stack. They are not a required or recommended technology choice; use whatever fits your app.
+The snippets below are **reference examples only**. They show one possible way to wire the WebView and the bridge in each stack. They are not a required or recommended technology choice; use whatever fits your app.
 
 <AccordionGroup>
   <Accordion title="React Native (react-native-webview)">

--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -14,7 +14,7 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
 </Accordion>
 
 <Accordion title="Does Yuno support VTEX subscriptions (recurring payments)?">
-  Yes. Orders created with VTEX's [subscriptions](https://help.vtex.com/docs/tutorials/how-subscriptions-work) feature are supported out of the box. The first purchase is processed like any other card payment. The automatic renewals that follow are charged even though the shopper is not present and no security code (CVV) is entered — Yuno processes them as stored-credential, merchant-initiated (MIT) payments, so recurring charges go through instead of being declined.
+  Yes. Orders created with VTEX's [subscriptions](https://help.vtex.com/docs/tutorials/how-subscriptions-work) feature are supported out of the box. The first purchase is processed like any other card payment. The automatic renewals that follow are charged even though the shopper is not present and no security code (CVV) is entered. Yuno processes them as stored-credential, merchant-initiated (MIT) payments, a classification that lets recurring charges go through instead of being declined.
 
   There is nothing extra to configure on the Yuno side: as long as you have set up subscriptions in VTEX, the integration handles them automatically, and your regular checkout is unaffected. Subscriptions apply to card payments only.
 </Accordion>

--- a/docs/plugins/vtex/index.mdx
+++ b/docs/plugins/vtex/index.mdx
@@ -1,17 +1,17 @@
 ---
-title: "Overview"
+title: "VTEX Plugin Overview"
 description: "Understand how the Yuno VTEX plugin works and the payment methods available for your store."
 ---
 
-Yuno and VTEX have joined forces to simplify payment processes for merchants worldwide. By integrating Yuno's payment orchestration platform with VTEX's leading e-commerce solution, businesses gain access to a wide variety of payment methods, advanced security features, and a streamlined checkout experience that drives conversion.
+Yuno and VTEX have joined forces to simplify payment processes for merchants worldwide. By integrating Yuno's payment orchestration platform with VTEX's e-commerce platform, businesses gain access to a wide variety of payment methods and advanced security features.
 
 <Frame>
   <img src="/images/plugins/vtex/image-20260429-131114.png" alt="Yuno and VTEX Integration" />
 </Frame>
 
-With Yuno, your VTEX store can offer shoppers credit and debit cards, alternative payment methods such as Pix and Boleto Bancário, digital wallets like Apple Pay, Google Pay, and Click to Pay, and Buy Now, Pay Later options — all from a single integration. Yuno's orchestration layer handles the routing and processing behind the scenes, so you can scale across markets without rebuilding the payment stack each time.
+With Yuno, your VTEX store can offer shoppers credit and debit cards and alternative payment methods such as Pix and Boleto Bancário. It also supports digital wallets like Apple Pay, Google Pay, and Click to Pay, plus Buy Now, Pay Later options, all through a single integration. Yuno's orchestration layer handles the routing and processing behind the scenes, so you can scale across markets without rebuilding the payment stack each time.
 
-Yuno is also PCI compliant, meeting rigorous security standards when handling card data, and the integration is designed to keep shoppers inside your VTEX checkout from start to finish. There are no redirects to external payment pages, which removes friction at the most sensitive point of the purchase journey and helps lift conversion.
+Yuno is also PCI compliant, meeting rigorous security standards when handling card data. The integration is designed to keep shoppers inside your VTEX checkout from start to finish. There are no redirects to external payment pages, which removes friction at the most sensitive point of the purchase journey and helps lift conversion.
 
 ## Payment methods available
 
@@ -40,15 +40,15 @@ The plugin is composed of three pieces that work together behind the scenes:
 *   **Yuno Payment App**: Renders the Yuno checkout experience inside the VTEX checkout. When a shopper picks a payment method, the Payment App displays the right form (card form, Pix QR, wallet button) and submits the payment.
 *   **Yuno SDK Web for VTEX**: The library used by the Payment App to render the Yuno UI where the shopper enters their payment data.
 
-You configure the **Payment Connector** in VTEX. The **Payment App** is installed afterward, and the **SDK Web** is loaded automatically during checkout — there is no separate setup for it.
+You configure the **Payment Connector** in VTEX. The **Payment App** is installed afterward, and the **SDK Web** is loaded automatically during checkout. There is no separate setup for it.
 
 ## Recurring payments, multi-seller & modified orders
 
 Beyond one-off checkout, the Yuno integration also handles three common VTEX scenarios automatically:
 
-*   **VTEX subscriptions (recurring payments)** — for products sold on a recurring basis, Yuno processes both the first purchase and the automatic renewals that follow. See the [FAQs](/docs/plugins/vtex/faqs) for details.
-*   **Multi-seller (split) orders** — when a cart combines products from different sellers or franchises, VTEX splits it into separate orders and Yuno charges every one of them, not just the first. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#advanced-scenarios).
-*   **Modified orders (changed totals)** — when an order's total changes after checkout (for example, products sold by weight), Yuno adjusts to the final amount: if it goes **down**, only the final (lower) amount is captured; if it goes **up**, the difference is charged automatically (when enabled). See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#order-modifications-changed-order-totals).
+*   **VTEX subscriptions (recurring payments)**: for products sold on a recurring basis, Yuno processes both the first purchase and the automatic renewals that follow. See the [FAQs](/docs/plugins/vtex/faqs) for details.
+*   **Multi-seller (split) orders**: when a cart combines products from different sellers or franchises, VTEX splits it into separate orders and Yuno charges every one of them, not just the first. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#advanced-scenarios).
+*   **Modified orders (changed totals)**: when an order's total changes after checkout (for example, products sold by weight), Yuno adjusts to the final amount. If it goes **down**, only the final (lower) amount is captured; if it goes **up**, the difference is charged automatically (when enabled). See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#order-modifications-changed-order-totals).
 
 ---
 

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -3,7 +3,7 @@ title: "Set up Yuno on VTEX"
 description: "Start accepting payments with Yuno on your VTEX store by following this end-to-end configuration guide."
 ---
 
-This page walks you through every step needed to start accepting payments with Yuno on your VTEX store. The setup happens in two places: your **VTEX dashboard** (to register Yuno as a payment provider, install the Payment App, and activate payment methods) and your **Yuno dashboard** (to configure the webhook that keeps order status in sync).
+This page walks you through every step needed to start accepting payments with Yuno on your VTEX store. The setup happens in two places. Your **VTEX dashboard** is where you register Yuno as a payment provider, install the Payment App, and activate payment methods. Your **Yuno dashboard** is where you configure the webhook that keeps order status in sync.
 
 ### Before you start
 
@@ -56,8 +56,8 @@ Have the following ready:
       | Option | Practical Behavior |
       | :--- | :--- |
       | **Use behavior recommended by payment processor** | **Immediate Capture**: The transaction is captured immediately after authorization. (Default) |
-      | **Automatic capture immediately after payment authorization** | **Immediate Capture**: Same as default. |
-      | **Automatic capture immediately after anti-fraud analysis** | **Immediate Capture**: Behaves the same as immediate capture. |
+      | **Automatic capture immediately after payment authorization** | **Immediate Capture**: The transaction is captured immediately after authorization. Same as default. |
+      | **Automatic capture immediately after anti-fraud analysis** | **Immediate Capture**: The transaction is captured immediately after authorization. |
       | **Disabled** | **Authorize Only**: The transaction is only authorized. Capture happens later when the order is **invoiced**. |
     </Accordion>
 
@@ -94,7 +94,7 @@ Have the following ready:
       <img src="/images/plugins/vtex/image-68c9e7f2.png" alt="Add Payment Condition" />
     </Frame>
 
-    2.  Select the payment method you want to activate (for example, Visa, Mastercard, Pix, Apple Pay, or any of the **Yuno \*** generic methods).
+    2.  Select the payment method you want to activate (for example, Visa, Mastercard, Pix, Apple Pay, or any of the generic **Yuno** methods, such as Yuno Card or Yuno Wallet).
 
     <Frame>
       <img src="/images/plugins/vtex/image-309cec4b.png" alt="Select Payment Method" />
@@ -118,7 +118,7 @@ Have the following ready:
     2.  Fill in the form:
         *   **Name**: For example `VTEX webhook`.
         *   **Endpoint URL**: `https://{store_name}.myvtex.com/_v/yunopartnerbr.yuno/v4/webhook`, replacing `{store_name}` with your VTEX account name.
-        *   **x-api-key** and **x-secret**: Enter any placeholder value (e.g., `VTEX`).
+        *   **x-api-key** and **x-secret**: Enter any placeholder value (for example, `VTEX`).
     3.  Select all events and click **Add**.
   </Step>
 </Steps>
@@ -135,7 +135,7 @@ To set this up, repeat Step 1 once per integration, giving each one a distinct *
 
 ### Multi-account
 
-If your business runs **multiple VTEX accounts** (e.g., a franchise model sharing the same Yuno credentials), use the **Main Account** fields in the provider configuration:
+If your business runs **multiple VTEX accounts** (for example, a franchise model sharing the same Yuno credentials), use the **Main Account** fields in the provider configuration:
 
 *   **Main Account Name**: The name of the main VTEX account.
 *   **Main Account App key** and **Main Account App token**: Application credentials of that main account.
@@ -144,13 +144,13 @@ When these fields are set, the plugin reads catalog and order data from the main
 
 ### Split orders (multiple sellers)
 
-When a shopper's cart contains products from **different sellers or franchises**, VTEX splits the purchase into multiple suborders and authorizes each one independently. The Yuno integration detects this and processes **every** suborder — so the entire order is paid, not just the first part — while sharing a single antifraud session across all of them.
+When a shopper's cart contains products from **different sellers or franchises**, VTEX splits the purchase into multiple suborders and authorizes each one independently. The Yuno integration detects this and processes **every** suborder, so the entire order is paid, not just the first part. A single antifraud session is shared across all of them.
 
 This works automatically; no extra setup is required. If you want to control which antifraud providers receive the shared session, use the **Antifraud Providers for Split Orders** field in the provider configuration (see the field reference in Step 1). Valid values are `RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, and `CIELO_CYBERSOURCE_FRAUD`; when left empty, it defaults to `RISKIFIED` + `CYBERSOURCE`.
 
 ### Order modifications (changed order totals)
 
-VTEX lets you **change an order after checkout**, when the final total turns out to be different from the amount that was authorized — for example if you sell products **by weight**, where the exact total is only known once the order is picked and packed.
+VTEX lets you **change an order after checkout**, when the final total turns out to be different from the amount that was authorized. This applies, for example, if you sell products **by weight**, where the exact total is only known once the order is picked and packed.
 
 *   If the final total is the **same or lower**, VTEX captures only the final amount. No extra setup is required.
 *   If the final total is **higher**, VTEX charges the difference as a **separate, automatic charge**. Since the shopper is no longer present and does not re-enter their card, Yuno charges the difference against the card they already used on the original order.
@@ -159,12 +159,12 @@ To enable automatic charges when an order total **increases**, configure the fol
 
 | Field | Value |
 | :--- | :--- |
-| **Vault Card for Order Modification** | **Yes** — stores the card on the original order so it can be charged again for the difference. |
-| **Create Customer** | **Yes** — required, so the card is stored against a Yuno customer. Both fields must be enabled together. |
-| **Automatic Settlement** | **Disabled** — recommended. The original payment is authorized at checkout and captured at invoicing. If the final total is **lower** than the authorized amount, only that lower amount is captured (a partial capture); if it is higher, the difference is charged as a separate additional charge. |
+| **Vault Card for Order Modification** | **Yes**: stores the card on the original order so it can be charged again for the difference. |
+| **Create Customer** | **Yes**: required, so the card is stored against a Yuno customer. Both fields must be enabled together. |
+| **Automatic Settlement** | **Disabled** (recommended). The original payment is authorized at checkout and captured at invoicing. If the final total is **lower** than the authorized amount, only that lower amount is captured (a partial capture). If it is higher, the difference is charged as a separate additional charge. |
 
 <Note>
-  Order-total **increases** are supported for **credit cards only** (a VTEX restriction). The card is stored at the time of the original payment, so **Vault Card for Order Modification** and **Create Customer** must be enabled **before** the order is placed — turning them on later does not apply to orders that already exist.
+  Order-total **increases** are supported for **credit cards only** (a VTEX restriction). The card is stored at the time of the original payment, so **Vault Card for Order Modification** and **Create Customer** must be enabled **before** the order is placed. Turning them on later does not apply to orders that already exist.
 </Note>
 
 <Note>


### PR DESCRIPTION
## PR Description
Applies the "Simples — Melhorias Identificadas" audit for the Plugins/VTEX section: a more descriptive page title, trimmed promotional/unsupported claims, em dash removal per house style, split overly long sentences, fixed an inconsistent field description, and fixed a broken escaped-asterisk markdown artifact.

## Changes
- `docs/plugins/vtex/index.mdx` — renamed the title from generic "Overview" to "VTEX Plugin Overview"; cut the unsupported "leading e-commerce solution" claim and the stacked promotional descriptors in the intro; replaced 5 em dashes with periods/colons; split 4 long sentences across the intro, security paragraph, and the "Modified orders" bullet.
- `docs/plugins/vtex/set-up-yuno-on-vtex.mdx` — split the long two-dashboard intro sentence; replaced 2 "e.g." abbreviations with "for example" to match the page's existing prose style; standardized the three "Immediate Capture" table rows to identical wording; fixed the broken escaped-asterisk artifact (`**Yuno \*** generic methods`) by spelling out example method names instead; replaced 7 em dashes with periods/colons and split the accompanying long sentences in the Advanced Scenarios section.
- `docs/plugins/vtex/apple-pay-google-pay-enhanced-experience.mdx` — replaced "seamless" in the frontmatter description with "direct"; fixed the remaining em dash.
- `docs/plugins/vtex/direct-sdk-integration.mdx` — replaced all 14 em dashes with periods, commas, or colons per house style; split 12 overly long sentences throughout the headless/WebView sections to improve readability of this technical integration page.
- `docs/plugins/vtex/faqs.mdx` — split the subscriptions FAQ answer, which crammed 4 facts into a single run-on sentence, into three clearer sentences.