### PR TITLE
docs(C2-18187): align reporting enums with API vocabulary (SUCCEEDED, AUTHORIZE)

### DIFF
--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -108,11 +108,11 @@
                         "result": {
                           "type": "string",
                           "enum": [
-                            "APPROVED",
+                            "SUCCEEDED",
                             "DECLINED",
                             "ERROR"
                           ],
-                          "description": "The outcome the provider gave you. Maps to the payment status together with the event type: `PURCHASE`+`APPROVED` → `SUCCEEDED`; `AUTHORIZATION`+`APPROVED` → `PENDING`/`AUTHORIZED` (an approved authorization is not captured money); `DECLINED` → `DECLINED`; `ERROR` → `ERROR`."
+                          "description": "The outcome the provider gave you. Maps to the payment status together with the event type: `PURCHASE`+result `SUCCEEDED` → payment `SUCCEEDED`; `AUTHORIZE`+`SUCCEEDED` → `PENDING`/`AUTHORIZED` (a successful authorization is not captured money); `DECLINED` → `DECLINED`; `ERROR` → `ERROR`."
                         },
                         "amount": {
                           "type": "object",
@@ -159,7 +159,7 @@
                           "type": "string",
                           "enum": [
                             "PURCHASE",
-                            "AUTHORIZATION"
+                            "AUTHORIZE"
                           ],
                           "default": "PURCHASE",
                           "description": "Optional. The operation you performed at the provider. Defaults to `PURCHASE` when omitted."
@@ -192,7 +192,7 @@
                         "merchant_order_id": "order_45678",
                         "country": "US",
                         "payment_method_type": "CARD",
-                        "result": "APPROVED",
+                        "result": "SUCCEEDED",
                         "amount": {
                           "currency": "USD",
                           "value": 99.0
@@ -211,7 +211,7 @@
                         "merchant_order_id": "order_45678",
                         "country": "US",
                         "payment_method_type": "CARD",
-                        "result": "APPROVED",
+                        "result": "SUCCEEDED",
                         "amount": {
                           "currency": "USD",
                           "value": 99.0
@@ -284,7 +284,7 @@
                           "report_id": "merchant-rpt-000124",
                           "code": "INVALID_EVENT",
                           "messages": [
-                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZATION."
+                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZE."
                           ]
                         }
                       ]

--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -21,9 +21,9 @@ This API requires activation for your organization. Contact your Key Account Man
 
 1. You process a transaction directly with your provider (e.g. a purchase on your own Adyen account).
 2. You report it here — one event or a batch of up to 500. For latency-sensitive integrations we recommend batches of up to 100 events: the full 500-event batch is processed synchronously and can take several seconds.
-3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type: a `PURCHASE` with `APPROVED` lands `SUCCEEDED`; an `AUTHORIZATION` with `APPROVED` lands `PENDING` with sub-status `AUTHORIZED` (an approved authorization is not captured money — it mirrors how Yuno-processed authorizations behave); `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
+3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type: a `PURCHASE` with result `SUCCEEDED` lands `SUCCEEDED`; an `AUTHORIZE` with result `SUCCEEDED` lands `PENDING` with sub-status `AUTHORIZED` (a successful authorization is not captured money — it mirrors how Yuno-processed authorizations behave); `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
 
-In this version the supported operations are `PURCHASE` (default) and `AUTHORIZATION`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
+In this version the supported operations are `PURCHASE` (default) and `AUTHORIZE`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
 
 ## Retries and deduplication
 


### PR DESCRIPTION
Matches the merged implementation change (public-api #2119, transaction-rails #133):

| Field | Before | After |
|---|---|---|
| `result` | `APPROVED` | `SUCCEEDED` |
| `event_type` | `AUTHORIZATION` | `AUTHORIZE` |

Updates enums, examples, the status-mapping text and the rejection-message example. Pre-GA contract change (POC live in Sandbox only), no aliases kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)