### PR TITLE
docs(ai-capabilities): add Claude/ChatGPT analytics connector guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -233,6 +233,7 @@
             "pages": [
               "setup-mcp",
               "docs/ai-capabilities/aida-ai-agent",
+              "docs/ai-capabilities/use-yuno-with-claude-and-chatgpt",
               "docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp",
               "docs/ai-capabilities/remote-yuno-mcp-server",
               "docs/ai-capabilities/agent-toolkit",

--- a/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx
+++ b/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx
@@ -7,6 +7,10 @@ Yuno offers tools to help you build AI-aware and merchant-friendly payment exper
 
 This guide introduces how to work with both components: how the LLM layer helps AI tools deliver more accurate and contextual integration support, and how the MCP embeds key payment and merchant functionality directly into your environment.
 
+<Note>
+  Looking for the one-click Claude/ChatGPT connector instead of building your own MCP client? See [Use Yuno with Claude and ChatGPT](/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt).
+</Note>
+
 ## Machine-ready content in plain text
 
 To help large language models understand and support Yuno integrations, Yuno provides a dedicated set of Markdown (.md) files designed specifically for machine readability. These files describe Yuno’s APIs, product behavior, and implementation details in a format that’s easy for LLMs to parse and analyze.

--- a/docs/ai-capabilities/remote-yuno-mcp-server.mdx
+++ b/docs/ai-capabilities/remote-yuno-mcp-server.mdx
@@ -5,6 +5,10 @@ description: "Provides a hosted MCP endpoint with API key auth, IP binding, rate
 
 The Remote Yuno MCP Server implements the Model Context Protocol (MCP) to provide secure, remote access to Yuno services. It acts as a hardened proxy so AI agents and automation clients can call Yuno APIs over MCP with enterprise-grade security and session controls.
 
+<Note>
+  Looking for the one-click Claude/ChatGPT connector instead of building your own MCP client? See [Use Yuno with Claude and ChatGPT](/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt).
+</Note>
+
 ## Key capabilities
 
 ### Security

--- a/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
+++ b/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
@@ -17,7 +17,7 @@ Connect your Yuno analytics data to the AI assistant you already use. Ask questi
 
     <Steps>
       <Step title="Open the Yuno connector listing">
-        Open the Yuno connector listing in the Claude directory: `claude.ai/directory/connectors/…9aae9f3`
+        Open the [Yuno connector listing](https://claude.ai/directory/connectors/yuno) in the Claude directory.
       </Step>
       <Step title="Connect and authorize">
         Click **Connect** and sign in with your Yuno credentials to authorize access to your account's analytics data.
@@ -39,7 +39,7 @@ Connect your Yuno analytics data to the AI assistant you already use. Ask questi
 
     <Steps>
       <Step title="Open the Yuno app listing">
-        Open the Yuno app listing in ChatGPT: `chatgpt.com/plugins/plugin_asdk_app_…3f8e`
+        Open the [Yuno app listing](https://chatgpt.com/plugins/plugin_asdk_app_6a3eabbf663c819186dda21300243f8e) in ChatGPT.
       </Step>
       <Step title="Add and link your account">
         Click **Add** (or **Connect**) and sign in with your Yuno credentials to link your account.

--- a/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
+++ b/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
@@ -1,0 +1,118 @@
+---
+title: "Use Yuno with Claude and ChatGPT"
+description: "Connect your Yuno analytics data to Claude or ChatGPT and ask questions in plain language, backed by live SQL against your Yuno analytics warehouse."
+---
+
+Connect your Yuno analytics data to the AI assistant you already use. Ask questions about your payments data in plain language — approval rates, decline reasons, volumes by country or payment method — and get answers backed by live SQL queries against your Yuno analytics warehouse.
+
+<Note>
+  These connectors are analytics-only. They query your Yuno analytics warehouse and cannot create payments, issue refunds, or change your payment configuration. If you're a developer looking to build payment flows into your own agent, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp) and the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server) instead.
+</Note>
+
+## Setup
+
+<Tabs>
+  <Tab title="Claude">
+    The fastest way to enable Yuno in Claude is through the connector directory.
+
+    <Steps>
+      <Step title="Open the Yuno connector listing">
+        Open the Yuno connector listing in the Claude directory: `claude.ai/directory/connectors/…9aae9f3`
+      </Step>
+      <Step title="Connect and authorize">
+        Click **Connect** and sign in with your Yuno credentials to authorize access to your account's analytics data.
+      </Step>
+      <Step title="Enable Yuno in your chat">
+        In any chat, open the search & tools menu and make sure **Yuno** is toggled on.
+      </Step>
+      <Step title="Ask your first question">
+        Try: *"Describe the tables available in my Yuno analytics warehouse."*
+      </Step>
+    </Steps>
+
+    <Note>
+      Connectors added from the directory sync across claude.ai, Claude Desktop, and the mobile apps automatically — you only need to connect once.
+    </Note>
+  </Tab>
+  <Tab title="ChatGPT">
+    Enable the Yuno app from the ChatGPT app directory.
+
+    <Steps>
+      <Step title="Open the Yuno app listing">
+        Open the Yuno app listing in ChatGPT: `chatgpt.com/plugins/plugin_asdk_app_…3f8e`
+      </Step>
+      <Step title="Add and link your account">
+        Click **Add** (or **Connect**) and sign in with your Yuno credentials to link your account.
+      </Step>
+      <Step title="Invoke the app">
+        In a new chat, invoke the app by name — type `@Yuno` or just ask a payments-data question and ChatGPT will call the Yuno tools when relevant.
+      </Step>
+      <Step title="Ask your first question">
+        Try: *"Using Yuno, what were my top decline reasons last week?"*
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+
+## What you can do
+
+Both connectors expose the same tools against your Yuno analytics warehouse. The assistant chooses the right tool automatically — you never have to call them by name, but knowing what's available helps you know what to ask.
+
+| Tool | Type | Description |
+| --- | --- | --- |
+| `read_query` | Read | Runs read-only SQL (`SELECT`, `WITH`, `SHOW`, `DESCRIBE`) against your analytics data. This powers most questions — metrics, breakdowns, trends, exports. |
+| `table_overview` | Read | Describes a table's columns and types and shows a few sample rows — how the assistant learns your data's shape before querying it. |
+| `analyze_query` | Read | Returns the execution plan of a query without running it, so expensive queries can be sanity-checked first. |
+
+## Ask in plain language
+
+* "What was my payment approval rate by payment method over the last 30 days?"
+* "Show transaction volume by country for July, and flag any country that dropped more than 10% vs June."
+* "What are my top 5 decline reasons this month, and which provider do they come from?"
+* "Compare conversion between credit card and PIX in Brazil this quarter."
+* "Describe the transactions table and show me a few sample rows."
+* "Build me a weekly summary: volume, approval rate, refund rate, and average ticket."
+
+## Read-only, scoped to your account
+
+* **Scoped to your account**: The connector authenticates with your Yuno credentials and can only see the analytics data your account is entitled to.
+* **Read-only by design**: The connectors only run read queries. Statements that modify data or schema are always rejected, so the assistant cannot change anything in your warehouse.
+* **Query limits**: Very large result sets are truncated rather than streamed in full, and sessions are rate-limited to keep the warehouse healthy. For bulk exports, use the Yuno dashboard or API.
+
+## Troubleshooting
+
+**Claude says the Yuno connector is disconnected**
+
+Go to Settings → Connectors, find Yuno, and click Reconnect, then re-authorize. If the connector doesn't appear in a chat, check that it's enabled in the chat's search & tools menu.
+
+**ChatGPT doesn't call the Yuno app**
+
+Invoke it explicitly by typing `@Yuno` at the start of your message, or mention "using Yuno" in the prompt. If it's still unavailable, remove and re-add the app from its directory listing.
+
+**Queries fail with a "no database selected" error**
+
+Ask the assistant to qualify tables with their database name (e.g. `analytics.transactions`) or to state which database to use. Asking "what tables are available?" first usually resolves this.
+
+**Results look truncated**
+
+That's expected for large outputs — ask the assistant to aggregate (totals, top-N, grouped summaries) instead of listing raw rows, or narrow the date range.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Do the Claude and ChatGPT connectors do the same thing?">
+    Yes — both expose the same Yuno analytics tools. Pick the assistant your team already uses, or connect both; access and permissions are identical because they're governed by your Yuno credential, not by the assistant.
+  </Accordion>
+  <Accordion title="Can the connector move money or change my payment configuration?">
+    No. These connectors are analytics-only — they query your data warehouse. They do not create payments, issue refunds, or touch your payment routing. For programmatic payment operations, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp) and the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server).
+  </Accordion>
+  <Accordion title="Is my data used to train AI models?">
+    Your data is transferred to the assistant only within your own conversation, subject to Anthropic's or OpenAI's data policies for your plan. Consult your workspace's AI data-handling policy — enterprise plans of both providers exclude business data from training by default.
+  </Accordion>
+  <Accordion title="I'm a developer — can I connect Yuno to my own agent or IDE?">
+    Yes. Yuno publishes an MCP server you can use from Cursor, Claude Code, or any MCP-compatible client. See the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server) and [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp).
+  </Accordion>
+  <Accordion title="Who do I contact if something's not working?">
+    Reach out to your Yuno account manager or open a ticket through the Yuno dashboard. For developer issues with the MCP server, file them on [GitHub](https://github.com/yunopayments/yuno-mcp).
+  </Accordion>
+</AccordionGroup>

--- a/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
+++ b/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
@@ -3,7 +3,7 @@ title: "Use Yuno with Claude and ChatGPT"
 description: "Connect your Yuno analytics data to Claude or ChatGPT and ask questions in plain language, backed by live SQL against your Yuno analytics warehouse."
 ---
 
-Connect your Yuno analytics data to the AI assistant you already use. Ask questions about your payments data in plain language — approval rates, decline reasons, volumes by country or payment method — and get answers backed by live SQL queries against your Yuno analytics warehouse.
+Connect your Yuno analytics data to the AI assistant you already use. Ask questions about your payments data in plain language, like approval rates, decline reasons, or volumes by country or payment method, and get answers backed by live SQL queries against your Yuno analytics warehouse.
 
 <Note>
   These connectors are analytics-only. They query your Yuno analytics warehouse and cannot create payments, issue refunds, or change your payment configuration. If you're a developer looking to build payment flows into your own agent, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp) and the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server) instead.
@@ -31,7 +31,7 @@ Connect your Yuno analytics data to the AI assistant you already use. Ask questi
     </Steps>
 
     <Note>
-      Connectors added from the directory sync across claude.ai, Claude Desktop, and the mobile apps automatically — you only need to connect once.
+      Connectors added from the directory sync across claude.ai, Claude Desktop, and the mobile apps automatically, so you only need to connect once.
     </Note>
   </Tab>
   <Tab title="ChatGPT">
@@ -45,7 +45,7 @@ Connect your Yuno analytics data to the AI assistant you already use. Ask questi
         Click **Add** (or **Connect**) and sign in with your Yuno credentials to link your account.
       </Step>
       <Step title="Invoke the app">
-        In a new chat, invoke the app by name — type `@Yuno` or just ask a payments-data question and ChatGPT will call the Yuno tools when relevant.
+        In a new chat, invoke the app by name: type `@Yuno`, or just ask a payments-data question and ChatGPT will call the Yuno tools when relevant.
       </Step>
       <Step title="Ask your first question">
         Try: *"Using Yuno, what were my top decline reasons last week?"*
@@ -56,12 +56,12 @@ Connect your Yuno analytics data to the AI assistant you already use. Ask questi
 
 ## What you can do
 
-Both connectors expose the same tools against your Yuno analytics warehouse. The assistant chooses the right tool automatically — you never have to call them by name, but knowing what's available helps you know what to ask.
+Both connectors expose the same tools against your Yuno analytics warehouse. The assistant chooses the right tool automatically, so you never have to call them by name, but knowing what's available helps you know what to ask.
 
 | Tool | Type | Description |
 | --- | --- | --- |
-| `read_query` | Read | Runs read-only SQL (`SELECT`, `WITH`, `SHOW`, `DESCRIBE`) against your analytics data. This powers most questions — metrics, breakdowns, trends, exports. |
-| `table_overview` | Read | Describes a table's columns and types and shows a few sample rows — how the assistant learns your data's shape before querying it. |
+| `read_query` | Read | Runs read-only SQL (`SELECT`, `WITH`, `SHOW`, `DESCRIBE`) against your analytics data. This powers most questions: metrics, breakdowns, trends, exports. |
+| `table_overview` | Read | Describes a table's columns and types and shows a few sample rows, so the assistant learns your data's shape before querying it. |
 | `analyze_query` | Read | Returns the execution plan of a query without running it, so expensive queries can be sanity-checked first. |
 
 ## Ask in plain language
@@ -95,21 +95,21 @@ Ask the assistant to qualify tables with their database name (e.g. `analytics.tr
 
 **Results look truncated**
 
-That's expected for large outputs — ask the assistant to aggregate (totals, top-N, grouped summaries) instead of listing raw rows, or narrow the date range.
+That's expected for large outputs. Ask the assistant to aggregate (totals, top-N, grouped summaries) instead of listing raw rows, or narrow the date range.
 
 ## FAQ
 
 <AccordionGroup>
   <Accordion title="Do the Claude and ChatGPT connectors do the same thing?">
-    Yes — both expose the same Yuno analytics tools. Pick the assistant your team already uses, or connect both; access and permissions are identical because they're governed by your Yuno credential, not by the assistant.
+    Yes. Both expose the same Yuno analytics tools. Pick the assistant your team already uses, or connect both; access and permissions are identical because they're governed by your Yuno credential, not by the assistant.
   </Accordion>
   <Accordion title="Can the connector move money or change my payment configuration?">
-    No. These connectors are analytics-only — they query your data warehouse. They do not create payments, issue refunds, or touch your payment routing. For programmatic payment operations, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp) and the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server).
+    No. These connectors are analytics-only: they query your data warehouse. They do not create payments, issue refunds, or touch your payment routing. For programmatic payment operations, see [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp) and the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server).
   </Accordion>
   <Accordion title="Is my data used to train AI models?">
-    Your data is transferred to the assistant only within your own conversation, subject to Anthropic's or OpenAI's data policies for your plan. Consult your workspace's AI data-handling policy — enterprise plans of both providers exclude business data from training by default.
+    Your data is transferred to the assistant only within your own conversation, subject to Anthropic's or OpenAI's data policies for your plan. Consult your workspace's AI data-handling policy; enterprise plans of both providers exclude business data from training by default.
   </Accordion>
-  <Accordion title="I'm a developer — can I connect Yuno to my own agent or IDE?">
+  <Accordion title="Can I connect Yuno to my own agent or IDE as a developer?">
     Yes. Yuno publishes an MCP server you can use from Cursor, Claude Code, or any MCP-compatible client. See the [Remote Yuno MCP Server](/docs/ai-capabilities/remote-yuno-mcp-server) and [Building AI Integrations with Yuno's LLMs and MCP](/docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp).
   </Accordion>
   <Accordion title="Who do I contact if something's not working?">

--- a/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
+++ b/docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx
@@ -91,7 +91,7 @@ Invoke it explicitly by typing `@Yuno` at the start of your message, or mention 
 
 **Queries fail with a "no database selected" error**
 
-Ask the assistant to qualify tables with their database name (e.g. `analytics.transactions`) or to state which database to use. Asking "what tables are available?" first usually resolves this.
+Ask the assistant to qualify tables with their database name (for example `analytics.transactions`) or to state which database to use. Asking "what tables are available?" first usually resolves this.
 
 **Results look truncated**
 


### PR DESCRIPTION
## PR Description
Content is adapted from Jhordy's draft PDF into Yuno's Mintlify docs style, with the Ramp connector docs used only as a structural reference per Jhordy's request. Two details still need confirmation from Jhordy/Simón before this is fully final (see flags below).

## Changes
- Added `docs/ai-capabilities/use-yuno-with-claude-and-chatgpt.mdx` — new guide covering setup for Claude and ChatGPT (`<Tabs>`/`<Steps>`), the three available tools (`read_query`, `table_overview`, `analyze_query`), example prompts, read-only/safety notes, troubleshooting, and an FAQ (`<AccordionGroup>`).
- Updated `docs.json` — added the new page to the "AI Capabilities" nav group, placed after `aida-ai-agent` and before the developer-facing MCP pages.
- Updated `docs/ai-capabilities/remote-yuno-mcp-server.mdx` — added a cross-link note pointing readers to the new page if they want the one-click connector instead of building their own MCP client.
- Updated `docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp.mdx` — same cross-link note added.

**Flags for reviewer:**
- The Claude connector URL (`claude.ai/directory/connectors/...9aae9f3`) and ChatGPT app URL (`chatgpt.com/plugins/plugin_asdk_app_...3f8e`) are truncated in Jhordy's source PDF — need the full URLs before this is publish-ready.
- The tool names/behavior (`read_query`, `table_overview`, `analyze_query`) are sourced from Jhordy's draft and should be confirmed against the live product before publishing.
