### PR TITLE
docs: revamp token migration guides (import + via API)

### DIFF
--- a/docs/security-and-compliance/data-migration-processes/network-token-migration-process.mdx
+++ b/docs/security-and-compliance/data-migration-processes/network-token-migration-process.mdx
@@ -3,6 +3,8 @@ title: "Network Token Migration Process"
 description: "Explains the steps and requirements for migrating network tokens from a provider into Yuno's vault."
 ---
 
+import MigrationPgpKey from '/snippets/migration-pgp-key.mdx'
+
 Network Token migration is the process of transferring `network_tokens` from an existing provider to Yuno's secure vault. During this process, a new token is generated for each `network_token`, ensuring seamless continuity and security for payment processing. The `network_token` migration process consists of three main steps:
 
 1. The merchant requests the `network_token` migration process from their current payment processor.
@@ -68,92 +70,4 @@ To proceed with the migration process, you will need to provide the following:
 In case of migration of multiple parent payment method types it is mandatory to send their corresponding `network_tokens` in different files.
 </Warning>
 
-### PGP public key
-
-Use our public key to encrypt the PCI-sensitive files you send to Yuno.
-
-| Property        | Value                                                              |
-| ---------------- | ------------------------------------------------------------------ |
-| Email       | [security-migrations@y.uno](mailto:security-migrations@y.uno)      |
-| Comment     | For encrypting sensitive data. Environment: production             |
-| Created     | 22 Nov 2024                                                         |
-| Expires     | 22 Nov 2026                                                         |
-| Key ID      | 73D3D88A                                                            |
-| Length      | 4096                                                                |
-| Algorithm   | RSA                                                                 |
-| Fingerprint | 5160 7134 4C00 D270 93FB C450 19ED AACD 73D3 D88A                   |
-
-<Card title="Public PGP Key" href="https://yuno-public-keys.prod.y.uno/generic-pgp-keys_public_key_production.asc" arrow />
-
-***
-
-<Accordion title="Production Key" icon="fa-info-circle">
-  ```
-  -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-  xsFNBGdAg2sBEAC4NW7xG06SGZcNCFVXreQsW8l3YGdcNo4y2ks0MZw8B1k6BwMJ
-  LqJjkiRouWAmRMCbP0Qauw4UPhhVlrIx9MsFrvJFgi/cnOGnwujVNIuhNw8S8cUZ
-  1K1+5ZAsxuc/hKcSQRH0Hp94UNP76seJgC0U6d422fW2EKG7VN2l1BcM4NlBmOuD
-  cQ+fOds+ACsBAQiQjL5ZA/sh6t/7cjUdCQhNK8eK5vylx1lKhHb6T1IvB+B/a6Pt
-  5xxEKNkBgwdQAucDFLFA3ypZsksy8/t9Y7AYw82Teo3z91cQxqiv1C6T62N3+YZ/
-  b48iNzfkml4kxfq15cNgdpxF+HJ/O6EHzSajbPT3KYsCFW9xS5aYOGTFSfgY+1qL
-  518YP72t9okj5HalUgDp6YCLuSr5ns+Z8t8K+cgGNjy08GwuRJKhDidvZBzgGMw6
-  bWavl1obnfThjb3VIHe0WEx/FQuQGGvJzi2EFI+Rne5nT0Q1ayv99kUglfXNdVOL
-  LDsaCwZwefw2Z7+7hNGiF08NQXxUE05tia5ElsmSl9Mo0OeG7UsVuYHVqwDnLs4W
-  dC6br3S3p9XKG9mopXOn8Y4Iu9WMhW3ZZHOlrFCzHip5PyBIyl3265LWfs/If8dc
-  vCKDXC/Hgjxdy7yNzgqguqgwJRnMrXrHx6s3MMHw/1YhNM6uwUjg3WADwwARAQAB
-  zW5zZWN1cml0eS1taWdyYXRpb25zQHkudW5vIChGb3IgZW5jcnlwdGluZyBzZW5z
-  aXRpdmUgZGF0YS4gRW52aXJvbm1lbnQ6IHByb2R1Y3Rpb24pIDxzZWN1cml0eS1t
-  aWdyYXRpb25zQHkudW5vPsLBiAQTAQgAMgUCZ0CDbAIbDgUJA8JnAAILCQIVCAIW
-  AgIeARYhBFFgcTRMANJwk/vEUBntqs1z09iKAAoJEBntqs1z09iKXJQQAIvBv0sa
-  C9Brd4ylSzznZdQQoGIilsGoeiWLNV6Gh6YEODspWljjeYKQl6SEb3NsoVrpB7A5
-  5UNYMGykcvly+fR8UvhNEiJO6vTVCRZnYU43MYLgC35CPj1798egw50GusVoSjKu
-  960tMOz6DUh3yBO2VSxveaOQ6pIYNqi4HtVFIzvcrpgY1/wIV4jpyYnRtJQEt+M4
-  LjD9rnkl7eGHeYQV6tpMjoMkLSWApdk5aDoUqmkvXae5aa7ab7iH/7p53oXxVQM7
-  lqjuNGTgmiJ48gcyHp6aF6M1hbNpoekS63FoGgSRr1h+oB1NlqCokhP8tIjbNbAv
-  rh3371lfPS8dmVq6rUYQwGxHt1XS5682wRw0ZdvsiGY7VjuZAHgGi0f2cEh3dsqy
-  Xa3+rbQ1vKX6lIvmmqPiv7Ggo2LLJXfRfg3Q8s35CCvccz1qQcuUl+HI8NQLbiyW
-  mpelG0+sOl7KHYg7c0HpS8756Eax3sSnr57Jb7Rx88NIF+hH8zE8kBL6OHkFnE+L
-  yLIbCYzmCSxK0ktvcnMjYb1BGmPxfSWgPEyXrI34MtfyRXpeLaDSBfKzGNL8fLLT
-  olLEABrWmn6Xvj6DeZAA+xoFmTUqdLYsZ/i/RLZ5lzQv3xp8Uks09dy2mm/dAVxS
-  4lox2wuJRalx5MZkqrSRZAkjyQMu6EwGiiQ1zsFNBGdAg2wBEACutTIUvApmEQkX
-  EBcAmDFUkQSquiR4EhmW8icPPWTabszNZu3LXLf/ou1v/dcLvkyyDUFZIezYUwdx
-  UXBYDFrXmPqddSx5TOSCOvY79pKrrx5S//40RTs9PM2eC1ufggT7fGVvNj8irYPh
-  jUDtI8LzQXedAMWNB5PLXPZEBnEnaE45PU0s5nREoLK14ldEQl1nCAqAFlEPTztQ
-  C+ILAprwSZ3qnj0pGYy+uRfmIZD51KpriGdRQqWDdbImM28SNh7tv3jPQenm5oCG
-  cavOZzhA54B+w2Hgc4aGER0qY5eZsd/YEGaVevjGHaEDE/Xm6ctMSuLKgg6A/zNH
-  F7kKcS1/5uXXQ0mlk15zRgMJcxNctrKFIYW78R1ECY8vIdN0aMd2/fRgaawwuTz2
-  WcTlLgsG84bAKcccsQnTwCOBxHR8qt3u+GKCEkIcaQVC/FNjP47iSzyWb1a0KeEV
-  4TJ9RtWdlj1DK3alGkvbexuCzqZ+1p8O+lCIsEiL5Cz3YeLfLebph1Z40o0HdGw3
-  XS/e0GnaBZpqzo4MCqud26x9fYX9kP+SHzNAacSSLfc/WJvJOLyuIDXvwiJu7QDC
-  SDMeS4vLiBmfcfYiBxUKXteRcS2g/9B5tkzKVLWv9xkMXIhsxsyIFDiepUoT4uEN
-  zPvOR8fbpzI+XkNdAOpm6gKyCTRxeQARAQABwsOsBBgBCAAgBQJnQINtAhsMFiEE
-  UWBxNEwA0nCT+8RQGe2qzXPT2IoCQAkQGe2qzXPT2IrBdCAEGQEIAB0FAmdAg20W
-  IQRAK7d6Jh6QEsLrtCje87+APhkLfwAKCRDe87+APhkLf9AqD/9QmNmEaSUZ6ujy
-  7resqaWT4nSMErhT3TNM8B1FPwF63Igt0HUnKqe4XSy840kKJsTY+ssGcLpbTTxv
-  CX/DLtR7No5G1WBAr3MZos7GfFhnb2tApDzQdmucHliKLVe2zSiyqvMGiK1irvXy
-  GKi6Dfvoobw54qkCeD7upz+z6eZAQYnDqh2xlGl7uc6OcgaJgctMhOA8jhlmLIrz
-  gk/MBXRgZXGfJ0/DZe2JTl7vw3XIUB62XnV3vpHU/UxM5UWpA87m14Lh8SNAvT+l
-  L8Y1wZ5DcQ1g83oO5NI/DwWorlqOeyhRU8a1a3Kd0aZ6bSWCbZadU4c6ciwvwpnS
-  MQ5nc4iX1bFsuN8z8WGQ/io4cPMXQbNFBQ22OgnSpxEVS3akDkQOJ25hJeUZaFZU
-  91CJVlknQipwvpVG3RuuOvTJstYxTKJ8Leg1IB0zo7QhlaMNTu/yWyr0WoJO52Jh
-  IMoykpfPY6gowKBGi6EZpNjiKoyElkBU1js47wMdqONfBZxyupJpAM2GeBWs0cYS
-  j7pUL68ah/RMslMuC6rKtjDytVChQJz/nXcxDQeBliYMMedDP3a6FksBmmdJKphw
-  ZbmVGAbNJd2TSFEsiYZjPJ+bH8SafjcRVVqaRw3cGReyJmwv1EhxhZR+dsZAjdnB
-  RX0jQSGjQjcWfyUTGmnpipgCNnJOkEFrEACm4QErrplv2jIAADFytyk/VL+3D6RB
-  0XTrhb0FqLgmVEqYJPuh9z3KkMpQQk9spd3uNBkuBGkTehf4WBWIRcGWIChpVNb+
-  YabmXfqxYhoRKnhoMS4vRfOZJbdzdBZ7tsjsz072kGi03nK9/B5RnBR2Amj2hry/
-  BdzZd+vuAUiblC7DJ8M9SAMBAHyXAJFKfgoYs9OxBdQqSePVKG8B2B2Vu12yeJWc
-  p00yrqfc6c5IvamRvKZ73EYAbt6uf/5ED969QngFeB4NhSUCH7L1h+67lKVjELw4
-  l2wA4kd2ZxEERfTVRx0/ZptxW2nkVm4iK2R/0DDMDyPZ5VfPo+XA6Y794kWJ/C2E
-  sX9T9ti6GK6taIZ4vdcR04CMFMNfOSrcnMWN4GDP6BQpYEOu2pOHqUpQAinFCSi9
-  umfNdhaPchGiHk2KjvXAgPJ6j4AYGadfM24qT6m8GLEtanL2pFGFNPOw8D03fGkV
-  yhsfHiamgAnnL2mz0khePCn8aTyUMrmSwUc2e5Agj1naMJetd//WnzaPFvWViy+l
-  V+EqUCVP6YPNq8PHD8ZOAy5T8GO+wNahsKiUaxAhn2kjCXhZRqwWDiJLCn3Wge6B
-  n4nHVHtvlw/ptDFyrDP2fUkk1XwmN2StG5y74eVN6HlvrTkwL5HmxQKGlSwZC1gK
-  sNugHSYrj1RUuA==
-  =ik2s
-  -----END PGP PUBLIC KEY BLOCK-----
-
-  ```
-</Accordion>
+<MigrationPgpKey />

--- a/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
+++ b/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
@@ -1,13 +1,17 @@
 ---
 title: "Token Migration Process"
-description: "Explains the steps, data format, and security requirements for migrating tokenized cards into Yuno."
+description: "Steps, file format, and security requirements for migrating tokenized cards from another provider into Yuno."
 ---
 
-Token migration is the process of transferring card numbers from an existing provider to Yuno's secure vault. During this process, a new token is generated for each card, ensuring seamless continuity and security for payment processing. The token migration process consists of three main steps:
+import MigrationPgpKey from '/snippets/migration-pgp-key.mdx'
 
-1. The merchant requests the token migration process from their current payment processor.
-2. Yuno and the payment provider collaborate to securely import all card data into the Yuno token vault.
-3. The merchant uses Yuno's token migration API to map the tokens from the payment provider to the `vaulted_tokens` of Yuno.
+Token migration is the process of transferring card numbers from an existing provider to Yuno's secure vault. During this process, a new token is generated for each card, ensuring seamless continuity for payment processing. Your card data belongs to you: Yuno supports both importing cards from your current provider and [exporting them out of Yuno](/docs/security-and-compliance/data-migration-processes/exporting-tokens-from-yuno) if you ever need to leave.
+
+The token migration process consists of three main steps:
+
+1. You request a card-on-file export from your current payment processor or vault.
+2. Yuno and your current provider collaborate to securely import the card data into the Yuno vault.
+3. You use the Yuno API to map each imported card to a Yuno `vaulted_token`.
 
 <Note>
 **First step**
@@ -15,71 +19,92 @@ Token migration is the process of transferring card numbers from an existing pro
 To initiate the token migration process, contact your business advisor at Yuno to assess the viability and schedule of the procedure.
 </Note>
 
-## Importing cards from a gateway account (steps 1 and 2)
+## Who does what
 
-Importing card data from a gateway account involves handling sensitive information, so strict security protocols must be followed. To import card data into Yuno from an existing gateway, complete the following steps:
+| Phase | You (merchant) | Yuno | Current provider |
+| --- | --- | --- | --- |
+| Request export | Open the export request and manage communication with your current provider | Supports the request and provides compliance documents on demand | Defines its own export procedure and timeline |
+| Secure transfer | Share the technical requirements listed below | Coordinates directly with the provider, receives and ingests the encrypted file | Encrypts and delivers the export file |
+| Token mapping | Create customers and enroll the imported cards [via API](/docs/security-and-compliance/data-migration-processes/via-api) | Returns a `vaulted_token` for each enrolled card | Not involved |
 
-1. **Coordinate with the current gateway**: Contact your current third-party vault or gateway and request an export of the payment method data. Ensure you follow their specified protocols.
-2. **Complete the formal request**: Submit a formal request to Yuno, ensuring all required details and processes are documented. The gateway's response time and procedures will determine the data transfer process.
+The exporting provider's response time and procedures determine the overall duration of the migration, so open the export request as early as possible.
+
+## Step 1: Request the export from your current provider
+
+Contact your current third-party vault or gateway and request a card-on-file export, following their specified protocols. Some providers document this process publicly; others require a support ticket or a signed letter from the account owner. Here is a template you can adapt:
+
+```text Export request template
+from: Account Owner <account_owner@yourcompany.com>
+to: Provider Support <support@currentprovider.com>
+cc: Your Yuno business advisor
+
+subject: Card-on-file token export request
+
+Dear provider team,
+
+We would like to proceed with a [full / partial] card-on-file export.
+
+Our new provider is Yuno (https://y.uno). I have copied our Yuno
+contact so both teams can coordinate the transfer directly.
+
+Data format: CSV is preferred. Please include the Network
+Transaction ID for each stored card.
+
+Timeline: we plan to complete the migration by [target_date].
+
+Regards,
+[Name], Account Owner
+```
+
+<Tip>
+**Ask for Network Transaction IDs**
+
+Request that your current provider includes the Network Transaction ID (NTI) of the last successful transaction for each stored card. Passing the NTI when processing merchant-initiated transactions (MIT) after the migration improves authorization rates and keeps you compliant with card network [stored credentials](/docs/payment-features/stored-credentials) requirements. Many providers only include this column if you explicitly ask for it in the export request.
+</Tip>
+
+Copying your Yuno business advisor on the request creates the introduction between both parties, so Yuno can take over the technical coordination and provide any compliance documents (such as Yuno's PCI DSS Attestation of Compliance) the exporting provider requires.
 
 <Warning>
 **Your responsibilities when migrating tokens**
 
-You are responsible for managing communication with your gateway provider throughout the migration process. The Yuno team will support and collaborate directly with the third-party vault/gateway to facilitate the importing process. Additionally, the customer subscription information, including amounts, dates, etc., must be obtained directly from the exporting entity, as Yuno will not extract this data from encrypted files.
+You are responsible for managing communication with your current provider throughout the migration process. The Yuno team will support and collaborate directly with the third-party vault or gateway to facilitate the import. Additionally, customer subscription information, including amounts and billing dates, must be obtained directly from the exporting entity, as Yuno will not extract this data from encrypted files.
 </Warning>
 
-<Note>
-**Data transfer security**
+## Step 2: Transfer the data to Yuno securely
 
-All data throughout the migration process is encrypted using PGP keys and transferred using SFTP (Secure File Transfer Protocol).
-</Note>
+All data throughout the migration is encrypted using PGP keys and transferred over SFTP. To set up the transfer, provide the following to your Yuno contact:
 
-## Client-side requirements (step 3)
+| Requirement | Purpose |
+| --- | --- |
+| Public SSH key | Provisions SFTP access. You can provide one key for production and another for testing. Generate one with `ssh-keygen -t rsa -b 4096 -C your_email@example.com` |
+| Outbound IPs | The IP addresses that will connect to the SFTP server during the migration, for allowlisting |
+| Template file | A sample of the export file (with test data, never real card numbers) so Yuno can validate its structure before processing |
 
-To successfully complete the token migration process, it is essential to fulfill the client-side requirements outlined in step 3. This involves providing the necessary user data, including the buyers and their existing payment methods.
+### Export file contents
 
-You can execute the token migration process using the Yuno API, which is specifically designed for merchants. As a merchant, you will use this API to:
+The export file comes from your current provider, so exact column names vary. It must include the following data for every card:
 
-1. **Add customers**: Register customers in the Yuno system.
-2. **Enroll payment methods**: Register payment methods obtained from payment processors for each customer in the Yuno system.
+| Data | Description |
+| --- | --- |
+| Cardholder name | The full name of the cardholder as stored by the current provider |
+| Expiration date | The expiry date of the card |
+| Card number | The complete card number (PAN) that will be tokenized by Yuno |
+| Card ID | The unique identifier the current provider assigned to each card. You will use it in step 3 to map each card to its new Yuno token |
 
-<Note>
-**API migration option**
+The following columns are optional but recommended:
 
-The API migration option allows merchants to manage their customers and their respective payment data. [Learn more](/docs/security-and-compliance/data-migration-processes/via-api)
-</Note>
+| Data | Why include it |
+| --- | --- |
+| Network Transaction ID | Preserves MIT authorization performance after the migration (see the tip above) |
+| Customer reference | Your internal customer identifier, to simplify reconciliation on your side |
 
-For a detailed guide on performing token migration using the API, click the button below:
+```csv Example export file
+card_id,holder_name,card_number,expiration_month,expiration_year,network_transaction_id,customer_reference
+card_9f3k2,JOHN DOE,4111111111111111,12,2030,013021692169808,cus_123
+card_7x1p8,JANE ROE,5555555555554444,8,2027,MCC5H1AW30919,cus_456
+```
 
-<Card title="Token migration via API" href="/docs/security-and-compliance/data-migration-processes/via-api" arrow/>
-
-### Data format
-
-Yuno specifies the required parameters for each customer and credit card to proceed with the migration process. The required parameters are listed below:
-
-* Account ID
-* Merchant customer ID
-* First name
-* Last name
-* Email
-* Country
-* Document number
-* Document type
-* Payment method type
-* Payment method ID
-* Payment method token
-
-Refer to the [Customer Object](/reference/the-customer-object) and [Payment Method Object](/reference/the-payment-method-object-api) to explore all possible parameters for importing/creating customers or enrolling payment objects.
-
-Technical limitations associated with alternative payment methods may make them ineligible for migration between service providers. If you are considering migrating alternative payment method tokens, such as Mercado Pago Wallet Connect or Bancolombia Tokenbox, to the Yuno vault, please contact the Yuno support team.
-
-## Data validation
-
-To ensure efficient processing and prevent delays during the token migration process, please provide the following information when communicating with Yuno Support:
-
-* The external identifier name that will be used for the import.
-* An approximate count of the expected number of payment methods to be included (a rough estimate is acceptable).
-* Any known data gaps, such as missing names or expiration dates.
+Keep the file structure consistent: every row must have the same number of columns, empty values must be left explicitly empty (for example `foo,,bar`), and fields must not contain line breaks. Yuno reviews your template file and confirms the structure with you before processing begins.
 
 <Warning>
 **Important notice**
@@ -87,108 +112,59 @@ To ensure efficient processing and prevent delays during the token migration pro
 Yuno does not validate expiration dates during credit card import.
 </Warning>
 
+### What can and cannot be migrated
+
+* **Cards (PANs)**: fully supported through this process.
+* **Network tokens**: supported through a dedicated process. See [Network Token Migration Process](/docs/security-and-compliance/data-migration-processes/network-token-migration-process).
+* **Digital wallet tokens (Apple Pay, Google Pay)**: device tokens (DPANs) are bound to the wallet provider and the original configuration, so they cannot be exported as card numbers. Customers keep paying with their wallets after migration, but existing wallet enrollments cannot be transferred as cards through this process. Contact the Yuno support team to evaluate the options for your case.
+* **Alternative payment method tokens** (such as Mercado Pago Wallet Connect or Bancolombia Tokenbox): technical limitations may make them ineligible for migration between providers. Contact the Yuno support team before planning to migrate them.
+
+<MigrationPgpKey />
+
+## Step 3: Map imported cards to Yuno vaulted tokens
+
+Once Yuno ingests the export file, you register your customers and enroll each imported card using the Yuno API. For each card, you reference the provider's card token (from the export file) and receive a Yuno `vaulted_token` in return, which you then use for all future payments.
+
+Yuno requires the following data for each customer and card:
+
+| Customer data | API field |
+| --- | --- |
+| Merchant customer ID | `merchant_customer_id` (required) |
+| First name | `first_name` |
+| Last name | `last_name` |
+| Email | `email` |
+| Country | `country` |
+| Document type and number | `document.document_type`, `document.document_number` |
+
+| Card data | API field |
+| --- | --- |
+| Account ID | `account_id` |
+| Payment method type | `type` (for example `CARD`) |
+| Payment method provider | `provider_data.id` |
+| Provider card token | `provider_data.payment_method_token` |
+
+Refer to the [Customer Object](/reference/the-customer-object) and [Payment Method Object](/reference/the-payment-method-object-api) for all available parameters.
+
+For the detailed step-by-step guide, including request and response examples and guidance for running the migration at scale:
+
+<Card title="Token migration via API" href="/docs/security-and-compliance/data-migration-processes/via-api" arrow />
+
+## Data validation
+
+To ensure efficient processing and prevent delays, provide the following information when communicating with Yuno Support:
+
+* The external identifier name that will be used for the import.
+* An approximate count of the expected number of payment methods (a rough estimate is acceptable).
+* Any known data gaps, such as missing names or expiration dates.
+
+## Before you switch off your old provider
+
+Do not cancel your previous provider or delete data on their side until you have verified the migration end to end:
+
+1. **Reconcile counts**: compare the number of cards in the export file against the number of successfully enrolled `vaulted_tokens`, and review every failed enrollment.
+2. **Test with a small cohort**: process a few real merchant-initiated transactions with migrated tokens before moving your full billing volume.
+3. **Run in parallel**: keep the previous provider active during the validation window so you can fall back if needed.
+
 ## Data protection
 
-When processing payments through Yuno, the platform connects to payment processors. Yuno tokenizes and encrypts the data to ensure security, simplifying the PCI compliance process. However, you are responsible for managing and protecting your customer's data. Additionally, you must communicate any additional fees or issues to your customer.
-
-## Gateway and payment provider requirements
-
-To proceed with the migration process, you will need to provide the following:
-
-* A public SSH key (you can provide one for production and another for testing). Use the following command to generate it: `ssh-keygen -t rsa -b 4096 -C your_email@example.com`
-* The outbound IPs that will be used during the migration.
-* A template file of the data to be migrated to understand its structure. It must include the following mandatory data:
-  * **Cardholder name**: The full name of the cardholder as stored by the current provider.
-  * **Expiration date**: The expiry date of the card.
-  * **Card number**: The complete card number (PAN) that will be tokenized by Yuno.
-  * **Card ID**: A unique identifier assigned to each card by the current provider, used by the client for referencing that card during transactions.
-
-### PGP public key
-
-Use our public key to encrypt the PCI-sensitive files you send to Yuno.
-
-| Property        | Value                                                              |
-| ---------------- | ------------------------------------------------------------------ |
-| Email       | [security-migrations@y.uno](mailto:security-migrations@y.uno)      |
-| Comment     | For encrypting sensitive data. Environment: production             |
-| Created     | 22 Nov 2024                                                         |
-| Expires     | 22 Nov 2026                                                         |
-| Key ID      | 73D3D88A                                                            |
-| Length      | 4096                                                                |
-| Algorithm   | RSA                                                                 |
-| Fingerprint | 5160 7134 4C00 D270 93FB C450 19ED AACD 73D3 D88A                   |
-
-<Card title="Public PGP Key" href="https://yuno-public-keys.prod.y.uno/generic-pgp-keys_public_key_production.asc" arrow />
-
-***
-
-<Accordion title="Production Key" icon="fa-info-circle">
-  ```
-  -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-  xsFNBGdAg2sBEAC4NW7xG06SGZcNCFVXreQsW8l3YGdcNo4y2ks0MZw8B1k6BwMJ
-  LqJjkiRouWAmRMCbP0Qauw4UPhhVlrIx9MsFrvJFgi/cnOGnwujVNIuhNw8S8cUZ
-  1K1+5ZAsxuc/hKcSQRH0Hp94UNP76seJgC0U6d422fW2EKG7VN2l1BcM4NlBmOuD
-  cQ+fOds+ACsBAQiQjL5ZA/sh6t/7cjUdCQhNK8eK5vylx1lKhHb6T1IvB+B/a6Pt
-  5xxEKNkBgwdQAucDFLFA3ypZsksy8/t9Y7AYw82Teo3z91cQxqiv1C6T62N3+YZ/
-  b48iNzfkml4kxfq15cNgdpxF+HJ/O6EHzSajbPT3KYsCFW9xS5aYOGTFSfgY+1qL
-  518YP72t9okj5HalUgDp6YCLuSr5ns+Z8t8K+cgGNjy08GwuRJKhDidvZBzgGMw6
-  bWavl1obnfThjb3VIHe0WEx/FQuQGGvJzi2EFI+Rne5nT0Q1ayv99kUglfXNdVOL
-  LDsaCwZwefw2Z7+7hNGiF08NQXxUE05tia5ElsmSl9Mo0OeG7UsVuYHVqwDnLs4W
-  dC6br3S3p9XKG9mopXOn8Y4Iu9WMhW3ZZHOlrFCzHip5PyBIyl3265LWfs/If8dc
-  vCKDXC/Hgjxdy7yNzgqguqgwJRnMrXrHx6s3MMHw/1YhNM6uwUjg3WADwwARAQAB
-  zW5zZWN1cml0eS1taWdyYXRpb25zQHkudW5vIChGb3IgZW5jcnlwdGluZyBzZW5z
-  aXRpdmUgZGF0YS4gRW52aXJvbm1lbnQ6IHByb2R1Y3Rpb24pIDxzZWN1cml0eS1t
-  aWdyYXRpb25zQHkudW5vPsLBiAQTAQgAMgUCZ0CDbAIbDgUJA8JnAAILCQIVCAIW
-  AgIeARYhBFFgcTRMANJwk/vEUBntqs1z09iKAAoJEBntqs1z09iKXJQQAIvBv0sa
-  C9Brd4ylSzznZdQQoGIilsGoeiWLNV6Gh6YEODspWljjeYKQl6SEb3NsoVrpB7A5
-  5UNYMGykcvly+fR8UvhNEiJO6vTVCRZnYU43MYLgC35CPj1798egw50GusVoSjKu
-  960tMOz6DUh3yBO2VSxveaOQ6pIYNqi4HtVFIzvcrpgY1/wIV4jpyYnRtJQEt+M4
-  LjD9rnkl7eGHeYQV6tpMjoMkLSWApdk5aDoUqmkvXae5aa7ab7iH/7p53oXxVQM7
-  lqjuNGTgmiJ48gcyHp6aF6M1hbNpoekS63FoGgSRr1h+oB1NlqCokhP8tIjbNbAv
-  rh3371lfPS8dmVq6rUYQwGxHt1XS5682wRw0ZdvsiGY7VjuZAHgGi0f2cEh3dsqy
-  Xa3+rbQ1vKX6lIvmmqPiv7Ggo2LLJXfRfg3Q8s35CCvccz1qQcuUl+HI8NQLbiyW
-  mpelG0+sOl7KHYg7c0HpS8756Eax3sSnr57Jb7Rx88NIF+hH8zE8kBL6OHkFnE+L
-  yLIbCYzmCSxK0ktvcnMjYb1BGmPxfSWgPEyXrI34MtfyRXpeLaDSBfKzGNL8fLLT
-  olLEABrWmn6Xvj6DeZAA+xoFmTUqdLYsZ/i/RLZ5lzQv3xp8Uks09dy2mm/dAVxS
-  4lox2wuJRalx5MZkqrSRZAkjyQMu6EwGiiQ1zsFNBGdAg2wBEACutTIUvApmEQkX
-  EBcAmDFUkQSquiR4EhmW8icPPWTabszNZu3LXLf/ou1v/dcLvkyyDUFZIezYUwdx
-  UXBYDFrXmPqddSx5TOSCOvY79pKrrx5S//40RTs9PM2eC1ufggT7fGVvNj8irYPh
-  jUDtI8LzQXedAMWNB5PLXPZEBnEnaE45PU0s5nREoLK14ldEQl1nCAqAFlEPTztQ
-  C+ILAprwSZ3qnj0pGYy+uRfmIZD51KpriGdRQqWDdbImM28SNh7tv3jPQenm5oCG
-  cavOZzhA54B+w2Hgc4aGER0qY5eZsd/YEGaVevjGHaEDE/Xm6ctMSuLKgg6A/zNH
-  F7kKcS1/5uXXQ0mlk15zRgMJcxNctrKFIYW78R1ECY8vIdN0aMd2/fRgaawwuTz2
-  WcTlLgsG84bAKcccsQnTwCOBxHR8qt3u+GKCEkIcaQVC/FNjP47iSzyWb1a0KeEV
-  4TJ9RtWdlj1DK3alGkvbexuCzqZ+1p8O+lCIsEiL5Cz3YeLfLebph1Z40o0HdGw3
-  XS/e0GnaBZpqzo4MCqud26x9fYX9kP+SHzNAacSSLfc/WJvJOLyuIDXvwiJu7QDC
-  SDMeS4vLiBmfcfYiBxUKXteRcS2g/9B5tkzKVLWv9xkMXIhsxsyIFDiepUoT4uEN
-  zPvOR8fbpzI+XkNdAOpm6gKyCTRxeQARAQABwsOsBBgBCAAgBQJnQINtAhsMFiEE
-  UWBxNEwA0nCT+8RQGe2qzXPT2IoCQAkQGe2qzXPT2IrBdCAEGQEIAB0FAmdAg20W
-  IQRAK7d6Jh6QEsLrtCje87+APhkLfwAKCRDe87+APhkLf9AqD/9QmNmEaSUZ6ujy
-  7resqaWT4nSMErhT3TNM8B1FPwF63Igt0HUnKqe4XSy840kKJsTY+ssGcLpbTTxv
-  CX/DLtR7No5G1WBAr3MZos7GfFhnb2tApDzQdmucHliKLVe2zSiyqvMGiK1irvXy
-  GKi6Dfvoobw54qkCeD7upz+z6eZAQYnDqh2xlGl7uc6OcgaJgctMhOA8jhlmLIrz
-  gk/MBXRgZXGfJ0/DZe2JTl7vw3XIUB62XnV3vpHU/UxM5UWpA87m14Lh8SNAvT+l
-  L8Y1wZ5DcQ1g83oO5NI/DwWorlqOeyhRU8a1a3Kd0aZ6bSWCbZadU4c6ciwvwpnS
-  MQ5nc4iX1bFsuN8z8WGQ/io4cPMXQbNFBQ22OgnSpxEVS3akDkQOJ25hJeUZaFZU
-  91CJVlknQipwvpVG3RuuOvTJstYxTKJ8Leg1IB0zo7QhlaMNTu/yWyr0WoJO52Jh
-  IMoykpfPY6gowKBGi6EZpNjiKoyElkBU1js47wMdqONfBZxyupJpAM2GeBWs0cYS
-  j7pUL68ah/RMslMuC6rKtjDytVChQJz/nXcxDQeBliYMMedDP3a6FksBmmdJKphw
-  ZbmVGAbNJd2TSFEsiYZjPJ+bH8SafjcRVVqaRw3cGReyJmwv1EhxhZR+dsZAjdnB
-  RX0jQSGjQjcWfyUTGmnpipgCNnJOkEFrEACm4QErrplv2jIAADFytyk/VL+3D6RB
-  0XTrhb0FqLgmVEqYJPuh9z3KkMpQQk9spd3uNBkuBGkTehf4WBWIRcGWIChpVNb+
-  YabmXfqxYhoRKnhoMS4vRfOZJbdzdBZ7tsjsz072kGi03nK9/B5RnBR2Amj2hry/
-  BdzZd+vuAUiblC7DJ8M9SAMBAHyXAJFKfgoYs9OxBdQqSePVKG8B2B2Vu12yeJWc
-  p00yrqfc6c5IvamRvKZ73EYAbt6uf/5ED969QngFeB4NhSUCH7L1h+67lKVjELw4
-  l2wA4kd2ZxEERfTVRx0/ZptxW2nkVm4iK2R/0DDMDyPZ5VfPo+XA6Y794kWJ/C2E
-  sX9T9ti6GK6taIZ4vdcR04CMFMNfOSrcnMWN4GDP6BQpYEOu2pOHqUpQAinFCSi9
-  umfNdhaPchGiHk2KjvXAgPJ6j4AYGadfM24qT6m8GLEtanL2pFGFNPOw8D03fGkV
-  yhsfHiamgAnnL2mz0khePCn8aTyUMrmSwUc2e5Agj1naMJetd//WnzaPFvWViy+l
-  V+EqUCVP6YPNq8PHD8ZOAy5T8GO+wNahsKiUaxAhn2kjCXhZRqwWDiJLCn3Wge6B
-  n4nHVHtvlw/ptDFyrDP2fUkk1XwmN2StG5y74eVN6HlvrTkwL5HmxQKGlSwZC1gK
-  sNugHSYrj1RUuA==
-  =ik2s
-  -----END PGP PUBLIC KEY BLOCK-----
-
-  ```
-</Accordion>
+When processing payments through Yuno, the platform connects to payment processors. Yuno tokenizes and encrypts the data to ensure security, simplifying the PCI compliance process. However, you are responsible for managing and protecting your customer's data, and for communicating any additional fees or issues to your customers.

--- a/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
+++ b/docs/security-and-compliance/data-migration-processes/token-migration-process.mdx
@@ -36,7 +36,7 @@ Contact your current third-party vault or gateway and request a card-on-file exp
 ```text Export request template
 from: Account Owner <account_owner@yourcompany.com>
 to: Provider Support <support@currentprovider.com>
-cc: Your Yuno business advisor
+cc: [Your Yuno TAM/SE], security-migrations@y.uno
 
 subject: Card-on-file token export request
 
@@ -62,7 +62,7 @@ Regards,
 Request that your current provider includes the Network Transaction ID (NTI) of the last successful transaction for each stored card. Passing the NTI when processing merchant-initiated transactions (MIT) after the migration improves authorization rates and keeps you compliant with card network [stored credentials](/docs/payment-features/stored-credentials) requirements. Many providers only include this column if you explicitly ask for it in the export request.
 </Tip>
 
-Copying your Yuno business advisor on the request creates the introduction between both parties, so Yuno can take over the technical coordination and provide any compliance documents (such as Yuno's PCI DSS Attestation of Compliance) the exporting provider requires.
+Copying your Yuno TAM/SE and [security-migrations@y.uno](mailto:security-migrations@y.uno) on the request creates the introduction between both parties, so Yuno can take over the technical coordination and provide any compliance documents (such as Yuno's PCI DSS Attestation of Compliance) the exporting provider requires.
 
 <Warning>
 **Your responsibilities when migrating tokens**

--- a/docs/security-and-compliance/data-migration-processes/via-api.mdx
+++ b/docs/security-and-compliance/data-migration-processes/via-api.mdx
@@ -1,49 +1,53 @@
 ---
-title: "Via API"
-description: "Walks through migrating customers and enrolling payment methods via the Yuno API endpoints."
+title: "Token Migration via API"
+sidebarTitle: "Via API"
+description: "Step-by-step guide to map migrated cards to Yuno vaulted tokens: create customers, enroll payment methods, and reconcile the results."
 ---
 
-This guide provides a step-by-step process for migrating tokens using the Yuno API endpoints. By following the steps outlined, you will compile a list of customers with their enrolled payment methods.
+This guide covers the final step of the [Token Migration Process](/docs/security-and-compliance/data-migration-processes/token-migration-process): once Yuno has ingested your card export, you use the API to register your customers and enroll each imported card, receiving a Yuno `vaulted_token` for every card.
 
 ## Requirements
 
 Before proceeding with the steps in this guide, ensure you have:
 
-* Completed the three steps related to the [importing cards from a gateway account](/docs/security-and-compliance/data-migration-processes/token-migration-process#importing-cards-from-a-gateway-account-steps-1-and-2) process.
+* Completed steps 1 and 2 of the [Token Migration Process](/docs/security-and-compliance/data-migration-processes/token-migration-process): the export file from your previous provider has been securely transferred to Yuno and ingested.
 * Accessed your [API credentials](/docs/using-yuno/settings/developers-credentials) on the Yuno Dashboard, which include:
   * `public-api-key`
   * `private-secret-key`
   * `account_id`
 
-Make sure you have completed these steps and have the necessary data before continuing with the guide.
+<Tip>
+**Rehearse in sandbox first**
+
+Run your migration script end to end against the sandbox environment (`https://api-sandbox.y.uno`) with test data before executing it in production. This validates your request payloads, error handling, and reconciliation logic without touching real card data.
+</Tip>
 
 ## Migrate tokens via API
 
-### Step 1: Create customers
+<Steps>
+<Step title="Create customers">
 
-To begin the token migration process, you will use the [Create Customer](/reference/create-customer) endpoint to add customers to the Yuno system. It is important to note that payment methods cannot be enrolled for customers who do not exist in the Yuno system. If the customers are already present in Yuno, you may skip this step.
+Use the [Create Customer](/reference/create-customer) endpoint to add customers to the Yuno system. Payment methods cannot be enrolled for customers who do not exist in Yuno. If the customers are already present in Yuno, you may skip this step.
 
-To register new customers, provide their personal information. Additionally, you must supply the `merchant_customer_id`, which is a unique identifier for the customer used in your system.
+To register new customers, provide their personal information. The only mandatory field is `merchant_customer_id`, the unique identifier for the customer in your system.
 
 <Note>
 **Customer complementary information**
 
 When creating a customer, certain information is optional but can enhance the user's payment experience if provided. Examples of non-mandatory data include phone number, billing address, and shipping address.
-
-If you choose to add optional information, ensure that all required mandatory fields are also provided.
 </Note>
 
 Upon completing the customer creation process, you will receive an `id` that identifies the user within the Yuno system. Use this `id` to enroll the existing payment methods.
 
-### Step 2: Check the customer data (optional)
+</Step>
+<Step title="Check the customer data (optional)">
 
-In this step, you have the option to verify the information of each registered customer. Use the [Retrieve Customer](/reference/customers/retrieve-customer) endpoint to access the customer data. To do this, provide the `id` that was generated when the customer was initially created.
+You can verify the information of each registered customer with the [Retrieve Customer](/reference/customers/retrieve-customer) endpoint, providing the `id` generated when the customer was created.
 
-### Step 3: Enroll a payment method
+</Step>
+<Step title="Enroll a payment method">
 
-To complete the migration process, you need to enroll payment methods for each customer using the third-party vault or gateway data.
-
-Utilize the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint to register the payment methods. Remember, the `customer_id` required for this request is the `id` obtained during the customer creation in [Step 1](/docs/security-and-compliance/data-migration-processes/via-api#step-1-create-customers). Additionally, include the `provider_data` object containing the external provider's token, as shown in the code snippet below:
+Enroll each imported card with the [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api) endpoint. The `customer_id` in the URL is the `id` obtained in step 1. Include the `provider_data` object containing the external provider's token from the export file:
 
 ```sh Request
 curl --request POST \
@@ -68,8 +72,63 @@ curl --request POST \
 '
 ```
 
-In the response from the endpoint, you will receive a `vaulted_token` that identifies the enrolled payment method. This `vaulted_token` will be used for future payments, eliminating the need for additional payment method details.
+The response contains the `vaulted_token` that identifies the enrolled payment method, along with the card details Yuno resolved for it:
 
-### Step 4: Check the enrolled payment method (optional)
+```json Response
+{
+  "name": "VISA ****1111",
+  "type": "CARD",
+  "category": "CARD",
+  "country": "BR",
+  "status": "ENROLLED",
+  "vaulted_token": "cbdcc878-ceb4-4dd8-b0f0-49d444855de0",
+  "created_at": "2024-06-06T13:32:49.715656Z",
+  "card_data": {
+    "iin": "41111111",
+    "lfd": "1111",
+    "holder_name": "JOHN DOE",
+    "expiration_month": 3,
+    "expiration_year": 26,
+    "brand": "VISA",
+    "issuer": "JPMORGAN CHASE BANK N A",
+    "category": "CREDIT",
+    "type": "CREDIT",
+    "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
+  }
+}
+```
 
-Once the payment method is enrolled, you can verify its successful enrollment using the [retrieve enrolled payment methods](/reference/retrieve-enrolled-payment-methods-api) endpoint. Remember, the `customer_id` needed for this request is the `id` obtained during the customer creation in [Step 1](/docs/security-and-compliance/data-migration-processes/via-api#step-1-create-customers).
+Store the returned `vaulted_token` against the provider's card token in your database: this mapping is the outcome of the migration, and the `vaulted_token` is what you will send in all future payment requests. The `card_data.fingerprint` lets you [detect duplicate cards](/docs/security-and-compliance/fingerprint) across enrollments.
+
+</Step>
+<Step title="Check the enrolled payment method (optional)">
+
+Verify successful enrollment with the [Retrieve Enrolled Payment Methods](/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api) endpoint, using the same `customer_id` from step 1.
+
+</Step>
+</Steps>
+
+## Running the migration at scale
+
+Migrations typically involve thousands of customers and cards. To run the loop reliably:
+
+* **Use one idempotency key per enrollment attempt.** The `X-Idempotency-Key` header makes retries safe: reusing the same key for the same card guarantees you never create a duplicate enrollment if a request times out and you retry it.
+* **Process incrementally and persist as you go.** Write each `provider token → vaulted_token` mapping to your database as soon as the enrollment succeeds, so an interrupted run can resume where it stopped instead of starting over.
+* **Retry transient failures, quarantine permanent ones.** Retry timeouts and `5xx` responses with backoff. Collect `4xx` failures in a separate list for review instead of retrying them blindly.
+* **Pace your requests.** Spread the migration over a controlled request rate rather than firing the full volume at once. Your Yuno contact can advise on the appropriate throughput for your migration size.
+
+Common error responses from the enrollment endpoint:
+
+| HTTP status | Code | What it means |
+| --- | --- | --- |
+| 400 | `INVALID_REQUEST` | The payload is malformed or a field is invalid. Review the request body and confirm the provider token matches the export file that was imported |
+| 401 | `INVALID_CREDENTIALS` | The `public-api-key` or `private-secret-key` is wrong, or the keys do not match the environment (sandbox vs. production) |
+| 403 | `AUTHORIZATION_REQUIRED` | Your merchant account is not enabled for this API. Contact your Yuno business advisor |
+
+## Reconcile before cutover
+
+When the run finishes, verify it before moving your billing volume to Yuno:
+
+1. Compare the number of rows in the export file against the number of `vaulted_tokens` you stored, and account for every failed row.
+2. Spot-check a sample of enrollments with the [Retrieve Enrolled Payment Methods](/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api) endpoint, confirming the card brand and last four digits match the source data.
+3. Process a small cohort of real payments with migrated tokens before the full cutover, and keep your previous provider active until you have validated the results. See [Before you switch off your old provider](/docs/security-and-compliance/data-migration-processes/token-migration-process#before-you-switch-off-your-old-provider).

--- a/snippets/migration-pgp-key.mdx
+++ b/snippets/migration-pgp-key.mdx
@@ -1,0 +1,89 @@
+### PGP public key
+
+Use our public key to encrypt the PCI-sensitive files you send to Yuno.
+
+| Property        | Value                                                              |
+| ---------------- | ------------------------------------------------------------------ |
+| Email       | [security-migrations@y.uno](mailto:security-migrations@y.uno)      |
+| Comment     | For encrypting sensitive data. Environment: production             |
+| Created     | 22 Nov 2024                                                         |
+| Expires     | 22 Nov 2026                                                         |
+| Key ID      | 73D3D88A                                                            |
+| Length      | 4096                                                                |
+| Algorithm   | RSA                                                                 |
+| Fingerprint | 5160 7134 4C00 D270 93FB C450 19ED AACD 73D3 D88A                   |
+
+<Card title="Public PGP Key" href="https://yuno-public-keys.prod.y.uno/generic-pgp-keys_public_key_production.asc" arrow />
+
+***
+
+<Accordion title="Production Key" icon="fa-info-circle">
+  ```
+  -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+  xsFNBGdAg2sBEAC4NW7xG06SGZcNCFVXreQsW8l3YGdcNo4y2ks0MZw8B1k6BwMJ
+  LqJjkiRouWAmRMCbP0Qauw4UPhhVlrIx9MsFrvJFgi/cnOGnwujVNIuhNw8S8cUZ
+  1K1+5ZAsxuc/hKcSQRH0Hp94UNP76seJgC0U6d422fW2EKG7VN2l1BcM4NlBmOuD
+  cQ+fOds+ACsBAQiQjL5ZA/sh6t/7cjUdCQhNK8eK5vylx1lKhHb6T1IvB+B/a6Pt
+  5xxEKNkBgwdQAucDFLFA3ypZsksy8/t9Y7AYw82Teo3z91cQxqiv1C6T62N3+YZ/
+  b48iNzfkml4kxfq15cNgdpxF+HJ/O6EHzSajbPT3KYsCFW9xS5aYOGTFSfgY+1qL
+  518YP72t9okj5HalUgDp6YCLuSr5ns+Z8t8K+cgGNjy08GwuRJKhDidvZBzgGMw6
+  bWavl1obnfThjb3VIHe0WEx/FQuQGGvJzi2EFI+Rne5nT0Q1ayv99kUglfXNdVOL
+  LDsaCwZwefw2Z7+7hNGiF08NQXxUE05tia5ElsmSl9Mo0OeG7UsVuYHVqwDnLs4W
+  dC6br3S3p9XKG9mopXOn8Y4Iu9WMhW3ZZHOlrFCzHip5PyBIyl3265LWfs/If8dc
+  vCKDXC/Hgjxdy7yNzgqguqgwJRnMrXrHx6s3MMHw/1YhNM6uwUjg3WADwwARAQAB
+  zW5zZWN1cml0eS1taWdyYXRpb25zQHkudW5vIChGb3IgZW5jcnlwdGluZyBzZW5z
+  aXRpdmUgZGF0YS4gRW52aXJvbm1lbnQ6IHByb2R1Y3Rpb24pIDxzZWN1cml0eS1t
+  aWdyYXRpb25zQHkudW5vPsLBiAQTAQgAMgUCZ0CDbAIbDgUJA8JnAAILCQIVCAIW
+  AgIeARYhBFFgcTRMANJwk/vEUBntqs1z09iKAAoJEBntqs1z09iKXJQQAIvBv0sa
+  C9Brd4ylSzznZdQQoGIilsGoeiWLNV6Gh6YEODspWljjeYKQl6SEb3NsoVrpB7A5
+  5UNYMGykcvly+fR8UvhNEiJO6vTVCRZnYU43MYLgC35CPj1798egw50GusVoSjKu
+  960tMOz6DUh3yBO2VSxveaOQ6pIYNqi4HtVFIzvcrpgY1/wIV4jpyYnRtJQEt+M4
+  LjD9rnkl7eGHeYQV6tpMjoMkLSWApdk5aDoUqmkvXae5aa7ab7iH/7p53oXxVQM7
+  lqjuNGTgmiJ48gcyHp6aF6M1hbNpoekS63FoGgSRr1h+oB1NlqCokhP8tIjbNbAv
+  rh3371lfPS8dmVq6rUYQwGxHt1XS5682wRw0ZdvsiGY7VjuZAHgGi0f2cEh3dsqy
+  Xa3+rbQ1vKX6lIvmmqPiv7Ggo2LLJXfRfg3Q8s35CCvccz1qQcuUl+HI8NQLbiyW
+  mpelG0+sOl7KHYg7c0HpS8756Eax3sSnr57Jb7Rx88NIF+hH8zE8kBL6OHkFnE+L
+  yLIbCYzmCSxK0ktvcnMjYb1BGmPxfSWgPEyXrI34MtfyRXpeLaDSBfKzGNL8fLLT
+  olLEABrWmn6Xvj6DeZAA+xoFmTUqdLYsZ/i/RLZ5lzQv3xp8Uks09dy2mm/dAVxS
+  4lox2wuJRalx5MZkqrSRZAkjyQMu6EwGiiQ1zsFNBGdAg2wBEACutTIUvApmEQkX
+  EBcAmDFUkQSquiR4EhmW8icPPWTabszNZu3LXLf/ou1v/dcLvkyyDUFZIezYUwdx
+  UXBYDFrXmPqddSx5TOSCOvY79pKrrx5S//40RTs9PM2eC1ufggT7fGVvNj8irYPh
+  jUDtI8LzQXedAMWNB5PLXPZEBnEnaE45PU0s5nREoLK14ldEQl1nCAqAFlEPTztQ
+  C+ILAprwSZ3qnj0pGYy+uRfmIZD51KpriGdRQqWDdbImM28SNh7tv3jPQenm5oCG
+  cavOZzhA54B+w2Hgc4aGER0qY5eZsd/YEGaVevjGHaEDE/Xm6ctMSuLKgg6A/zNH
+  F7kKcS1/5uXXQ0mlk15zRgMJcxNctrKFIYW78R1ECY8vIdN0aMd2/fRgaawwuTz2
+  WcTlLgsG84bAKcccsQnTwCOBxHR8qt3u+GKCEkIcaQVC/FNjP47iSzyWb1a0KeEV
+  4TJ9RtWdlj1DK3alGkvbexuCzqZ+1p8O+lCIsEiL5Cz3YeLfLebph1Z40o0HdGw3
+  XS/e0GnaBZpqzo4MCqud26x9fYX9kP+SHzNAacSSLfc/WJvJOLyuIDXvwiJu7QDC
+  SDMeS4vLiBmfcfYiBxUKXteRcS2g/9B5tkzKVLWv9xkMXIhsxsyIFDiepUoT4uEN
+  zPvOR8fbpzI+XkNdAOpm6gKyCTRxeQARAQABwsOsBBgBCAAgBQJnQINtAhsMFiEE
+  UWBxNEwA0nCT+8RQGe2qzXPT2IoCQAkQGe2qzXPT2IrBdCAEGQEIAB0FAmdAg20W
+  IQRAK7d6Jh6QEsLrtCje87+APhkLfwAKCRDe87+APhkLf9AqD/9QmNmEaSUZ6ujy
+  7resqaWT4nSMErhT3TNM8B1FPwF63Igt0HUnKqe4XSy840kKJsTY+ssGcLpbTTxv
+  CX/DLtR7No5G1WBAr3MZos7GfFhnb2tApDzQdmucHliKLVe2zSiyqvMGiK1irvXy
+  GKi6Dfvoobw54qkCeD7upz+z6eZAQYnDqh2xlGl7uc6OcgaJgctMhOA8jhlmLIrz
+  gk/MBXRgZXGfJ0/DZe2JTl7vw3XIUB62XnV3vpHU/UxM5UWpA87m14Lh8SNAvT+l
+  L8Y1wZ5DcQ1g83oO5NI/DwWorlqOeyhRU8a1a3Kd0aZ6bSWCbZadU4c6ciwvwpnS
+  MQ5nc4iX1bFsuN8z8WGQ/io4cPMXQbNFBQ22OgnSpxEVS3akDkQOJ25hJeUZaFZU
+  91CJVlknQipwvpVG3RuuOvTJstYxTKJ8Leg1IB0zo7QhlaMNTu/yWyr0WoJO52Jh
+  IMoykpfPY6gowKBGi6EZpNjiKoyElkBU1js47wMdqONfBZxyupJpAM2GeBWs0cYS
+  j7pUL68ah/RMslMuC6rKtjDytVChQJz/nXcxDQeBliYMMedDP3a6FksBmmdJKphw
+  ZbmVGAbNJd2TSFEsiYZjPJ+bH8SafjcRVVqaRw3cGReyJmwv1EhxhZR+dsZAjdnB
+  RX0jQSGjQjcWfyUTGmnpipgCNnJOkEFrEACm4QErrplv2jIAADFytyk/VL+3D6RB
+  0XTrhb0FqLgmVEqYJPuh9z3KkMpQQk9spd3uNBkuBGkTehf4WBWIRcGWIChpVNb+
+  YabmXfqxYhoRKnhoMS4vRfOZJbdzdBZ7tsjsz072kGi03nK9/B5RnBR2Amj2hry/
+  BdzZd+vuAUiblC7DJ8M9SAMBAHyXAJFKfgoYs9OxBdQqSePVKG8B2B2Vu12yeJWc
+  p00yrqfc6c5IvamRvKZ73EYAbt6uf/5ED969QngFeB4NhSUCH7L1h+67lKVjELw4
+  l2wA4kd2ZxEERfTVRx0/ZptxW2nkVm4iK2R/0DDMDyPZ5VfPo+XA6Y794kWJ/C2E
+  sX9T9ti6GK6taIZ4vdcR04CMFMNfOSrcnMWN4GDP6BQpYEOu2pOHqUpQAinFCSi9
+  umfNdhaPchGiHk2KjvXAgPJ6j4AYGadfM24qT6m8GLEtanL2pFGFNPOw8D03fGkV
+  yhsfHiamgAnnL2mz0khePCn8aTyUMrmSwUc2e5Agj1naMJetd//WnzaPFvWViy+l
+  V+EqUCVP6YPNq8PHD8ZOAy5T8GO+wNahsKiUaxAhn2kjCXhZRqwWDiJLCn3Wge6B
+  n4nHVHtvlw/ptDFyrDP2fUkk1XwmN2StG5y74eVN6HlvrTkwL5HmxQKGlSwZC1gK
+  sNugHSYrj1RUuA==
+  =ik2s
+  -----END PGP PUBLIC KEY BLOCK-----
+
+  ```
+</Accordion>


### PR DESCRIPTION
## What

Rewrites the two core token migration pages and dedupes the shared PGP key block, benchmarked against best-in-class competitor migration docs (Basis Theory's import/export card-on-file guides).

### `token-migration-process`
- **Who does what** table (merchant / Yuno / current provider per phase)
- Copy-paste **export request email template** for the incumbent provider, cc'ing the Yuno business advisor
- **NTI guidance**: tip telling merchants to explicitly request Network Transaction IDs in the export, linked to stored-credentials (preserves MIT auth rates after cutover)
- Requirements table with purpose per item, **example export CSV**, and file hygiene rules
- **What can and cannot be migrated**: cards, network tokens, wallet DPANs (non-portable), APM tokens
- Data format bullets replaced with **API field mapping tables** (verified against the OpenAPI specs in this repo)
- New **"Before you switch off your old provider"** reconciliation/cutover-safety section

### `via-api`
- Title → "Token Migration via API" (sidebar label and slug unchanged, no links break)
- Steps component, plus a **201 response example** taken from `openapi/payment-methods-direct-workflow/enroll-payment-method-api.json`
- New **"Running the migration at scale"** section: idempotency keys, resume-safe persistence, retry vs quarantine, pacing
- **Error table** (400/401/403 from the spec) and a **"Reconcile before cutover"** checklist
- Sandbox rehearsal tip; fixed a requirement link that pointed at a removed heading anchor

### Dedup
- The identical 88-line PGP key block on both import pages is now `snippets/migration-pgp-key.mdx`, so the Nov 2026 key rotation is a one-file change

## Notes for reviewers

No SLA numbers or rate limits were invented; those are phrased as "your Yuno contact will advise". Three assertions deserve a quick SEGINF/DX sanity check:
1. The CSV hygiene rules (consistent column count, explicit empty values, no line breaks)
2. The wallet DPAN portability wording
3. The 400 `INVALID_REQUEST` row in the error table

## Verification

- `mint validate` passes
- `mint broken-links` clean
- Both pages verified rendering locally with `mint dev` (tables, Steps, callouts, snippet import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)