### PR TITLE
chore: web sdk changelog 1.9.32

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.32",
+      "release_date": "2026-08-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.32",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Clipped Field Borders and Focus Animation in the Card Form",
+          "description": "Card form field borders no longer render cut off on some mobile devices, and the focus animation is no longer clipped.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18856"
+      ]
+    },
+    {
       "version": "1.10.5",
       "release_date": "2026-08-14",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,27 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.32",
-      "release_date": "2026-08-13",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.32",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Fixed Clipped Field Borders and Focus Animation in the Card Form",
-          "description": "Card form field borders no longer render cut off on some mobile devices, and the focus animation is no longer clipped.",
-          "group": "Card Payments",
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
-        "CORECM-18856"
-      ]
-    },
-    {
       "version": "1.10.5",
       "release_date": "2026-08-14",
       "upgrade": {
@@ -348,6 +327,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.32",
+      "release_date": "2026-08-13",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.32",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Fixed Clipped Field Borders and Focus Animation in the Card Form",
+          "description": "Card form field borders no longer render cut off on some mobile devices, and the focus animation is no longer clipped.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18856"
       ]
     },
     {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -141,6 +141,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
+## v1.9.32
+*August 13, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Fixed Clipped Field Borders and Focus Animation in the Card Form**  
+  Card form field borders no longer render cut off on some mobile devices, and the focus animation is no longer clipped.
+
 ## v1.9.30
 *August 13, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.32`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v1.9.32

1 entry.