### PR TITLE
chore: web sdk changelog 1.9.33

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.33",
+      "release_date": "2026-08-14",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.33",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Hebrew and Persian RTL in the Card Form",
+          "description": "Card form secure fields now render right-to-left for Hebrew and Persian, matching the checkout shell direction.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6496"
+      ]
+    },
+    {
       "version": "1.10.5",
       "release_date": "2026-08-14",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,27 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.33",
-      "release_date": "2026-08-14",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.33",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Hebrew and Persian RTL in the Card Form",
-          "description": "Card form secure fields now render right-to-left for Hebrew and Persian, matching the checkout shell direction.",
-          "group": "Card Payments",
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
-        "YSHUB-6496"
-      ]
-    },
-    {
       "version": "1.10.5",
       "release_date": "2026-08-14",
       "upgrade": {
@@ -348,6 +327,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.33",
+      "release_date": "2026-08-14",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.33",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Hebrew and Persian RTL in the Card Form",
+          "description": "Card form secure fields now render right-to-left for Hebrew and Persian, matching the checkout shell direction.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "YSHUB-6496"
       ]
     },
     {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -141,6 +141,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
+## v1.9.33
+*August 14, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Hebrew and Persian RTL in the Card Form**  
+  Card form secure fields now render right-to-left for Hebrew and Persian, matching the checkout shell direction.
+
 ## v1.9.32
 *August 13, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.33`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.33

1 entry.