### PR TITLE
docs(subscriptions): billing_cycles.total minimum + omission semantics (SUB-27)

### DIFF
--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -212,12 +212,13 @@
                   },
                   "billing_cycles": {
                     "type": "object",
-                    "description": "Specifies the `billing_cycles` object. Defines the number of charges associated to the subscription.",
+                    "description": "Specifies the `billing_cycles` object. Defines the number of charges associated to the subscription. If omitted, the subscription has no cycle limit and continues billing until it is canceled.",
                     "properties": {
                       "total": {
                         "type": "integer",
-                        "description": "The total number of billing cycles for the subscription (MIN 1).",
-                        "format": "int32"
+                        "description": "The total number of billing cycles for the subscription (MIN 1). Values lower than 1 are rejected with a `400` error.",
+                        "format": "int32",
+                        "minimum": 1
                       }
                     }
                   },

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -131,8 +131,9 @@
                     "properties": {
                       "total": {
                         "type": "integer",
-                        "description": "The total number of billing cycles for the subscription.",
-                        "format": "int32"
+                        "description": "The total number of billing cycles for the subscription (MIN 1). Values lower than 1 are rejected with a `400` error.",
+                        "format": "int32",
+                        "minimum": 1
                       }
                     }
                   },


### PR DESCRIPTION
## Summary
- **Create subscription**: add the machine-readable `minimum: 1` constraint to `billing_cycles.total` (the "MIN 1" existed only as prose), note that values below 1 are rejected with a `400`, and document that omitting `billing_cycles` means the subscription has no cycle limit and bills until canceled.
- **Update subscription**: align `billing_cycles.total` with the same constraint and description — it was missing the MIN 1 note even though `public-api` enforces it there too (shared `BillingCycles` struct, `request/subscription.go`).

## Context
[subscription-ms#292](https://github.com/yuno-payments/subscription-ms/pull/292) closes the last enforcement gap for `total < 1` (the public create endpoint of subscription-ms). This PR makes the public reference match the enforced contract precisely.

Jira: [SUB-27](https://yunopayments.atlassian.net/browse/SUB-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SUB-27]: https://yunopayments.atlassian.net/browse/SUB-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ