### PR TITLE
docs(C2-17978): PCI Proxy destination authentication

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -255,7 +255,8 @@
                 "pages": [
                   "docs/security-and-compliance/pci-proxy/overview",
                   "docs/security-and-compliance/pci-proxy/forward-proxy",
-                  "docs/security-and-compliance/pci-proxy/allowlist"
+                  "docs/security-and-compliance/pci-proxy/allowlist",
+                  "docs/security-and-compliance/pci-proxy/destination-authentication"
                 ]
               },
               {

--- a/docs/security-and-compliance/pci-proxy/allowlist.mdx
+++ b/docs/security-and-compliance/pci-proxy/allowlist.mdx
@@ -57,6 +57,15 @@ The destination object returns `id`, `hostname`, `purpose`, `account_id`, `statu
 (`ENABLED` / `DISABLED`), `created_at`, and `updated_at`. When you call via the API the actor
 is your API key, so the object does not carry a user email.
 
+<Tip>
+**Authenticate the forwards to this destination**
+
+A destination can also carry persisted authentication — a dLocal HMAC signing profile or an
+mTLS client certificate — so the proxy authenticates every forward for you instead of you
+sending credentials on each request. Add an `authentication` array on registration, or manage
+it later. See [Destination Authentication](/docs/security-and-compliance/pci-proxy/destination-authentication).
+</Tip>
+
 ## List your destinations
 
 ```sh

--- a/docs/security-and-compliance/pci-proxy/destination-authentication.mdx
+++ b/docs/security-and-compliance/pci-proxy/destination-authentication.mdx
@@ -26,7 +26,7 @@ non-secret material: the `x_login` identifier, or the certificate's fingerprint 
 
 ## Precedence: per-request headers always win
 
-The [per-request signing headers](/docs/security-and-compliance/pci-proxy/forward-proxy#request-signing)
+The [per-request signing headers](/docs/security-and-compliance/pci-proxy/forward-proxy#signed-destinations-hmac-request-signing)
 (`yuno-proxy-auth` + `yuno-proxy-auth-secret-key`) keep working exactly as before. On any
 forward:
 

--- a/docs/security-and-compliance/pci-proxy/destination-authentication.mdx
+++ b/docs/security-and-compliance/pci-proxy/destination-authentication.mdx
@@ -1,0 +1,146 @@
+---
+title: "Destination Authentication"
+description: "Register a destination's authentication once — HMAC signing credentials or an mTLS client certificate — and let the PCI Proxy authenticate every forward for you. Secrets are write-only and encrypted at rest."
+keywords: ["pci proxy", "authentication", "mtls", "hmac", "signing", "client certificate", "rotation"]
+---
+
+Instead of sending signing credentials on every forward, you can attach authentication to an
+allowlisted destination once. From then on, any forward to that host is authenticated by the
+proxy automatically: HMAC-signed, presented with your mTLS client certificate, or both.
+
+Two authentication types are supported today, and they can be combined on one destination:
+
+| Type | What the proxy does on each forward |
+|---|---|
+| `DLOCAL_HMAC` | Signs the outgoing request with your dLocal credentials: sets `X-Login`, `X-Trans-Key`, `X-Date`, and the `Authorization` HMAC signature |
+| `MTLS` | Presents your client certificate during the TLS handshake with the destination |
+
+<Info>
+**Your secrets are write-only**
+
+Secret material — signing keys and private keys — is accepted on registration and never
+returned by any endpoint. It is encrypted with a dedicated KMS key before it is stored;
+the plaintext exists only in memory while a request is being signed. Reads echo only
+non-secret material: the `x_login` identifier, or the certificate's fingerprint and expiry.
+</Info>
+
+## Precedence: per-request headers always win
+
+The [per-request signing headers](/docs/security-and-compliance/pci-proxy/forward-proxy#request-signing)
+(`yuno-proxy-auth` + `yuno-proxy-auth-secret-key`) keep working exactly as before. On any
+forward:
+
+1. If the request carries `yuno-proxy-auth*` headers, those credentials are used.
+2. Otherwise, if the destination has a persisted profile, the proxy uses it.
+3. Otherwise, the request is forwarded without authentication, as a plain allowlist entry.
+
+When a persisted `DLOCAL_HMAC` profile is applied, the proxy sets all four headers
+(`X-Login`, `X-Trans-Key`, `X-Date`, `Authorization`) from the profile — values you send for
+those headers on that request are replaced. An mTLS certificate is presented whenever the
+destination has an `MTLS` profile, regardless of how the request is signed.
+
+If the same hostname is registered both organization-wide and for a specific account, the
+account-scoped destination — and its authentication — wins for requests carrying that
+`yuno-account-id`.
+
+## Register a destination with authentication
+
+Add an `authentication` array to the [destination registration](/docs/security-and-compliance/pci-proxy/allowlist#register-a-destination) —
+at most one entry per type:
+
+```sh
+curl -X POST "https://api.y.uno/v1/pci-proxy/destinations" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "hostname": "api.dlocal.com",
+    "purpose": "Direct payins - dLocal",
+    "authentication": [
+      {
+        "type": "DLOCAL_HMAC",
+        "x_login": "sak_live_...",
+        "x_trans_key": "...",
+        "secret_key": "..."
+      }
+    ]
+  }'
+```
+
+An mTLS entry carries the certificate and its private key in PEM format. The certificate may
+include intermediates; the private key is write-only:
+
+```json
+{
+  "type": "MTLS",
+  "certificate": "-----BEGIN CERTIFICATE-----\n...",
+  "private_key": "<your PEM private key>"
+}
+```
+
+The response — like every read of the destination — echoes only non-secret material:
+
+```json
+{
+  "id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+  "hostname": "api.dlocal.com",
+  "status": "ENABLED",
+  "authentication": [
+    { "type": "DLOCAL_HMAC", "x_login": "sak_live_..." },
+    {
+      "type": "MTLS",
+      "certificate_fingerprint": "sha256:9f86d081...",
+      "certificate_expires_at": "2027-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+An invalid configuration returns `422 INVALID_AUTHENTICATION`: an unknown `type`, a duplicated
+`type`, a missing or empty required field, an unexpected field, a certificate or key that does
+not parse, a key that does not match the certificate, or an expired certificate.
+
+## Rotate credentials
+
+Rotation is a full replace of the destination's authentication — send the complete new
+configuration; there is no partial patch:
+
+```sh
+curl -X PUT "https://api.y.uno/v1/pci-proxy/destinations/{id}/authentication" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "authentication": [
+      { "type": "DLOCAL_HMAC", "x_login": "sak_live_new", "x_trans_key": "...", "secret_key": "..." }
+    ]
+  }'
+```
+
+Returns `200` with the destination and its new authentication summary. The overwrite is
+idempotent and takes effect immediately — the next forward already uses the new credentials.
+Use `certificate_expires_at` on your reads to schedule certificate rotation before expiry.
+
+## Remove authentication
+
+```sh
+curl -X DELETE "https://api.y.uno/v1/pci-proxy/destinations/{id}/authentication" \
+  -H "public-api-key: $PUBLIC_API_KEY" \
+  -H "private-secret-key: $PRIVATE_SECRET_KEY"
+```
+
+Returns `200`. The destination keeps working as a plain allowlist entry; forwards to it are
+simply no longer authenticated by the proxy. Deleting the destination itself also removes its
+authentication.
+
+Every authentication change is recorded in the destination audit trail as `AUTH_SET` or
+`AUTH_REMOVED`.
+
+## Errors
+
+| Status | Code | When |
+|---|---|---|
+| `400` | `INVALID_PARAMETERS` | Malformed body, an empty `authentication` array on `PUT`, or an invalid destination id |
+| `404` | `NOT_FOUND` | The destination does not exist or is not visible to your account scope |
+| `422` | `INVALID_AUTHENTICATION` | The authentication configuration is invalid (static message; the specific reason is not disclosed) |
+| `502` | `DESTINATION_UNREACHABLE` | On forwards: the destination rejected the TLS handshake — check that your client certificate is the one the destination expects and has not expired |

--- a/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
+++ b/docs/security-and-compliance/pci-proxy/forward-proxy.mdx
@@ -323,9 +323,9 @@ Do not send `X-Date` or `Authorization` yourself on a signed destination — the
 An unknown `yuno-proxy-auth` value, a missing `yuno-proxy-auth-secret-key`, or a `DLOCAL_HMAC` request without the `X-Login` or `X-Trans-Key` headers is rejected with `400 INVALID_REQUEST` before the destination is contacted. A `401` from the destination itself (wrong credentials) comes back as a destination response, with `yuno-proxy-destination-status: 401`.
 
 <Note>
-**Mutual TLS is not yet supported**
+**Mutual TLS is configured per destination, not inline**
 
-Destinations that require **mutual TLS** (a client certificate) are not supported inline: the certificate is presented by Yuno during the TLS handshake, not sent in your request, so it must be configured with Yuno per destination rather than passed in the body or a header. mTLS is planned for a later release.
+Destinations that require **mutual TLS** (a client certificate) are not supported inline: the certificate is presented by Yuno during the TLS handshake, not sent in your request. Register it once on the destination instead — see [Destination Authentication](/docs/security-and-compliance/pci-proxy/destination-authentication).
 </Note>
 
 ## Timeouts


### PR DESCRIPTION
## What

Docs for PCI Proxy v1.2 (yuno-payments/pci-proxy-ms#22): new **Destination Authentication** page under Security & Compliance › PCI Proxy.

Covers: the register-once model (DLOCAL_HMAC profiles + mTLS client certificates, combinable), write-only secrets encrypted with KMS, the precedence rule (per-request `yuno-proxy-auth*` headers always win; profile-driven signing replaces the four signing headers), idempotent rotation via `PUT`, removal via `DELETE`, `certificate_expires_at` visibility for rotation scheduling, audit trail, and the error table.

Ticket: [C2-17978](https://yunopayments.atlassian.net/browse/C2-17978)

Generated with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrtotrzuXXc2bgCVZJLYHj

[C2-17978]: https://yunopayments.atlassian.net/browse/C2-17978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modified in this repo.
> 
> **Overview**
> Documents **PCI Proxy destination authentication** (v1.2): a new **Destination Authentication** page in the PCI Proxy nav, plus cross-links from the allowlist and forward-proxy guides.
> 
> The new page explains registering **DLOCAL_HMAC** and **MTLS** profiles on allowlisted destinations (combinable), **write-only** secrets with KMS encryption, and **precedence** (per-request `yuno-proxy-auth*` headers override stored profiles). It covers registration via `authentication` on `POST /destinations`, full replace rotation via `PUT …/authentication`, removal via `DELETE`, audit events (`AUTH_SET` / `AUTH_REMOVED`), and related error codes.
> 
> **Allowlist** gains a tip pointing merchants at persisted auth instead of per-forward credentials. **Forward proxy** updates the mTLS note from “planned later” to **per-destination registration** via the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799a1ce0f80ee2ea51e451c5845778a0eccb61f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->