### PR TITLE
docs: add EMEA production base URL (api.eu.y.uno)

### DIFF
--- a/auth.md
+++ b/auth.md
@@ -15,10 +15,11 @@ Do not share `private-secret-key` in public places like GitHub or Bitbucket.
 
 ## Base URLs
 
-| Environment | Base URL                    |
-| ----------- | --------------------------- |
-| Sandbox     | `https://api-sandbox.y.uno` |
-| Production  | `https://api.y.uno`         |
+| Environment           | Base URL                    |
+| --------------------- | --------------------------- |
+| Sandbox               | `https://api-sandbox.y.uno` |
+| Production (US)       | `https://api.y.uno`         |
+| Production (EMEA)     | `https://api.eu.y.uno`      |
 
 Sandbox data is simulated and does not affect live accounting or metrics. See [API environments](/reference/getting-started/api-environments) for full details.
 

--- a/reference/getting-started/api-environments.mdx
+++ b/reference/getting-started/api-environments.mdx
@@ -39,12 +39,20 @@ Use this base URL for all API requests when testing. Data is simulated and does 
 https://api-sandbox.y.uno
 ```
 
-### Production
+### Production (US)
 
-Use this base URL when your integration is live and you are processing real payments.
+Use this base URL when your integration is live and you are processing real payments in the US environment.
 
 ```
 https://api.y.uno
+```
+
+### Production (EMEA)
+
+Use this base URL when your integration is live and you are processing real payments in the EMEA environment.
+
+```
+https://api.eu.y.uno
 ```
 
 ## Processing time and timeout


### PR DESCRIPTION
## What

Adds the new EMEA production domain `https://api.eu.y.uno` to the public docs:

- **API Environments** (`reference/getting-started/api-environments.mdx`): the overview table already listed Production (EMEA), but the *Base URLs* section below only had the US URL — added a dedicated **Production (EMEA)** subsection.
- **Authentication for AI agents** (`auth.md`): added the Production (EMEA) row to the base URL table.

## Out of scope (flagged for follow-up)

- OpenAPI `servers` arrays (~170 files under `openapi/`) still list only sandbox/US — adding `api.eu.y.uno` there would surface it in the API playground server dropdown for every endpoint, which needs a product decision on EMEA availability per product.
- Product-specific base URL tables (e.g. Checkout Builder overview) left untouched for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)