### PR TITLE
docs(changelog): React Native SDK 1.4.0 - native SDK bumps

### DIFF
--- a/changelog/react-native.mdx
+++ b/changelog/react-native.mdx
@@ -8,6 +8,12 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 <Info>
   Release notes for the React Native SDK are published here as new versions are released. Check back after each SDK update for a detailed summary of changes, new features, and migration guidance.
 </Info>
+## v1.4.0
+*August 14, 2026*
+
+- <ChangelogBadge type="changed" /> **Native SDKs Updated: iOS 2.22.0 and Android 2.21.1**  
+  The underlying native dependencies were bumped: `YunoSDK` (iOS) from 2.18.0 to 2.22.0 and `com.yuno.payments:android-sdk` from 2.17.2 to 2.21.1.
+
 ## v1.3.2
 *August 3, 2026*
 

--- a/changelog/source/react-native.json
+++ b/changelog/source/react-native.json
@@ -2,6 +2,24 @@
   "sdk": "react-native",
   "releases": [
     {
+      "version": "1.4.0",
+      "release_date": "2026-08-14",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/yuno-sdk-react-native@1.4.0",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Native SDKs Updated: iOS 2.22.0 and Android 2.21.1",
+          "description": "The underlying native dependencies were bumped: `YunoSDK` (iOS) from 2.18.0 to 2.22.0 and `com.yuno.payments:android-sdk` from 2.17.2 to 2.21.1.",
+          "group": null,
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "1.3.2",
       "release_date": "2026-08-03",
       "upgrade": {


### PR DESCRIPTION
## Context
Publishes the React Native SDK 1.4.0 release to the public changelog (`changelog/source/react-native.json`). The npm package is already live as `latest`.

## Changes
- Adds the `1.4.0` release entry (newest-first) with the native dependency bumps: `YunoSDK` (iOS) 2.18.0 -> 2.22.0 and `com.yuno.payments:android-sdk` 2.17.2 -> 2.21.1.

## Notes
- Entry mirrors `changelog/1.4.0.json` in `yuno-payments/yuno-sdk-react-native` (tag `v1.4.0-PROD`), created manually because the Bitrise Publish step could not open the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)