### PR TITLE
docs(reporting): give the full example its own report_id

### DIFF
--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -208,8 +208,8 @@
                     "account_id": "3f2a1b6c-8d4e-4f5a-9b0c-1d2e3f4a5b6c",
                     "events": [
                       {
-                        "report_id": "merchant-rpt-000123",
-                        "merchant_order_id": "order_45678",
+                        "report_id": "merchant-rpt-000125",
+                        "merchant_order_id": "order_45679",
                         "country": "US",
                         "payment_method_type": "CARD",
                         "result": "SUCCEEDED",


### PR DESCRIPTION
Follow-up to #757. The page's `minimal` and `full` request examples shared `report_id: merchant-rpt-000123`, so a reader running both verbatim gets `duplicates: 1` on the second call instead of an ingestion (verified on sandbox just now). The full example now uses `merchant-rpt-000125` / `order_45679` (000124 is taken by the rejected event in the 202 response example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)