### PR TITLE
chore: web sdk changelog 1.9.24

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.24",
+      "release_date": "2026-08-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.24",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "PayPal enrollment: avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
+          "description": "",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6262"
+      ]
+    },
+    {
       "version": "1.10.1",
       "release_date": "2026-07-30",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -74,17 +74,17 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
-## v1.9.23
-*July 31, 2026*
-
-- <ChangelogBadge type="changed" /> **PayPal Enrollment Payment Status**  
-  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves.
-
 ## v1.9.24
 *August 3, 2026*
 
 - <ChangelogBadge type="changed" /> **PayPal enrollment: avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.**  
   
+
+## v1.9.23
+*July 31, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal Enrollment Payment Status**  
+  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves.
 
 ## v1.9.19
 *July 29, 2026*

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.24
+*August 3, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal enrollment: avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.**  
+  
+
 ## v1.10.1
 *July 30, 2026*
 

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -77,8 +77,8 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 ## v1.9.24
 *August 3, 2026*
 
-- <ChangelogBadge type="changed" /> **PayPal enrollment: avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.**  
-  
+- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
+  Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
 
 ## v1.9.23
 *July 31, 2026*

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,12 +5,6 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
-## v1.9.24
-*August 3, 2026*
-
-- <ChangelogBadge type="changed" /> **PayPal enrollment: avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.**  
-  
-
 ## v1.10.1
 *July 30, 2026*
 
@@ -85,6 +79,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="changed" /> **PayPal Enrollment Payment Status**  
   Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves.
+
+## v1.9.24
+*August 3, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal enrollment: avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.**  
+  
 
 ## v1.9.19
 *July 29, 2026*


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.24`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.24

1 entry.