### PR TITLE
[SUB-79] Current billing period is derived from the schedule

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1847,8 +1847,13 @@ Treat `cancellation_source` as open-ended. New values can be added as Yuno intro
         "type": "FIXED",
         "value": 36000
       },
-      "current_period_start": null,
-      "current_period_end": null,
+      "billing_cycles": {
+        "total": 5,
+        "current": 5,
+        "next_at": "2026-01-04T00:35:25.485281Z"
+      },
+      "current_period_start": "2025-12-04T00:35:25.485281Z",
+      "current_period_end": "2026-01-04T00:35:25.485281Z",
       "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
@@ -1857,6 +1862,8 @@ Treat `cancellation_source` as open-ended. New values can be added as Yuno intro
   }
 }
 ```
+
+A terminal subscription reports its final billing period rather than an empty one — the pair above is frozen at whatever window was current when the subscription reached `CANCELED`, the same way a `PAUSED` subscription freezes its window (see the [`subscription.pause`](#subscription-pause) note).
 
 ### subscription.complete
 
@@ -1879,8 +1886,13 @@ Sent when a subscription reaches its end date or total billing cycles and transi
         "type": "FIXED",
         "value": 36000
       },
-      "current_period_start": null,
-      "current_period_end": null,
+      "billing_cycles": {
+        "total": 5,
+        "current": 5,
+        "next_at": "2026-01-04T00:35:25.485281Z"
+      },
+      "current_period_start": "2025-12-04T00:35:25.485281Z",
+      "current_period_end": "2026-01-04T00:35:25.485281Z",
       "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"

--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -1463,6 +1463,9 @@ Example payload:
         "current": 1,
         "next_at": "2026-02-28T18:25:49.995376Z"
       },
+      "current_period_start": "2026-01-28T18:25:49.995376Z",
+      "current_period_end": "2026-02-28T18:25:49.995376Z",
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       },
@@ -1539,6 +1542,9 @@ Sent when a subscription transitions from any other valid status into `ACTIVE`. 
         "current": 2,
         "next_at": "2025-12-04T00:32:25.485281Z"
       },
+      "current_period_start": "2025-12-04T00:29:25.485281Z",
+      "current_period_end": "2025-12-04T00:32:25.485281Z",
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       },
@@ -1614,6 +1620,9 @@ Sent when a subscription enters a plan's trial phase from another status. Enteri
         "current": 2,
         "next_at": "2025-12-04T00:32:25.485281Z"
       },
+      "current_period_start": "2025-12-04T00:29:25.485281Z",
+      "current_period_end": "2025-12-04T00:32:25.485281Z",
+      "current_phase_end": "2025-12-04T00:32:25.485281Z",
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       },
@@ -1656,6 +1665,9 @@ This event is only emitted for accounts where the `PAST_DUE` status is enabled. 
         "current": 3,
         "next_at": "2025-12-04T00:35:25.485281Z"
       },
+      "current_period_start": "2025-12-04T00:32:25.485281Z",
+      "current_period_end": "2025-12-04T00:35:25.485281Z",
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       },
@@ -1675,6 +1687,10 @@ This event is only emitted for accounts where the `PAST_DUE` status is enabled. 
 
 Sent when a subscription is paused. Use this event to update the status in your system and pause related services.
 
+<Note>
+**A paused subscription's window is frozen where it was, not moved forward.** `current_period_start`/`current_period_end` (and `current_phase_end`, if the subscription is inside a phase) keep whatever window was current at the moment of pause — Yuno does not advance them while billing is suspended. The longer a subscription stays paused, the further `current_period_end` falls into the past; on prod, the large majority of currently-paused subscriptions already show an elapsed window. Don't treat `current_period_end` as "the next charge date" without also checking `status` — for a paused subscription it isn't one.
+</Note>
+
 ```json JSON
 {
   "type": "subscription",
@@ -1692,6 +1708,14 @@ Sent when a subscription is paused. Use this event to update the status in your 
         "type": "FIXED",
         "value": 36000
       },
+      "billing_cycles": {
+        "total": 5,
+        "current": 3,
+        "next_at": "2025-12-04T00:35:25.485281Z"
+      },
+      "current_period_start": "2025-12-04T00:32:25.485281Z",
+      "current_period_end": "2025-12-04T00:35:25.485281Z",
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       }
@@ -1737,6 +1761,9 @@ Sent when a paused subscription is resumed and transitions back to the `ACTIVE` 
         "current": 2,
         "next_at": "2026-07-14T19:19:31.914Z"
       },
+      "current_period_start": "2026-06-14T19:19:31.914Z",
+      "current_period_end": "2026-07-14T19:19:31.914Z",
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       },
@@ -1820,6 +1847,9 @@ Treat `cancellation_source` as open-ended. New values can be added as Yuno intro
         "type": "FIXED",
         "value": 36000
       },
+      "current_period_start": null,
+      "current_period_end": null,
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       }
@@ -1849,6 +1879,9 @@ Sent when a subscription reaches its end date or total billing cycles and transi
         "type": "FIXED",
         "value": 36000
       },
+      "current_period_start": null,
+      "current_period_end": null,
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       }
@@ -1894,6 +1927,9 @@ Sent ahead of an upcoming renewal. Timing is controlled by `renewal_notification
         "current": 2,
         "next_at": "2026-07-14T19:19:31.914Z"
       },
+      "current_period_start": "2026-06-14T19:19:31.914Z",
+      "current_period_end": "2026-07-14T19:19:31.914Z",
+      "current_phase_end": null,
       "customer_payer": {
         "code": "a9f9140a-1216-481c-8356-1a125078f905"
       },
@@ -1973,6 +2009,9 @@ Sent for plan-based subscriptions when a `$0` cycle is executed, either a trial 
         "current": 2,
         "next_at": "2026-07-14T19:19:31.914Z"
       },
+      "current_period_start": "2026-06-14T19:19:31.914Z",
+      "current_period_end": "2026-07-14T19:19:31.914Z",
+      "current_phase_end": "2026-07-14T19:19:31.914Z",
       "payments": []
     },
     "cycle": 1,

--- a/openapi/subscriptions/list-subscriptions.json
+++ b/openapi/subscriptions/list-subscriptions.json
@@ -93,7 +93,9 @@
                           "billing_cycles": { "total": 10, "current": 2, "next_at": "2023-02-16T20:00:00.786342Z" },
                           "payment_method": { "type": "CARD" },
                           "plan_id": "00000000-0000-4000-8000-000000000001",
-                          "created_at": "2023-12-16T20:46:54.786342Z"
+                          "created_at": "2023-12-16T20:46:54.786342Z",
+                          "current_period_start": "2023-01-16T20:00:00.912480Z",
+                          "current_period_end": "2023-02-16T20:00:00.786342Z"
                         }
                       ],
                       "pagination": { "page": 1, "size": 20, "total": 1, "total_pages": 1 }
@@ -152,7 +154,9 @@
                             }
                           },
                           "plan_id": { "type": "string", "nullable": true, "description": "The plan the subscription is linked to, or `null` for subscriptions created with a raw `amount`/`frequency`." },
-                          "created_at": { "type": "string" }
+                          "created_at": { "type": "string" },
+                          "current_period_start": { "type": "string", "nullable": true, "description": "Same semantics as on [The Subscription Object](/reference/subscriptions/the-subscription-object): start of the billing period the subscription is currently in." },
+                          "current_period_end": { "type": "string", "nullable": true, "description": "End of the billing period the subscription is currently in. Equal to `billing_cycles.next_at`." }
                         }
                       }
                     },

--- a/openapi/subscriptions/retrieve-subscription.json
+++ b/openapi/subscriptions/retrieve-subscription.json
@@ -259,12 +259,14 @@
                     },
                     "current_period_start": {
                       "type": "string",
-                      "description": "Only returned by this endpoint, and only once the first billing cycle has been charged. Always returned together with current_period_end.",
+                      "nullable": true,
+                      "description": "Start of the billing period the subscription is currently in, one cadence before `current_period_end`. Inside a trial or any other plan phase it follows that phase's cadence. Null once the subscription has ended (`CANCELED` or `COMPLETED`) and for a subscription with no recurring cadence. Always returned together with current_period_end.",
                       "example": "2023-01-16T20:00:00.912480Z"
                     },
                     "current_period_end": {
                       "type": "string",
-                      "description": "Only returned by this endpoint, and only once the first billing cycle has been charged. Equal to billing_cycles.next_at. Always returned together with current_period_start.",
+                      "nullable": true,
+                      "description": "End of the billing period the subscription is currently in. Equal to billing_cycles.next_at. Always returned together with current_period_start.",
                       "example": "2023-02-16T20:00:00.786342Z"
                     },
                     "billing_date": {
@@ -538,6 +540,12 @@
                       "type": "string",
                       "description": "Only present on plan-linked subscriptions.",
                       "example": "REGULAR"
+                    },
+                    "current_phase_end": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "When the phase named by `current_phase` hands over to the next one — for a subscription in its trial, when it switches to the regular price. End of the last billing period the phase covers, so on the final period of a trial it equals `current_period_end`. Null for a subscription with no plan and for one that already left the phase ladder.",
+                      "example": "2023-03-16T20:00:00.786342Z"
                     },
                     "billing_phases": {
                       "type": "array",

--- a/reference/subscriptions/list-subscriptions.mdx
+++ b/reference/subscriptions/list-subscriptions.mdx
@@ -7,7 +7,7 @@ description: "Returns a paginated list of an account's subscriptions."
 <Warning>
 **List items are a summary, not the full subscription**
 
-Each item carries the fields needed to render a grid. Everything else — `availability`, `retries`, `metadata`, `trial_period`, `payments`, `current_period_start`/`current_period_end`, `pending_plan_change`, `billing_phases` and the rest of [The Subscription Object](/reference/subscriptions/the-subscription-object) — is only returned by [Retrieve Subscription](/reference/subscriptions/retrieve-subscription). Call it per item when you need any of them.
+Each item carries the fields needed to render a grid, including `current_period_start`/`current_period_end`. Everything else — `availability`, `retries`, `metadata`, `trial_period`, `payments`, `pending_plan_change`, `billing_phases` and the rest of [The Subscription Object](/reference/subscriptions/the-subscription-object) — is only returned by [Retrieve Subscription](/reference/subscriptions/retrieve-subscription). Call it per item when you need any of them.
 </Warning>
 
 <Note>

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -129,6 +129,14 @@ This object represents a subscription that can be associated with a customer.
   Possible values: `TRIAL`, `REGULAR`.
 </ParamField>
 
+<ParamField body="current_phase_end" type="Timestamp">
+  When the phase named by `current_phase` hands over to the next one — for a subscription in its trial, the moment it switches to the regular price. It is the end of the last billing period the phase covers, so on the final period of a trial it equals `current_period_end`.
+
+  `null` on subscriptions that are not inside a phase: those with no plan, and plan-linked ones that already left the ladder and are on the plan's regular price.
+
+  Example: 2023-03-16T20:00:00.786342Z
+</ParamField>
+
 <ParamField body="billing_phases" type="array of objects">
   The plan's leading TRIAL phases, snapshotted for this subscriber's country at creation time. Only present on plan-linked subscriptions whose plan has phases. Absent as well when the subscription was created by a [plan change](/reference/subscriptions/change-subscription-plan) with `skip_trial: true` — that subscription is plan-linked and its plan has phases, but it never enters the ladder.
 
@@ -230,11 +238,15 @@ This object represents a subscription that can be associated with a customer.
 </ParamField>
 
 <ParamField body="current_period_start" type="Timestamp">
-  The start of the billing period currently in progress — the timestamp of that cycle's first (non-retry) payment attempt. Zero-amount cycles, such as a free trial phase, open a period the same way even though no charge is sent.
+  The start of the billing period currently in progress: one billing cadence before `current_period_end`. It is derived from the schedule, not from payments, so a subscription reports its window from the moment it is created, before any charge has been attempted.
 
-  Returned only by [Retrieve Subscription](/reference/subscriptions/retrieve-subscription) — `GET /v1/subscriptions/{subscription_id}` — and only once the first cycle has been charged. Every other response omits the pair regardless of how many cycles have been charged: create, update, pause, resume, cancel and retry. It is never populated on subscription list responses or on webhook payloads.
+  The cadence used is the one that scheduled the window. Inside a plan phase — a trial, an introductory price, any phase of a [plan](/reference/plans/the-plan-object) — that is the phase's own step, so a 14-day trial reports 14-day periods even when the plan bills monthly. On the first cycle after a phase ends the window still measures the cadence of the phase that scheduled it.
 
-  On REST responses the keys are omitted entirely when unresolved; webhook payloads may carry them as `null`. Treat null and missing as the same thing.
+  It never falls before `availability.start_at`: the first period of a subscription starts when the subscription does.
+
+  Returned on [Retrieve Subscription](/reference/subscriptions/retrieve-subscription), on [List Subscriptions](/reference/subscriptions/list-subscriptions) and on subscription webhook payloads.
+
+  `null`, together with `current_period_end`, in two cases: the subscription has ended (`CANCELED` or `COMPLETED`), or it has no recurring cadence at all. On REST responses the keys may be omitted entirely instead of sent as `null` — treat null and missing as the same thing.
 
   Example: 2023-01-16T20:00:00.912480Z
 </ParamField>
@@ -242,11 +254,9 @@ This object represents a subscription that can be associated with a customer.
 <ParamField body="current_period_end" type="Timestamp">
   The end of the billing period currently in progress, which is also when the next charge is scheduled. Always equal to `billing_cycles.next_at`.
 
-  This pair describes the period the subscription is **scheduled** into, not one that is necessarily paid for: if a cycle's charge failed and its retries are still running, the window has already moved to the period that charge was meant to open.
+  This pair describes the period the subscription is **scheduled** into, not one that is necessarily paid for: if a cycle's charge failed and its retries are still running, the window has already moved to the period that charge was meant to open. A `PAUSED` subscription keeps the window it was paused inside.
 
-  Absent under the same conditions as `current_period_start`; the two are always present or absent together.
-
-  These values are only meaningful while the subscription is live. A `CANCELED` or `COMPLETED` subscription keeps whatever window it last had; `current_period_end` then refers to a charge that will not be taken, and on a completed fixed-term subscription it can fall before `current_period_start`.
+  `null` under the same conditions as `current_period_start`; the two are always returned together.
 
   Example: 2023-02-16T20:00:00.786342Z
 </ParamField>

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -246,7 +246,7 @@ This object represents a subscription that can be associated with a customer.
 
   Returned on [Retrieve Subscription](/reference/subscriptions/retrieve-subscription), on [List Subscriptions](/reference/subscriptions/list-subscriptions) and on subscription webhook payloads.
 
-  `null`, together with `current_period_end`, in two cases: the subscription has ended (`CANCELED` or `COMPLETED`), or it has no recurring cadence at all. On REST responses the keys may be omitted entirely instead of sent as `null` — treat null and missing as the same thing.
+  Terminal subscriptions report their final billing period rather than going `null` — a `CANCELED` or `COMPLETED` subscription keeps the window it last had, the same way `PAUSED` freezes its window instead of advancing it. `null`, together with `current_period_end`, only when the subscription has no recurring cadence at all. On REST responses the keys may be omitted entirely instead of sent as `null` — treat null and missing as the same thing.
 
   Example: 2023-01-16T20:00:00.912480Z
 </ParamField>
@@ -254,7 +254,7 @@ This object represents a subscription that can be associated with a customer.
 <ParamField body="current_period_end" type="Timestamp">
   The end of the billing period currently in progress, which is also when the next charge is scheduled. Always equal to `billing_cycles.next_at`.
 
-  This pair describes the period the subscription is **scheduled** into, not one that is necessarily paid for: if a cycle's charge failed and its retries are still running, the window has already moved to the period that charge was meant to open. A `PAUSED` subscription keeps the window it was paused inside rather than advancing it, so `current_period_end` can be well in the past for a subscription that has been paused for a while — check `status` before reading it as an upcoming date.
+  This pair describes the period the subscription is **scheduled** into, not one that is necessarily paid for: if a cycle's charge failed and its retries are still running, the window has already moved to the period that charge was meant to open. A `PAUSED` subscription keeps the window it was paused inside rather than advancing it, and a `CANCELED` or `COMPLETED` subscription keeps its final window rather than clearing it — in both cases `current_period_end` can be well in the past, so check `status` before reading it as an upcoming date.
 
   `null` under the same conditions as `current_period_start`; the two are always returned together.
 

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -254,7 +254,7 @@ This object represents a subscription that can be associated with a customer.
 <ParamField body="current_period_end" type="Timestamp">
   The end of the billing period currently in progress, which is also when the next charge is scheduled. Always equal to `billing_cycles.next_at`.
 
-  This pair describes the period the subscription is **scheduled** into, not one that is necessarily paid for: if a cycle's charge failed and its retries are still running, the window has already moved to the period that charge was meant to open. A `PAUSED` subscription keeps the window it was paused inside.
+  This pair describes the period the subscription is **scheduled** into, not one that is necessarily paid for: if a cycle's charge failed and its retries are still running, the window has already moved to the period that charge was meant to open. A `PAUSED` subscription keeps the window it was paused inside rather than advancing it, so `current_period_end` can be well in the past for a subscription that has been paused for a while — check `status` before reading it as an upcoming date.
 
   `null` under the same conditions as `current_period_start`; the two are always returned together.
 


### PR DESCRIPTION
## What changed

`current_period_start` / `current_period_end` are now derived from the billing schedule instead of from the first payment attempt of the cycle, so the documentation no longer matches the API.

- **The Subscription Object** — rewrote both fields: the window is one billing cadence wide, ending on `billing_cycles.next_at`; it follows the cadence of the plan phase in progress, so a 14-day trial reports 14-day periods on a monthly plan; it is reported from creation, before any charge; it never starts before `availability.start_at`; and it is `null` once the subscription is no longer running or when the subscription has no recurring cadence.
- **Retrieve Subscription** — same, on the two schema descriptions, and both are marked nullable.
- **List Subscriptions** — the pair is part of the list item now: added to the schema and to the example, and removed from the "only on Retrieve" warning.

The pair also travels on subscription webhook payloads now, which the object page states.

Ticket: SUB-79.

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code; integrators should still re-read period-field semantics and new webhook payloads to avoid misinterpreting dates on paused or ended subscriptions.
> 
> **Overview**
> Updates subscription API docs so **`current_period_start` / `current_period_end`** match schedule-derived semantics (one cadence ending at `billing_cycles.next_at`), available from creation, phase-aware cadence, and frozen on **`PAUSED` / `CANCELED` / `COMPLETED`** rather than cleared.
> 
> **Reference & OpenAPI:** Rewrites **The Subscription Object** and **Retrieve Subscription** field descriptions (nullable rules, webhook/list coverage); adds **`current_phase_end`**; exposes the period pair on **List Subscriptions** (schema, example, and list-page warning).
> 
> **Webhooks:** Subscription event JSON examples now include **`current_period_start`**, **`current_period_end`**, and often **`current_phase_end`** / **`billing_cycles`**; adds guidance that paused subscriptions freeze the billing window and that terminal states keep the last period.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b7975d0948da4bc65fe676f408514b00833afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->