### PR TITLE
docs(subscriptions): billing_cycles.paid on the subscription object (SUB-54) — HOLD until Tue deploy

### DIFF
--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -179,6 +179,12 @@ This object represents a subscription that can be associated with a customer.
       Example: 2
     </ParamField>
 
+    <ParamField body="paid" type="number">
+      Number of billing cycles with a confirmed successful payment. Unlike `current`, which tracks the cycle being billed, `paid` only counts cycles whose payment succeeded. `0` for subscriptions created before this field was introduced.
+
+      Example: 1
+    </ParamField>
+
     <ParamField body="next_at" type="Timestamp">
       The date of the next payment for the subscription.
 


### PR DESCRIPTION
**DRAFT — merge only after the Tue Aug-11 train deploys** (merging publishes).

Documents the new `billing_cycles.paid` field ([SUB-54](https://yunopayments.atlassian.net/browse/SUB-54), Dani's call 2026-08-06: expose the confirmed-paid cycle count in responses and webhooks). Engine yuno-payments/subscription-ms#323 · payment-api #828 · public-api #2089.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SUB-54]: https://yunopayments.atlassian.net/browse/SUB-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ