### PR TITLE
Restore sticky sidebar search after Mintlify DOM change

### DIFF
--- a/style.css
+++ b/style.css
@@ -431,18 +431,30 @@ aside.sticky:has(pre) {
 }
 
 /* Pin sidebar logo/toggle + search while the nav list scrolls under them.
-   Both are direct children of #sidebar-content (the scroll container);
-   the search row's top offset accounts for the logo row's height. The
-   box-shadow extends each box's background over the padding/margin gap
-   above it, so scrolling nav items don't show through. */
-#sidebar-content > div:first-child {
+   maple renders the sidebar in one of two DOM shapes, apparently chosen per
+   page by nav-list length, and both appear across the live site:
+   - plain: #sidebar-content itself is the overflow-y-auto scroll container,
+     logo/search are its direct children (original shape this fix targeted).
+   - ScrollArea: #sidebar-content wraps a base-ui ScrollArea, so logo/search
+     sit two levels deeper, inside [data-component-part="scroll-area-content"].
+   Both selectors are needed together; the :not(:has(...)) guard keeps the
+   plain-shape rule from also matching the ScrollArea wrapper div (which would
+   otherwise get double, conflicting sticky rules applied to it).
+   Re-verify this nesting after any Mintlify version bump — see DM-90, where
+   the ScrollArea shape was rolled out and silently broke the plain-shape-only
+   selectors that were here before. The search row's top offset accounts for
+   the logo row's height. The box-shadow extends each box's background over
+   the padding/margin gap above it, so scrolling nav items don't show through. */
+#sidebar-content:not(:has([data-component-part="scroll-area-viewport"])) > div:first-child,
+#sidebar-content [data-component-part="scroll-area-content"] > div:first-child {
   position: sticky;
   top: 0;
   z-index: 21;
   background: #fff;
   box-shadow: 0 -24px 0 0 #fff;
 }
-#sidebar-content > div:has(#search-bar-entry) {
+#sidebar-content:not(:has([data-component-part="scroll-area-viewport"])) > div:has(#search-bar-entry),
+#sidebar-content [data-component-part="scroll-area-content"] > div:has(#search-bar-entry) {
   position: sticky;
   top: 52px;
   z-index: 20;
@@ -450,8 +462,10 @@ aside.sticky:has(pre) {
   padding-bottom: 0.6rem;
   box-shadow: 0 -24px 0 0 #fff;
 }
-html.dark #sidebar-content > div:first-child,
-html.dark #sidebar-content > div:has(#search-bar-entry) {
+html.dark #sidebar-content:not(:has([data-component-part="scroll-area-viewport"])) > div:first-child,
+html.dark #sidebar-content [data-component-part="scroll-area-content"] > div:first-child,
+html.dark #sidebar-content:not(:has([data-component-part="scroll-area-viewport"])) > div:has(#search-bar-entry),
+html.dark #sidebar-content [data-component-part="scroll-area-content"] > div:has(#search-bar-entry) {
   background: rgb(var(--background-dark));
   box-shadow: 0 -24px 0 0 rgb(var(--background-dark));
 }


### PR DESCRIPTION
## Problem

Reported by Segundo: the sidebar search box (and logo/toggle row) stopped staying pinned while scrolling, on pages where it had worked fine since #548.

## Root cause

Mintlify started rendering the sidebar with a `ScrollArea` component on some pages, which wraps the logo/search rows inside two extra nested divs (`[data-component-part="scroll-area-viewport"]` → `[data-component-part="scroll-area-content"]`). This pushes logo/search two levels deeper than before.

The existing selectors (`#sidebar-content > div:first-child`, `#sidebar-content > div:has(#search-bar-entry)`) only matched the older structure, where logo/search were direct children of `#sidebar-content`. On ScrollArea-rendered pages, `#sidebar-content`'s only direct child is the wrapper itself, so the selectors stopped matching anything — sticky silently stopped applying, no errors.

Confirmed via `git log`/`git blame` that nothing in our own commits touched this CSS block since #548 — the DOM it depends on changed underneath it, on Mintlify's side.

Both DOM shapes coexist across the live site today (older structure e.g. on `docs/how-yuno-works/what-is-yuno`, ScrollArea structure e.g. on `reference/...` and `changelog/web`).

## Fix

`style.css` now targets both shapes:
- the original plain structure (direct children of `#sidebar-content`)
- the new `[data-component-part="scroll-area-content"]` nesting

A `:not(:has([data-component-part="scroll-area-viewport"]))` guard keeps the plain-structure rule from also (incorrectly) matching the ScrollArea wrapper on pages using the new shape.

## Verified

Tested locally with `mint dev` on both DOM shapes:
- `docs/how-yuno-works/what-is-yuno` (plain structure)
- `reference/payments/the-payment-object` (ScrollArea structure)
- `changelog/web` (ScrollArea structure)

Logo/toggle/search stay pinned while scrolling on all three, light and dark mode.

## Notes for review

- `#sidebar-content`, `[data-component-part="scroll-area-viewport"]`, `[data-component-part="scroll-area-content"]`, and `#search-bar-entry` are all Mintlify-generated — re-verify this nesting after any future Mintlify update, same caveat as the original PR #548.