### PR TITLE
chore: web sdk changelog 1.9.27

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,27 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.27",
-      "release_date": "2026-08-09",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.27",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "CHANGED",
-          "title": "Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time, and ship the deploy-time half so it actually takes effect. The three sdk-3ds URLs now use the `_ENVIRONMENT_` templated form in the shared environment file, so `resolveEnvHost` resolves them at runtime. Until now every published bundle carried a concrete host baked at build time: a sandbox merchant running the prod bundle kept landing on `sdk-3ds.prod.y.uno` with a sandbox-signed session token and got a bare 403 Forbidden instead of the 3DS challenge, leaving the payment stuck in `PENDING / WAITING_ADDITIONAL_STEP`. When the public API key carries no recognizable environment prefix, the host falls back to the environment the bundle was built for so the placeholder never reaches a request.",
-          "description": "",
-          "group": null,
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
-        "YSHUB-6400"
-      ]
-    },
-    {
       "version": "1.10.3",
       "release_date": "2026-08-05",
       "upgrade": {
@@ -250,6 +229,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.27",
+      "release_date": "2026-08-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.27",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Environment-Aware 3DS Host Resolution",
+          "description": "Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time, and ship the deploy-time half so it actually takes effect. The three sdk-3ds URLs now use the `_ENVIRONMENT_` templated form in the shared environment file, so `resolveEnvHost` resolves them at runtime. Until now every published bundle carried a concrete host baked at build time: a sandbox merchant running the prod bundle kept landing on `sdk-3ds.prod.y.uno` with a sandbox-signed session token and got a bare 403 Forbidden instead of the 3DS challenge, leaving the payment stuck in `PENDING / WAITING_ADDITIONAL_STEP`. When the public API key carries no recognizable environment prefix, the host falls back to the environment the bundle was built for so the placeholder never reaches a request.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6400"
       ]
     },
     {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.27",
+      "release_date": "2026-08-09",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.27",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time, and ship the deploy-time half so it actually takes effect. The three sdk-3ds URLs now use the `_ENVIRONMENT_` templated form in the shared environment file, so `resolveEnvHost` resolves them at runtime. Until now every published bundle carried a concrete host baked at build time: a sandbox merchant running the prod bundle kept landing on `sdk-3ds.prod.y.uno` with a sandbox-signed session token and got a bare 403 Forbidden instead of the 3DS challenge, leaving the payment stuck in `PENDING / WAITING_ADDITIONAL_STEP`. When the public API key carries no recognizable environment prefix, the host falls back to the environment the bundle was built for so the placeholder never reaches a request.",
+          "description": "",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6400"
+      ]
+    },
+    {
       "version": "1.10.3",
       "release_date": "2026-08-05",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,12 +5,6 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
-## v1.9.27
-*August 9, 2026*
-
-- <ChangelogBadge type="changed" /> **Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time, and ship the deploy-time half so it actually takes effect. The three sdk-3ds URLs now use the `_ENVIRONMENT_` templated form in the shared environment file, so `resolveEnvHost` resolves them at runtime. Until now every published bundle carried a concrete host baked at build time: a sandbox merchant running the prod bundle kept landing on `sdk-3ds.prod.y.uno` with a sandbox-signed session token and got a bare 403 Forbidden instead of the 3DS challenge, leaving the payment stuck in `PENDING / WAITING_ADDITIONAL_STEP`. When the public API key carries no recognizable environment prefix, the host falls back to the environment the bundle was built for so the placeholder never reaches a request.**  
-  
-
 ## v1.10.3
 *August 5, 2026*
 
@@ -104,6 +98,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
+
+## v1.9.27
+*August 9, 2026*
+
+- <ChangelogBadge type="changed" /> **Environment-Aware 3DS Host Resolution**  
+  Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time, and ship the deploy-time half so it actually takes effect. The three sdk-3ds URLs now use the `_ENVIRONMENT_` templated form in the shared environment file, so `resolveEnvHost` resolves them at runtime. Until now every published bundle carried a concrete host baked at build time: a sandbox merchant running the prod bundle kept landing on `sdk-3ds.prod.y.uno` with a sandbox-signed session token and got a bare 403 Forbidden instead of the 3DS challenge, leaving the payment stuck in `PENDING / WAITING_ADDITIONAL_STEP`. When the public API key carries no recognizable environment prefix, the host falls back to the environment the bundle was built for so the placeholder never reaches a request.
 
 ## v1.9.25
 *August 6, 2026*

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,12 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.9.27
+*August 9, 2026*
+
+- <ChangelogBadge type="changed" /> **Resolve the sdk-3ds host (challenge.html, session-id.html and the 3DS event origin) from the SDK's runtime environment — encoded in the public API key — instead of freezing it into the bundle at build time, and ship the deploy-time half so it actually takes effect. The three sdk-3ds URLs now use the `_ENVIRONMENT_` templated form in the shared environment file, so `resolveEnvHost` resolves them at runtime. Until now every published bundle carried a concrete host baked at build time: a sandbox merchant running the prod bundle kept landing on `sdk-3ds.prod.y.uno` with a sandbox-signed session token and got a bare 403 Forbidden instead of the 3DS challenge, leaving the payment stuck in `PENDING / WAITING_ADDITIONAL_STEP`. When the public API key carries no recognizable environment prefix, the host falls back to the environment the bundle was built for so the placeholder never reaches a request.**  
+  
+
 ## v1.10.3
 *August 5, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.27`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.27

1 entry.