### PR TITLE
chore: web sdk changelog 1.9.28

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.28",
+      "release_date": "2026-08-10",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.28",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Installment Selection Issues in the Card Form",
+          "description": "The selected installment is kept while typing in the card form, and onInstallmentSelected notifies the last selection again when returning to the card payment method.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6409"
+      ]
+    },
+    {
       "version": "1.10.3",
       "release_date": "2026-08-05",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.28`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.28

1 entry.