### PR TITLE
docs(sdks/overview): apply docs-evaluation fixes to Quickstart, Choose Integration, and Understanding Flows

### DIFF
--- a/docs/sdks/overview/choose-integration.mdx
+++ b/docs/sdks/overview/choose-integration.mdx
@@ -8,12 +8,12 @@ description: "Compare Seamless SDK, Lite SDK, and secure-fields integration type
 ---
 Within each platform's SDK, Yuno offers various **integration methods** allowing varying degrees of control over the UI and user experience.
 
-The integration method you select affects the level of maintenance effort required, the ease of managing payment methods (which may range from no-code configuration in the Yuno Dashboard to hands-on developer work), and your compliance obligations, since some integration types require certifications such as **PCI-DSS** or **ISO**.
+The integration method you select affects the level of maintenance effort required. It also determines how you manage payment methods, which may range from no-code configuration in the Yuno Dashboard to hands-on developer work. Some integration types also require certifications such as **PCI-DSS** or **ISO**, which affects your compliance obligations.
 
 <Check>
 **Recommended Integration**
 
-We recommend using **Seamless SDK** for its flexibility and ease of integration. It provides pre-built UI components while giving you full control over the payment experience and automatic payment method display.
+Yuno recommends using **Seamless SDK** for its flexibility and ease of integration. It provides pre-built UI components while giving you full control over the payment experience and automatic payment method display.
 </Check>
 
 ## Integration Types
@@ -28,12 +28,12 @@ Below, you can see the specifications for each integration type.
 | Use Yuno's PCI-DSS Certification | ✅ | ✅ | ✅ |
 | Use 3D Secure | ✅ | ✅ | ✅ |
 | Use an antifraud solution without code | ✅ | ✅ | ✅ |
-| Set checkout conditions using our dashboard | ✅ | ❌ | ❌ |
-| Customize the look and feel of your checkout using our dashboard | ✅ | ❌ | ❌ |
+| Set checkout conditions using the Yuno Dashboard | ✅ | ❌ | ❌ |
+| Customize the look and feel of your checkout using the Yuno Dashboard | ✅ | ❌ | ❌ |
 
 <CardGroup cols={3}>
   <Card title="seamless-sdk" icon="browser">
-    Our most flexible and recommended integration solution. Provides pre-built UI components with full control over the payment experience and automatic payment method management.
+    The most flexible and recommended integration solution. Provides pre-built UI components with full control over the payment experience and automatic payment method management.
     * **User experience management**: You control the UI while Yuno handles the heavy lifting.
     * **No-code configuration**: Add and configure payment methods directly from the dashboard.
     * **Flexibility**: Ideal for businesses wanting a balance between control and simplicity.
@@ -45,7 +45,7 @@ Below, you can see the specifications for each integration type.
     * **Customizable**: Best for businesses with highly specific UX requirements. Use [Web](/docs/sdks/lite-web/payment), [Android](/docs/sdks/lite-android/checkout), or [iOS](/docs/sdks/lite-ios/checkout).
   </Card>
   <Card title="secure-fields" icon="shield-check">
-    A secure and seamless checkout solution using prebuilt UI components (Web Only).
+    Prebuilt secure input fields you embed directly into your own payment form, so raw card data never touches your servers (Web Only).
     * **Secure data collection**: Simplifies tokenizing payment card details.
     * **PCI compliance**: Ensures a PCI-compliant experience with a customized UI.
     * **Balanced solution**: Ideal for a balance between security and flexibility. See [implementation](/docs/sdks/customization/secure-fields/index).

--- a/docs/sdks/overview/quickstart.mdx
+++ b/docs/sdks/overview/quickstart.mdx
@@ -7,9 +7,9 @@ metadata:
 description: "Implement Yuno's full payment flow on Web, iOS, and Android with pre-built checkout UI"
 ---
 
-Welcome to the Yuno SDKs quickstart guide. This guide shows you how to easily implement our full payment flow, Yuno's most straightforward solution with pre-built UI and automatic payment method display.
+Welcome to the Yuno SDKs quickstart guide. This guide shows you how to easily implement Yuno's full payment flow, its most straightforward solution with pre-built UI and automatic payment method display.
 
-Choose your platform and follow the steps to start process your first payments with Yuno.
+Choose your platform and follow the steps to start processing your first payments with Yuno.
 
 <Tabs>
     <Tab title="Web SDK integration">
@@ -84,7 +84,7 @@ Choose your platform and follow the steps to start process your first payments w
     </script>
     ```
 
-    **Test with**: Card `4111 1111 1111 1111`, any future date, any CVV
+    See [Test cards](#test-cards) below.
 
     For a comprehensive overview of all Web SDK parameters, see [Web SDK Common Reference](/docs/sdks/resources/references/web).
 
@@ -168,7 +168,7 @@ Choose your platform and follow the steps to start process your first payments w
     }
     ```
 
-    **Test with**: Card `4111 1111 1111 1111`, any future date, any CVV
+    See [Test cards](#test-cards) below.
 
     For a comprehensive overview of all iOS SDK parameters, see [iOS SDK Common Reference](/docs/sdks/resources/references/ios).
 
@@ -286,7 +286,7 @@ Choose your platform and follow the steps to start process your first payments w
     }
     ```
 
-    **Test with**: Card `4111 1111 1111 1111`, any future date, any CVV
+    See [Test cards](#test-cards) below.
 
     For a comprehensive overview of all Android SDK parameters, see [Android SDK Common Reference](/docs/sdks/resources/references/android).
 
@@ -353,7 +353,7 @@ Primary parameters used in this quickstart:
 | --------- | ----------- |
 | `publicKey` / `apiKey` | Your Yuno public API key (frontend). From [Yuno Dashboard](https://dashboard.y.uno/) → **Developers** > **Credentials**. |
 | `checkoutSession` | Checkout session ID returned by your backend (create session endpoint). Required to start payment. |
-| `countryCode` | ISO country code for the payment (e.g. `US`, `CO`). See [Country coverage](/docs/sdks/resources/country-coverage). |
+| `countryCode` | ISO country code for the payment (for example, `US`, `CO`). See [Country coverage](/docs/sdks/resources/country-coverage). |
 | `elementSelector` (Web) | CSS selector for the element where the payment form is mounted (e.g. `#payment-form`). |
 
 Full parameter reference: [Payment flows (Web)](/docs/sdks/full-checkout/web-payments), [Payment flows (iOS)](/docs/sdks/full-checkout/ios-payments), [Payment flows (Android)](/docs/sdks/full-checkout/android-payments).
@@ -369,7 +369,7 @@ A lightweight integration that gives you full control over the payment method di
 - [iOS Implementation](/docs/sdks/lite-ios/checkout)
 
 ### Secure Fields
-Build your own payment forms from scratch using our UI components for maximum customization (Web Only).
+Build your own payment forms from scratch using Yuno's UI components for maximum customization (Web Only).
 - [Secure Fields Guide](/docs/sdks/customization/secure-fields/index)
 
 ## Test cards

--- a/docs/sdks/overview/understanding-flows.mdx
+++ b/docs/sdks/overview/understanding-flows.mdx
@@ -7,13 +7,13 @@ metadata:
 description: "Understand payment, enrollment, vaulted token, and Headless SDK flows with diagrams and step sequences"
 ---
 
-In Yuno SDKs, **payment flows** and **enrollment flows** are separate. Payment is the process of completing a transaction; enrollment is the process of saving a payment method (e.g. a card) to a customer account for future use. This page explains both flows at a high level with diagrams and step sequences. Use the Quickstart guide and platform flow pages for implementation details.
+In Yuno SDKs, **payment flows** and **enrollment flows** are separate. Payment is the process of completing a transaction. Enrollment is the process of saving a payment method (for example, a card) to a customer's account for future use. This page explains both flows at a high level with diagrams and step sequences. Use the [Quickstart guide](/docs/sdks/overview/quickstart) and platform flow pages ([Web](/docs/sdks/full-checkout/web-payments), [iOS](/docs/sdks/full-checkout/ios-payments), [Android](/docs/sdks/full-checkout/android-payments)) for implementation details.
 
 ## Payment flow
 
 The SDK provides a unified payment experience: customers complete transactions using multiple payment methods within a single integration. The diagram below illustrates the main payment workflow.
 
-<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/full-checkout-flow.html" style={{ width: "100%", aspectRatio: "1600 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
+<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/full-checkout-flow.html" title="Payment flow diagram" style={{ width: "100%", aspectRatio: "1600 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
 
 <div style={{ display: "flex", gap: "20px", flexWrap: "wrap", fontSize: "13px", color: "#64748b", marginTop: "8px", marginBottom: "4px" }}><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#3e4fe0" }}></span>Request</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#f97316" }}></span>Response</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#15803d" }}></span>Success</span></div>
 
@@ -40,7 +40,7 @@ The SDK provides a unified payment experience: customers complete transactions u
 
 If a customer has an enrolled payment method, they can use a **vaulted token** to pay without entering payment details again.
 
-<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/payment-flow-using-vaulted-token.html" style={{ width: "100%", aspectRatio: "1510 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
+<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/payment-flow-using-vaulted-token.html" title="Payment flow using a vaulted token diagram" style={{ width: "100%", aspectRatio: "1510 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
 
 <div style={{ display: "flex", gap: "20px", flexWrap: "wrap", fontSize: "13px", color: "#64748b", marginTop: "8px", marginBottom: "4px" }}><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#3e4fe0" }}></span>Request</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#f97316" }}></span>Response</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#15803d" }}></span>Success</span></div>
 
@@ -62,7 +62,7 @@ If a customer has an enrolled payment method, they can use a **vaulted token** t
 
 **Enrollment** is the process of saving a payment method (e.g. a card) to a customer’s account so it can be used later (e.g. with a vaulted token). full-checkout supports enrollment; the diagram below describes the enrollment workflow.
 
-<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/payment-method-enrollment-flow.html" style={{ width: "100%", aspectRatio: "1460 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
+<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/payment-method-enrollment-flow.html" title="Enrollment flow diagram" style={{ width: "100%", aspectRatio: "1460 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
 
 <div style={{ display: "flex", gap: "20px", flexWrap: "wrap", fontSize: "13px", color: "#64748b", marginTop: "8px", marginBottom: "4px" }}><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#3e4fe0" }}></span>Request</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#f97316" }}></span>Response</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#15803d" }}></span>Success</span></div>
 
@@ -85,16 +85,16 @@ If a customer has an enrolled payment method, they can use a **vaulted token** t
 
 The **Headless SDK** provides maximum flexibility by allowing you to manage the entire user interface while Yuno handles the complex payment logic and security (like 3DS).
 
-<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/headless-sdk-flow.html" style={{ width: "100%", aspectRatio: "1600 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
+<iframe src="https://writechoiceorg.github.io/yuno-diagrams-public/diagrams/sdks/overview/understanding-flows/headless-sdk-flow.html" title="Headless SDK flow diagram" style={{ width: "100%", aspectRatio: "1600 / 874" }} frameBorder="0" allow="fullscreen" allowFullScreen></iframe>
 
 <div style={{ display: "flex", gap: "20px", flexWrap: "wrap", fontSize: "13px", color: "#64748b", marginTop: "8px", marginBottom: "4px" }}><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#3e4fe0" }}></span>Request</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#f97316" }}></span>Response</span><span style={{ display: "flex", alignItems: "center", gap: "6px" }}><span style={{ display: "inline-block", width: "10px", height: "10px", borderRadius: "50%", background: "#15803d" }}></span>Success</span></div>
 
 ### Headless flow steps
 
-1. **Merchant Server**: `Create Customer` → **Yuno Server**: `Creates Customer`
-2. **Merchant Client**: `Initiate Checkout` → **Merchant Server**: `Create Checkout session`
-3. **Merchant Client**: `Collect Information` → User enters card/payment details in your custom UI.
-4. **Merchant Client**: `Generate Token` → **Yuno SDK**: Call `generateToken(details)` to receive a `one-time token`.
-5. **Merchant Client**: `Process Payment` → **Merchant Server**: Send `one-time token` to your backend.
-6. **Merchant Server**: `Create Payment` → **Yuno Server**: Call [Create Payment](/reference/payments/create-payment) API.
-7. **Merchant Client**: `Handle Actions` → If API response returns `sdk_action_required: true`, use the SDK to handle 3DS or other [Payment Actions](/docs/sdks/headless-web/payment#step-7-get-payment-actions).
+1. Merchant Server: `Create Customer` → Yuno Server: `Creates Customer`
+2. Merchant Client: `Initiate Checkout` → Merchant Server: `Create Checkout session`
+3. Merchant Client: `Collect Information` → User enters card/payment details in your custom UI.
+4. Merchant Client: `Generate Token` → Yuno SDK: Call `generateToken(details)` to receive a `one-time token`.
+5. Merchant Client: `Process Payment` → Merchant Server: Send `one-time token` to your backend.
+6. Merchant Server: `Create Payment` → Yuno Server: Call [Create Payment](/reference/payments/create-payment) API.
+7. Merchant Client: `Handle Actions` → If API response returns `sdk_action_required: true`, use the SDK to handle 3DS or other [Payment Actions](/docs/sdks/headless-web/payment#step-7-get-payment-actions).


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged grammar, voice-consistency, and clarity issues on the three "Overview" SDK pages. This PR applies the confirmed fixes: grammar correction, standardizing third-person Yuno voice, expanding "e.g." abbreviations, trimming repeated content in favor of an existing reference table, splitting overlong/semicolon-joined sentences, adding accessible titles to diagram iframes, and standardizing step-list formatting and wording across the pages.

## Changes
- **docs/sdks/overview/quickstart.mdx**: fixed "start process your first payments" → "start processing your first payments"; replaced "our full payment flow" and "our UI components" with Yuno-voiced phrasing; expanded "e.g." in the `countryCode` parameter row; replaced the three repeated `Test with: Card 4111 1111 1111 1111...` lines (one per SDK tab) with a link to the existing Test cards table.
- **docs/sdks/overview/choose-integration.mdx**: rewrote the generic "A secure and seamless checkout solution" line on the `secure-fields` card with a concrete description; standardized voice ("We recommend" → "Yuno recommends", "our dashboard" → "the Yuno Dashboard" in both table rows, "Our most flexible" → "The most flexible"); split the 25+ word sentence covering maintenance effort, payment-method management, and compliance obligations into three separate sentences.
- **docs/sdks/overview/understanding-flows.mdx**: split the semicolon-joined payment/enrollment definition sentence into two sentences; expanded "e.g." to "for example"; added descriptive `title` attributes to all 4 diagram `<iframe>` embeds; removed bold actor-label formatting from "Headless flow steps" to match the other three step lists; standardized "a customer account" to "a customer's account"; linked the previously bare "Quickstart guide" and "platform flow pages" mentions to their respective docs pages.