### PR TITLE
[YSHUB-6383] Document List Subscriptions and complete the Retrieve Subscription schema

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -554,6 +554,7 @@
               "reference/subscriptions/the-subscription-object",
               "reference/subscriptions/create-subscription",
               "reference/subscriptions/retrieve-subscription",
+              "reference/subscriptions/list-subscriptions",
               "reference/subscriptions/update-subscription",
               "reference/subscriptions/change-subscription-plan",
               "reference/subscriptions/retry-subscription",

--- a/docs/payment-features/subscriptions/index.mdx
+++ b/docs/payment-features/subscriptions/index.mdx
@@ -40,6 +40,7 @@ To start using the subscriptions feature, you need a Yuno account and integratio
 * **Resume**: Resume a previously paused subscription with the [Resume Subscription endpoint](/reference/subscriptions/resume-subscription).
 * **Cancel**: Cancel an active subscription with the [Cancel Subscription endpoint](/reference/subscriptions/cancel-subscription).
 * **Retrieve**: Use the [Retrieve Subscription endpoint](/reference/subscriptions/retrieve-subscription) to get the details of a subscription.
+* **List**: Use the [List Subscriptions endpoint](/reference/subscriptions/list-subscriptions) to page through an account's subscriptions, filtered by customer, status, plan, creation date or payment method type.
 
 ## New concepts
 

--- a/openapi/subscriptions/list-subscriptions.json
+++ b/openapi/subscriptions/list-subscriptions.json
@@ -1,0 +1,203 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "subscription", "version": "1.0.0" },
+  "servers": [{ "url": "https://api-sandbox.y.uno/v1" }, { "url": "https://api.eu.y.uno/v1" }],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "public-api-key", "x-default": "<Your public-api-key>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "private-secret-key", "x-default": "<Your private-secret-key>" }
+    }
+  },
+  "security": [{ "sec0": [], "sec1": [] }],
+  "paths": {
+    "/subscriptions": {
+      "get": {
+        "summary": "List Subscriptions",
+        "description": "Returns a paginated list of the account's subscriptions, newest first (`created_at` descending). Filters are combinable and every one of them is optional; with none set, subscriptions in every status are returned. 1-indexed pagination.",
+        "operationId": "list-subscriptions",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-account-code",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The `account_id` found in your [Yuno Dashboard](https://dashboard.y.uno/developers) (UUID). Required — the list is always scoped to a single account. Omitting it returns `400 INVALID_PARAMETERS` (\"x-account-code header is required.\")."
+          },
+          {
+            "name": "customer_id",
+            "in": "query",
+            "description": "Filter by the customer that owns the subscription (`customer_payer.id`, UUID). A value that isn't a UUID returns `400 BAD_REQUEST` (\"Invalid customer_id.\").",
+            "schema": { "type": "string", "example": "3t04911d-5df9-429e-8488-ad41abea1a2c" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status. Accepts several values separated by commas, matching any of them — `ACTIVE,PAUSED`. Values must be spelled exactly as in [Subscription statuses](/reference/subscriptions/status-subscriptions); an unknown one returns `400 BAD_REQUEST` (\"Invalid status: FOO.\").",
+            "schema": { "type": "string", "example": "ACTIVE,PAUSED" }
+          },
+          {
+            "name": "plan_id",
+            "in": "query",
+            "description": "Filter by the [plan](/reference/plans/the-plan-object) the subscription is linked to (UUID). A plan with no subscribers — or one that doesn't exist — returns an empty list, not an error. A value that isn't a UUID returns `400 BAD_REQUEST` (\"Invalid plan_id.\").",
+            "schema": { "type": "string", "example": "00000000-0000-4000-8000-000000000001" }
+          },
+          {
+            "name": "created_at_from",
+            "in": "query",
+            "description": "Only return subscriptions created at or after this instant (ISO 8601 with offset, inclusive). A value that doesn't parse returns `400 BAD_REQUEST` (\"Invalid created_at_from.\").",
+            "schema": { "type": "string", "example": "2024-01-01T00:00:00Z" }
+          },
+          {
+            "name": "created_at_to",
+            "in": "query",
+            "description": "Only return subscriptions created at or before this instant (ISO 8601 with offset, inclusive). A value that doesn't parse returns `400 BAD_REQUEST` (\"Invalid created_at_to.\").",
+            "schema": { "type": "string", "example": "2024-12-31T23:59:59Z" }
+          },
+          {
+            "name": "payment_method_type",
+            "in": "query",
+            "description": "Filter by the subscription's payment method type, for example `CARD`.",
+            "schema": { "type": "string", "example": "CARD" }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-indexed page number. Must be >= 1, else `400 BAD_REQUEST` (\"The page must be greater than or equal to 1.\").",
+            "schema": { "type": "integer", "default": 1, "minimum": 1 }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Page size. Must be between 1 and 100 inclusive, else `400 BAD_REQUEST` (\"The size must be greater than or equal to 1.\" if too low, \"The size must be at most 100.\" if too high).",
+            "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "items": [
+                        {
+                          "id": "7304911d-5df9-429e-8488-ad41abea1a4c",
+                          "name": "sub_001",
+                          "status": "ACTIVE",
+                          "merchant_reference": "001_marzo_23",
+                          "account_id": "2404911d-5df9-429e-8488-ad41abea1a4b",
+                          "customer_payer": { "id": "3t04911d-5df9-429e-8488-ad41abea1a2c" },
+                          "amount": { "currency": "USD", "value": 12100.0 },
+                          "frequency": { "type": "MONTH", "value": 1 },
+                          "billing_cycles": { "total": 10, "current": 2, "next_at": "2023-02-16T20:00:00.786342Z" },
+                          "payment_method": { "type": "CARD" },
+                          "plan_id": "00000000-0000-4000-8000-000000000001",
+                          "created_at": "2023-12-16T20:46:54.786342Z"
+                        }
+                      ],
+                      "pagination": { "page": 1, "size": 20, "total": 1, "total_pages": 1 }
+                    },
+                    "summary": "Result"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string", "description": "The unique identifier of the subscription." },
+                          "name": { "type": "string" },
+                          "status": { "type": "string", "description": "See [Subscription statuses](/reference/subscriptions/status-subscriptions)." },
+                          "merchant_reference": { "type": "string" },
+                          "account_id": { "type": "string" },
+                          "customer_payer": {
+                            "type": "object",
+                            "properties": {
+                              "id": { "type": "string", "description": "The unique identifier of the customer." }
+                            }
+                          },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": { "type": "string" },
+                              "value": { "type": "number" }
+                            }
+                          },
+                          "frequency": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "`null` on subscriptions billed with `billing_date` instead of a frequency.",
+                            "properties": {
+                              "type": { "type": "string" },
+                              "value": { "type": "integer" }
+                            }
+                          },
+                          "billing_cycles": {
+                            "type": "object",
+                            "description": "Same semantics as on [The Subscription Object](/reference/subscriptions/the-subscription-object) — `current` is the next cycle to be charged, not the one in progress.",
+                            "properties": {
+                              "total": { "type": "integer", "nullable": true },
+                              "current": { "type": "integer" },
+                              "next_at": { "type": "string" }
+                            }
+                          },
+                          "payment_method": {
+                            "type": "object",
+                            "properties": {
+                              "type": { "type": "string", "description": "The payment method type, for example `CARD`." }
+                            }
+                          },
+                          "plan_id": { "type": "string", "nullable": true, "description": "The plan the subscription is linked to, or `null` for subscriptions created with a raw `amount`/`frequency`." },
+                          "created_at": { "type": "string" }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "page": { "type": "integer", "description": "The page returned — echoes the request." },
+                        "size": { "type": "integer", "description": "The page size returned — echoes the request." },
+                        "total": { "type": "integer", "description": "Total subscriptions matching the filters, across every page." },
+                        "total_pages": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": ["The page must be greater than or equal to 1."]
+                    },
+                    "summary": "Result"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string", "example": "BAD_REQUEST" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": { "headers": [{ "value": "utf-8", "key": "charset" }], "explorer-enabled": true, "proxy-enabled": true },
+  "x-readme-fauxas": true
+}

--- a/openapi/subscriptions/retrieve-subscription.json
+++ b/openapi/subscriptions/retrieve-subscription.json
@@ -63,6 +63,7 @@
                       "name": "sub_001",
                       "description": "streaming service",
                       "account_id": "2404911d-5df9-429e-8488-ad41abea1a4b",
+                      "country": "US",
                       "merchant_reference": "001_marzo_23",
                       "soft_descriptor": "ACME SUBSCRIPTION",
                       "status": "ACTIVE",
@@ -81,6 +82,7 @@
                       },
                       "current_period_start": "2023-01-16T20:00:00.912480Z",
                       "current_period_end": "2023-02-16T20:00:00.786342Z",
+                      "billing_date": null,
                       "customer_payer": {
                         "id": "3t04911d-5df9-429e-8488-ad41abea1a2c"
                       },
@@ -97,6 +99,14 @@
                         "start_at": "2024-01-16T00:00:00.786342Z",
                         "finish_at": "2024-05-26T20:00:00.786342Z"
                       },
+                      "retries": {
+                        "retry_on_decline": true,
+                        "amount": 4,
+                        "strategy": "DEFAULT",
+                        "schedule": null,
+                        "stop_on_hard_decline": null,
+                        "cancel_on_exhausted_retries": null
+                      },
                       "trial_period": {
                         "billing_cycles": 1,
                         "amount": {
@@ -104,18 +114,48 @@
                           "currency": ""
                         }
                       },
+                      "initial_payment_validation": false,
                       "metadata": [
                         {
                           "key": "sub_ext_id",
                           "value": "AA001"
                         }
                       ],
+                      "additional_data": null,
+                      "reason": null,
+                      "renewal_notification_days": 3,
                       "payments": [
                         "5104911d-5df9-229e-8468-bd41abea1a4s"
                       ],
                       "subscription_agreement_id": null,
+                      "cancellation_time": null,
+                      "cancellation_source": null,
+                      "ending_time": null,
                       "plan_id": "00000000-0000-4000-8000-000000000001",
                       "plan_assigned_at": "2023-12-16T20:46:54.786342Z",
+                      "previous_subscription_id": null,
+                      "phases": [
+                        {
+                          "order": 1,
+                          "name": "Intro",
+                          "type": "TRIAL",
+                          "duration": { "type": "MONTH", "value": 3 },
+                          "frequency": { "type": "MONTH", "value": 1 },
+                          "amount": { "currency": "USD", "value": 9.99 },
+                          "total_payments": 3,
+                          "country_prices": []
+                        },
+                        {
+                          "order": 2,
+                          "name": "Regular",
+                          "type": "REGULAR",
+                          "duration": null,
+                          "frequency": null,
+                          "amount": null,
+                          "total_payments": null,
+                          "country_prices": []
+                        }
+                      ],
                       "current_phase": "REGULAR",
                       "billing_phases": [
                         {
@@ -152,6 +192,11 @@
                     "account_id": {
                       "type": "string",
                       "example": "2404911d-5df9-429e-8488-ad41abea1a4b"
+                    },
+                    "country": {
+                      "type": "string",
+                      "description": "The subscription's country (ISO 3166-1 alpha-2).",
+                      "example": "US"
                     },
                     "merchant_reference": {
                       "type": "string",
@@ -222,6 +267,21 @@
                       "description": "Only returned by this endpoint, and only once the first billing cycle has been charged. Equal to billing_cycles.next_at. Always returned together with current_period_start.",
                       "example": "2023-02-16T20:00:00.786342Z"
                     },
+                    "billing_date": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Only present on subscriptions billed on a fixed date instead of a frequency; mutually exclusive with `frequency`.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "DAY"
+                        },
+                        "day": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    },
                     "customer_payer": {
                       "type": "object",
                       "properties": {
@@ -274,6 +334,44 @@
                         }
                       }
                     },
+                    "retries": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "The retry policy applied when a recurring charge is declined. See [Retries](/docs/payment-features/subscriptions/retries).",
+                      "properties": {
+                        "retry_on_decline": {
+                          "type": "boolean",
+                          "description": "Whether declined charges are retried at all.",
+                          "example": true
+                        },
+                        "amount": {
+                          "type": "integer",
+                          "description": "How many retries a billing cycle gets. Capped by your environment's retry schedule length (6 in production).",
+                          "example": 4
+                        },
+                        "strategy": {
+                          "type": "string",
+                          "description": "How the timing of each retry is decided: `DEFAULT`, `SMART` or `CUSTOM_SCHEDULE`. Treat as open-ended — handle unrecognized values gracefully.",
+                          "example": "DEFAULT"
+                        },
+                        "schedule": {
+                          "type": "array",
+                          "nullable": true,
+                          "description": "The per-attempt schedule, only set when `strategy` is `CUSTOM_SCHEDULE`; `null` otherwise.",
+                          "items": { "type": "object" }
+                        },
+                        "stop_on_hard_decline": {
+                          "type": "boolean",
+                          "nullable": true,
+                          "description": "When true, a hard decline stops the retries for the current billing cycle."
+                        },
+                        "cancel_on_exhausted_retries": {
+                          "type": "boolean",
+                          "nullable": true,
+                          "description": "When true, the subscription is canceled once a cycle's retries end without a successful payment, with `cancellation_source` set to `RETRIES_EXHAUSTED`."
+                        }
+                      }
+                    },
                     "trial_period": {
                       "type": "object",
                       "properties": {
@@ -314,6 +412,28 @@
                         }
                       }
                     },
+                    "additional_data": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "The optional order enrichment sent at creation, echoed back. See [The Subscription Object](/reference/subscriptions/the-subscription-object) for its full shape."
+                    },
+                    "initial_payment_validation": {
+                      "type": "boolean",
+                      "description": "Whether the subscription waited for its first payment to succeed before activating. `false` by default.",
+                      "example": false
+                    },
+                    "reason": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Free-form reason for the subscription's current status, when one was recorded; `null` otherwise.",
+                      "example": "merchant request"
+                    },
+                    "renewal_notification_days": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "How many days before the next billing date the `subscription.close_to_renewal` webhook is sent. `null` means no renewal notification is sent.",
+                      "example": 3
+                    },
                     "payments": {
                       "type": "array",
                       "items": {
@@ -324,6 +444,24 @@
                     "subscription_agreement_id": {
                       "type": "string",
                       "example": "sa_6af2dfcd-44c0-4f16-a331-8bed3ed9c9fa"
+                    },
+                    "cancellation_time": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "When the subscription was canceled. Only set once it reaches `CANCELED`; `null` otherwise.",
+                      "example": "2023-12-16T20:46:54.786342Z"
+                    },
+                    "cancellation_source": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "What triggered the cancellation: `MERCHANT`, `SYSTEM`, `PLAN_CHANGE` or `RETRIES_EXHAUSTED`. Only set once the subscription reaches `CANCELED`; `null` otherwise. Treat as open-ended — handle unrecognized values gracefully.",
+                      "example": "MERCHANT"
+                    },
+                    "ending_time": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "When the subscription completed or expired. Only set once it reaches `COMPLETED`; `null` otherwise.",
+                      "example": "2024-12-16T20:46:54.786342Z"
                     },
                     "plan_id": {
                       "type": "string",
@@ -338,6 +476,63 @@
                     "previous_subscription_id": {
                       "type": "string",
                       "description": "Only present when this subscription was created by a plan change (switching an existing subscription to a different plan)."
+                    },
+                    "phases": {
+                      "type": "array",
+                      "description": "The linked plan's phase definitions, as the plan declares them — including the terminal `REGULAR` phase. Only present on plan-linked subscriptions whose plan has phases. This is the plan's own ladder, not this subscriber's snapshot: for what was pinned for this subscription at creation, use `billing_phases`.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "order": { "type": "integer" },
+                          "name": { "type": "string" },
+                          "type": { "type": "string", "description": "`TRIAL` or `REGULAR`." },
+                          "duration": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "How long the phase lasts. `null` on the terminal `REGULAR` phase, which runs until the subscription ends.",
+                            "properties": {
+                              "type": { "type": "string" },
+                              "value": { "type": "integer" }
+                            }
+                          },
+                          "frequency": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "How often the phase bills. `null` on the terminal `REGULAR` phase, which bills at the plan's own frequency.",
+                            "properties": {
+                              "type": { "type": "string" },
+                              "value": { "type": "integer" }
+                            }
+                          },
+                          "amount": {
+                            "type": "object",
+                            "nullable": true,
+                            "description": "The phase price. `null` on the terminal `REGULAR` phase, whose price resolves from the plan at every billing.",
+                            "properties": {
+                              "currency": { "type": "string" },
+                              "value": { "type": "number" }
+                            }
+                          },
+                          "total_payments": { "type": "integer", "nullable": true },
+                          "country_prices": {
+                            "type": "array",
+                            "description": "Per-country overrides of the phase price, empty when the phase has none.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "country": { "type": "string" },
+                                "amount": {
+                                  "type": "object",
+                                  "properties": {
+                                    "currency": { "type": "string" },
+                                    "value": { "type": "number" }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     },
                     "current_phase": {
                       "type": "string",

--- a/reference/subscriptions/list-subscriptions.mdx
+++ b/reference/subscriptions/list-subscriptions.mdx
@@ -1,0 +1,23 @@
+---
+title: "List Subscriptions"
+openapi: "/openapi/subscriptions/list-subscriptions.json GET /subscriptions"
+description: "Returns a paginated list of an account's subscriptions."
+---
+
+<Warning>
+**List items are a summary, not the full subscription**
+
+Each item carries the fields needed to render a grid. Everything else — `availability`, `retries`, `metadata`, `trial_period`, `payments`, `current_period_start`/`current_period_end`, `pending_plan_change`, `billing_phases` and the rest of [The Subscription Object](/reference/subscriptions/the-subscription-object) — is only returned by [Retrieve Subscription](/reference/subscriptions/retrieve-subscription). Call it per item when you need any of them.
+</Warning>
+
+<Note>
+**`merchant_reference` is not a filter on this endpoint**
+
+Sending it has no effect: the parameter is ignored and the full, unfiltered page is returned. To look a subscription up by merchant reference, keep the `id` you received when you created it, or page through this endpoint and match client-side.
+</Note>
+
+## Scope and ordering
+
+The list is always scoped to the single account in the `x-account-code` header — there is no cross-account variant. Results are ordered by `created_at` descending, so a subscription created while you page can shift items across page boundaries. For a stable sweep, filter with `created_at_to` fixed at the moment you started.
+
+Filters are combinable and all optional; each one narrows the result set further. With none set, subscriptions in every status are returned, including `CANCELED` and `COMPLETED` ones.

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -92,6 +92,37 @@ This object represents a subscription that can be associated with a customer.
   Scheduled changes made with the `plan_change` object on [Update Subscription](/reference/subscriptions/update-subscription) apply in place and never set this field.
 </ParamField>
 
+<ParamField body="phases" type="array of objects">
+  The linked plan's phase definitions, exactly as the plan declares them. Only present on plan-linked subscriptions whose plan has phases.
+
+  This is the plan's ladder, not this subscriber's. Unlike `billing_phases` it includes the terminal `REGULAR` phase, and it is read from the plan rather than snapshotted at creation, so it reflects the plan as it stands today. On the `REGULAR` row `duration`, `frequency` and `amount` are all `null` — that phase runs until the subscription ends and its price resolves from the plan at every billing.
+
+  Use `billing_phases` for what this subscription will actually be charged, and `phases` to describe the plan behind it.
+
+  <Expandable title="properties">
+    <ParamField body="order" type="int" />
+    <ParamField body="name" type="string" />
+    <ParamField body="type" type="enum">
+      `TRIAL` or `REGULAR`.
+    </ParamField>
+    <ParamField body="duration" type="object">
+      How long the phase lasts, as `type` and `value`. `null` on the `REGULAR` phase.
+    </ParamField>
+    <ParamField body="frequency" type="object">
+      How often the phase bills, as `type` and `value`. `null` on the `REGULAR` phase.
+    </ParamField>
+    <ParamField body="amount" type="object">
+      The phase price, as `currency` and `value`. `null` on the `REGULAR` phase.
+    </ParamField>
+    <ParamField body="total_payments" type="int">
+      How many charges the phase covers. `null` on the `REGULAR` phase.
+    </ParamField>
+    <ParamField body="country_prices" type="array of objects">
+      Per-country overrides of the phase price, each with a `country` and an `amount`. Empty when the phase has none.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
 <ParamField body="current_phase" type="enum">
   Which phase of the linked plan's trial ladder the subscription is currently in. Only present on plan-linked subscriptions. Absent as well when the subscription was created by a [plan change](/reference/subscriptions/change-subscription-plan) with `skip_trial: true` — that subscription is plan-linked and its plan has phases, but it never enters the ladder.
 


### PR DESCRIPTION
Follow-up to #725, which filed three items as out of scope. This closes all three.

### 1. `GET /v1/subscriptions` had no documentation at all

The endpoint has been live on `public-api` master since SUB-40 with eight filters, and had no reference page, no OpenAPI file and no nav entry. Adds `openapi/subscriptions/list-subscriptions.json`, `reference/subscriptions/list-subscriptions.mdx`, the `docs.json` entry and a link from the subscriptions overview.

Everything documented was verified against staging rather than read off the source:

| Checked | Result |
|---|---|
| Filters | `customer_id`, `status` (comma-separated multi-value), `plan_id`, `created_at_from`, `created_at_to`, `payment_method_type` |
| Pagination | 1-indexed, `size` 1-100 default 20, envelope `{items, pagination{page,size,total,total_pages}}` |
| Ordering | `created_at` descending |
| `page=0` | `400 BAD_REQUEST` "The page must be greater than or equal to 1." |
| `size=200` | `400 BAD_REQUEST` "The size must be at most 100." |
| `status=FOO` | `400 BAD_REQUEST` "Invalid status: FOO." |
| `customer_id=abc` | `400 BAD_REQUEST` "Invalid customer_id." |
| no `x-account-code` | `400 INVALID_PARAMETERS` "x-account-code header is required." |
| unknown `plan_id` | `200` with an empty list, not an error |
| `merchant_reference=...` | ignored, `total` unchanged at 94 |

That last row is the one worth calling out. `merchant_reference` reaches the engine as a dispatch to the legacy single-object lookup, which would break the list envelope, so the gateway strips it from the forwarded query. The result is a silent no-op rather than a `400`, and the page documents it as unsupported with an explicit note so nobody builds a lookup on it.

The lake-backed `503`/`Retry-After` path is deliberately left undocumented: it only triggers on an internal source header that merchants cannot send.

### 2. `retrieve-subscription.json` was missing eleven fields

It described 27 of the fields the endpoint returns. Missing: `country`, `billing_date`, `retries`, `additional_data`, `initial_payment_validation`, `reason`, `renewal_notification_days`, `cancellation_time`, `cancellation_source`, `ending_time`, `phases`. All eleven added to both the schema and the example.

Diffed the resulting property set against two live staging responses, a plain subscription and a plan-linked one with phases. Nothing the API returns is undocumented now; the only two documented fields not in those payloads are `billing_date` and `previous_subscription_id`, both conditional and both described as such.

### 3. `previous_subscription_id` vs `previous_subscription_code`

Not a discrepancy to resolve, no doc change needed. `previous_subscription_id` is the public API spelling and the one merchants see. `previous_subscription_code` belongs to the internal `payment-api` hop that `public-api` proxies through, which speaks `code`/`account_code` throughout and never reaches merchants. Confirmed on the live staging response, which returns `previous_subscription_id`.

### Also

`phases` had no entry anywhere in the docs. Unlike `billing_phases` it is the plan's own ladder rather than the subscriber's snapshot, it includes the terminal `REGULAR` phase, and `duration`/`frequency`/`amount` are all `null` on that row, so it gets its own description on the subscription object page.

### Not touched

`components.schemas.Subscription` in the root `openapi.json` is a seven-field stub carrying `interval` and `next_payment_date`, neither of which exists in the API. Out of scope here, worth its own pass.

### Verification

- `node scripts/check-descriptions.cjs` passes, 405 nav pages
- all three JSON files parse
- example and schema property sets match exactly on the retrieve endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
