### PR TITLE
docs(C2-18046): document provider raw_request and raw_response on unreferenced refunds

### DIFF
--- a/reference/unreferenced-refunds/create-unreferenced-refund.mdx
+++ b/reference/unreferenced-refunds/create-unreferenced-refund.mdx
@@ -15,9 +15,14 @@ Use this endpoint when the original charge was processed outside Yuno (legacy bi
 <Info>
 **Provider raw data**
 
-The `provider` object of the response can include `raw_request`, the exact payload Yuno sent to the provider. Its shape is defined by the provider, not by Yuno, so it varies per provider and per operation.
+The `provider` object carries the untouched provider exchange in two fields. The shape of both is defined by the provider, not by Yuno, so it varies per provider and per operation.
 
-This field is available only for accounts enabled for provider raw data. Contact your Yuno account manager to request access — without it, the field is omitted from the response.
+| Field | Content | Availability |
+| --- | --- | --- |
+| `raw_request` | The exact payload Yuno sent to the provider. | Accounts enabled for provider raw data. Contact your Yuno account manager to request access. Otherwise omitted. |
+| `raw_response` | The full payload the provider returned. | Not returned on this endpoint. Retrieve it with [Retrieve Unreferenced Refund by ID](/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id) using `include_raw_responses=true`. |
+
+`raw_response_code` and `raw_response_message` are summaries of the provider's answer and are always returned, independently of both fields above.
 </Info>
 
 <ParamField header="public-api-key" type="string" required>

--- a/reference/unreferenced-refunds/create-unreferenced-refund.mdx
+++ b/reference/unreferenced-refunds/create-unreferenced-refund.mdx
@@ -12,6 +12,14 @@ This request allows you to create an unreferenced refund — a credit pushed dir
 Use this endpoint when the original charge was processed outside Yuno (legacy billing system, external subscription engine) or when you need to send a goodwill / promotional credit. For reversing a Yuno-captured payment, use [Refund Payment endpoint with transaction](/reference/refund-payment) instead.
 </Info>
 
+<Info>
+**Provider raw data**
+
+The `provider` object of the response can include `raw_request`, the exact payload Yuno sent to the provider. Its shape is defined by the provider, not by Yuno, so it varies per provider and per operation.
+
+This field is available only for accounts enabled for provider raw data. Contact your Yuno account manager to request access — without it, the field is omitted from the response.
+</Info>
+
 <ParamField header="public-api-key" type="string" required>
 The unique public API key for your account. You find this on [the Yuno dashboard](https://dashboard.y.uno/).
 </ParamField>
@@ -254,7 +262,13 @@ When `stand_alone: true`, Yuno runs an ML fraud check before submitting to the p
     "connection_id": "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
     "reference": "re_3OqQz92eZvKYlo2C0g6XK1Yj",
     "category": "APPROVED",
-    "raw_response_code": "succeeded"
+    "raw_response_code": "succeeded",
+    "raw_request": {
+      "amount": 2500,
+      "currency": "usd",
+      "payment_method": "pm_1OqQz92eZvKYlo2C7Kx9Vbnm",
+      "metadata": { "merchant_order_id": "REFUND-2026-05-14-001" }
+    }
   },
   "metadata": [
     { "key": "billing_cycle_id", "value": "bc_2026_05" }

--- a/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
+++ b/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
@@ -9,9 +9,14 @@ This request enables you to retrieve details of an unreferenced refund based on 
 <Info>
 **Provider raw data**
 
-The `provider` object can include `raw_request`, the exact payload Yuno sent to the provider. Its shape is defined by the provider, not by Yuno, so it varies per provider and per operation.
+The `provider` object carries the untouched provider exchange in two fields. The shape of both is defined by the provider, not by Yuno, so it varies per provider and per operation. Each is controlled separately:
 
-This field is available only for accounts enabled for provider raw data, and is controlled independently of the `include_raw_responses` parameter below. Contact your Yuno account manager to request access — without it, the field is omitted from the response.
+| Field | Content | How to obtain it |
+| --- | --- | --- |
+| `raw_request` | The exact payload Yuno sent to the provider. | Requires your account to be enabled for provider raw data. Contact your Yuno account manager to request access. Not affected by `include_raw_responses`. |
+| `raw_response` | The full payload the provider returned. | Pass `include_raw_responses=true` on this request. |
+
+`raw_response_code` and `raw_response_message` are summaries of the provider's answer and are always returned, independently of both fields above.
 </Info>
 
 <ParamField header="public-api-key" type="string" required>

--- a/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
+++ b/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
@@ -6,6 +6,14 @@ api: "GET /v1/unreferenced-refunds/{unreferenced_refund_id}"
 
 This request enables you to retrieve details of an unreferenced refund based on its `id`, which needs to be provided in the request path.
 
+<Info>
+**Provider raw data**
+
+The `provider` object can include `raw_request`, the exact payload Yuno sent to the provider. Its shape is defined by the provider, not by Yuno, so it varies per provider and per operation.
+
+This field is available only for accounts enabled for provider raw data, and is controlled independently of the `include_raw_responses` parameter below. Contact your Yuno account manager to request access — without it, the field is omitted from the response.
+</Info>
+
 <ParamField header="public-api-key" type="string" required>
 The unique public API key for your account.
 </ParamField>
@@ -19,7 +27,7 @@ Yuno-generated unique identifier of the unreferenced refund.
 </ParamField>
 
 <ParamField query="include_raw_responses" type="boolean" default="false">
-When `true`, the `provider` object in the response payload will include `raw_response_code` and `raw_response_message`.
+When `true`, the `provider` object in the response payload will include `raw_response`, the full payload the provider returned. The `raw_response_code` and `raw_response_message` summary fields are always returned, regardless of this parameter.
 </ParamField>
 
 <ParamField query="include_transaction_responses" type="boolean" default="false">
@@ -63,7 +71,20 @@ curl --request GET \
     "reference": "re_3OqQz92eZvKYlo2C0g6XK1Yj",
     "category": "APPROVED",
     "raw_response_code": "succeeded",
-    "raw_response_message": "Refund settled"
+    "raw_response_message": "Refund settled",
+    "raw_request": {
+      "amount": 2500,
+      "currency": "usd",
+      "payment_method": "pm_1OqQz92eZvKYlo2C7Kx9Vbnm",
+      "metadata": { "merchant_order_id": "REFUND-2026-05-14-001" }
+    },
+    "raw_response": {
+      "id": "re_3OqQz92eZvKYlo2C0g6XK1Yj",
+      "object": "refund",
+      "amount": 2500,
+      "currency": "usd",
+      "status": "succeeded"
+    }
   },
   "created_at": "2026-05-14T11:47:13.482Z",
   "updated_at": "2026-05-14T11:47:18.030Z"


### PR DESCRIPTION
## [C2-18046] Document the provider raw fields on unreferenced refunds

Both raw fields of the `provider` object are now documented on the two unreferenced-refund reference pages, and one pre-existing error is corrected.

`raw_request` is new (backend PRs below). `raw_response` already shipped but was never described — only referenced obliquely by the `include_raw_responses` parameter, and inaccurately.

### What each page says now

One table per page, drawing the distinction that actually matters to an integrator: **the two fields are gated by different things.**

| Field | Content | How to obtain it |
|---|---|---|
| `raw_request` | The exact payload Yuno sent to the provider. | Account must be enabled for provider raw data — contact your account manager. **Not** affected by `include_raw_responses`. |
| `raw_response` | The full payload the provider returned. | `include_raw_responses=true` on the retrieve request. |

Both state that the shape is defined by the provider, not by Yuno, so it varies per provider and per operation — the same framing `the-payment-object.mdx` and `the-payout-object.mdx` already use for `raw_response`.

### Per file

**`create-unreferenced-refund.mdx`**
- New "Provider raw data" `<Info>` callout with the table.
- States `raw_response` is **not returned on this endpoint** and links to the retrieve endpoint. This matches the implementation: the create path never populates it, and there is no query parameter on POST to ask for it.
- `raw_request` added to the 201 response example.

**`retrieve-unreferenced-refund-by-id.mdx`**
- Same callout, with the "controlled separately" wording.
- `raw_request` and `raw_response` added to the 200 example — the example request already passes `?include_raw_responses=true`, so the payload now matches the request that produced it.
- **Bug fix:** `include_raw_responses` was documented as making the provider object include `raw_response_code` and `raw_response_message`. Those two are returned *always*; the parameter controls `raw_response`. Corrected, and the always-returned pair is now called out explicitly in both callouts.

### Notes for the copy reviewer

Two judgement calls, both open to change:

1. **Access wording** — "Contact your Yuno account manager to request access". No internal mechanism (env var, header, allow-list) is named. Follows the one existing precedent, in `docs/wallets/google-pay/google-pay-with-pix.mdx`.
2. **Scope** — `raw_request` also ships on payments and secondary operations (C2-16596) and is undocumented there. Documenting it here makes `the-payment-object.mdx` the inconsistent one. Not touched in this PR; worth a follow-up if you agree.

### Verification

- All 6 JSON examples across both pages re-validated as parseable.
- Internal links resolve: `/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id` points at a real file. (The short form `/reference/retrieve-...` would 404 — unlike `/reference/refund-payment`, this page has no entry in `redirects.json`.)
- Field behaviour confirmed against the deployed services on STG, not just the source: create returns `raw_request` and no `raw_response`; retrieve returns `raw_request` with or without the query parameter, and `raw_response` only with it.

Backend PRs: [unref-transaction-ms#12](https://github.com/yuno-payments/unref-transaction-ms/pull/12) · [public-api#2075](https://github.com/yuno-payments/public-api/pull/2075)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[C2-18046]: https://yunopayments.atlassian.net/browse/C2-18046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ