### PR TITLE
chore: web sdk changelog 1.9.30

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.30",
+      "release_date": "2026-08-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.30",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Google Pay Button Stuck Hover State",
+          "description": "Fixed the Google Pay button staying in its gray hover state on touch devices after the payment sheet was opened and dismissed.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6477"
+      ]
+    },
+    {
       "version": "1.10.4",
       "release_date": "2026-08-10",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,27 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.30",
-      "release_date": "2026-08-13",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.30",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Fixed Google Pay Button Stuck Hover State",
-          "description": "Fixed the Google Pay button staying in its gray hover state on touch devices after the payment sheet was opened and dismissed.",
-          "group": "Google Pay",
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
-        "YSHUB-6477"
-      ]
-    },
-    {
       "version": "1.10.4",
       "release_date": "2026-08-10",
       "upgrade": {
@@ -281,6 +260,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.30",
+      "release_date": "2026-08-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.30",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Google Pay Button Stuck Hover State",
+          "description": "Fixed the Google Pay button staying in its gray hover state on touch devices after the payment sheet was opened and dismissed.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6477"
       ]
     },
     {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -112,6 +112,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
+## v1.9.30
+*August 13, 2026*
+
+**Google Pay**
+
+- <ChangelogBadge type="fixed" /> **Fixed Google Pay Button Stuck Hover State**  
+  Fixed the Google Pay button staying in its gray hover state on touch devices after the payment sheet was opened and dismissed.
+
 ## v1.9.29
 *August 12, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.30`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.30

1 entry.