### PR TITLE
docs(yuno-sdk): call out that customerSession triggers enrollment mode (CORECM-19112)

### DIFF
--- a/docs/yuno-sdk/features/enrollment.mdx
+++ b/docs/yuno-sdk/features/enrollment.mdx
@@ -9,6 +9,10 @@ Enrollment lets you tokenize and save a customer's payment method without proces
 
 The same `Transaction` class handles enrollment. Only the session type changes.
 
+<Note>
+The session type is what selects the mode: passing `checkoutSession` runs a **payment**, while passing `customerSession` runs an **enrollment**. Exactly one of the two must be provided — supplying both, or neither, fails at construction time with the validation error `Exactly one of checkoutSession or customerSession must be provided`. See [Where do I start?](/docs/yuno-sdk/where-do-i-start) for the full decision guide.
+</Note>
+
 ## Before you start
 
 Your backend must create the resources required for enrollment:


### PR DESCRIPTION
## What

Alpha2 docs feedback ([CORECM-19112](https://yunopayments.atlassian.net/browse/CORECM-19112)): the Universal SDK enrollment page never stated that passing `customerSession` (without `checkoutSession`) in `TransactionConfig` is what triggers enrollment mode — the mutual-exclusivity rule was only discoverable through the SDK's runtime validation error.

Adds a `<Note>` callout at the top of `docs/yuno-sdk/features/enrollment.mdx` contrasting the two session types, stating the exactly-one rule, and quoting the literal validation error (`Exactly one of checkoutSession or customerSession must be provided`) so it is searchable. Links to the Where do I start? decision guide.

Note: the page's existing **Before you start** section already documents the back-to-back enrollment-record creation — the prerequisite behind CORECM-19111, closed as working-as-designed.

Replaces yuno-payments/yuno-sdk-docs#7 (opened against the wrong base — the Universal SDK docs are managed on `universal-sdk-alpha-overview-playground` in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-19112]: https://yunopayments.atlassian.net/browse/CORECM-19112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ