### PR TITLE
docs(nova): add NOVA AI payment recovery agent overview page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -236,7 +236,8 @@
               "docs/ai-capabilities/building-ai-integrations-with-yunos-llms-and-mcp",
               "docs/ai-capabilities/remote-yuno-mcp-server",
               "docs/ai-capabilities/agent-toolkit",
-              "docs/ai-capabilities/payment-concierge"
+              "docs/ai-capabilities/payment-concierge",
+              "docs/ai-capabilities/nova"
             ]
           },
           {

--- a/docs/ai-capabilities/nova.mdx
+++ b/docs/ai-capabilities/nova.mdx
@@ -6,7 +6,7 @@ description: "AI agent that recovers declined payments by reaching your customer
 Every declined payment is a customer who already decided to buy. NOVA is Yuno's AI payment recovery agent: when one of your customers' payments is declined, it reaches out to that customer through WhatsApp or a phone call, explains what happened, resolves their doubts, and guides them to complete the payment. It speaks in your brand's voice, in your customer's language, with the full context of the failed payment. There's nothing to integrate: NOVA runs on the Yuno side, on the payments you already process.
 
 ## How NOVA recovers a payment
-z
+
 <Steps>
   <Step title="Detect">
     Every declined or failed payment is captured in real time and evaluated against the targeting rules agreed with you: which payment types, amounts, and markets qualify for outreach. You can also hold out a control group so you can measure NOVA's incremental impact against customers it didn't contact.

--- a/docs/ai-capabilities/nova.mdx
+++ b/docs/ai-capabilities/nova.mdx
@@ -1,0 +1,144 @@
+---
+title: "NOVA"
+description: "AI agent that recovers declined payments by reaching your customers on WhatsApp or through a natural-sounding voice call"
+---
+
+Every declined payment is a customer who already decided to buy. NOVA is Yuno's AI payment recovery agent: when one of your customers' payments is declined, it reaches out to that customer through WhatsApp or a phone call, explains what happened, resolves their doubts, and guides them to complete the payment. It speaks in your brand's voice, in your customer's language, with the full context of the failed payment. There's nothing to integrate: NOVA runs on the Yuno side, on the payments you already process.
+
+## How NOVA recovers a payment
+z
+<Steps>
+  <Step title="Detect">
+    Every declined or failed payment is captured in real time and evaluated against the targeting rules agreed with you: which payment types, amounts, and markets qualify for outreach. You can also hold out a control group so you can measure NOVA's incremental impact against customers it didn't contact.
+  </Step>
+  <Step title="Reach">
+    NOVA contacts the customer on the best-fit channel with a message or call built for that specific case: what they were buying, why the payment failed, and how to complete it, including a secure Yuno checkout link with the payment methods you enable.
+  </Step>
+  <Step title="Recover">
+    The customer pays through their normal Yuno checkout flow. The recovered payment lands in your account like any other successful payment, no new money flow to reconcile.
+  </Step>
+</Steps>
+
+NOVA holds a real, two-way conversation rather than sending a one-off blast: it answers questions, explains the decline, and offers alternatives before guiding the customer back to the payment link. If a voice call goes unanswered, NOVA automatically schedules follow-up attempts on a schedule you configure, since a single retry meaningfully lifts recovery. Every communication carries a full status trail (sent, delivered or answered, completed, outcome), which feeds your reporting.
+
+## The channels
+
+Both channels are available globally and configured per merchant and market. The mix is a strategy decision, not an availability constraint: use WhatsApp where messaging volume is large, voice where a live conversation carries more weight, or combine both in the same market.
+
+<Tabs>
+  <Tab title="WhatsApp">
+    The scale channel. The conversation opens with a personalized message and continues as a real dialogue inside WhatsApp: NOVA answers questions, explains the decline, offers alternative payment methods, and re-shares the payment link. Delivery is tracked end to end, so you know whether each message reached the customer.
+
+    <Frame>
+    *"Hi Ana! This is Sofía from YourStore. Your \$28 payment for your monthly subscription didn't go through, it looks like the card didn't have sufficient funds this time. No worries: you can complete it here with any of your payment methods → [secure payment link]. I'm here if you have any questions!"*
+
+    *Customer: "Can I pay with a different card?"*
+    *NOVA: "Of course! The same link lets you pay with any card or alternative method enabled for YourStore. It takes less than a minute, and your subscription stays active."*
+    </Frame>
+  </Tab>
+  <Tab title="Voice">
+    The conversion channel. NOVA places an outbound call with a natural, conversational AI voice, speaking as your named agent in your customer's language. A live conversation resolves objections on the spot. Every call outcome (answered, voicemail, no answer, busy) is classified automatically, which drives both reporting and the retry logic: if the customer doesn't answer, NOVA automatically retries on a schedule configured for you. Voicemails and busy signals don't end the story, follow-up attempts are one of the strongest levers of recovery.
+  </Tab>
+</Tabs>
+
+## Built to convert, and to feel like you
+
+<CardGroup cols={2}>
+  <Card title="Your brand, your persona">
+    A named agent identity (for example, "Sofía from YourStore"), your tone of voice, and your support references, configured during onboarding.
+  </Card>
+  <Card title="Your customer's language">
+    Conversations run in the language of each market. Spanish and Portuguese are in production today; additional languages are enabled per merchant.
+  </Card>
+  <Card title="Context-aware, not scripted">
+    Each outreach is generated from the actual payment: the customer's name, the amount, the product, and the decline reason, so the suggested solution fits the real problem.
+  </Card>
+  <Card title="Two-way, not a blast">
+    NOVA holds the conversation: questions answered, alternatives offered, objections resolved.
+  </Card>
+</CardGroup>
+
+## Getting started
+
+There's no SDK, API integration, or code change on your side. Onboarding with your Yuno account team is a configuration exercise, typically measured in days:
+
+| What gets configured | Examples |
+| :--- | :--- |
+| Brand and persona | Store name, agent name, tone of voice, support references |
+| Language and market | Spanish or Portuguese; which countries and currencies |
+| Channel strategy | WhatsApp, voice, or a mix, per market |
+| Targeting filters | Which declined payments qualify: payment types, amounts, product categories |
+| Payment completion | Which payment methods to offer, and the secure Yuno checkout link customers receive |
+| Retry policy (voice) | How many follow-up attempts, and with what delays |
+| Measurement | Optional control group, for A/B measurement of incremental impact |
+
+Once live, NOVA works autonomously: declines are detected, customers contacted, conversations handled, and payments recovered, continuously. Recovered payments show up as normal successful payments in your existing Yuno reporting.
+
+## Honest measurement
+
+NOVA's reporting is conservative by design. A payment counts as recovered only when the customer was actually reached **and** then completed a successful payment within a defined attribution window. Customers who were never reached, or who came back on their own later, aren't claimed as a recovery.
+
+Your reporting includes:
+
+* **Communications**: outreach attempts sent, by channel and market.
+* **Completion rate**: the share of communications where the customer was actually reached, the reach ceiling of the whole program.
+* **Recovery from total**: recovered payments ÷ all communications sent (the business outcome).
+* **Recovery from completed**: recovered payments ÷ customers reached (conversion quality once connected).
+* **Recovered value**: the declined payment value brought back, in USD.
+* **Customer satisfaction**: see below.
+
+<Note>
+Want proof it's incremental? Enable a **control group**: NOVA holds out a share of eligible customers so you can compare recovery with and without outreach.
+</Note>
+
+### Customer satisfaction, measured
+
+After a WhatsApp conversation ends, NOVA can send a short two-question satisfaction survey, so you don't just see recovered payments, you see how customers experienced being contacted. Results feed your reporting alongside recovery metrics.
+
+## Data and security
+
+<CardGroup cols={2}>
+  <Card title="Payments stay in Yuno's checkout">
+    NOVA shares a secure payment link. It never asks for card numbers or credentials inside the conversation.
+  </Card>
+  <Card title="Scoped to your organization">
+    NOVA only contacts your customers about your payments, under the targeting rules agreed with you.
+  </Card>
+  <Card title="Customers stay in control">
+    Requests to stop being contacted are honored, and merchant-level exclusion rules are always respected.
+  </Card>
+  <Card title="Fully auditable">
+    Every communication carries a complete status trail, sent, delivered, answered, outcome, reflected in your reporting.
+  </Card>
+</CardGroup>
+
+## Getting access
+
+NOVA is available to Yuno merchants, there's no integration work on your side. Contact your Yuno account manager to enable it for your organization.
+
+<Note>
+NOVA improves continuously: conversation quality and recovery performance are tuned from every interaction, and new channels and markets are enabled as merchants need them.
+</Note>
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="What exactly counts as a recovered payment?">
+    Only a payment where the customer was actually reached (message delivered and engaged, or call answered) and then completed a successful payment within a defined attribution window after the contact. Customers who were never reached, or who paid on their own outside the window, aren't counted.
+  </Accordion>
+  <Accordion title="Do I need to integrate anything?">
+    No. NOVA runs on the Yuno side, using the payments you already process with Yuno. Onboarding is configuration (brand voice, channels, targeting), not code.
+  </Accordion>
+  <Accordion title="Which customers does NOVA contact?">
+    Only customers whose payment was declined and who match the targeting filters agreed with you (payment types, amounts, markets). You can also hold out a control group to measure incremental impact.
+  </Accordion>
+  <Accordion title="What happens if the customer doesn't answer a call?">
+    NOVA automatically retries on a configurable schedule (the number of attempts and delays are set per merchant). Follow-up attempts are one of the strongest levers of recovery performance.
+  </Accordion>
+  <Accordion title="How does NOVA identify itself to my customers?">
+    As your brand: a named agent persona speaking for your store, configured during onboarding. The experience is designed to feel like your own support team reaching out to help complete the purchase.
+  </Accordion>
+  <Accordion title="How quickly does NOVA act after a decline?">
+    Detection is real time and event driven; outreach follows the campaign rules configured for your organization.
+  </Accordion>
+</AccordionGroup>

--- a/docs/ai-capabilities/nova.mdx
+++ b/docs/ai-capabilities/nova.mdx
@@ -19,8 +19,6 @@ Every declined payment is a customer who already decided to buy. NOVA is Yuno's 
   </Step>
 </Steps>
 
-NOVA holds a real, two-way conversation rather than sending a one-off blast: it answers questions, explains the decline, and offers alternatives before guiding the customer back to the payment link. If a voice call goes unanswered, NOVA automatically schedules follow-up attempts on a schedule you configure, since a single retry meaningfully lifts recovery. Every communication carries a full status trail (sent, delivered or answered, completed, outcome), which feeds your reporting.
-
 ## The channels
 
 Both channels are available globally and configured per merchant and market. The mix is a strategy decision, not an availability constraint: use WhatsApp where messaging volume is large, voice where a live conversation carries more weight, or combine both in the same market.
@@ -37,7 +35,7 @@ Both channels are available globally and configured per merchant and market. The
     </Frame>
   </Tab>
   <Tab title="Voice">
-    The conversion channel. NOVA places an outbound call with a natural, conversational AI voice, speaking as your named agent in your customer's language. A live conversation resolves objections on the spot. Every call outcome (answered, voicemail, no answer, busy) is classified automatically, which drives both reporting and the retry logic: if the customer doesn't answer, NOVA automatically retries on a schedule configured for you. Voicemails and busy signals don't end the story, follow-up attempts are one of the strongest levers of recovery.
+    The conversion channel. NOVA places an outbound call with a natural, conversational AI voice, speaking as your named agent in your customer's language. A live conversation resolves objections on the spot. Every call outcome (answered and engaged, short call, voicemail, no answer, busy, or failed) is classified automatically, which drives both reporting and the retry logic: if the customer doesn't answer, NOVA automatically retries on a schedule configured for you. Voicemails and busy signals don't end the story, follow-up attempts are one of the strongest levers of recovery.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Adds a new overview page for NOVA, Yuno's AI payment recovery agent, under **AI Capabilities**.

### Content
- New page: `docs/ai-capabilities/nova.mdx`
- Added to `docs.json` under **AI Capabilities**, after `payment-concierge`

The page covers:
- What NOVA is and the Detect → Reach → Recover recovery flow
- The two outreach channels (WhatsApp, Voice) and how each conversation runs
- Personalization and language coverage (Spanish and Portuguese in production today)
- Getting started: what gets configured during onboarding (brand/persona, language/market, channel strategy, targeting filters, payment methods, retry policy, control group)
- Reporting/metrics methodology (completion rate, recovery from total, recovery from completed, recovered value, control group, customer satisfaction)
- Data and security guarantees
- How merchants get access
- FAQ section (6 questions, adapted from the internal FAQ brief)