### PR TITLE
chore: web sdk changelog 1.10.2

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,28 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.2",
+      "release_date": "2026-08-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.2",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "PayPal enrollment: resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
+          "description": "",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "VULS-3673",
+        "YSHUB-6262"
+      ]
+    },
+    {
       "version": "1.10.1",
       "release_date": "2026-07-30",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -11,8 +11,8 @@
       "entries": [
         {
           "type": "CHANGED",
-          "title": "PayPal enrollment: resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
-          "description": "",
+          "title": "PayPal Enrollment",
+          "description": "Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
           "group": null,
           "migration_guide": null,
           "links": []

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -24,6 +24,27 @@
       ]
     },
     {
+      "version": "1.9.24",
+      "release_date": "2026-08-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.24",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "PayPal Enrollment",
+          "description": "Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6262"
+      ]
+    },
+    {
       "version": "1.10.1",
       "release_date": "2026-07-30",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -80,6 +80,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
+## v1.9.24
+*August 3, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
+  Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
+
 ## v1.9.23
 *July 31, 2026*
 

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.2
+*August 3, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
+  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
+
 ## v1.10.1
 *July 30, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.2`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.3

1 entry.