### PR TITLE
chore: web sdk changelog 1.9.31

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.31",
+      "release_date": "2026-08-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.31",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Extended Google Pay Button Hover Fix",
+          "description": "Extended the Google Pay button stuck-hover fix to the plain button variant shown when the user is not signed into Google.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6477"
+      ]
+    },
+    {
       "version": "1.10.4",
       "release_date": "2026-08-10",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.31`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.31

1 entry.