### PR TITLE
fix(reference): add missing MERCADO_PAGO_WALLET payment method type

### DIFF
--- a/reference/api-enums.mdx
+++ b/reference/api-enums.mdx
@@ -273,6 +273,7 @@ Specifies the payment instrument or channel used (e.g., credit card, bank transf
   | `MAYA_CHECKOUT` | Maya Checkout |
   | `MAYA_WALLET` | Maya Wallet |
   | `MERCADO_PAGO_CHECKOUT_PRO` | Mercado Pago Checkout Pro |
+  | `MERCADO_PAGO_WALLET` | Mercado Pago Wallet Connect |
   | `MINI_STOP` | Mini Stop Cash |
   | `MOBILEPAY` | MobilePay |
   | `MODO` | MODO (Argentina) |

--- a/reference/payment-type-list.mdx
+++ b/reference/payment-type-list.mdx
@@ -275,7 +275,7 @@ This reference lists all payment methods supported by Yuno's API, organized by c
 | Google Pay<br />`GOOGLE_PAY` | `GOOGLE_PAY` | `WALLET` |
 | IPSP - SberPay<br />`IPSP` | `SBERPAY` | `WALLET` |
 | Maya<br />`MAYA` | `MAYA_WALLET` | `WALLET` |
-| Mercado Pago<br />`MERCADO_PAGO` | `QR`<br />`WALLET_CONNECT` | `WALLET` |
+| Mercado Pago<br />`MERCADO_PAGO` | `MERCADO_PAGO_WALLET`<br />`QR`<br />`WALLET_CONNECT` | `WALLET` |
 | MODO<br />`MODO` | `MODO` | `WALLET` |
 | Monnet - QR<br />`MONNET` | `MONNET_QR` | `WALLET` |
 | Monnet - Wallet<br />`MONNET` | `MONNET_WALLET` | `WALLET` |


### PR DESCRIPTION
## PR Description
`MERCADO_PAGO_WALLET` is a valid `payment_method_type` enum value in the OpenAPI specs (`create-payment`, `authorize-payment`, `enroll-payment-method-checkout`), but it was missing from both public reference tables. Reported by Max via Slack doc-gap report: 12.6M payments processed since October 2025, active in production for merchant NetEaseGames, who could not find the value documented to confirm it existed. `WALLET_CONNECT` is a distinct, already-documented enum value (the generic WalletConnect protocol) and was left untouched.

## Changes
- `reference/api-enums.mdx` — added a new row for `MERCADO_PAGO_WALLET` (`Mercado Pago Wallet Connect`) to the `payment_method_type` enum table, alphabetically between `MERCADO_PAGO_CHECKOUT_PRO` and `MINI_STOP`.
- `reference/payment-type-list.mdx` — added `MERCADO_PAGO_WALLET` to the existing Mercado Pago row's Payment Method cell in the `WALLET` category table, alongside `QR` and `WALLET_CONNECT`.