### PR TITLE
docs(react-native-sdk): publish changelog for 1.3.1 and 1.3.2

### DIFF
--- a/changelog/react-native.mdx
+++ b/changelog/react-native.mdx
@@ -8,6 +8,21 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 <Info>
   Release notes for the React Native SDK are published here as new versions are released. Check back after each SDK update for a detailed summary of changes, new features, and migration guidance.
 </Info>
+## v1.3.2
+*August 3, 2026*
+
+- <ChangelogBadge type="fixed" /> **Headless Token Generation and Enrollment Accept the Documented camelCase Properties**  
+  `YunoSdk.generateToken()` and `YunoSdk.continueEnrollment()` failed at runtime when called with the camelCase properties declared by the package's own TypeScript types (`checkoutSession`, `paymentMethod`, `expirationMonth`, …), because the native bridges decode snake_case keys only. On iOS this surfaced as `TOKEN_GENERATION_ERROR` ("No value associated with key checkout_session") and on Android as a `NullPointerException` on `PaymentMethod.getType()`. The SDK now converts payload keys from camelCase to snake_case at the JS boundary before invoking the native bridge, so the documented TypeScript contract works on both platforms. Payloads already using snake_case keys are passed through unchanged, so no migration is required.
+
+## v1.3.1
+*July 13, 2026*
+
+- <ChangelogBadge type="fixed" /> **iOS Build Failure on Case-Insensitive File Systems**  
+  Renamed the React Native bridge pod from `YunoSdk` to `YunoSdkReactNative` to eliminate a name collision with the native `YunoSDK` pod on case-insensitive macOS file systems (the default on all Macs). The collision caused linker failures during `pod install` / build — notably on Xcode 26 — unless `use_frameworks!` was enabled. Projects using React Native autolinking require no changes; if your Podfile references `pod 'YunoSdk'` directly, update it to `pod 'YunoSdkReactNative'`.
+
+- <ChangelogBadge type="fixed" /> **TypeScript Definitions Now Published to npm**  
+  The npm package now ships the TypeScript declaration files referenced by its `types` field (`lib/typescript/index.d.ts`). Previous versions declared the types but did not include them in the published package, so TypeScript consumers got no type resolution out of the box. TypeScript projects now get full typing and autocompletion without workarounds.
+
 ## v1.3.0
 *July 2, 2026*
 

--- a/changelog/source/react-native.json
+++ b/changelog/source/react-native.json
@@ -2,6 +2,50 @@
   "sdk": "react-native",
   "releases": [
     {
+      "version": "1.3.2",
+      "release_date": "2026-08-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.3.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Headless Token Generation and Enrollment Accept the Documented camelCase Properties",
+          "description": "`YunoSdk.generateToken()` and `YunoSdk.continueEnrollment()` failed at runtime when called with the camelCase properties declared by the package's own TypeScript types (`checkoutSession`, `paymentMethod`, `expirationMonth`, …), because the native bridges decode snake_case keys only. On iOS this surfaced as `TOKEN_GENERATION_ERROR` (\"No value associated with key checkout_session\") and on Android as a `NullPointerException` on `PaymentMethod.getType()`. The SDK now converts payload keys from camelCase to snake_case at the JS boundary before invoking the native bridge, so the documented TypeScript contract works on both platforms. Payloads already using snake_case keys are passed through unchanged, so no migration is required.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "1.3.1",
+      "release_date": "2026-07-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.3.1",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "iOS Build Failure on Case-Insensitive File Systems",
+          "description": "Renamed the React Native bridge pod from `YunoSdk` to `YunoSdkReactNative` to eliminate a name collision with the native `YunoSDK` pod on case-insensitive macOS file systems (the default on all Macs). The collision caused linker failures during `pod install` / build — notably on Xcode 26 — unless `use_frameworks!` was enabled. Projects using React Native autolinking require no changes; if your Podfile references `pod 'YunoSdk'` directly, update it to `pod 'YunoSdkReactNative'`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "TypeScript Definitions Now Published to npm",
+          "description": "The npm package now ships the TypeScript declaration files referenced by its `types` field (`lib/typescript/index.d.ts`). Previous versions declared the types but did not include them in the published package, so TypeScript consumers got no type resolution out of the box. TypeScript projects now get full typing and autocompletion without workarounds.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.3.0",
       "release_date": "2026-07-02",
       "upgrade": {


### PR DESCRIPTION
## Summary
- Adds the **1.3.2** release entry to `changelog/source/react-native.json` — the Bitrise `Publish` workflow for tag `v1.3.2-PROD` prepared this change but failed to push (git credentials), so this lands it manually.
- Backfills the **1.3.1** entry, which never reached docs because its release tag was never pushed — this is the changelog gap Grupo Azzas reported in [YSHUB-6285](https://yunopayments.atlassian.net/browse/YSHUB-6285).
- Entries copied 1:1 from the SDK repo's `changelog/1.3.1.json` and `changelog/1.3.2.json`; releases stay newest-first (1.3.2 → 1.3.1 → 1.3.0 …).

## Test plan
- [x] JSON valid, release order and object shape match existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[YSHUB-6285]: https://yunopayments.atlassian.net/browse/YSHUB-6285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ