### PR TITLE
fix(docs): point Understanding Flows platform links to seamless-sdk

### DIFF
--- a/docs/sdks/overview/understanding-flows.mdx
+++ b/docs/sdks/overview/understanding-flows.mdx
@@ -7,7 +7,7 @@ metadata:
 description: "Understand payment, enrollment, vaulted token, and Headless SDK flows with diagrams and step sequences"
 ---
 
-In Yuno SDKs, **payment flows** and **enrollment flows** are separate. Payment is the process of completing a transaction. Enrollment is the process of saving a payment method (for example, a card) to a customer's account for future use. This page explains both flows at a high level with diagrams and step sequences. Use the [Quickstart guide](/docs/sdks/overview/quickstart) and platform flow pages ([Web](/docs/sdks/full-checkout/web-payments), [iOS](/docs/sdks/full-checkout/ios-payments), [Android](/docs/sdks/full-checkout/android-payments)) for implementation details.
+In Yuno SDKs, **payment flows** and **enrollment flows** are separate. Payment is the process of completing a transaction. Enrollment is the process of saving a payment method (for example, a card) to a customer's account for future use. This page explains both flows at a high level with diagrams and step sequences. Use the [Quickstart guide](/docs/sdks/overview/quickstart) and platform flow pages ([Web](/docs/sdks/seamless-sdk/web-payments), [iOS](/docs/sdks/seamless-sdk/ios-payments), [Android](/docs/sdks/seamless-sdk/android-payments)) for implementation details.
 
 ## Payment flow
 


### PR DESCRIPTION
## PR Description
Follow-up to #755. That PR linked "platform flow pages" in `understanding-flows.mdx` to `docs/sdks/full-checkout/*`, which exist in the repo but aren't part of `docs.json`'s navigation tree (only referenced by legacy redirects) — so visiting them left the left sidebar with no active page. This fix was pushed to the old branch after #755 had already merged, so it never made it into `main`.

## Changes
- **docs/sdks/overview/understanding-flows.mdx**: changed the "platform flow pages" links from `/docs/sdks/full-checkout/{web,ios,android}-payments` to `/docs/sdks/seamless-sdk/{web,ios,android}-payments`, which are the current pages actually present in the nav.