### PR TITLE
docs(C2-18187): neutral example identifiers in the reporting reference

### DIFF
--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -78,7 +78,7 @@
                           "maxLength": 255,
                           "description": "Your unique identifier for this event — the deduplication key. An event with a `report_id` already ingested is counted as a duplicate and never ingested twice, which makes retries safe.",
                           "examples": [
-                            "spacex-rpt-000123"
+                            "merchant-rpt-000123"
                           ]
                         },
                         "merchant_order_id": {
@@ -86,7 +86,7 @@
                           "maxLength": 255,
                           "description": "Your order reference — how you find the payment in the dashboard.",
                           "examples": [
-                            "starlink_order_45678"
+                            "order_45678"
                           ]
                         },
                         "country": {
@@ -188,8 +188,8 @@
                     "account_id": "3f2a1b6c-8d4e-4f5a-9b0c-1d2e3f4a5b6c",
                     "events": [
                       {
-                        "report_id": "spacex-rpt-000123",
-                        "merchant_order_id": "starlink_order_45678",
+                        "report_id": "merchant-rpt-000123",
+                        "merchant_order_id": "order_45678",
                         "country": "US",
                         "payment_method_type": "CARD",
                         "result": "APPROVED",
@@ -207,8 +207,8 @@
                     "account_id": "3f2a1b6c-8d4e-4f5a-9b0c-1d2e3f4a5b6c",
                     "events": [
                       {
-                        "report_id": "spacex-rpt-000123",
-                        "merchant_order_id": "starlink_order_45678",
+                        "report_id": "merchant-rpt-000123",
+                        "merchant_order_id": "order_45678",
                         "country": "US",
                         "payment_method_type": "CARD",
                         "result": "APPROVED",
@@ -281,7 +281,7 @@
                       "duplicates": 1,
                       "rejected": [
                         {
-                          "report_id": "spacex-rpt-000124",
+                          "report_id": "merchant-rpt-000124",
                           "code": "INVALID_EVENT",
                           "messages": [
                             "The field 'event_type' must be one of: PURCHASE, AUTHORIZATION."


### PR DESCRIPTION
Replaces merchant-specific example identifiers (`spacex-rpt-*`, `starlink_order_*`) with neutral ones (`merchant-rpt-*`, `order_*`) in the Transaction Reporting reference — examples in public docs should not reference a real merchant or its customers.

No contract or content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)