### PR TITLE
docs(C2-18121): document the security code expression on the forward proxy

### DIFF
--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -35,15 +35,52 @@ Proxy requests detokenize card data and must only be made from your backend. Nev
     }
     ```
 
-    The card fields you can reference are `number`, `expiration_month`, `expiration_year`, and `holder_name` — they resolve to the stored **card (PAN) data**. If the card has a **network token**, you can also reference `network_token_number` (the DPAN), `network_token_expiration_month`, and `network_token_expiration_year`. And `network_transaction_id` resolves to the card's NTID — the scheme's reference for its original transaction, required by many processors for merchant-initiated transactions. All fields can be mixed in the same request — send your processor whatever it needs: PAN, DPAN + NTID, or a combination. Provider tokens are not resolved, and neither are cryptograms — a cryptogram is generated per transaction, so if your destination requires one, obtain it separately and include the value directly in the body.
+    The card fields you can reference are `number`, `expiration_month`, `expiration_year`, and `holder_name` — they resolve to the stored **card (PAN) data**. If the card was enrolled with a security code, you can also reference `security_code`, within a bounded window — see below. If the card has a **network token**, you can also reference `network_token_number` (the DPAN), `network_token_expiration_month`, and `network_token_expiration_year`. And `network_transaction_id` resolves to the card's NTID — the scheme's reference for its original transaction, required by many processors for merchant-initiated transactions. All fields can be mixed in the same request — send your processor whatever it needs: PAN, DPAN + NTID, or a combination. Provider tokens are not resolved, and neither are cryptograms — a cryptogram is generated per transaction, so if your destination requires one, obtain it separately and include the value directly in the body.
 
     Expressions work in the request body and in header values. Everything that is not an expression is forwarded untouched.
 
     <Warning>
-    **No CVV**
+    **The security code expires — by default 3 hours after enrollment**
 
-    Transmitting a raw security code keeps that request in your PCI scope. There is no placeholder for the CVV/CVC: card networks do not allow it to be stored after a payment is authorized, so a stored payment method has none to inject. If your destination requires the CVV, your customer must supply it and you include it directly in the body yourself; the proxy forwards it without storing it.
+    `security_code` is the one field with a lifetime. The security code is never stored: it is held briefly after your customer enters it, and Yuno stops serving it once that window closes. Reference it only for a charge that happens shortly after enrollment.
+
+    When it is unavailable — expired, or never captured — the forward fails with `EXPRESSION_RESOLUTION_FAILED` naming `security_code`, and **no** partial substitution happens. Your PAN expressions are unaffected: an expired security code costs you that field only.
+
+    If your destination requires the CVV outside that window, your customer must supply it and you include it directly in the body yourself; the proxy forwards it without storing it. Transmitting a raw security code keeps that request in your PCI scope.
     </Warning>
+
+    #### Storing a security code
+
+    A card only has a security code to inject if one was supplied when it was enrolled. Send it as `card.security_code` on [Enroll Payment Method](/reference/payment-methods-direct-workflow/enroll-payment-method-api):
+
+    ```json
+    {
+      "customer_id": "...",
+      "card": {
+        "number": "4111111111111111",
+        "expiration_month": 12,
+        "expiration_year": 2030,
+        "holder_name": "JOHN DOE",
+        "security_code": "123"
+      }
+    }
+    ```
+
+    Enroll without it and the card is still usable for every other expression — only `security_code` will be unavailable.
+
+    #### Checking how much of the window is left
+
+    Read `card_data.security_code_expires_in` from [Retrieve Enrolled Payment Method](/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api):
+
+    | Value | Meaning |
+    |---|---|
+    | A positive number | Seconds left before the security code stops being available |
+    | `-1` | The window has closed; the security code can no longer be injected |
+    | Field absent | The card was enrolled without a security code, or your organization does not have the proxy enabled |
+
+    <Note>
+    The enrollment response does **not** include `security_code_expires_in`. Read it from the payment method endpoint above when you need to know where you stand before building a forward.
+    </Note>
   </Step>
 
   <Step title="Send it through the proxy">

--- a/docs/security-and-compliance/pci-proxy/overview.mdx
+++ b/docs/security-and-compliance/pci-proxy/overview.mdx
@@ -59,9 +59,9 @@ These expressions resolve a vaulted token to the data stored with it: the card (
 </Note>
 
 <Note>
-**No `vaulted_token` expression for the security code (CVV)**
+**The security code (CVV) expression has a lifetime**
 
-Card networks do not allow the security code to be stored after a payment is authorized, so a stored payment method has no CVV to inject — there is no `{{vaulted_token.<TOKEN>.security_code}}` expression. If your destination requires the CVV and you have it, include it directly in the request body yourself; the proxy forwards it without storing it. Note that transmitting a raw security code keeps that request in your PCI scope.
+`{{vaulted_token.<TOKEN>.security_code}}` resolves only while the security code is still available — by default for 3 hours after enrollment. It is never stored: it is held briefly after your customer enters it, and Yuno stops serving it once that window closes. Supply it as `card.security_code` when you enroll the card, and check `card_data.security_code_expires_in` on the payment method before relying on it. Outside that window, include the CVV directly in the request body yourself if your destination requires it; the proxy forwards it without storing it. Note that transmitting a raw security code keeps that request in your PCI scope.
 </Note>
 
 ## Your PCI scope

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
@@ -340,6 +340,11 @@
                           "example": 3,
                           "default": 0
                         },
+                        "security_code_expires_in": {
+                          "type": "integer",
+                          "example": 842,
+                          "description": "Seconds left before the stored security code stops being available to the PCI forward proxy. Returns -1 once that window has closed, and is omitted entirely when the card carries no security code. Only present for organizations with the PCI forward proxy enabled."
+                        },
                         "brand": {
                           "type": "string",
                           "example": "VISA"

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -378,6 +378,11 @@
                           "example": 3,
                           "default": 0
                         },
+                        "security_code_expires_in": {
+                          "type": "integer",
+                          "example": 842,
+                          "description": "Seconds left before the stored security code stops being available to the PCI forward proxy. Returns -1 once that window has closed, and is omitted entirely when the card carries no security code. Only present for organizations with the PCI forward proxy enabled."
+                        },
                         "brand": {
                           "type": "string",
                           "example": "VISA"

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-methods-api.json
@@ -214,6 +214,11 @@
                                 "example": 3,
                                 "default": 0
                               },
+                              "security_code_expires_in": {
+                                "type": "integer",
+                                "example": 842,
+                                "description": "Seconds left before the stored security code stops being available to the PCI forward proxy. Returns -1 once that window has closed, and is omitted entirely when the card carries no security code. Only present for organizations with the PCI forward proxy enabled."
+                              },
                               "brand": {
                                 "type": "string",
                                 "example": "VISA"


### PR DESCRIPTION
## What

The PCI proxy can now resolve `{{vaulted_token.<TOKEN>.security_code}}` on a forward. Both proxy pages currently state the opposite — that no such expression exists and that a stored payment method has no CVV to inject — so they contradict the product as of C2-18121.

## Framing

The security code is **still never stored**. It is held briefly after the cardholder enters it and Yuno stops serving it once that window closes, so the docs lead with the lifetime rather than presenting `security_code` as one more card attribute alongside `number` or `holder_name`. A merchant who reads it as equivalent to the others will build a flow that breaks the moment the window closes.

The pages now point at `card_data.security_code_expires_in` as the way to know where you stand before building a request around it, and keep the existing guidance for everything outside the window: supply the CVV yourself, and accept that doing so keeps the request in your PCI scope.

## Changes

- `forward-proxy.mdx` — `security_code` added to the referenceable fields; the **No CVV** warning rewritten as **The security code expires**, covering the window, how to read it, and the failure mode (`EXPRESSION_RESOLUTION_FAILED` naming the field, with no partial substitution).
- `overview.mdx` — the equivalent callout updated.
- Three payment method specs gain `security_code_expires_in` on `card_data`, documented as seconds remaining, `-1` once closed, absent when the card carries none, and only present for organizations with the proxy enabled.

## Notes

Draft until the implementation PRs merge, so the docs do not describe a capability before it ships. Implementation: customer-payment-method-ms#461, pci-proxy-ms#18, public-api#2077 and four more, tracked in C2-18121.

Generated with Claude Code