### PR TITLE
docs(C2-17837): add wallet card_data.lfd to Create Payment API reference

### DIFF
--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -2612,6 +2612,16 @@
                                     }
                                   }
                                 }
+                              },
+                              "card_data": {
+                                "type": "object",
+                                "description": "Card information provided by the merchant for the wallet payment.",
+                                "properties": {
+                                  "lfd": {
+                                    "type": "string",
+                                    "description": "Last four digits of the shopper's real card (FPAN), exactly 4 numeric digits. Google Pay server-to-server only: for CRYPTOGRAM_3DS device tokens the encrypted token decrypts to the DPAN, so send the value from paymentMethodData.info.cardDetails in Google's response and Yuno uses it in place of the DPAN-derived last four. Ignored for PAN_ONLY credentials and for other wallets. See the guide: /docs/google-pay-direct-integration#card-last-four-digits-for-device-tokens."
+                                  }
+                                }
                               }
                             }
                           },

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -3996,6 +3996,34 @@
                     "merchant_order_id": "TEST01"
                   }
                 },
+                "Wallet - Google Pay with card last four": {
+                  "summary": "Wallet - Google Pay device token with card last four",
+                  "value": {
+                    "description": "Google Pay server-to-server payment with merchant-provided card last four",
+                    "account_id": "<account_id>",
+                    "merchant_order_id": "0000024",
+                    "country": "US",
+                    "amount": {
+                      "currency": "USD",
+                      "value": 5000
+                    },
+                    "customer_payer": {
+                      "email": "johndoe@example.com"
+                    },
+                    "workflow": "DIRECT",
+                    "payment_method": {
+                      "type": "GOOGLE_PAY",
+                      "detail": {
+                        "wallet": {
+                          "payment_token": "{\"signature\":\"...\",\"intermediateSigningKey\":{...},\"protocolVersion\":\"ECv2\",\"signedMessage\":\"...\"}",
+                          "card_data": {
+                            "lfd": "1515"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
                 "Split marketplace": {
                   "value": {
                     "description": "Split marketplace payment",


### PR DESCRIPTION
## What

Adds the `payment_method.detail.wallet.card_data.lfd` field to the Create Payment API reference (`openapi/payments/create-payment.json`).

## Why

C2-17837 shipped merchant-provided card last four for Google Pay device tokens in server-to-server payments. The guide page was already updated in #652, but the API reference request schema for `wallet` did not include `card_data`, so the new field was not visible there.

## Scope

Only `lfd` (the field introduced by C2-17837). Pre-existing wallet `card_data` fields remain undocumented in the reference and are out of scope for this PR.

Jira: [C2-17837](https://yunopayments.atlassian.net/browse/C2-17837)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[C2-17837]: https://yunopayments.atlassian.net/browse/C2-17837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ