### PR TITLE
chore: web sdk changelog 1.10.4

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,37 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.4",
+      "release_date": "2026-08-10",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.4",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Faster Lite and External Buttons Loading",
+          "description": "The Lite, Seamless Lite and standalone external button flows now load faster: SDK resources download in parallel with the initial API calls and mounting only waits for the settings request, reducing the time to show the payment form and express buttons.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed showPaymentStatus on Payment Failures",
+          "description": "When showPaymentStatus is set to false, the SDK no longer renders the full-screen \"Transaction failed\" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18747",
+        "YSHUB-6355",
+        "YSHUB-6400"
+      ]
+    },
+    {
       "version": "1.10.3",
       "release_date": "2026-08-05",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,19 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.4
+*August 10, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Faster Lite and External Buttons Loading**  
+  The Lite, Seamless Lite and standalone external button flows now load faster: SDK resources download in parallel with the initial API calls and mounting only waits for the settings request, reducing the time to show the payment form and express buttons.
+
+**Payment Actions**
+
+- <ChangelogBadge type="fixed" /> **Fixed showPaymentStatus on Payment Failures**  
+  When showPaymentStatus is set to false, the SDK no longer renders the full-screen "Transaction failed" message on early payment failures (payment not found or not yet processed); the error is delivered through the onError callback instead.
+
 ## v1.10.3
 *August 5, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.4`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.5

2 entries.