### PR TITLE
docs(reporting): align Report Off-Yuno Transactions enums with the live API

### DIFF
--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -108,11 +108,11 @@
                         "result": {
                           "type": "string",
                           "enum": [
-                            "APPROVED",
+                            "SUCCEEDED",
                             "DECLINED",
                             "ERROR"
                           ],
-                          "description": "The outcome the provider gave you. Maps to the payment status together with the event type: `PURCHASE`+`APPROVED` → `SUCCEEDED`; `AUTHORIZATION`+`APPROVED` → `PENDING`/`AUTHORIZED` (an approved authorization is not captured money); `DECLINED` → `DECLINED`; `ERROR` → `ERROR`."
+                          "description": "The outcome the provider gave you. Maps to the payment status together with the event type: `PURCHASE`+`SUCCEEDED` → payment `SUCCEEDED`; `AUTHORIZE`+`SUCCEEDED` → `PENDING`/`AUTHORIZED` (an approved authorization is not captured money); `DECLINED` → `DECLINED`; `ERROR` → `ERROR`."
                         },
                         "amount": {
                           "type": "object",
@@ -124,7 +124,8 @@
                           "properties": {
                             "value": {
                               "type": "number",
-                              "description": "Decimal amount.",
+                              "exclusiveMinimum": 0,
+                              "description": "Decimal amount, greater than zero.",
                               "examples": [
                                 99.0
                               ]
@@ -159,7 +160,7 @@
                           "type": "string",
                           "enum": [
                             "PURCHASE",
-                            "AUTHORIZATION"
+                            "AUTHORIZE"
                           ],
                           "default": "PURCHASE",
                           "description": "Optional. The operation you performed at the provider. Defaults to `PURCHASE` when omitted."
@@ -192,7 +193,7 @@
                         "merchant_order_id": "order_45678",
                         "country": "US",
                         "payment_method_type": "CARD",
-                        "result": "APPROVED",
+                        "result": "SUCCEEDED",
                         "amount": {
                           "currency": "USD",
                           "value": 99.0
@@ -211,7 +212,7 @@
                         "merchant_order_id": "order_45678",
                         "country": "US",
                         "payment_method_type": "CARD",
-                        "result": "APPROVED",
+                        "result": "SUCCEEDED",
                         "amount": {
                           "currency": "USD",
                           "value": 99.0
@@ -284,7 +285,7 @@
                           "report_id": "merchant-rpt-000124",
                           "code": "INVALID_EVENT",
                           "messages": [
-                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZATION."
+                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZE."
                           ]
                         }
                       ]

--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -100,7 +100,7 @@
                         },
                         "payment_method_type": {
                           "type": "string",
-                          "description": "Payment method type used at the provider (e.g. `CARD`).",
+                          "description": "Payment method type used at the provider \u2014 must be one of Yuno's payment-method types (e.g. `CARD`, `PIX`); unknown types are rejected.",
                           "examples": [
                             "CARD"
                           ]

--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -21,9 +21,9 @@ This API requires activation for your organization. Contact your Key Account Man
 
 1. You process a transaction directly with your provider (e.g. a purchase on your own Adyen account).
 2. You report it here — one event or a batch of up to 500. For latency-sensitive integrations we recommend batches of up to 100 events: the full 500-event batch is processed synchronously and can take several seconds.
-3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type: a `PURCHASE` with `APPROVED` lands `SUCCEEDED`; an `AUTHORIZATION` with `APPROVED` lands `PENDING` with sub-status `AUTHORIZED` (an approved authorization is not captured money — it mirrors how Yuno-processed authorizations behave); `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
+3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type: a `PURCHASE` with result `SUCCEEDED` lands the payment `SUCCEEDED`; an `AUTHORIZE` with result `SUCCEEDED` lands `PENDING` with sub-status `AUTHORIZED` (an approved authorization is not captured money — it mirrors how Yuno-processed authorizations behave); `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
 
-In this version the supported operations are `PURCHASE` (default) and `AUTHORIZATION`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
+In this version the supported operations are `PURCHASE` (default) and `AUTHORIZE`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
 
 ## Retries and deduplication
 

--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -29,6 +29,8 @@ In this version the supported operations are `PURCHASE` (default) and `AUTHORIZE
 
 There is **no idempotency header on this endpoint — and none is needed**. The `report_id` you generate per event is the deduplication key: an event whose `report_id` was already ingested is counted in `duplicates` and never ingested twice, no matter when or in which batch it arrives. Retrying a whole batch after a network failure is always safe.
 
+Because `report_id` alone decides, an event that reuses an already-ingested `report_id` with a *different* payload is also counted as a duplicate and silently discarded — never reuse a `report_id` across different transactions.
+
 The batch is processed **per event**: one invalid event lands in `rejected[]` with its reason, and the rest of the batch is unaffected.
 
 ## The raw provider response
@@ -53,5 +55,6 @@ Errors return a `code` and a `messages` array.
 | ---- | ------ | ---- |
 | 400 | `INVALID_REQUEST` | Malformed body, missing required field, or a batch over 500 events. |
 | 400 | `INVALID_ACCOUNT_ID` | The `account_id` does not exist or does not belong to your organization. |
+| 401 | `NOT_AUTHENTICATED` / `INVALID_CREDENTIALS` | Missing or invalid `PUBLIC-API-KEY` / `PRIVATE-SECRET-KEY` headers. |
 | 403 | `PRODUCT_NOT_ENABLED` | "The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it." |
 | — | `INVALID_EVENT` (per event, in `rejected[]`) | Invalid enum value, wrong field type, unknown field, or `raw_provider_response` over 64 KB. |


### PR DESCRIPTION
## What

The Report Off-Yuno Transactions page (`/reference/reporting/report-transactions`) documents enum values the live API rejects. This PR aligns the docs with the live sandbox behavior, verified end to end on 2026-08-16 (last re-check 22:32 UTC) against `api-sandbox.y.uno`:

| Field | Doc said | Live API accepts | Live rejection of the doc value |
|---|---|---|---|
| `result` | `APPROVED` | `SUCCEEDED` | "The field 'result' must be one of: SUCCEEDED, DECLINED, ERROR." |
| `event_type` | `AUTHORIZATION` | `AUTHORIZE` | "The field 'event_type' must be one of: PURCHASE, AUTHORIZE." |

Both doc example payloads (`minimal` and `full`) fail against sandbox today because they use `result: APPROVED`; with `SUCCEEDED` the same payloads ingest (`accepted: 1`) and land as `origin: REPORTED` payments with the documented status mapping (verified: `SUCCEEDED/APPROVED`, `PENDING/AUTHORIZED`, `DECLINED`, `ERROR`).

Also documents one live constraint the page was silent on: `amount.value` must be greater than zero (live rejection: "The field 'amount' must carry an uppercase ISO 4217 currency and a value greater than zero.").

## What this PR deliberately does NOT touch

- The 403 `OPERATION_NOT_ALLOWED_FOR_REPORTED_PAYMENT` section is correct as written, but refund/capture on a reported payment whose event omitted `provider_id` currently returns 500 `INTERNAL_ERROR` instead (10 consistent reproductions; with `provider_id` present the documented 403 comes back). That is an API bug being raised separately, not a docs change.
- If the API team intends to rename the live values to match the original doc (`APPROVED`/`AUTHORIZATION`) instead, close this PR — but as of the verification timestamp the live contract is what this PR documents.

Raw request/response evidence for every claim is archived internally (Caio has it: `~/yuno-workspace/SpaceX/report-transactions-audit/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)