### PR TITLE
chore: web sdk changelog 1.10.3

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,54 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.3",
+      "release_date": "2026-08-05",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.3",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Dead analytics events cleanup",
+          "description": "Removes 17 analytics emit methods that had zero callers (verified against develop plus a cross-repo audit of the card iframe and mobile SDKs), including the miswired `securityCodeForm.*` methods that emitted `enrollStatus_pageViewed`. No emitted event changes: every event that fires today keeps firing; `enrollPaymentMethodForm_submitted` keeps its live inline emitter and `payment_created` stays reserved for the audit pipeline.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Null onInstallmentSelected event when installments become unavailable",
+          "description": "The `onInstallmentSelected` callback now fires with a `null` payload when installment options that were previously notified become unavailable — most commonly when the shopper switches from a card with installments to a card without them. The null event only fires if a real installment selection was notified before; forms where installments were never available stay silent. Callback invocations are also wrapped so a merchant handler that throws on `null` cannot break the card form. Applies to new-card, secure-fields, enrolled-card, and Click to Pay flows.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Phone Country Code Autofill From Customer",
+          "description": "The checkout form phone country-code dropdown now preselects the country matching the customer's phone prefix sent at session creation, disambiguated by the customer's country, instead of always defaulting to the session country.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Environment-Aware 3DS Host Resolution",
+          "description": "Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time. A bundle built for one environment (e.g. prod) but run against another (e.g. sandbox) was sending an environment-mismatched 3DS session token to the wrong `sdk-3ds.<env>.y.uno` host, where the session-binding verifier rejected it with 403 Forbidden and the challenge never loaded. The API and WebSocket hosts already resolve per environment this way; the 3DS host now does too. Backward-compatible: a concrete host with no `_ENVIRONMENT_` placeholder passes through unchanged.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18291",
+        "CORECM-18475",
+        "CORECM-18795",
+        "YSHUB-6348"
+      ]
+    },
+    {
       "version": "1.10.2",
       "release_date": "2026-08-03",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -60,7 +60,7 @@
         {
           "type": "CHANGED",
           "title": "PayPal Enrollment",
-          "description": "Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
+          "description": "Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.",
           "group": null,
           "migration_guide": null,
           "links": []
@@ -68,27 +68,6 @@
       ],
       "consumed_tickets": [
         "VULS-3673",
-        "YSHUB-6262"
-      ]
-    },
-    {
-      "version": "1.9.24",
-      "release_date": "2026-08-03",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.24",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "CHANGED",
-          "title": "PayPal Enrollment",
-          "description": "Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.",
-          "group": null,
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
         "YSHUB-6262"
       ]
     },
@@ -250,6 +229,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.24",
+      "release_date": "2026-08-03",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.24",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "PayPal Enrollment",
+          "description": "Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6262"
       ]
     },
     {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,11 +5,36 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.3
+*August 5, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Dead analytics events cleanup**  
+  Removes 17 analytics emit methods that had zero callers (verified against develop plus a cross-repo audit of the card iframe and mobile SDKs), including the miswired `securityCodeForm.*` methods that emitted `enrollStatus_pageViewed`. No emitted event changes: every event that fires today keeps firing; `enrollPaymentMethodForm_submitted` keeps its live inline emitter and `payment_created` stays reserved for the audit pipeline.
+
+- <ChangelogBadge type="fixed" /> **Phone Country Code Autofill From Customer**  
+  The checkout form phone country-code dropdown now preselects the country matching the customer's phone prefix sent at session creation, disambiguated by the customer's country, instead of always defaulting to the session country.
+
+**Card Payments**
+
+- <ChangelogBadge type="added" /> **Null onInstallmentSelected event when installments become unavailable**  
+  The `onInstallmentSelected` callback now fires with a `null` payload when installment options that were previously notified become unavailable — most commonly when the shopper switches from a card with installments to a card without them. The null event only fires if a real installment selection was notified before; forms where installments were never available stay silent. Callback invocations are also wrapped so a merchant handler that throws on `null` cannot break the card form. Applies to new-card, secure-fields, enrolled-card, and Click to Pay flows.
+
+- <ChangelogBadge type="fixed" /> **Environment-Aware 3DS Host Resolution**  
+  Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time. A bundle built for one environment (e.g. prod) but run against another (e.g. sandbox) was sending an environment-mismatched 3DS session token to the wrong `sdk-3ds.<env>.y.uno` host, where the session-binding verifier rejected it with 403 Forbidden and the challenge never loaded. The API and WebSocket hosts already resolve per environment this way; the 3DS host now does too. Backward-compatible: a concrete host with no `_ENVIRONMENT_` placeholder passes through unchanged.
+
 ## v1.10.2
 *August 3, 2026*
 
 - <ChangelogBadge type="changed" /> **PayPal Enrollment**  
-  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
+  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.
+
+## v1.9.24
+*August 3, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
+  Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.
 
 ## v1.10.1
 *July 30, 2026*
@@ -79,12 +104,6 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
-
-## v1.9.24
-*August 3, 2026*
-
-- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
-  Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
 
 ## v1.9.23
 *July 31, 2026*

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -28,13 +28,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 *August 3, 2026*
 
 - <ChangelogBadge type="changed" /> **PayPal Enrollment**  
-  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.
-
-## v1.9.24
-*August 3, 2026*
-
-- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
-  Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring showPaymentStatus.
+  Resolve the payment status reported to the merchant from the server instead of assuming SUCCEEDED when PayPal approves, and avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
 
 ## v1.10.1
 *July 30, 2026*
@@ -104,6 +98,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
+
+## v1.9.24
+*August 3, 2026*
+
+- <ChangelogBadge type="changed" /> **PayPal Enrollment**  
+  Avoid double error handling when the payment lookup fails after approval — the error screen or merchant error callback now fires exactly once, honoring `showPaymentStatus`.
 
 ## v1.9.23
 *July 31, 2026*


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.3`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.4

4 entries.