### PR TITLE
docs(C2-17837): lfd copy follow-ups

### DIFF
--- a/docs/wallets/google-pay/google-pay-direct-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-direct-integration.mdx
@@ -195,10 +195,6 @@ The field is optional and backward compatible. If you do not send it, behavior i
 * Only `lfd` is accepted. `brand` and the remaining card fields keep their decrypted values, because the DPAN's BIN already identifies the card network correctly.
 * The value is ignored for other wallets, such as Apple Pay.
 
-<Warning>
-  `lfd` is applied on `POST /v1/payments`. It is accepted and validated on `POST /v1/payments/rx`, but not applied there — the payment succeeds and the last four digits come back empty or DPAN-derived, exactly as before.
-</Warning>
-
 Once applied, the value appears in the create payment response, in the Get payment by ID response, and in payment webhooks, under `payment_method.detail.card.card_data.lfd`. Webhook payloads nest it under `payment_method_detail` instead of `detail`.
 
 If `lfd` is present but is not exactly 4 numeric digits, the request is rejected:

--- a/docs/wallets/google-pay/google-pay-direct-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-direct-integration.mdx
@@ -196,7 +196,7 @@ The field is optional and backward compatible. If you do not send it, behavior i
 * The value is ignored for other wallets, such as Apple Pay.
 
 <Warning>
-  `lfd` is applied on `POST /v1/payments`. It is accepted and validated on `POST /v1/payments/rx` and `POST /v2/payments`, but not applied on those endpoints — the payment succeeds and the last four digits come back empty or DPAN-derived, exactly as before.
+  `lfd` is applied on `POST /v1/payments`. It is accepted and validated on `POST /v1/payments/rx`, but not applied there — the payment succeeds and the last four digits come back empty or DPAN-derived, exactly as before.
 </Warning>
 
 Once applied, the value appears in the create payment response, in the Get payment by ID response, and in payment webhooks, under `payment_method.detail.card.card_data.lfd`. Webhook payloads nest it under `payment_method_detail` instead of `detail`.

--- a/docs/wallets/google-pay/google-pay-direct-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-direct-integration.mdx
@@ -77,7 +77,7 @@ Key details for your Google Pay integration with Yuno:
 Yuno supports both Google Pay API authorization methods:
 
 * **`PAN_ONLY`**: Card credentials stored in the user's Google account. When used, Yuno automatically handles 3D Secure authentication if enabled.
-* **`CRYPTOGRAM_3DS`**: Device-based card credentials with built-in authentication. These credentials include cryptographic authentication and don't require additional 3DS processing. These credentials decrypt to a device-specific number (DPAN), so see [Card last four digits for device tokens](#card-last-four-digits-for-device-tokens) if you display the card's last four digits to the shopper.
+* **`CRYPTOGRAM_3DS`**: Device-based card credentials with built-in authentication. These credentials include cryptographic authentication and don't require additional 3DS processing. These credentials decrypt to a device-specific number (DPAN), so see [Card last four digits for device tokens](#card-last-four-digits-for-device-tokens) if you display the card's last four digits to the cardholder.
 
 Both methods are supported globally across all countries where Yuno operates. On the frontend, include both `PAN_ONLY` and `CRYPTOGRAM_3DS` in your `allowedAuthMethods` array for maximum payment success rates.
 
@@ -148,7 +148,7 @@ The Google Pay SDK returns the following object structure, which must be passed 
 
 ## Card last four digits for device tokens
 
-When Google Pay returns a `CRYPTOGRAM_3DS` credential, the encrypted token decrypts to the **DPAN** — a device-specific number, not the card stored by the shopper. Its last four digits are not the ones the shopper recognizes, so `card_data.lfd` in the payment response is empty or shows the DPAN's last four.
+When Google Pay returns a `CRYPTOGRAM_3DS` credential, the encrypted token decrypts to the **DPAN** — a device-specific number, not the card stored by the cardholder. Its last four digits are not the ones the cardholder recognizes, so `card_data.lfd` in the payment response is empty or shows the DPAN's last four.
 
 The real card's last four digits are available to you in Google's response, outside the encrypted token:
 
@@ -186,7 +186,7 @@ Send `paymentMethodData.info.cardDetails` as `payment_method.detail.wallet.card_
 
 | Field | Type | Required | Description |
 | :---- | :--- | :------- | :---------- |
-| `lfd` | string | No | Last four digits of the shopper's real card, taken from `paymentMethodData.info.cardDetails`. Must be exactly 4 numeric digits. |
+| `lfd` | string | No | Last four digits of the cardholder's real card, taken from `paymentMethodData.info.cardDetails`. Must be exactly 4 numeric digits. |
 
 The field is optional and backward compatible. If you do not send it, behavior is unchanged.
 

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -2619,7 +2619,7 @@
                                 "properties": {
                                   "lfd": {
                                     "type": "string",
-                                    "description": "Last four digits of the shopper's real card (FPAN), exactly 4 numeric digits. Google Pay server-to-server only: for CRYPTOGRAM_3DS device tokens the encrypted token decrypts to the DPAN, so send the value from paymentMethodData.info.cardDetails in Google's response and Yuno uses it in place of the DPAN-derived last four. Ignored for PAN_ONLY credentials and for other wallets. See the guide: /docs/google-pay-direct-integration#card-last-four-digits-for-device-tokens."
+                                    "description": "Last four digits of the shopper's real card (FPAN), exactly 4 numeric digits. Google Pay server-to-server only: for CRYPTOGRAM_3DS device tokens the encrypted token decrypts to the DPAN, so send the value from paymentMethodData.info.cardDetails in Google's response and Yuno uses it in place of the DPAN-derived last four. Ignored for PAN_ONLY credentials and for other wallets. See [Card last four digits for device tokens](/docs/wallets/google-pay/google-pay-direct-integration#card-last-four-digits-for-device-tokens)."
                                   }
                                 }
                               }

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -2619,7 +2619,7 @@
                                 "properties": {
                                   "lfd": {
                                     "type": "string",
-                                    "description": "Last four digits of the shopper's real card (FPAN), exactly 4 numeric digits. Google Pay server-to-server only: for CRYPTOGRAM_3DS device tokens the encrypted token decrypts to the DPAN, so send the value from paymentMethodData.info.cardDetails in Google's response and Yuno uses it in place of the DPAN-derived last four. Ignored for PAN_ONLY credentials and for other wallets. See [Card last four digits for device tokens](/docs/wallets/google-pay/google-pay-direct-integration#card-last-four-digits-for-device-tokens)."
+                                    "description": "Last four digits of the cardholder's real card (FPAN), exactly 4 numeric digits. Google Pay server-to-server only: for CRYPTOGRAM_3DS device tokens the encrypted token decrypts to the DPAN, so send the value from paymentMethodData.info.cardDetails in Google's response and Yuno uses it in place of the DPAN-derived last four. Ignored for PAN_ONLY credentials and for other wallets. See [Card last four digits for device tokens](/docs/wallets/google-pay/google-pay-direct-integration#card-last-four-digits-for-device-tokens)."
                                   }
                                 }
                               }


### PR DESCRIPTION
Copy follow-ups to #702 / #652 on the `card_data.lfd` docs:

1. **Clickable guide link (API reference):** the `card_data.lfd` description referenced the guide as plain text (`See the guide: /docs/...`), which Mintlify does not render as a link. Replaced with a markdown link to the canonical guide URL (`/docs/wallets/google-pay/google-pay-direct-integration#card-last-four-digits-for-device-tokens`, returns 200), same pattern as `soft_descriptor` in this spec.

2. **Remove the endpoint warning from the guide:** it named `POST /v2/payments` (unused today) and `POST /v1/payments/rx` (internal — must not appear in public docs). Without those, the warning only restated the documented endpoint, so the block is removed entirely.

3. **`cardholder` instead of `shopper`:** aligns with the terminology the create-payment spec already uses (e.g. `soft_descriptor`).

Jira: [C2-17837](https://yunopayments.atlassian.net/browse/C2-17837)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[C2-17837]: https://yunopayments.atlassian.net/browse/C2-17837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ