### PR TITLE
docs(subscriptions): payment methods are CARD and PAYPAL_ENROLLMENT

### DIFF
--- a/docs/payment-features/subscriptions/index.mdx
+++ b/docs/payment-features/subscriptions/index.mdx
@@ -74,7 +74,7 @@ To use the subscription solution, normally, you will follow the steps described 
 <Note>
 **Available Payment Methods**
 
-Currently, only Cards can be used as payment methods for subscriptions.
+Subscriptions support `CARD` and `PAYPAL_ENROLLMENT` as payment methods, both through previously enrolled (vaulted) instruments.
 </Note>
 
 <Danger>

--- a/openapi/subscriptions/create-subscription.json
+++ b/openapi/subscriptions/create-subscription.json
@@ -236,7 +236,7 @@
                   },
                   "payment_method": {
                     "type": "object",
-                    "description": "Specifies the `payment_method` object. Currently, only card is available as a payment method using previously enrolled cards (`vaulted_token`)",
+                    "description": "Specifies the `payment_method` object. Supported types are `CARD` and `PAYPAL_ENROLLMENT`, both using previously enrolled payment methods (`vaulted_token`)",
                     "required": [
                       "type"
                     ],
@@ -245,7 +245,8 @@
                         "type": "string",
                         "description": "Payment method type.",
                         "enum": [
-                          "CARD"
+                          "CARD",
+                          "PAYPAL_ENROLLMENT"
                         ]
                       },
                       "vaulted_token": {

--- a/openapi/subscriptions/update-subscription.json
+++ b/openapi/subscriptions/update-subscription.json
@@ -154,7 +154,7 @@
                   },
                   "payment_method": {
                     "type": "object",
-                    "description": "Specifies the `payment_method` object. Currently, only card as available as payment methods. You can use the card `token`, the `vaulted_token` or the card information using through the card object.",
+                    "description": "Specifies the `payment_method` object. Supported types are `CARD` and `PAYPAL_ENROLLMENT`. You can use the `token`, the `vaulted_token`, or the card information through the card object.",
                     "properties": {
                       "type": {
                         "type": "string",

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -257,7 +257,7 @@ This object represents a subscription that can be associated with a customer.
     <ParamField body="type" type="enum">
       Type of the payment method.
 
-      Possible enum values: `CARD`
+      Possible enum values: `CARD`, `PAYPAL_ENROLLMENT`
     </ParamField>
 
     <ParamField body="token" type="string">


### PR DESCRIPTION
The subscriptions docs claimed card-only in four places, which contradicts production — `PAYPAL_ENROLLMENT` subscriptions have been billing through the engine since January (wallet stored-credential charges via the PayPal provider), and the docs' own enrollment pages already describe non-card enrollment enabling subscriptions.

Aligned, conservatively (no new promises — just the two types that demonstrably work today):

- `docs/payment-features/subscriptions/index.mdx` — the **Available Payment Methods** note: `CARD` and `PAYPAL_ENROLLMENT`, both via vaulted instruments
- `openapi/subscriptions/create-subscription.json` — `payment_method` description + the `type` enum (was hard-locked to `CARD`, which made a valid live request shape invalid per spec)
- `openapi/subscriptions/update-subscription.json` — description (also fixes the 'only card as available as payment methods' typo)
- `reference/subscriptions/the-subscription-object.mdx` — `payment_method.type` possible values

Deliberately NOT added: `PIX_AUTOMATIC` / `NU_PAY_ENROLLMENT` (documented on their own flow pages, availability is account-specific) and `APPLE_PAY` (attempted in prod, never activated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)