### PR TITLE
docs(C2-18187): Transaction Reporting API — report off-Yuno transactions

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -477,6 +477,13 @@
             ]
           },
           {
+            "group": "Transaction Reporting",
+            "tag": "Beta",
+            "pages": [
+              "reference/reporting/report-transactions"
+            ]
+          },
+          {
             "group": "Payment Links",
             "pages": [
               "reference/payment-links/status-payment-links",

--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -142,7 +142,7 @@
                         },
                         "provider_id": {
                           "type": "string",
-                          "description": "Optional, recommended. The provider you processed the transaction with (e.g. `ADYEN`). Shown on the payment, enabling provider-level segmentation in the dashboard and analytics.",
+                          "description": "Optional, recommended. The provider you processed the transaction with — must be one of Yuno's catalog provider ids (e.g. `ADYEN`); unknown providers are rejected. Shown on the payment, enabling provider-level segmentation in the dashboard and analytics.",
                           "examples": [
                             "ADYEN"
                           ]

--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -101,6 +101,11 @@
                             }
                           }
                         },
+                        "provider_id": {
+                          "type": "string",
+                          "description": "Optional, recommended. The provider you processed the transaction with (e.g. `ADYEN`). Shown on the payment, enabling provider-level segmentation in the dashboard and analytics.",
+                          "examples": ["ADYEN"]
+                        },
                         "event_type": {
                           "type": "string",
                           "enum": ["PURCHASE", "AUTHORIZATION"],
@@ -151,6 +156,7 @@
                         "payment_method_type": "CARD",
                         "result": "APPROVED",
                         "amount": { "currency": "USD", "value": 99.00 },
+                        "provider_id": "ADYEN",
                         "event_type": "PURCHASE",
                         "occurred_at": "2026-08-14T10:41:07Z",
                         "raw_provider_response": {

--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -5,9 +5,15 @@
     "version": "1.0"
   },
   "servers": [
-    { "url": "https://api-sandbox.y.uno/v1" },
-    { "url": "https://api.y.uno/v1" },
-    { "url": "https://api.eu.y.uno/v1" }
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
   ],
   "security": [],
   "paths": {
@@ -20,13 +26,17 @@
           {
             "in": "header",
             "name": "PUBLIC-API-KEY",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Your public API key."
           },
           {
             "in": "header",
             "name": "PRIVATE-SECRET-KEY",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Your private secret key. Never expose it client-side."
           }
         ],
@@ -36,7 +46,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["account_id", "events"],
+                "required": [
+                  "account_id",
+                  "events"
+                ],
                 "properties": {
                   "account_id": {
                     "type": "string",
@@ -51,64 +64,103 @@
                     "items": {
                       "type": "object",
                       "additionalProperties": false,
-                      "required": ["report_id", "merchant_order_id", "country", "payment_method_type", "result", "amount"],
+                      "required": [
+                        "report_id",
+                        "merchant_order_id",
+                        "country",
+                        "payment_method_type",
+                        "result",
+                        "amount"
+                      ],
                       "properties": {
                         "report_id": {
                           "type": "string",
                           "maxLength": 255,
                           "description": "Your unique identifier for this event — the deduplication key. An event with a `report_id` already ingested in the last 30 days is counted as a duplicate and never ingested twice, which makes retries safe.",
-                          "examples": ["spacex-rpt-000123"]
+                          "examples": [
+                            "spacex-rpt-000123"
+                          ]
                         },
                         "merchant_order_id": {
                           "type": "string",
                           "maxLength": 255,
                           "description": "Your order reference — how you find the payment in the dashboard.",
-                          "examples": ["starlink_order_45678"]
+                          "examples": [
+                            "starlink_order_45678"
+                          ]
                         },
                         "country": {
                           "type": "string",
                           "minLength": 2,
                           "maxLength": 2,
                           "description": "ISO 3166-1 alpha-2 country code of the transaction.",
-                          "examples": ["US"]
+                          "examples": [
+                            "US"
+                          ]
                         },
                         "payment_method_type": {
                           "type": "string",
                           "description": "Payment method type used at the provider (e.g. `CARD`).",
-                          "examples": ["CARD"]
+                          "examples": [
+                            "CARD"
+                          ]
                         },
                         "result": {
                           "type": "string",
-                          "enum": ["APPROVED", "DECLINED", "ERROR"],
+                          "enum": [
+                            "APPROVED",
+                            "DECLINED",
+                            "ERROR"
+                          ],
                           "description": "The outcome the provider gave you. Maps to the payment status: `APPROVED` → `SUCCEEDED`, `DECLINED` → `DECLINED`, `ERROR` → `ERROR`."
                         },
                         "amount": {
                           "type": "object",
-                          "required": ["value", "currency"],
+                          "required": [
+                            "value",
+                            "currency"
+                          ],
                           "description": "Transaction amount. Decimal value — a payment of $99 is `99.00`, not `9900`.",
                           "properties": {
                             "value": {
                               "type": "number",
                               "description": "Decimal amount.",
-                              "examples": [99.00]
+                              "examples": [
+                                99.0
+                              ]
                             },
                             "currency": {
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 3,
                               "description": "ISO 4217 currency code.",
-                              "examples": ["USD"]
+                              "examples": [
+                                "USD"
+                              ]
                             }
                           }
                         },
                         "provider_id": {
                           "type": "string",
                           "description": "Optional, recommended. The provider you processed the transaction with (e.g. `ADYEN`). Shown on the payment, enabling provider-level segmentation in the dashboard and analytics.",
-                          "examples": ["ADYEN"]
+                          "examples": [
+                            "ADYEN"
+                          ]
+                        },
+                        "latency_ms": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Optional. The provider's response time as observed by you, in milliseconds (round-trip of the authorization call). Feeds latency analytics per provider.",
+                          "examples": [
+                            180
+                          ]
                         },
                         "event_type": {
                           "type": "string",
-                          "enum": ["PURCHASE", "AUTHORIZATION"],
+                          "enum": [
+                            "PURCHASE",
+                            "AUTHORIZATION"
+                          ],
                           "default": "PURCHASE",
                           "description": "Optional. The operation you performed at the provider. Defaults to `PURCHASE` when omitted."
                         },
@@ -116,7 +168,9 @@
                           "type": "string",
                           "format": "date-time",
                           "description": "Optional. When the transaction happened at the provider (RFC 3339, UTC). Defaults to the time Yuno receives the event.",
-                          "examples": ["2026-08-14T10:41:07Z"]
+                          "examples": [
+                            "2026-08-14T10:41:07Z"
+                          ]
                         },
                         "raw_provider_response": {
                           "type": "object",
@@ -139,7 +193,10 @@
                         "country": "US",
                         "payment_method_type": "CARD",
                         "result": "APPROVED",
-                        "amount": { "currency": "USD", "value": 99.00 }
+                        "amount": {
+                          "currency": "USD",
+                          "value": 99.0
+                        }
                       }
                     ]
                   }
@@ -155,8 +212,12 @@
                         "country": "US",
                         "payment_method_type": "CARD",
                         "result": "APPROVED",
-                        "amount": { "currency": "USD", "value": 99.00 },
+                        "amount": {
+                          "currency": "USD",
+                          "value": 99.0
+                        },
                         "provider_id": "ADYEN",
+                        "latency_ms": 180,
                         "event_type": "PURCHASE",
                         "occurred_at": "2026-08-14T10:41:07Z",
                         "raw_provider_response": {
@@ -193,11 +254,20 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "report_id": { "type": "string" },
-                          "code": { "type": "string", "examples": ["INVALID_EVENT"] },
+                          "report_id": {
+                            "type": "string"
+                          },
+                          "code": {
+                            "type": "string",
+                            "examples": [
+                              "INVALID_EVENT"
+                            ]
+                          },
                           "messages": {
                             "type": "array",
-                            "items": { "type": "string" }
+                            "items": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
@@ -213,7 +283,9 @@
                         {
                           "report_id": "spacex-rpt-000124",
                           "code": "INVALID_EVENT",
-                          "messages": ["The field 'event_type' must be one of: PURCHASE, AUTHORIZATION."]
+                          "messages": [
+                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZATION."
+                          ]
                         }
                       ]
                     }
@@ -229,13 +301,25 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "code": { "type": "string" },
-                    "messages": { "type": "array", "items": { "type": "string" } }
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 },
                 "examples": {
                   "invalid_request": {
-                    "value": { "code": "INVALID_REQUEST", "messages": ["The field 'events' must contain between 1 and 500 items."] }
+                    "value": {
+                      "code": "INVALID_REQUEST",
+                      "messages": [
+                        "The field 'events' must contain between 1 and 500 items."
+                      ]
+                    }
                   }
                 }
               }
@@ -248,13 +332,25 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "code": { "type": "string" },
-                    "messages": { "type": "array", "items": { "type": "string" } }
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 },
                 "examples": {
                   "product_not_enabled": {
-                    "value": { "code": "PRODUCT_NOT_ENABLED", "messages": ["The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it."] }
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it."
+                      ]
+                    }
                   }
                 }
               }

--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -76,7 +76,7 @@
                         "report_id": {
                           "type": "string",
                           "maxLength": 255,
-                          "description": "Your unique identifier for this event — the deduplication key. An event with a `report_id` already ingested in the last 30 days is counted as a duplicate and never ingested twice, which makes retries safe.",
+                          "description": "Your unique identifier for this event — the deduplication key. An event with a `report_id` already ingested is counted as a duplicate and never ingested twice, which makes retries safe.",
                           "examples": [
                             "spacex-rpt-000123"
                           ]
@@ -93,7 +93,7 @@
                           "type": "string",
                           "minLength": 2,
                           "maxLength": 2,
-                          "description": "ISO 3166-1 alpha-2 country code of the transaction.",
+                          "description": "Uppercase ISO 3166-1 alpha-2 country code of the transaction (e.g. `US`); lowercase or unknown codes are rejected.",
                           "examples": [
                             "US"
                           ]
@@ -112,7 +112,7 @@
                             "DECLINED",
                             "ERROR"
                           ],
-                          "description": "The outcome the provider gave you. Maps to the payment status: `APPROVED` → `SUCCEEDED`, `DECLINED` → `DECLINED`, `ERROR` → `ERROR`."
+                          "description": "The outcome the provider gave you. Maps to the payment status together with the event type: `PURCHASE`+`APPROVED` → `SUCCEEDED`; `AUTHORIZATION`+`APPROVED` → `PENDING`/`AUTHORIZED` (an approved authorization is not captured money); `DECLINED` → `DECLINED`; `ERROR` → `ERROR`."
                         },
                         "amount": {
                           "type": "object",
@@ -133,7 +133,7 @@
                               "type": "string",
                               "minLength": 3,
                               "maxLength": 3,
-                              "description": "ISO 4217 currency code.",
+                              "description": "Uppercase ISO 4217 currency code (e.g. `USD`); lowercase or unknown codes are rejected.",
                               "examples": [
                                 "USD"
                               ]
@@ -295,7 +295,7 @@
             }
           },
           "400": {
-            "description": "Request-level validation failure — malformed body, missing required field, batch over 500 events, or `account_id` not belonging to your organization.",
+            "description": "Request-level validation failure — malformed body, missing required field, or a batch over 500 events. An `account_id` that does not exist or does not belong to your organization answers `INVALID_ACCOUNT_ID`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -317,7 +317,7 @@
                     "value": {
                       "code": "INVALID_REQUEST",
                       "messages": [
-                        "The field 'events' must contain between 1 and 500 items."
+                        "The field 'events' must contain between 1 and 500 events."
                       ]
                     }
                   }

--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -1,0 +1,261 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Yuno Transaction Reporting API",
+    "version": "1.0"
+  },
+  "servers": [
+    { "url": "https://api-sandbox.y.uno/v1" },
+    { "url": "https://api.y.uno/v1" },
+    { "url": "https://api.eu.y.uno/v1" }
+  ],
+  "security": [],
+  "paths": {
+    "/reporting/transactions": {
+      "post": {
+        "summary": "Report Off-Yuno Transactions",
+        "description": "Reports transactions processed directly with a provider (outside Yuno). Each accepted event is persisted as a regular Yuno payment with `origin: REPORTED` — visible in the dashboard, listings and analytics, but never routed, retried or charged by Yuno.",
+        "operationId": "report-transactions",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "PUBLIC-API-KEY",
+            "schema": { "type": "string" },
+            "description": "Your public API key."
+          },
+          {
+            "in": "header",
+            "name": "PRIVATE-SECRET-KEY",
+            "schema": { "type": "string" },
+            "description": "Your private secret key. Never expose it client-side."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["account_id", "events"],
+                "properties": {
+                  "account_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "UUID of the Yuno account the reported payments belong to."
+                  },
+                  "events": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 500,
+                    "description": "One event or a batch of up to 500. Events are processed per item: one invalid event never rejects the batch.",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["report_id", "merchant_order_id", "country", "payment_method_type", "result", "amount"],
+                      "properties": {
+                        "report_id": {
+                          "type": "string",
+                          "maxLength": 255,
+                          "description": "Your unique identifier for this event — the deduplication key. An event with a `report_id` already ingested in the last 30 days is counted as a duplicate and never ingested twice, which makes retries safe.",
+                          "examples": ["spacex-rpt-000123"]
+                        },
+                        "merchant_order_id": {
+                          "type": "string",
+                          "maxLength": 255,
+                          "description": "Your order reference — how you find the payment in the dashboard.",
+                          "examples": ["starlink_order_45678"]
+                        },
+                        "country": {
+                          "type": "string",
+                          "minLength": 2,
+                          "maxLength": 2,
+                          "description": "ISO 3166-1 alpha-2 country code of the transaction.",
+                          "examples": ["US"]
+                        },
+                        "payment_method_type": {
+                          "type": "string",
+                          "description": "Payment method type used at the provider (e.g. `CARD`).",
+                          "examples": ["CARD"]
+                        },
+                        "result": {
+                          "type": "string",
+                          "enum": ["APPROVED", "DECLINED", "ERROR"],
+                          "description": "The outcome the provider gave you. Maps to the payment status: `APPROVED` → `SUCCEEDED`, `DECLINED` → `DECLINED`, `ERROR` → `ERROR`."
+                        },
+                        "amount": {
+                          "type": "object",
+                          "required": ["value", "currency"],
+                          "description": "Transaction amount. Decimal value — a payment of $99 is `99.00`, not `9900`.",
+                          "properties": {
+                            "value": {
+                              "type": "number",
+                              "description": "Decimal amount.",
+                              "examples": [99.00]
+                            },
+                            "currency": {
+                              "type": "string",
+                              "minLength": 3,
+                              "maxLength": 3,
+                              "description": "ISO 4217 currency code.",
+                              "examples": ["USD"]
+                            }
+                          }
+                        },
+                        "event_type": {
+                          "type": "string",
+                          "enum": ["PURCHASE", "AUTHORIZATION"],
+                          "default": "PURCHASE",
+                          "description": "Optional. The operation you performed at the provider. Defaults to `PURCHASE` when omitted."
+                        },
+                        "occurred_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Optional. When the transaction happened at the provider (RFC 3339, UTC). Defaults to the time Yuno receives the event.",
+                          "examples": ["2026-08-14T10:41:07Z"]
+                        },
+                        "raw_provider_response": {
+                          "type": "object",
+                          "description": "Optional. The provider's response payload, verbatim (JSON, up to 64 KB). Stored with defensive card-data redaction applied; never returned by any API. Archiving it lets Yuno enrich the payment later without asking you for anything new."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "minimal": {
+                  "summary": "Minimal event (required fields only)",
+                  "value": {
+                    "account_id": "3f2a1b6c-8d4e-4f5a-9b0c-1d2e3f4a5b6c",
+                    "events": [
+                      {
+                        "report_id": "spacex-rpt-000123",
+                        "merchant_order_id": "starlink_order_45678",
+                        "country": "US",
+                        "payment_method_type": "CARD",
+                        "result": "APPROVED",
+                        "amount": { "currency": "USD", "value": 99.00 }
+                      }
+                    ]
+                  }
+                },
+                "full": {
+                  "summary": "Full event (all v1 fields)",
+                  "value": {
+                    "account_id": "3f2a1b6c-8d4e-4f5a-9b0c-1d2e3f4a5b6c",
+                    "events": [
+                      {
+                        "report_id": "spacex-rpt-000123",
+                        "merchant_order_id": "starlink_order_45678",
+                        "country": "US",
+                        "payment_method_type": "CARD",
+                        "result": "APPROVED",
+                        "amount": { "currency": "USD", "value": 99.00 },
+                        "event_type": "PURCHASE",
+                        "occurred_at": "2026-08-14T10:41:07Z",
+                        "raw_provider_response": {
+                          "pspReference": "8815992887",
+                          "resultCode": "Authorised"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Batch accepted and processed per event.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "accepted": {
+                      "type": "integer",
+                      "description": "Events ingested as payments."
+                    },
+                    "duplicates": {
+                      "type": "integer",
+                      "description": "Events skipped because their `report_id` was already ingested."
+                    },
+                    "rejected": {
+                      "type": "array",
+                      "description": "Events that failed validation, each with its reason. The rest of the batch is unaffected.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "report_id": { "type": "string" },
+                          "code": { "type": "string", "examples": ["INVALID_EVENT"] },
+                          "messages": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "mixed": {
+                    "value": {
+                      "accepted": 2,
+                      "duplicates": 1,
+                      "rejected": [
+                        {
+                          "report_id": "spacex-rpt-000124",
+                          "code": "INVALID_EVENT",
+                          "messages": ["The field 'event_type' must be one of: PURCHASE, AUTHORIZATION."]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request-level validation failure — malformed body, missing required field, batch over 500 events, or `account_id` not belonging to your organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                },
+                "examples": {
+                  "invalid_request": {
+                    "value": { "code": "INVALID_REQUEST", "messages": ["The field 'events' must contain between 1 and 500 items."] }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — `PRODUCT_NOT_ENABLED` (the product is not enabled for your organization).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                },
+                "examples": {
+                  "product_not_enabled": {
+                    "value": { "code": "PRODUCT_NOT_ENABLED", "messages": ["The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it."] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -20,14 +20,14 @@ This API requires activation for your organization. Contact your Key Account Man
 ## How it works
 
 1. You process a transaction directly with your provider (e.g. a purchase on your own Adyen account).
-2. You report it here — one event or a batch of up to 500.
-3. Each accepted event creates **one payment** with one transaction, with the status derived from `result`: `APPROVED` → `SUCCEEDED`, `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
+2. You report it here — one event or a batch of up to 500. For latency-sensitive integrations we recommend batches of up to 100 events: the full 500-event batch is processed synchronously and can take several seconds.
+3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type: a `PURCHASE` with `APPROVED` lands `SUCCEEDED`; an `AUTHORIZATION` with `APPROVED` lands `PENDING` with sub-status `AUTHORIZED` (an approved authorization is not captured money — it mirrors how Yuno-processed authorizations behave); `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
 
 In this version the supported operations are `PURCHASE` (default) and `AUTHORIZATION`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
 
 ## Retries and deduplication
 
-There is **no idempotency header on this endpoint — and none is needed**. The `report_id` you generate per event is the deduplication key: an event whose `report_id` was already ingested (in the last 30 days) is counted in `duplicates` and never ingested twice, no matter when or in which batch it arrives. Retrying a whole batch after a network failure is always safe.
+There is **no idempotency header on this endpoint — and none is needed**. The `report_id` you generate per event is the deduplication key: an event whose `report_id` was already ingested is counted in `duplicates` and never ingested twice, no matter when or in which batch it arrives. Retrying a whole batch after a network failure is always safe.
 
 The batch is processed **per event**: one invalid event lands in `rejected[]` with its reason, and the rest of the batch is unaffected.
 
@@ -51,6 +51,7 @@ Errors return a `code` and a `messages` array.
 
 | HTTP | `code` | When |
 | ---- | ------ | ---- |
-| 400 | `INVALID_REQUEST` | Malformed body, missing required field, batch over 500 events, or `account_id` not belonging to your organization. |
+| 400 | `INVALID_REQUEST` | Malformed body, missing required field, or a batch over 500 events. |
+| 400 | `INVALID_ACCOUNT_ID` | The `account_id` does not exist or does not belong to your organization. |
 | 403 | `PRODUCT_NOT_ENABLED` | "The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it." |
 | — | `INVALID_EVENT` (per event, in `rejected[]`) | Invalid enum value, wrong field type, unknown field, or `raw_provider_response` over 64 KB. |

--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -1,0 +1,56 @@
+---
+title: "Report Off-Yuno Transactions"
+openapi: "/openapi/reporting/report-transactions.json POST /reporting/transactions"
+description: "Report transactions processed directly with your providers so they appear in Yuno as payments — dashboard, listings and analytics included."
+---
+
+This endpoint gives Yuno visibility over the traffic you process **directly with your providers**, outside Yuno's transaction path. Each accepted event is persisted as a **regular Yuno payment**, differentiated by the `origin` field:
+
+- `origin: YUNO` — payments processed by Yuno (every existing payment).
+- `origin: REPORTED` — payments that entered through this API.
+
+Reported payments appear in the dashboard, in `GET /v1/payments`, and in analytics — filtered by `origin` — but Yuno **never processes them**: no routing, no provider calls, no retries, and no money movement. The money already moved at your provider; Yuno records the fact.
+
+<Note>
+**Enabled per organization**
+
+This API requires activation for your organization. Contact your Key Account Manager (KAM) to enable it.
+</Note>
+
+## How it works
+
+1. You process a transaction directly with your provider (e.g. a purchase on your own Adyen account).
+2. You report it here — one event or a batch of up to 500.
+3. Each accepted event creates **one payment** with one transaction, with the status derived from `result`: `APPROVED` → `SUCCEEDED`, `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
+
+In this version the supported operations are `PURCHASE` (default) and `AUTHORIZATION`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
+
+## Retries and deduplication
+
+There is **no idempotency header on this endpoint — and none is needed**. The `report_id` you generate per event is the deduplication key: an event whose `report_id` was already ingested (in the last 30 days) is counted in `duplicates` and never ingested twice, no matter when or in which batch it arrives. Retrying a whole batch after a network failure is always safe.
+
+The batch is processed **per event**: one invalid event lands in `rejected[]` with its reason, and the rest of the batch is unaffected.
+
+## The raw provider response
+
+If you include `raw_provider_response` (the provider's response payload, verbatim, up to 64 KB), Yuno stores it with defensive card-data redaction applied — primary account numbers and security codes are removed before anything is persisted. It is never returned by any API.
+
+Sending it is recommended: it lets Yuno enrich the reported payment later (network transaction references, decline reasons) without asking you for anything new.
+
+<Warning>
+**Never send card data in the event fields.** Reported events carry references and outcomes, not cardholder data. The only place a card number may transit is inside `raw_provider_response`, where it is redacted on ingestion.
+</Warning>
+
+## Operations on reported payments
+
+Reported payments cannot be operated through Yuno — a refund or capture request on a payment with `origin: REPORTED` returns `403 OPERATION_NOT_ALLOWED_FOR_REPORTED_PAYMENT`. Perform the operation at your provider and report it as a new event when lifecycle events become available.
+
+## Errors
+
+Errors return a `code` and a `messages` array.
+
+| HTTP | `code` | When |
+| ---- | ------ | ---- |
+| 400 | `INVALID_REQUEST` | Malformed body, missing required field, batch over 500 events, or `account_id` not belonging to your organization. |
+| 403 | `PRODUCT_NOT_ENABLED` | "The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it." |
+| — | `INVALID_EVENT` (per event, in `rejected[]`) | Invalid enum value, wrong field type, unknown field, or `raw_provider_response` over 64 KB. |


### PR DESCRIPTION
## What

Documents the new **Transaction Reporting API** ([C2-18187](https://yunopayments.atlassian.net/browse/C2-18187)) — merchants report transactions processed directly with their providers, and each accepted event is persisted as a regular Yuno payment with `origin: REPORTED`.

- **New reference page** (`reference/reporting/report-transactions.mdx` + OpenAPI spec):
  - v1 contract: **11 fields** — 6 required (`report_id`, `merchant_order_id`, `country`, `payment_method_type`, `result`, `amount`), 2 optional with defaults (`event_type` → `PURCHASE`, `occurred_at` → ingest time), plus `provider_id`, `latency_ms`, and `raw_provider_response` (stored redacted, never re-exposed, not parsed).
  - `PURCHASE` and `AUTHORIZATION` only; one accepted event = one payment; per-event `202` batch semantics (`accepted`/`duplicates`/`rejected[]`), batch up to 500.
  - **Explicit no-idempotency-header note**: retries are safe via `report_id` deduplication (30 days) — per the ticket's AC.
  - Gating per organization: `403 PRODUCT_NOT_ENABLED` with the KAM message.
  - Documents the new `origin` field (`YUNO | REPORTED`) on payment responses.
- **Navigation**: new "Transaction Reporting" group (tag: Beta) in the API reference, after Dry-run.

## Notes

- **DRAFT — merge when the feature goes live in Sandbox (target: Sunday)**; production stays dark by configuration (empty allowlist).
- The `origin` field should also be added to the Payment Object page when this releases — kept out of this PR to avoid touching shared pages before the contract is final.
- Follow-ups documented in the delivery-phases page (remaining event types — refunds, captures, cancellations, chargebacks — then NTID, routing signals, thin mode): https://yunopayments.atlassian.net/wiki/spaces/TECH/pages/3048472580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[C2-18187]: https://yunopayments.atlassian.net/browse/C2-18187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ