### PR TITLE
chore: web sdk changelog 1.9.25

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.25",
+      "release_date": "2026-08-06",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.25",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed showPaymentStatus on Payment Failures",
+          "description": "When showPaymentStatus is set to false, the SDK no longer renders the full-screen \"Transaction failed\" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6355"
+      ]
+    },
+    {
       "version": "1.10.3",
       "release_date": "2026-08-05",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,27 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.25",
-      "release_date": "2026-08-06",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.25",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Fixed showPaymentStatus on Payment Failures",
-          "description": "When showPaymentStatus is set to false, the SDK no longer renders the full-screen \"Transaction failed\" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.",
-          "group": "Payment Actions",
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
-        "YSHUB-6355"
-      ]
-    },
-    {
       "version": "1.10.3",
       "release_date": "2026-08-05",
       "upgrade": {
@@ -250,6 +229,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.25",
+      "release_date": "2026-08-06",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.25",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed showPaymentStatus on Payment Failures",
+          "description": "When showPaymentStatus is set to false, the SDK no longer renders the full-screen \"Transaction failed\" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6355"
       ]
     },
     {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,14 +5,6 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
-## v1.9.25
-*August 6, 2026*
-
-**Payment Actions**
-
-- <ChangelogBadge type="fixed" /> **Fixed showPaymentStatus on Payment Failures**  
-  When showPaymentStatus is set to false, the SDK no longer renders the full-screen "Transaction failed" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.
-
 ## v1.10.3
 *August 5, 2026*
 
@@ -106,6 +98,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
+
+## v1.9.25
+*August 6, 2026*
+
+**Payment Actions**
+
+- <ChangelogBadge type="fixed" /> **Fixed showPaymentStatus on Payment Failures**  
+  When showPaymentStatus is set to false, the SDK no longer renders the full-screen "Transaction failed" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.
 
 ## v1.9.24
 *August 3, 2026*

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.25
+*August 6, 2026*
+
+**Payment Actions**
+
+- <ChangelogBadge type="fixed" /> **Fixed showPaymentStatus on Payment Failures**  
+  When showPaymentStatus is set to false, the SDK no longer renders the full-screen "Transaction failed" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.
+
 ## v1.10.3
 *August 5, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.25`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.25

1 entry.