### PR TITLE
docs(C2-18044): document provider_data raw_request/raw_response on enrollment

### DIFF
--- a/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
+++ b/openapi/payment-methods-direct-workflow/enroll-payment-method-api.json
@@ -862,6 +862,19 @@
                             },
                             "payment": {}
                           }
+                        },
+                        "provider_data": {
+                          "type": "object",
+                          "description": "Additional data from the provider",
+                          "properties": {
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
+                            "raw_response": {
+                              "type": "object"
+                            }
+                          }
                         }
                       }
                     },
@@ -1148,6 +1161,10 @@
                                               }
                                             }
                                           },
+                                          "raw_request": {
+                                            "type": "object",
+                                            "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                                          },
                                           "third_party_transaction_id": {}
                                         }
                                       },
@@ -1180,6 +1197,19 @@
                                   }
                                 }
                               }
+                            }
+                          }
+                        },
+                        "provider_data": {
+                          "type": "object",
+                          "description": "Additional data from the provider",
+                          "properties": {
+                            "raw_request": {
+                              "type": "object",
+                              "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                            },
+                            "raw_response": {
+                              "type": "object"
                             }
                           }
                         }

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
@@ -381,7 +381,20 @@
                         "payment": {}
                       }
                     },
-                    "preferred": {}
+                    "preferred": {},
+                    "provider_data": {
+                      "type": "object",
+                      "description": "Additional data from the provider",
+                      "properties": {
+                        "raw_request": {
+                          "type": "object",
+                          "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                        },
+                        "raw_response": {
+                          "type": "object"
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -509,6 +509,19 @@
                       "nullable": true,
                       "description": "Whether this is the customer's preferred payment method.",
                       "example": null
+                    },
+                    "provider_data": {
+                      "type": "object",
+                      "description": "Additional data from the provider",
+                      "properties": {
+                        "raw_request": {
+                          "type": "object",
+                          "description": "Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."
+                        },
+                        "raw_response": {
+                          "type": "object"
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
Documents the `provider_data` raw payloads on the enrollment surfaces, using the exact wording the payments endpoints already use. Backs **[C2-18044](https://yunopayments.atlassian.net/browse/C2-18044)**.

## What was missing

| Surface | Before | Now |
|---|---|---|
| `POST /customers/{customer_id}/payment-methods` | no `provider_data` on either response variant | declared on both `oneOf` variants |
| `POST …` nested `verify.payment.transactions[].provider_data` | only `raw_response` | `raw_request` added alongside it |
| `GET /customers/{customer_id}/payment-methods/{payment_method_id}` | no `provider_data` | declared |
| `GET …` (PCI variant) | no `provider_data` | declared |

## Wording — identical to payments

Descriptions were taken verbatim from the payments specs rather than written fresh, so both surfaces read the same:

- `raw_request` → *"Obfuscated copy of the request Yuno sent to the provider. Only returned for allowlisted organizations."*
- `provider_data` → *"Additional data from the provider"*
- `raw_response` → no description, matching how payments declares it in response schemas

## Scope

Schema declarations only — no example payloads changed. Additive apart from one comma (`"preferred": {}` now has a key after it). All three files validate as JSON and keep their original trailing-newline state.

Behaviour worth knowing when reading these schemas: both raws are gated by `ALLOWED_RAW_REQUEST_ORGANIZATION_CODE` and are omitted entirely — not null — for organizations outside it. `raw_response` is populated today; `raw_request` returns null on the enrollment leg until `gateway-integration-api` exposes it. Enrollments that never reach a provider — plain card enrollment — carry no `provider_data` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[C2-18044]: https://yunopayments.atlassian.net/browse/C2-18044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ