### PR TITLE
[SUB-64] Document clearing availability.finish_at on Update Subscription

### DIFF
--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -227,7 +227,7 @@
                   },
                   "availability": {
                     "type": "object",
-                    "description": "Specifies the `availability` object. Defines a date interval based on starting and ending dates when the subscription is available to use.",
+                    "description": "Specifies the `availability` object. Defines a date interval based on starting and ending dates when the subscription is available to use. If this object is omitted from the request, the availability dates are left unchanged.",
                     "properties": {
                       "start_at": {
                         "type": "string",
@@ -235,8 +235,8 @@
                         "format": "date-time"
                       },
                       "finish_at": {
-                        "type": "string",
-                        "description": "The end date until the subscription plan will be available to use. If not defined, the subscription does not have an expiration date.",
+                        "type": ["string", "null"],
+                        "description": "The end date until the subscription will be available to use. Send an explicit `null` to clear a previously set end date: the subscription becomes open-ended and keeps renewing until it is canceled. Send a date-time to update the end date. Note that `availability.finish_at` and `billing_cycles.total` are independent end conditions: whichever is reached first completes the subscription.",
                         "format": "date-time"
                       }
                     }

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -227,7 +227,7 @@
                   },
                   "availability": {
                     "type": "object",
-                    "description": "Specifies the `availability` object. Defines a date interval based on starting and ending dates when the subscription is available to use. If this object is omitted from the request, the availability dates are left unchanged.",
+                    "description": "Specifies the `availability` object. Defines a date interval based on starting and ending dates when the subscription is available to use. If this object is omitted from the request, the availability dates are left unchanged. When it is included, the interval is applied as sent: omitting `finish_at` (or sending it as `null`) removes any previously set end date.",
                     "properties": {
                       "start_at": {
                         "type": "string",
@@ -235,8 +235,11 @@
                         "format": "date-time"
                       },
                       "finish_at": {
-                        "type": ["string", "null"],
-                        "description": "The end date until the subscription will be available to use. Send an explicit `null` to clear a previously set end date: the subscription becomes open-ended and keeps renewing until it is canceled. Send a date-time to update the end date. Note that `availability.finish_at` and `billing_cycles.total` are independent end conditions: whichever is reached first completes the subscription.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "The end date until the subscription will be available to use. When the `availability` object is included in the request, omit this field or send `null` to clear a previously set end date: the subscription becomes open-ended and keeps renewing until it is canceled. Send a date-time to set or update the end date. Note that `availability.finish_at` and `billing_cycles.total` are independent end conditions: whichever is reached first completes the subscription.",
                         "format": "date-time"
                       }
                     }

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -221,11 +221,11 @@
                   },
                   "availability": {
                     "type": "object",
-                    "description": "Specifies the `availability` object. Defines a date interval based on starting and ending dates when the subscription is available to use. If this object is omitted from the request, the availability dates are left unchanged. When it is included, the interval is applied as sent: omitting `finish_at` (or sending it as `null`) removes any previously set end date.",
+                    "description": "Specifies the `availability` object. Defines a date interval based on starting and ending dates when the subscription is available to use. If this object is omitted from the request, the availability dates are left unchanged. When it is included, omitting `finish_at` (or sending it as `null`) removes any previously set end date; omitting `start_at` leaves the current start date unchanged.",
                     "properties": {
                       "start_at": {
                         "type": "string",
-                        "description": "The start date that the subscription plan will be available to use. If not set, the subscription is available from the moment it is created.",
+                        "description": "The start date that the subscription plan will be available to use. If not set, the subscription is available from the moment it is created. On update, omitting this field leaves the current start date unchanged, and the start date can only be moved earlier: sending a later date returns a 400 error.",
                         "format": "date-time"
                       },
                       "finish_at": {

--- a/reference/subscriptions/update-subscription.mdx
+++ b/reference/subscriptions/update-subscription.mdx
@@ -9,7 +9,7 @@ description: "Updates a subscription's fields, including retroactively adding st
 
 The fields `billing_cycles` and `availability.finish_at` have an impact on each other. If both are completed during the subscription creation, it will transition to the `COMPLETED` state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`. They are independent end conditions: whichever is reached first completes the subscription.
 
-To remove a previously set end date, send `availability.finish_at` with an explicit `null` value. The subscription becomes open-ended and keeps renewing until it is canceled. Omitting the `availability` object leaves the end date unchanged.
+The `availability` interval is applied as sent. To remove a previously set end date, send the `availability` object with `finish_at` as `null` or without the `finish_at` field: the subscription becomes open-ended and keeps renewing until it is canceled. This means that when you update `availability.start_at`, you must include `finish_at` in the same request if you want to keep the end date. Omitting the whole `availability` object leaves both dates unchanged.
 </Warning>
 
 <Note>

--- a/reference/subscriptions/update-subscription.mdx
+++ b/reference/subscriptions/update-subscription.mdx
@@ -9,7 +9,9 @@ description: "Updates a subscription's fields, including retroactively adding st
 
 The fields `billing_cycles` and `availability.finish_at` have an impact on each other. If both are completed during the subscription creation, it will transition to the `COMPLETED` state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`. They are independent end conditions: whichever is reached first completes the subscription.
 
-The `availability` interval is applied as sent. To remove a previously set end date, send the `availability` object with `finish_at` as `null` or without the `finish_at` field: the subscription becomes open-ended and keeps renewing until it is canceled. This means that when you update `availability.start_at`, you must include `finish_at` in the same request if you want to keep the end date. Omitting the whole `availability` object leaves both dates unchanged.
+When the `availability` object is included, `finish_at` is applied as sent: omit it or send it as `null` and any previously set end date is removed, so the subscription becomes open-ended and keeps renewing until it is canceled. This means that when you update `availability.start_at`, you must include `finish_at` in the same request if you want to keep the end date. `start_at` does not behave this way: omitting it leaves the current start date unchanged. Omitting the whole `availability` object leaves both dates unchanged.
+
+Note that `availability.start_at` can only be moved earlier on update. Sending a later date returns a 400 error: `The availability start date cannot be greater than the current availability start date`.
 </Warning>
 
 <Note>

--- a/reference/subscriptions/update-subscription.mdx
+++ b/reference/subscriptions/update-subscription.mdx
@@ -7,7 +7,9 @@ description: "Updates a subscription's fields, including retroactively adding st
 <Warning>
 **Subscription Transition**
 
-The fields `billing_cycles` and `availability.finish_at` have an impact on each other. If both are completed during the subscription creation, it will transition to the `COMPLETED` state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`.
+The fields `billing_cycles` and `availability.finish_at` have an impact on each other. If both are completed during the subscription creation, it will transition to the `COMPLETED` state upon reaching the nearest event defined in these fields, whether it is the billing cycle or the corresponding `finish_at`. They are independent end conditions: whichever is reached first completes the subscription.
+
+To remove a previously set end date, send `availability.finish_at` with an explicit `null` value. The subscription becomes open-ended and keeps renewing until it is canceled. Omitting the `availability` object leaves the end date unchanged.
 </Warning>
 
 <Note>


### PR DESCRIPTION
## What

Documents the `availability` behavior of **Update Subscription** (`PATCH /subscriptions/{id}`), which was previously undocumented and is now live:

- `availability.finish_at` is explicitly nullable (`"type": ["string", "null"]`). When the `availability` object is included in the request, **sending `finish_at` as `null` or omitting it** clears a previously set end date, and the subscription becomes open-ended: it keeps renewing until it is canceled.
- Omitting the whole `availability` object leaves both dates unchanged. `start_at` is never cleared by omission.
- Clarifies that `availability.finish_at` and `billing_cycles.total` are independent end conditions: whichever is reached first completes the subscription.
- Documents the pre-existing validation that `start_at` can only be moved earlier on update.

## Why

Until this change, sending `finish_at: null` on update returned `200` and silently kept the date, so an end date could never be removed once set. The workaround merchants were given was to set a far-future date instead.

The important consequence to document is that omitting `finish_at` inside a present `availability` object clears the end date, exactly like an explicit `null`. That is why the reference page now states that you must resend `finish_at` when you update `start_at` if you want to keep the end date.

## Verified against staging

Every row was run against the live API and followed by a `GET` to confirm what persisted.

| Request body | HTTP | Resulting availability |
|---|---|---|
| `{"availability":{"finish_at":"2026-12-15T00:00:00Z"}}` | 200 | end date set to 2026-12-15 |
| `{"description":"..."}` with no `availability` object | 200 | unchanged, end date still 2026-12-15 |
| `{"availability":{"finish_at":null}}` | 200 | end date cleared |
| `{"availability":{"start_at":"2026-07-20T00:00:00Z"}}`, no `finish_at` | 200 | start date moved, end date cleared |
| `{"availability":{"start_at":"2027-01-01T00:00:00Z", ...}}`, later start | 400 | `The availability start date cannot be greater than the current availability start date` |

Row 2 is the guard worth calling out: a request that does not mention `availability` at all leaves both dates alone, so the clearing behavior is scoped to requests that already touch `availability`.

## Files

- `openapi/subscriptions/update-subscription.json` — `availability` and `finish_at` schema and descriptions
- `reference/subscriptions/update-subscription.mdx` — warning block on end conditions, how to clear, and the `start_at` validation
