### PR TITLE
docs(vtex): document Legacy checkout redirect mode

### DIFF
--- a/docs/plugins/vtex/apple-pay-google-pay-enhanced-experience.mdx
+++ b/docs/plugins/vtex/apple-pay-google-pay-enhanced-experience.mdx
@@ -5,6 +5,10 @@ description: "Enable a direct wallet experience on VTEX checkout and unlock Appl
 
 The Apple Pay & Google Pay enhanced experience is an optional add-on for stores already using the Yuno VTEX plugin. It improves the checkout experience for shoppers by removing an intermediate screen between the VTEX checkout and the device's native wallet sheet, which is known to reduce conversion on wallet payments.
 
+<Note>
+  This add-on requires VTEX's current checkout. It is not available for stores running VTEX's Legacy checkout (**Payment Mode** set to **Legacy**), where wallet payments are completed on the Yuno-hosted page instead.
+</Note>
+
 <div className="grid grid-cols-2 gap-4">
   <Frame caption="Default experience (with intermediate screen)">
     <img src="/images/plugins/vtex/image-20260422-170119.png" alt="Default wallet experience" />

--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -49,6 +49,14 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
   Automatic charges for **increased** totals apply to **credit cards** and must be enabled in advance: set **Vault Card for Order Modification** and **Create Customer** to **Yes** in your provider configuration before the orders are placed. See [Advanced Scenarios](/docs/plugins/vtex/set-up-yuno-on-vtex#order-modifications-changed-order-totals) for the full setup.
 </Accordion>
 
+<Accordion title="Does Yuno work with VTEX's Legacy checkout?">
+  Yes. VTEX Legacy checkout cannot embed the Yuno checkout experience, so those stores use a redirect flow: the shopper is sent to a Yuno-hosted page to complete the payment and is then returned to your store.
+
+  To enable it, set **Payment Mode** to **Legacy** in your Yuno provider configuration. The rest of the setup is unchanged, and installing the Yuno Payment App is not required. Cards, Pix, boleto, digital wallets, and the other supported methods all work through it, and order status, settlement, cancellations, and refunds behave exactly as they do on the current checkout.
+
+  If your store runs VTEX's current checkout, leave this field on its default (**Payment App**).
+</Accordion>
+
 <Accordion title="Where can I troubleshoot a specific order?">
   Open the order in your **Yuno dashboard** to see the full lifecycle of every payment attempt, including provider responses and errors. Cross-reference the VTEX order ID with the Yuno payment ID to follow the transaction end-to-end.
 </Accordion>

--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -50,9 +50,9 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
 </Accordion>
 
 <Accordion title="Does Yuno work with VTEX's Legacy checkout?">
-  Yes. VTEX Legacy checkout cannot embed the Yuno checkout experience, so those stores use a redirect flow: the shopper is sent to a Yuno-hosted page to complete the payment and is then returned to your store.
+  Yes. VTEX Legacy checkout cannot run the Yuno Payment App, which is what renders the checkout experience inside VTEX. Those stores use a redirect flow instead: the shopper is sent to a Yuno-hosted page to complete the payment and is then returned to your store.
 
-  To enable it, set **Payment Mode** to **Legacy** in your Yuno provider configuration. The rest of the setup is unchanged, and installing the Yuno Payment App is not required. Cards, Pix, boleto, digital wallets, and the other supported methods all work through it, and order status, settlement, cancellations, and refunds behave exactly as they do on the current checkout.
+  To enable it, set **Payment Mode** to **Legacy** in your Yuno provider configuration. The rest of the setup is unchanged, and the Payment App installation step does not apply. Cards, Pix, boleto, digital wallets, and the other supported methods all work through it, and order status, settlement, cancellations, and refunds behave exactly as they do on the current checkout.
 
   If your store runs VTEX's current checkout, leave this field on its default (**Payment App**).
 </Accordion>

--- a/docs/plugins/vtex/index.mdx
+++ b/docs/plugins/vtex/index.mdx
@@ -11,7 +11,11 @@ Yuno and VTEX have joined forces to simplify payment processes for merchants wor
 
 With Yuno, your VTEX store can offer shoppers credit and debit cards and alternative payment methods such as Pix and Boleto Bancário. It also supports digital wallets like Apple Pay, Google Pay, and Click to Pay, plus Buy Now, Pay Later options, all through a single integration. Yuno's orchestration layer handles the routing and processing behind the scenes, so you can scale across markets without rebuilding the payment stack each time.
 
-Yuno is also PCI compliant, meeting rigorous security standards when handling card data. The integration is designed to keep shoppers inside your VTEX checkout from start to finish. There are no redirects to external payment pages, which removes friction at the most sensitive point of the purchase journey and helps lift conversion.
+Yuno is also PCI compliant, meeting rigorous security standards when handling card data. On VTEX's current checkout, the integration is designed to keep shoppers inside your VTEX checkout from start to finish. There are no redirects to external payment pages, which removes friction at the most sensitive point of the purchase journey and helps lift conversion.
+
+<Note>
+  Stores still running VTEX's **Legacy checkout** cannot embed the Yuno checkout experience. Those stores use a redirect flow instead, where the shopper completes the payment on a Yuno-hosted page and is returned to the store. See **Payment Mode** in the [field reference](/docs/plugins/vtex/set-up-yuno-on-vtex).
+</Note>
 
 ## Payment methods available
 
@@ -41,6 +45,8 @@ The plugin is composed of three pieces that work together behind the scenes:
 *   **Yuno SDK Web for VTEX**: The library used by the Payment App to render the Yuno UI where the shopper enters their payment data.
 
 You configure the **Payment Connector** in VTEX. The **Payment App** is installed afterward, and the **SDK Web** is loaded automatically during checkout. There is no separate setup for it.
+
+On VTEX Legacy checkout only the **Payment Connector** applies: the Payment App cannot be embedded, so the shopper is redirected to a Yuno-hosted checkout page instead.
 
 ## Recurring payments, multi-seller & modified orders
 

--- a/docs/plugins/vtex/index.mdx
+++ b/docs/plugins/vtex/index.mdx
@@ -14,7 +14,7 @@ With Yuno, your VTEX store can offer shoppers credit and debit cards and alterna
 Yuno is also PCI compliant, meeting rigorous security standards when handling card data. On VTEX's current checkout, the integration is designed to keep shoppers inside your VTEX checkout from start to finish. There are no redirects to external payment pages, which removes friction at the most sensitive point of the purchase journey and helps lift conversion.
 
 <Note>
-  Stores still running VTEX's **Legacy checkout** cannot embed the Yuno checkout experience. Those stores use a redirect flow instead, where the shopper completes the payment on a Yuno-hosted page and is returned to the store. See **Payment Mode** in the [field reference](/docs/plugins/vtex/set-up-yuno-on-vtex).
+  Stores still running VTEX's **Legacy checkout** cannot run the Yuno Payment App, so the Yuno checkout experience cannot be shown inside VTEX. Those stores use a redirect flow instead, where the shopper completes the payment on a Yuno-hosted page and is returned to the store. See **Payment Mode** in the [field reference](/docs/plugins/vtex/set-up-yuno-on-vtex).
 </Note>
 
 ## Payment methods available
@@ -46,7 +46,7 @@ The plugin is composed of three pieces that work together behind the scenes:
 
 You configure the **Payment Connector** in VTEX. The **Payment App** is installed afterward, and the **SDK Web** is loaded automatically during checkout. There is no separate setup for it.
 
-On VTEX Legacy checkout only the **Payment Connector** applies: the Payment App cannot be embedded, so the shopper is redirected to a Yuno-hosted checkout page instead.
+On VTEX Legacy checkout only the **Payment Connector** applies: Legacy cannot run the Payment App, so the shopper is redirected to a Yuno-hosted checkout page instead.
 
 ## Recurring payments, multi-seller & modified orders
 

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -44,7 +44,7 @@ Have the following ready:
       | **Soft Descriptor** | Optional | Custom text that appears on the shopper's card statement. |
       | **Create Customer** | Optional | When set to **Yes**, the plugin creates a corresponding customer record in Yuno. |
       | **VTEX IO orderPlaced page URL** | Optional | A custom URL where shoppers should be redirected after payment. |
-      | **Payment Mode** | Optional | Which checkout your store runs. Keep the default, **Payment App**, unless your store still uses VTEX's **Legacy checkout**, which cannot embed the Yuno checkout experience. With **Legacy**, the shopper is redirected to a Yuno-hosted page to complete the payment and is then returned to your store. Order status, settlement, cancellations, and refunds behave the same way, and installing the Yuno Payment App is not required. |
+      | **Payment Mode** | Optional | Which checkout your store runs. Keep the default, **Payment App**, unless your store still uses VTEX's **Legacy checkout**, which cannot run the Yuno Payment App. With **Legacy**, the shopper is redirected to a Yuno-hosted page to complete the payment and is then returned to your store. Order status, settlement, cancellations, and refunds behave the same way. |
       | **Transaction Identification From** | Optional | **Yuno TID** or **Provider TID**. |
       | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, `CIELO_CYBERSOURCE_FRAUD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
       | **Vault Card for Order Modification** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores the card used on each order so that, if the order total later increases, the additional amount can be charged automatically. See [Order modifications](#order-modifications-changed-order-totals). |
@@ -85,7 +85,7 @@ Have the following ready:
     Once installed, the Payment App takes care of rendering the Yuno checkout experience inside your VTEX checkout.
 
     <Note>
-      Skip this step if you set **Payment Mode** to **Legacy** in Step 1. VTEX Legacy checkout cannot embed the Payment App, so it is not used.
+      Skip this step if you set **Payment Mode** to **Legacy** in Step 1. VTEX Legacy checkout cannot run the Yuno Payment App — that is the reason Legacy mode redirects the shopper to a Yuno-hosted page instead.
     </Note>
   </Step>
 

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -44,7 +44,7 @@ Have the following ready:
       | **Soft Descriptor** | Optional | Custom text that appears on the shopper's card statement. |
       | **Create Customer** | Optional | When set to **Yes**, the plugin creates a corresponding customer record in Yuno. |
       | **VTEX IO orderPlaced page URL** | Optional | A custom URL where shoppers should be redirected after payment. |
-      | **Payment Mode** | Optional | **Payment App** (modern) or **Legacy** (redirect). |
+      | **Payment Mode** | Optional | Which checkout your store runs. Keep the default, **Payment App**, unless your store still uses VTEX's **Legacy checkout**, which cannot embed the Yuno checkout experience. With **Legacy**, the shopper is redirected to a Yuno-hosted page to complete the payment and is then returned to your store. Order status, settlement, cancellations, and refunds behave the same way, and installing the Yuno Payment App is not required. |
       | **Transaction Identification From** | Optional | **Yuno TID** or **Provider TID**. |
       | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, `CIELO_CYBERSOURCE_FRAUD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
       | **Vault Card for Order Modification** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores the card used on each order so that, if the order total later increases, the additional amount can be charged automatically. See [Order modifications](#order-modifications-changed-order-totals). |
@@ -83,6 +83,10 @@ Have the following ready:
     3.  Click **Install** to complete the setup.
 
     Once installed, the Payment App takes care of rendering the Yuno checkout experience inside your VTEX checkout.
+
+    <Note>
+      Skip this step if you set **Payment Mode** to **Legacy** in Step 1. VTEX Legacy checkout cannot embed the Payment App, so it is not used.
+    </Note>
   </Step>
 
   <Step title="Activate payment methods">


### PR DESCRIPTION
## What

The VTEX plugin now supports stores running VTEX's **Legacy checkout**, which cannot embed the Yuno checkout experience. Those merchants set **Payment Mode** to **Legacy** and the shopper completes the payment on a Yuno-hosted page, then returns to the store.

Shipping in connector `4.2.343` ([yuno-payments/sdk-vtex-connector#251](https://github.com/yuno-payments/sdk-vtex-connector/pull/251)).

## Approach: mentions, not a new page

Deliberately kept to targeted edits in four existing files instead of a dedicated page. The audience is small — VTEX is deprecating Legacy and one merchant is adopting this — and the entire decision reduces to a single configuration field. A dedicated page would duplicate most of the setup guide for readers who should ignore it. The FAQ entry acts as the entry point for anyone who needs it.

`docs.json` is unchanged (no new page, no nav entry).

## Changes

**`index.mdx` — a claim that no longer held universally.** The page stated:

> The integration is designed to keep shoppers inside your VTEX checkout from start to finish. **There are no redirects to external payment pages**…

That is false for a store in Legacy mode. It is now scoped to VTEX's current checkout rather than removed, so the conversion argument still lands for the ~all of readers it applies to, with a `<Note>` covering the exception. The "How the plugin works" section also notes the Payment App is not used in Legacy.

**`set-up-yuno-on-vtex.mdx`** — the **Payment Mode** row said only "**Payment App** (modern) or **Legacy** (redirect)", which does not tell a merchant when to pick either or what changes. Expanded. A `<Note>` on the *Install the Yuno Payment App* step marks it skippable in Legacy mode, since it is presented as mandatory today.

**`faqs.mdx`** — new entry: *Does Yuno work with VTEX's Legacy checkout?*

**`apple-pay-google-pay-enhanced-experience.mdx`** — a `<Note>` that the add-on requires the current checkout and is not available in Legacy mode (confirmed with the integration team).

## Not changed

**`direct-sdk-integration.mdx`** — headless and Legacy are orthogonal and mutually exclusive in practice: a headless store renders its own front-end, a Legacy store uses VTEX's old checkout. No reader of that page needs this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)