### PR TITLE
docs: add EU production base URL across dashboard docs and OpenAPI specs

### DIFF
--- a/docs/using-yuno/environments.mdx
+++ b/docs/using-yuno/environments.mdx
@@ -5,7 +5,18 @@ description: "Understand Test Mode and Live Mode in the Dashboard and how to swi
 
 This guide explains how **Test Mode** and **Live Mode** work in the Yuno dashboard and how to switch between them. For API base URLs and credentials per environment, see the [API Environments](/reference/api-environments) reference.
 
-Yuno uses a single account for both environments. You can switch between Test Mode and Live Mode with one toggle, using the same username and password.
+Yuno uses a single account for both environments. You can switch between Test Mode and Live Mode with one toggle, using the same username and password. This Test Mode/Live Mode toggle is separate from the US/EMEA regional dashboards described below — it does not change which region your account operates in.
+
+## Regional dashboards (US and EMEA)
+
+Yuno operates two regional dashboards: `https://dashboard.y.uno` (US) and `https://dashboard.eu.y.uno` (EMEA). How organizations and users relate across the two:
+
+* **Organizations replicate across regions:** every organization/merchant that exists in US also exists in EMEA, and vice versa.
+* **Users replicate, but accounts don't:** every user that exists in US also exists in EMEA. However, **accounts are not synchronized** between the two regions — only users are.
+* **New users need explicit EMEA access:** a user invited to US from now on automatically gets a corresponding user in EMEA, but with no account access or permissions there. An EMEA admin must explicitly grant that user access before they can use the EMEA dashboard.
+* **Same behavior via the public API:** this replication is not limited to the dashboard UI — if a user is created through the public API, it is created in both US and EMEA regardless of which base URL (US or EMEA) was called.
+
+Beyond account/user replication, other dashboard behavior may differ between the US and EMEA regions; check with your Yuno contact for specifics not covered here.
 
 ## Understanding the environments
 

--- a/openapi.json
+++ b/openapi.json
@@ -17,6 +17,10 @@
     {
       "url": "https://api.y.uno",
       "description": "Production"
+    },
+    {
+      "url": "https://api.eu.y.uno",
+      "description": "Production (EMEA)"
     }
   ],
   "security": [

--- a/openapi/ai-caller/declined-payment-calls.json
+++ b/openapi/ai-caller/declined-payment-calls.json
@@ -9,6 +9,9 @@
     {
       "url": "https://api-sandbox.y.uno/v1",
       "description": "Production server"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "security": [

--- a/openapi/ai-caller/initiate-recovery-outreach-for-abandoned-user-flows.json
+++ b/openapi/ai-caller/initiate-recovery-outreach-for-abandoned-user-flows.json
@@ -9,6 +9,9 @@
     {
       "url": "https://api-sandbox.y.uno/v1",
       "description": "Production server"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "security": [

--- a/openapi/banking-connectivity/accounts/close-account-banking.json
+++ b/openapi/banking-connectivity/accounts/close-account-banking.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/accounts/create-account-banking.json
+++ b/openapi/banking-connectivity/accounts/create-account-banking.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/accounts/get-account-details-banking.json
+++ b/openapi/banking-connectivity/accounts/get-account-details-banking.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/accounts/update-account-banking.json
+++ b/openapi/banking-connectivity/accounts/update-account-banking.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entities-banking-connectivity/create-entity.json
+++ b/openapi/banking-connectivity/entities-banking-connectivity/create-entity.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entities-banking-connectivity/get-entity-details.json
+++ b/openapi/banking-connectivity/entities-banking-connectivity/get-entity-details.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entities-banking-connectivity/update-entity.json
+++ b/openapi/banking-connectivity/entities-banking-connectivity/update-entity.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-onboarding-banking-connectivity/cancel-entity-onboarding.json
+++ b/openapi/banking-connectivity/entity-onboarding-banking-connectivity/cancel-entity-onboarding.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-onboarding-banking-connectivity/create-entity-onboarding.json
+++ b/openapi/banking-connectivity/entity-onboarding-banking-connectivity/create-entity-onboarding.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-onboarding-banking-connectivity/get-entity-onboarding-status.json
+++ b/openapi/banking-connectivity/entity-onboarding-banking-connectivity/get-entity-onboarding-status.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-transfers-banking-connectivity/cancel-entity-transfer.json
+++ b/openapi/banking-connectivity/entity-transfers-banking-connectivity/cancel-entity-transfer.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-transfers-banking-connectivity/get-entity-transfer-status.json
+++ b/openapi/banking-connectivity/entity-transfers-banking-connectivity/get-entity-transfer-status.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-transfers-banking-connectivity/initiate-entity-transfer.json
+++ b/openapi/banking-connectivity/entity-transfers-banking-connectivity/initiate-entity-transfer.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/banking-connectivity/entity-transfers-banking-connectivity/update-entity-onboarding.json
+++ b/openapi/banking-connectivity/entity-transfers-banking-connectivity/update-entity-onboarding.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/checkout-builder/create-checkout.json
+++ b/openapi/checkout-builder/create-checkout.json
@@ -10,6 +10,9 @@
     },
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -10,6 +10,9 @@
     },
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-builder/list-checkouts.json
+++ b/openapi/checkout-builder/list-checkouts.json
@@ -10,6 +10,9 @@
     },
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-builder/manage-checkout-lifecycle.json
+++ b/openapi/checkout-builder/manage-checkout-lifecycle.json
@@ -10,6 +10,9 @@
     },
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-builder/publish-checkout-configuration.json
+++ b/openapi/checkout-builder/publish-checkout-configuration.json
@@ -10,6 +10,9 @@
     },
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-sessions/create-checkout-session.json
+++ b/openapi/checkout-sessions/create-checkout-session.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-sessions/create-one-time-use-token-sdk-checkout.json
+++ b/openapi/checkout-sessions/create-one-time-use-token-sdk-checkout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-sessions/create-one-time-use-token.json
+++ b/openapi/checkout-sessions/create-one-time-use-token.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-sessions/retrieve-checkout-session.json
+++ b/openapi/checkout-sessions/retrieve-checkout-session.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-sessions/retrieve-payment-methods-for-checkout.json
+++ b/openapi/checkout-sessions/retrieve-payment-methods-for-checkout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/checkout-sessions/update-checkout-session.json
+++ b/openapi/checkout-sessions/update-checkout-session.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/communications-campaigns/create-campaign.json
+++ b/openapi/communications-campaigns/create-campaign.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/create-rules.json
+++ b/openapi/communications-campaigns/create-rules.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/get-campaign.json
+++ b/openapi/communications-campaigns/get-campaign.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/get-rule.json
+++ b/openapi/communications-campaigns/get-rule.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/list-campaigns.json
+++ b/openapi/communications-campaigns/list-campaigns.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/update-campaign-status.json
+++ b/openapi/communications-campaigns/update-campaign-status.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/update-rule-status.json
+++ b/openapi/communications-campaigns/update-rule-status.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/communications-campaigns/update-rule.json
+++ b/openapi/communications-campaigns/update-rule.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/conversion-rate/get-conversion-rate.json
+++ b/openapi/conversion-rate/get-conversion-rate.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/customer-sessions-enrollment/create-customer-session.json
+++ b/openapi/customer-sessions-enrollment/create-customer-session.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/customers/create-customer.json
+++ b/openapi/customers/create-customer.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/customers/delete-customer.json
+++ b/openapi/customers/delete-customer.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/customers/retrieve-customer-by-external-id.json
+++ b/openapi/customers/retrieve-customer-by-external-id.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/customers/retrieve-customer.json
+++ b/openapi/customers/retrieve-customer.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/customers/update-customer.json
+++ b/openapi/customers/update-customer.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/domains/delete-domain.json
+++ b/openapi/domains/delete-domain.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno"
+    },
+    {
+      "url": "https://api.eu.y.uno"
     }
   ],
   "paths": {

--- a/openapi/domains/get-domain.json
+++ b/openapi/domains/get-domain.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno"
+    },
+    {
+      "url": "https://api.eu.y.uno"
     }
   ],
   "paths": {

--- a/openapi/domains/register-domain.json
+++ b/openapi/domains/register-domain.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno"
+    },
+    {
+      "url": "https://api.eu.y.uno"
     }
   ],
   "paths": {

--- a/openapi/dry-run/register-dry-run-provider-event.json
+++ b/openapi/dry-run/register-dry-run-provider-event.json
@@ -10,6 +10,9 @@
     },
     {
       "url": "https://api.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "paths": {

--- a/openapi/installments/apm-installments.json
+++ b/openapi/installments/apm-installments.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/installments/create-installments-plan.json
+++ b/openapi/installments/create-installments-plan.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/installments/delete-installments-plan-by-id.json
+++ b/openapi/installments/delete-installments-plan-by-id.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/installments/get-installments-plan-by-account.json
+++ b/openapi/installments/get-installments-plan-by-account.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/installments/get-installments-plan.json
+++ b/openapi/installments/get-installments-plan.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/installments/update-plan.json
+++ b/openapi/installments/update-plan.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/network-tokens/generate-network-token-cryptogram.json
+++ b/openapi/network-tokens/generate-network-token-cryptogram.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/authenticate-whitelabel-user.json
+++ b/openapi/organizations/authenticate-whitelabel-user.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Organization Authentication API", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/connections/create-connection.json
+++ b/openapi/organizations/connections/create-connection.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Connections API - Create", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/connections/get-provider-catalog.json
+++ b/openapi/organizations/connections/get-provider-catalog.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Connections API - Get Provider Catalog", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/connections/retrieve-connection.json
+++ b/openapi/organizations/connections/retrieve-connection.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Connections API - Retrieve", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/create-account-group.json
+++ b/openapi/organizations/create-account-group.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/create-account.json
+++ b/openapi/organizations/create-account.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/create-role.json
+++ b/openapi/organizations/create-role.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/create-user.json
+++ b/openapi/organizations/create-user.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/delete-account-group.json
+++ b/openapi/organizations/delete-account-group.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/delete-account.json
+++ b/openapi/organizations/delete-account.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/delete-role.json
+++ b/openapi/organizations/delete-role.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/delete-user-account-group-permission.json
+++ b/openapi/organizations/delete-user-account-group-permission.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Group Permissions API - Delete", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/delete-user-account-permission.json
+++ b/openapi/organizations/delete-user-account-permission.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Permissions API - Delete", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/delete-user.json
+++ b/openapi/organizations/delete-user.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/list-account-groups.json
+++ b/openapi/organizations/list-account-groups.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/list-accounts-of-group.json
+++ b/openapi/organizations/list-accounts-of-group.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/list-accounts.json
+++ b/openapi/organizations/list-accounts.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/list-permissions-catalog.json
+++ b/openapi/organizations/list-permissions-catalog.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/list-roles.json
+++ b/openapi/organizations/list-roles.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/list-users.json
+++ b/openapi/organizations/list-users.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/replace-user-account-group-permissions.json
+++ b/openapi/organizations/replace-user-account-group-permissions.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Group Permissions API - Replace", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/replace-user-account-permissions.json
+++ b/openapi/organizations/replace-user-account-permissions.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Permissions API - Replace", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/retrieve-account-group.json
+++ b/openapi/organizations/retrieve-account-group.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/retrieve-account.json
+++ b/openapi/organizations/retrieve-account.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/retrieve-user-account-group-permissions.json
+++ b/openapi/organizations/retrieve-user-account-group-permissions.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Group Permissions API - Retrieve", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/retrieve-user-account-permissions.json
+++ b/openapi/organizations/retrieve-user-account-permissions.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Permissions API - Retrieve", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/retrieve-user.json
+++ b/openapi/organizations/retrieve-user.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/routing/create-routing.json
+++ b/openapi/organizations/routing/create-routing.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Routing API - Create", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/routing/list-routings.json
+++ b/openapi/organizations/routing/list-routings.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Routing API - List", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/routing/retrieve-routing.json
+++ b/openapi/organizations/routing/retrieve-routing.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Routing API - Retrieve", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/routing/update-routing.json
+++ b/openapi/organizations/routing/update-routing.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "Routing API - Update", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/update-account-group.json
+++ b/openapi/organizations/update-account-group.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/update-account.json
+++ b/openapi/organizations/update-account.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/update-role.json
+++ b/openapi/organizations/update-role.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/organizations/update-user-account-group-permissions.json
+++ b/openapi/organizations/update-user-account-group-permissions.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Group Permissions API - Update", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/update-user-account-permissions.json
+++ b/openapi/organizations/update-user-account-permissions.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "User Account Permissions API - Update", "version": "1.0.0" },
-  "servers": [ { "url": "https://api-sandbox.y.uno/v1" } ],
+  "servers": [ { "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" } ],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },

--- a/openapi/organizations/update-user.json
+++ b/openapi/organizations/update-user.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-links/cancel-payment-link.json
+++ b/openapi/payment-links/cancel-payment-link.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-links/create-payment-link.json
+++ b/openapi/payment-links/create-payment-link.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-links/retrieve-payment-link.json
+++ b/openapi/payment-links/retrieve-payment-link.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-checkout/enroll-payment-method-checkout.json
+++ b/openapi/payment-methods-checkout/enroll-payment-method-checkout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json
+++ b/openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.json
+++ b/openapi/payment-methods-checkout/retrieve-payment-methods-to-enroll-checkout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-checkout/unenroll-payment-method-checkout.json
+++ b/openapi/payment-methods-checkout/unenroll-payment-method-checkout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/reassign-payment-method-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json
+++ b/openapi/payment-methods-direct-workflow/register-cards-for-account-updater-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payment-methods-direct-workflow/unenroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/unenroll-payment-method-api.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/authorize-payment.json
+++ b/openapi/payments/authorize-payment.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/cancel-or-refund-a-payment.json
+++ b/openapi/payments/cancel-or-refund-a-payment.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/cancel-or-refund-payment-with-transaction.json
+++ b/openapi/payments/cancel-or-refund-payment-with-transaction.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/cancel-payment.json
+++ b/openapi/payments/cancel-payment.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/capture-authorization.json
+++ b/openapi/payments/capture-authorization.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/disputes.json
+++ b/openapi/payments/disputes.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/notify-fulfillments.json
+++ b/openapi/payments/notify-fulfillments.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/refund-payment.json
+++ b/openapi/payments/refund-payment.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/retrieve-issuers.json
+++ b/openapi/payments/retrieve-issuers.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payments/update-dispute.json
+++ b/openapi/payments/update-dispute.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payouts/create-payout.json
+++ b/openapi/payouts/create-payout.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payouts/retrieve-payout-by-id.json
+++ b/openapi/payouts/retrieve-payout-by-id.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/payouts/retrieve-payout-by-merchant-reference.json
+++ b/openapi/payouts/retrieve-payout-by-merchant-reference.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/pci-proxy/invoke-forward-proxy.json
+++ b/openapi/pci-proxy/invoke-forward-proxy.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "security": [

--- a/openapi/pci-proxy/manage-destinations.json
+++ b/openapi/pci-proxy/manage-destinations.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "security": [

--- a/openapi/plans/cancel-plan.json
+++ b/openapi/plans/cancel-plan.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "plans", "version": "1.0.0" },
-  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" }],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },

--- a/openapi/plans/create-plan.json
+++ b/openapi/plans/create-plan.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/plans/list-plans.json
+++ b/openapi/plans/list-plans.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "plans", "version": "1.0.0" },
-  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" }],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },

--- a/openapi/plans/retrieve-plan.json
+++ b/openapi/plans/retrieve-plan.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "plans", "version": "1.0.0" },
-  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" }],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },

--- a/openapi/pre-debit-notifications/create-pre-debit-notification.json
+++ b/openapi/pre-debit-notifications/create-pre-debit-notification.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/pre-debit-notifications/retrieve-pre-debit-notification-by-id.json
+++ b/openapi/pre-debit-notifications/retrieve-pre-debit-notification-by-id.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/pre-debit-notifications/retrieve-pre-debit-notification-by-merchant-reference.json
+++ b/openapi/pre-debit-notifications/retrieve-pre-debit-notification-by-merchant-reference.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/block-recipient.json
+++ b/openapi/recipients-for-marketplace/block-recipient.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/cancel-recipient.json
+++ b/openapi/recipients-for-marketplace/cancel-recipient.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/continue-onboarding.json
+++ b/openapi/recipients-for-marketplace/continue-onboarding.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/create-onboarding.json
+++ b/openapi/recipients-for-marketplace/create-onboarding.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/create-recipient-1.json
+++ b/openapi/recipients-for-marketplace/create-recipient-1.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/delete-recipient.json
+++ b/openapi/recipients-for-marketplace/delete-recipient.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/get-onboarding.json
+++ b/openapi/recipients-for-marketplace/get-onboarding.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/get-recipient.json
+++ b/openapi/recipients-for-marketplace/get-recipient.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/get-transfers/get-transfer-by-id.json
+++ b/openapi/recipients-for-marketplace/get-transfers/get-transfer-by-id.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/get-transfers/list-onboarding-transfers.json
+++ b/openapi/recipients-for-marketplace/get-transfers/list-onboarding-transfers.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/get-transfers/list-recipient-transfers.json
+++ b/openapi/recipients-for-marketplace/get-transfers/list-recipient-transfers.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/list-recipients.json
+++ b/openapi/recipients-for-marketplace/list-recipients.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/request-a-transfer.json
+++ b/openapi/recipients-for-marketplace/request-a-transfer.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/reverse-onboarding.json
+++ b/openapi/recipients-for-marketplace/reverse-onboarding.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/transfer-onboarding.json
+++ b/openapi/recipients-for-marketplace/transfer-onboarding.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/unblock-recipient.json
+++ b/openapi/recipients-for-marketplace/unblock-recipient.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/update-onboarding.json
+++ b/openapi/recipients-for-marketplace/update-onboarding.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/recipients-for-marketplace/update-recipient-1.json
+++ b/openapi/recipients-for-marketplace/update-recipient-1.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/reports/create-a-report.json
+++ b/openapi/reports/create-a-report.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/reports/download-a-report.json
+++ b/openapi/reports/download-a-report.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v2"
+    },
+    {
+      "url": "https://api.eu.y.uno/v2"
     }
   ],
   "components": {

--- a/openapi/reports/list-all-reports.json
+++ b/openapi/reports/list-all-reports.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/reports/retrieve-a-report.json
+++ b/openapi/reports/retrieve-a-report.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/sellers/sellers-api.json
+++ b/openapi/sellers/sellers-api.json
@@ -13,6 +13,10 @@
     {
       "url": "https://api.y.uno/v1",
       "description": "Production"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1",
+      "description": "Production (EMEA)"
     }
   ],
   "paths": {

--- a/openapi/subscriptions/cancel-subscription.json
+++ b/openapi/subscriptions/cancel-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/subscriptions/list-subscription-payments.json
+++ b/openapi/subscriptions/list-subscription-payments.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "subscription", "version": "1.0.2" },
-  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }],
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" }],
   "components": {
     "securitySchemes": {
       "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },

--- a/openapi/subscriptions/pause-subscription.json
+++ b/openapi/subscriptions/pause-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/subscriptions/resume-subscription.json
+++ b/openapi/subscriptions/resume-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/subscriptions/retrieve-subscription.json
+++ b/openapi/subscriptions/retrieve-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/subscriptions/retry-subscription.json
+++ b/openapi/subscriptions/retry-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/three-d-secure-setups/create-three-d-secure-setup.json
+++ b/openapi/three-d-secure-setups/create-three-d-secure-setup.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/transfers/create-standalone-transfer.json
+++ b/openapi/transfers/create-standalone-transfer.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/transfers/get-standalone-transfer.json
+++ b/openapi/transfers/get-standalone-transfer.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/transfers/reverse-standalone-transfer.json
+++ b/openapi/transfers/reverse-standalone-transfer.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/transfers/standalone-transfers.json
+++ b/openapi/transfers/standalone-transfers.json
@@ -8,6 +8,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "components": {

--- a/openapi/webhooks/manage-webhooks.json
+++ b/openapi/webhooks/manage-webhooks.json
@@ -7,6 +7,9 @@
   "servers": [
     {
       "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
     }
   ],
   "security": [

--- a/openapi/yuno_sandbox_tested.json
+++ b/openapi/yuno_sandbox_tested.json
@@ -20,6 +20,10 @@
     {
       "url": "https://api.y.uno",
       "description": "Production"
+    },
+    {
+      "url": "https://api.eu.y.uno",
+      "description": "Production (EMEA)"
     }
   ],
   "security": [

--- a/reference/getting-started/api-environments.mdx
+++ b/reference/getting-started/api-environments.mdx
@@ -39,12 +39,20 @@ Use this base URL for all API requests when testing. Data is simulated and does 
 https://api-sandbox.y.uno
 ```
 
-### Production
+### Production (US)
 
-Use this base URL when your integration is live and you are processing real payments.
+Use this base URL when your integration is live and based in the US, processing real payments.
 
 ```
 https://api.y.uno
+```
+
+### Production (EMEA)
+
+Use this base URL when your integration is live and based in EMEA, processing real payments.
+
+```
+https://api.eu.y.uno
 ```
 
 ## Processing time and timeout


### PR DESCRIPTION
## PR Description
Andrea Bautista asked in Slack (cc Heitor, Andres Sanz, Cass, Damián, Caio) to audit the docs for the new EMEA production base URL (`https://api.eu.y.uno`) beyond the one place already covered by PR #710, and to document how the EU/US dashboard now works. Andres Sanz explained that organizations and users replicate between the US and EU dashboards, but accounts/permissions don't sync — an EU admin must explicitly grant access to a user before they can use the EU dashboard, and this behavior applies whether the operation happens through the dashboard UI or the public API. Separately, Heitor confirmed it's fine to add the new EU base URL as a server entry across every OpenAPI spec, not just the ones that already listed US production, and asked for Damián to review.

## Changes
- `docs/using-yuno/environments.mdx`: added a new "Regional dashboards (US and EMEA)" section documenting the EU dashboard URL (`dashboard.eu.y.uno`), organization/user replication between US and EU, the "new US user gets no EU access until an EU admin grants it" nuance, that accounts don't sync but users do, and that this applies to both the dashboard UI and the public API. Also clarified that the existing Test Mode/Live Mode toggle is unrelated to the US/EMEA regional split.
- `openapi.json` (root combined spec): added a `https://api.eu.y.uno` server entry alongside the existing Sandbox/Production entries.
- 168 files under `openapi/**/*.json`: added a `https://api.eu.y.uno` (or `/v1`, `/v2` as applicable) server entry to each spec's `servers` array, mirroring each file's existing production or sandbox URL suffix and description style.
- Left `openapi/banking-connectivity/webhooks/webhook-notifications-banking.json` untouched — its `servers` entry is a merchant-supplied placeholder URL (`{merchant_base_URL}`), not a Yuno API base URL.