### PR TITLE
docs(YSHUB-6308): remove unsupported mount arguments from Web Full and Seamless

### DIFF
--- a/docs/sdks/full-checkout/web-payments.mdx
+++ b/docs/sdks/full-checkout/web-payments.mdx
@@ -158,15 +158,6 @@ Display the payment methods:
 await yuno.mountCheckout();
 ```
 
-Alternatively, mount with a default payment method selected:
-
-```javascript
-await yuno.mountCheckout({
-  paymentMethodType: PAYMENT_METHOD_TYPE,
-  vaultedToken: VAULTED_TOKEN,
-});
-```
-
 ### Step 5: Initiate the payment process
 
 Call `await yuno.startPayment()` to initiate the payment flow after the user selects a payment method:

--- a/docs/sdks/seamless-sdk/web-payments.mdx
+++ b/docs/sdks/seamless-sdk/web-payments.mdx
@@ -178,18 +178,11 @@ The step-by-step on this page refers to a customer-initiated transaction without
 
 ## Step 5: Mount the SDK
 
-To present the checkout process based on the selected payment method, use the `await yuno.mountSeamlessCheckout()` function. This step ensures the SDK is properly mounted on your chosen HTML element.
+To present the checkout process, use the `await yuno.mountSeamlessCheckout()` function. This step ensures the SDK is properly mounted on your chosen HTML element.
 
 ```javascript
-await yuno.mountSeamlessCheckout({
-  paymentMethodType: PAYMENT_METHOD_TYPE,
-  vaultedToken: VAULTED_TOKEN,
-});
+await yuno.mountSeamlessCheckout();
 ```
-
-See the [Payment type](/reference/payment-type-list) page to view the complete list of payment method types you can use when mounting the SDK.
-
-The `vaultedToken` is optional. It represents a previously enrolled payment method. If you provide the `vaultedToken`, the user will not be required to provide the payment information again since it was provided in a previous transaction.
 
 After mounting, you must start the checkout flow by calling `await yuno.startPayment()`. If you skip this call, the payment form will not open.
 
@@ -198,10 +191,7 @@ After mounting, you must start the checkout flow by calling `await yuno.startPay
 Call `await yuno.startPayment()` immediately after `await yuno.mountSeamlessCheckout()` to open the selected payment method UI:
 
 ```javascript
-await yuno.mountSeamlessCheckout({
-  paymentMethodType: PAYMENT_METHOD_TYPE,
-  vaultedToken: VAULTED_TOKEN,
-});
+await yuno.mountSeamlessCheckout();
 
 await yuno.startPayment();
 ```


### PR DESCRIPTION
## Context

Reported in [YSHUB-6308](https://yunopayments.atlassian.net/browse/YSHUB-6308): a merchant followed the Full checkout docs to preselect a payment method via `mountCheckout({ paymentMethodType: 'PIX' })` and the parameter had no effect — no error, no warning. While tracing it we found the Seamless page documents the same unsupported pattern.

## What's wrong

Both pages document mounting with a payment method selected by default:

```javascript
await yuno.mountCheckout({ paymentMethodType: PAYMENT_METHOD_TYPE, vaultedToken: VAULTED_TOKEN });
await yuno.mountSeamlessCheckout({ paymentMethodType: PAYMENT_METHOD_TYPE, vaultedToken: VAULTED_TOKEN });
```

That behavior did exist, but it was removed in **July 2025**. In the current SDK neither `mountCheckout()` nor `mountSeamlessCheckout()` accepts any arguments, so the object is silently discarded.

Confirmed with the team that this is **by design**, not a bug. Preselection in the Full and Seamless checkouts is driven by the payment method ordering — enrolled methods first, then the order configured in the Checkout builder — and the first method in the resulting list is the one that gets preselected.

## Changes

**`docs/sdks/full-checkout/web-payments.mdx`** (Step 4) — removes the "Alternatively, mount with a default payment method selected" block. The valid `await yuno.mountCheckout();` example above it is kept.

**`docs/sdks/seamless-sdk/web-payments.mdx`** (Steps 5 and 6) — both snippets now call `await yuno.mountSeamlessCheckout();` with no arguments. Also drops the two paragraphs that only existed to explain the removed parameters (the *Payment type* link and the `vaultedToken` note), and the "based on the selected payment method" phrasing that no longer describes what the method does.

## Not touched

`paymentMethodType` and `vaultedToken` stay documented where they are still supported — `mountCheckoutLite`, `mountSeamlessCheckoutLite` and the external buttons setup. Changelog entries and migration guides are left as-is since they record what was true in past versions. Other platforms (Flutter, React Native, iOS, Android) are out of scope.

## Related

Same correction applied to the example repo README in [yuno-sdk-web#157](https://github.com/yuno-payments/yuno-sdk-web/pull/157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[YSHUB-6308]: https://yunopayments.atlassian.net/browse/YSHUB-6308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ