### PR TITLE
chore: web sdk changelog 1.10.5

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,73 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.5",
+      "release_date": "2026-08-14",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.5",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Removed the default heading from alternative payment method forms",
+          "description": "Alternative payment method forms no longer display the \"Enter the following details to continue\" heading, reducing visual noise. Context-specific headings, such as the NuPay enrollment title, are still shown.",
+          "group": "Alternative Payment Methods",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed Clipped Field Borders and Focus Animation in the Card Form",
+          "description": "Card form field borders no longer render cut off on some mobile devices, and the focus animation is no longer clipped.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Improved Google Pay Double Tap Handling",
+          "description": "Fixed an issue where quickly tapping the Google Pay button twice caused a page reload while the payment sheet was open, leaving the sheet unable to complete the payment.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed Installment Selection Issues in the Card Form",
+          "description": "The selected installment is kept while typing in the card form, and onInstallmentSelected notifies the last selection again when returning to the card payment method.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Fixed Google Pay Button Stuck Hover State",
+          "description": "Fixed the Google Pay button staying in its gray hover state on touch devices after the payment sheet was opened and dismissed.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Improved Checkout Load Performance",
+          "description": "The checkout now displays a loading skeleton instead of a blank space while its resources download, and external payment buttons render faster thanks to smaller, parallelized downloads. Also fixes a race condition that could leave the document type dropdown empty.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18149",
+        "CORECM-18736",
+        "CORECM-18856",
+        "YSHUB-6360",
+        "YSHUB-6409",
+        "YSHUB-6477",
+        "YSHUB-6491"
+      ]
+    },
+    {
       "version": "1.10.4",
       "release_date": "2026-08-10",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,35 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.5
+*August 14, 2026*
+
+**Alternative Payment Methods**
+
+- <ChangelogBadge type="changed" /> **Removed the default heading from alternative payment method forms**  
+  Alternative payment method forms no longer display the "Enter the following details to continue" heading, reducing visual noise. Context-specific headings, such as the NuPay enrollment title, are still shown.
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Fixed Clipped Field Borders and Focus Animation in the Card Form**  
+  Card form field borders no longer render cut off on some mobile devices, and the focus animation is no longer clipped.
+
+- <ChangelogBadge type="fixed" /> **Fixed Installment Selection Issues in the Card Form**  
+  The selected installment is kept while typing in the card form, and onInstallmentSelected notifies the last selection again when returning to the card payment method.
+
+**Google Pay**
+
+- <ChangelogBadge type="fixed" /> **Improved Google Pay Double Tap Handling**  
+  Fixed an issue where quickly tapping the Google Pay button twice caused a page reload while the payment sheet was open, leaving the sheet unable to complete the payment.
+
+- <ChangelogBadge type="fixed" /> **Fixed Google Pay Button Stuck Hover State**  
+  Fixed the Google Pay button staying in its gray hover state on touch devices after the payment sheet was opened and dismissed.
+
+**Core SDK**
+
+- <ChangelogBadge type="changed" /> **Improved Checkout Load Performance**  
+  The checkout now displays a loading skeleton instead of a blank space while its resources download, and external payment buttons render faster thanks to smaller, parallelized downloads. Also fixes a race condition that could leave the document type dropdown empty.
+
 ## v1.10.4
 *August 10, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.5`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.6

6 entries.