### PR TITLE
docs: fix contradictory idempotency retry guidance (Authentication reference)

### DIFF
--- a/reference/getting-started/authentication.mdx
+++ b/reference/getting-started/authentication.mdx
@@ -27,7 +27,7 @@ curl --request <Method> \\
 
 ## Idempotency
 
-Idempotency is the ability to make multiple identical requests and always get the same response. This is useful when a request fails due to a connection issue and the outcome is unclear; you can retry using the same `X-Idempotency-Key` and the API will not duplicate the operation.
+Idempotency lets you safely retry a request when its outcome is unclear — a timeout, a connection error, or a `500` response — without the risk of performing the operation twice.
 
 Some requests include a unique identifier sent as the `X-Idempotency-Key` header (e.g., `7bf41af5-70ae-4e79-9b28-a8fa75c3ac53`). This key also serves to identify a specific transaction.
 
@@ -35,14 +35,17 @@ Some requests include a unique identifier sent as the `X-Idempotency-Key` header
   Set the `x-idempotency-key` value to `{$randomUUID}` to generate keys automatically.
 </Note>
 
-Yuno stores the `X-Idempotency-Key` and the transaction status for 24 hours, regardless of the outcome (captured, authorized, or failed). Any subsequent request with the same key within that window returns the original response instead of creating a new transaction.
+Reusing an `X-Idempotency-Key` produces one of the following results:
 
-If two requests are sent simultaneously, the API may receive the second before responding to the first. In that case, the second request returns a `400 Bad Request` with error code `REQUEST_IN_PROCESS`, indicating there is already an open call for that `X-Idempotency-Key`. Retry the request after a few seconds.
+- **The original response.** If the first request with this key created a payment — whatever its status (approved, authorized, or declined) — any later request with the same key returns that original payment instead of creating a new one. The body of the retry is ignored.
+- **`400 REQUEST_IN_PROCESS`.** The first request with this key is still being processed. Retry with the same key after a few seconds.
+- **`400 IDEMPOTENCY_DUPLICATED`.** The first request with this key failed before a payment was created. No payment exists for this key, and the key cannot be reused: correct the request and send it with a new key.
+- **Normal processing.** If the first request was rejected before processing started (for example, a malformed body), the key was not consumed and the retry is processed as a new request.
 
-<Note>
-  If two requests are sent with the same key but different body contents, the API processes only the first one.
-</Note>
+### Recommended retry logic
 
-An `X-Idempotency-Key` is consumed by the first request that uses it, whether or not that request succeeds. To retry a request that returned a `400` or `500` error, correct it and send it with a new key.
+1. If a request fails with an unclear outcome — a timeout, a connection error, a `500`, or a response you cannot parse — retry it **with the same key**. The retry either returns the original result, processes normally, or returns `IDEMPOTENCY_DUPLICATED`, which means no payment was created.
+2. Use a **new key** only to start a genuinely new attempt: a new order, or a new attempt after a decline or after `IDEMPOTENCY_DUPLICATED`.
+3. Never retry an unclear failure with a new key. If the original request actually succeeded, retrying it with a new key creates a duplicate operation.
 
 <br />


### PR DESCRIPTION
## Why

The **Idempotency** section of `reference/getting-started/authentication` currently gives contradictory retry guidance:

- the intro says: outcome unclear → *"you can retry using the same `X-Idempotency-Key` and the API will not duplicate the operation"*;
- the storage paragraph says: same key within 24h *"returns the original response"*;
- the closing paragraph (added ~05 Aug with the YSHUB-6261 closure) says the opposite: the key *"is consumed by the first request that uses it, whether or not that request succeeds. To retry a request that returned a 400 or 500 error, correct it and send it with a new key."*

The closing paragraph is not only contradictory — as guidance it is **dangerous**: after an ambiguous failure (timeout / `500` / non-JSON edge response) whose original attempt actually landed, "retry with a new key" produces a **duplicate charge**. This came up with a production merchant (SpaceX) this week, via YSHUB-6261 context.

## Verified behavior (sandbox, 2026-08-12, account `7ddd4996…`)

| First request outcome | Same-key retry returns |
|---|---|
| Payment created, `SUCCEEDED` (`277ffbd3-a864-4aac-acf0-e795d7da2770`) | `201` with the **original payment object** (replay; retry body ignored) |
| Payment created, `DECLINED` (`90cb20e0-94c1-4ad2-98e0-9ea084dacee4`) | `201` with the same `DECLINED` payment (replay) |
| `400` at early schema validation (bad ISO-4217 currency) | key **not** consumed — corrected same-key retry processes normally |
| `400` mid-pipeline (missing card data; expired checkout session in YSHUB-6261) | `400 IDEMPOTENCY_DUPLICATED` — no payment exists for the key |

So replay is implemented and works; "consumed whether or not it succeeds" describes only the last quadrant.

## What changed

- Replaced the three conflicting statements with a single outcome table for key reuse (replay / `REQUEST_IN_PROCESS` / `IDEMPOTENCY_DUPLICATED` / normal processing) matching the verified behavior above.
- Added an explicit **Recommended retry logic**: same key for ambiguous failures; new key only for genuinely new attempts (after a decline or `IDEMPOTENCY_DUPLICATED`); never a new key straight after an ambiguous failure.
- Removed the **24-hour window** claim: YSHUB-6261 code review found no time bound on the dedup lookup, and the number could not be verified. If Core confirms a real TTL, it can be re-added with the correct value.
- Kept the `{$randomUUID}` note and the `REQUEST_IN_PROCESS` paragraph (verified accurate).

The `X-Idempotency-Key` description in the create-payment reference ("processed only once, even if it is retried due to network issues or timeouts") already matches the corrected text — no change needed there.

Context: YSHUB-6261 (closed as working-as-designed on the code side — this PR only aligns the docs with actual behavior). cc @douglasrmachado

🤖 Generated with [Claude Code](https://claude.com/claude-code)
