### PR TITLE
docs(sdks/headless): apply docs-evaluation text fixes to Web, Android, and iOS guides

### DIFF
--- a/docs/sdks/headless-android/checkout.mdx
+++ b/docs/sdks/headless-android/checkout.mdx
@@ -1,8 +1,6 @@
 ---
 title: Headless SDK (Payment Android)
-description: >-
-  Step-by-step guide on integrating Yuno's Headless SDK (Payment Android) into
-  your mobile application.
+description: "Create payments using the Headless SDK on Android, generating one-time tokens and handling 3DS actions"
 robots: index
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
@@ -23,7 +21,7 @@ The Headless SDK includes core features like:
 * 3DS authentication handling
 * Fraud prevention data collection
 
-For merchants preferring a pre-built UI solution, consider using our [Full Checkout SDK](/docs/sdks/full-checkout/android-payments) or [Lite SDK](/docs/sdks/lite-android/checkout) instead.
+For merchants preferring a pre-built UI solution, consider using Yuno's [Full Checkout SDK](/docs/sdks/full-checkout/android-payments) or [Lite SDK](/docs/sdks/lite-android/checkout) instead.
 
 ## Requirements
 
@@ -173,7 +171,7 @@ After collecting the user information, create a one-time token (OTT) using the `
 
 ### Benefits of using a vaulted token
 
-When you use a vaulted token with the SDK, all the fraud information from the providers you configured in your card routing is collected and attached to the one-time token. You can also add installment information and a security code if the provider requires it.
+When you use a vaulted token with the SDK, all the fraud information from the providers you configured in your card routing is collected. This information is attached to the one-time token. You can also add installment information and a security code if the provider requires it.
 
 ```kotlin Example 1
 apiClientPayment.generateToken(
@@ -381,7 +379,7 @@ The endpoint response includes the `sdk_action_required` parameter that indicate
 
 ## Step 8: Continue the payment (if required)
 
-When a payment created from your backend requires an additional step — for example, a 3DS challenge — the Create Payment endpoint response includes:
+When a payment created from your backend requires an additional step, such as a 3DS challenge, the Create Payment endpoint response includes:
 
 * Status `PENDING` and sub-status `WAITING_ADDITIONAL_STEP`
 * `sdk_action_required = true`
@@ -447,7 +445,7 @@ Yuno Android SDK provides additional services and configurations you can use to 
 
 ### Loader
 
-The loader functionality is controlled through the `keepLoader` parameter in the `YunoConfig` data class, which is documented inline in the SDK configuration section above.
+The loader functionality is controlled through the `keepLoader` parameter in the `YunoConfig` data class, which is documented inline in the preceding SDK configuration section.
 
 ### SDK customization
 
@@ -471,5 +469,5 @@ If your integration requires these features, consider using the [Full Checkout S
 
 ## Error handling
 
-Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
+Handle errors returned by the SDK in your app, such as failed payments or validation errors. For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
 

--- a/docs/sdks/headless-android/enrollment.mdx
+++ b/docs/sdks/headless-android/enrollment.mdx
@@ -1,8 +1,6 @@
 ---
 title: Headless SDK (Enrollment Android)
-description: >-
-  Step-by-step guide on integrating Yuno's Headless SDK (Enrollment Android) into
-  your mobile application.
+description: "Enroll payment methods using the Headless SDK on Android, generating a vaulted token for card data"
 robots: index
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
@@ -25,7 +23,7 @@ The Headless SDK includes core features like:
 * Direct API access
 * Custom error handling
 
-For merchants requiring a pre-built UI solution or simpler integration, consider using our other SDK implementations:
+For merchants requiring a pre-built UI solution or simpler integration, consider using Yuno's other SDK implementations:
 
 * [Full Checkout SDK](/docs/sdks/full-checkout/android-payments)
 * [Lite SDK](/docs/sdks/lite-android/enrollment)
@@ -261,12 +259,10 @@ The following table provides additional information about the possible states:
 <Info>
 **Webhook Status Tracking**
 
-Consider using the enrollment status received via [Webhooks](/docs/webhooks/index). Yuno recommends always using this status to base and make business decisions on your platform.
+Consider using the enrollment status received via [Webhooks](/docs/webhooks/index). Yuno recommends always basing business decisions on your platform on this status.
 </Info>
-
-<br />
 
 ## Error handling
 
-Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
+Handle errors returned by the SDK in your app, such as failed payments or validation errors. For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
 

--- a/docs/sdks/headless-ios/checkout.mdx
+++ b/docs/sdks/headless-ios/checkout.mdx
@@ -2,18 +2,18 @@
 title: Headless SDK (Payment iOS)
 description: >-
   Step-by-step guide on integrating Yuno's Headless SDK (Payment iOS) into
-  your mobile application.
+  your mobile app.
 robots: index
 ---
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
 
 <GenericOrientation />
-Yuno's Headless iOS SDK lets you create payments and enroll payment methods simultaneously. Note that when using the Headless SDK, you will need to request and send via API all the mandatory fields the payment provider requires to generate payment in their API.
+Yuno's Headless iOS SDK lets you create payments and enroll payment methods simultaneously. When using the Headless SDK, note that you will need to request and send via API all the mandatory fields the payment provider requires. These fields are needed to generate the payment in their API.
 
 Yuno's Headless SDK enables you to create payments in two different scenarios:
 
 * Create a One-Time Use Token using credit card information or alternative payment methods, then create a payment.
-* Create a One-Time Use Token using a `vaulted_token` from a previously enrolled payment method to collect relevant information for fraud providers, then create a payment.
+* Create a One-Time Use Token using a `vaulted_token` from a previously enrolled payment method. This collects relevant information for fraud providers before you create a payment.
 
 The following steps describe creating a payment using Yuno's Headless SDK.
 
@@ -70,7 +70,7 @@ If you're using Swift 6, you'll need to handle concurrency correctly when using 
 
 Next, you will start the checkout process using the `apiClientPayment` function, providing the necessary configuration parameters. You need to call this function once your customer selects the payment method. As a result, the SDK will start collecting relevant information for 3DS and fraud prevention tools you have configured in your routing.
 
-Parameters
+### Parameters
 
 The following table lists all required parameters and their descriptions.
 
@@ -220,11 +220,11 @@ The following code block presents the `apiClientPayment.generateToken` function 
 
 ## Step 5: Create the payment
 
-Once you have completed the steps described before, you can create a payment. The back-to-back payment creation must be carried out using the [Create Payment endpoint](/reference/payments/create-payment). The merchant should call their backend to create the payment within Yuno, using the one-time token and the checkout session.
+Once you have completed the steps described before, you can create the payment. Call the [Create Payment endpoint](/reference/payments/create-payment) from your backend right after generating the token, using the one-time token and the checkout session.
 
 The endpoint response includes the `sdk_action_required` parameter that indicates whether additional actions are needed to complete the payment:
 
-For synchronous payment methods, the payment completes instantly. In this case, `sdk_action_required` will be false in the API response and the payment process ends. If the payment requires further interaction from the SDK to complete the flow, `sdk_action_required` will be true; in this case, proceed with Step 6 for instructions.
+For synchronous payment methods, the payment completes instantly. In this case, `sdk_action_required` will be false in the API response and the payment process ends. If the payment requires further interaction from the SDK to complete the flow, `sdk_action_required` will be true. In this case, proceed with Step 6 for instructions.
 
 ## Step 6: Process asynchronous payments (Optional)
 
@@ -282,7 +282,7 @@ When you call `continueCardPayment`, the SDK will:
 3. Dismiss the challenge automatically once the customer completes it.
 4. Listen for the transaction result in real time and deliver each status update through the `onResult` closure, which is invoked on the main thread.
 
-The `onResult` closure can be called more than once: you will receive the intermediate `processing` status while the transaction is confirmed, followed by a terminal status (`succeeded`, `reject`, `fail`, `userCancelled`, or `internalError`).
+The `onResult` closure can be called more than once. You will receive the intermediate `processing` status while the transaction is confirmed, followed by a terminal status (`succeeded`, `reject`, `fail`, `userCancelled`, or `internalError`).
 
 <Warning>
 **Deprecated: `getThreeDSecureChallenge`**
@@ -292,5 +292,5 @@ The `getThreeDSecureChallenge` method was deprecated in version 2.18.0. Use `con
 
 ## Error handling
 
-Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
+Handle errors returned by the SDK in your app, such as failed payments or validation errors. For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
 

--- a/docs/sdks/headless-ios/enrollment.mdx
+++ b/docs/sdks/headless-ios/enrollment.mdx
@@ -14,10 +14,10 @@ The following steps describe enrolling a payment method using Yuno's Headless SD
 
 ## Requirements
 
-To execute the enrollment process, you need to provide the `customer_session` to start the enrollment process in Step 3. To acquire the  `customer_session`, you need to:
+To execute the enrollment process, you need to provide the `customer_session` to start the enrollment process in Step 3. To acquire the `customer_session`, you need to:
 
 1. **Create a customer**: A customer is required to enroll in payments. Use the [Create Customer](/reference/customers/create-customer) endpoint to create new customers. In the response, you will receive the customer `id`, which you use to create the customer session.
-2. **Create the customer session**: Use the  customer `id` and the [Create Customer Session](/reference/customer-sessions-enrollment/create-customer-session) endpoint to receive the `customer_session`.
+2. **Create the customer session**: Use the customer `id` and the [Create Customer Session](/reference/customer-sessions-enrollment/create-customer-session) endpoint to receive the `customer_session`.
 
 ## Step 1: Include the library in your project
 
@@ -66,14 +66,14 @@ If you're using Swift 6, you'll need to handle concurrency correctly when using 
 <Info>
 **UISceneDelegate Initialization**
 
-If your app uses a `UISceneDelegate`, you can initialize Yuno within your `SceneDelegate`. However, if you prefer to initialize Yuno in a different part of your app, the initialization method provides a callback that notifies you when the process has finished.
+If your app uses a `UISceneDelegate`, you can initialize Yuno within your `SceneDelegate`. However, if you prefer to initialize Yuno in a different part of your app, you can. The initialization method provides a callback that notifies you when the process has finished.
 </Info>
 
 ## Step 3: Create a customer session
 
 To start the enrollment process, you need to provide the `customer_session`. First, you need to create a customer. You need a customer to enroll payments with. Use the [Create Customer](/reference/customers/create-customer) endpoint to create new customers. In the response, you will receive the customer `id`, which you use to create the customer session.
 
-After creating the customer, you can create the customer session. Use the  customer `id` and the [Create Customer Session](/reference/customer-sessions-enrollment/create-customer-session) endpoint. The `customer_session` will be provided in the response. You need a new `customer_session` every time you enroll in a new payment method.
+After creating the customer, you can create the customer session. Use the customer `id` and the [Create Customer Session](/reference/customer-sessions-enrollment/create-customer-session) endpoint. The `customer_session` will be provided in the response. You need a new `customer_session` every time you enroll in a new payment method.
 
 ## Step 4: Create an enrollment payment method object
 
@@ -95,7 +95,7 @@ Next, you will start the checkout process using the `apiClientEnroll` function, 
 This method throws an error if the Yuno SDK has not been initialized before calling it.
 </Warning>
 
-Parameters
+### Parameters
 
 The following table lists all required parameters and their descriptions.
 
@@ -117,7 +117,7 @@ apiClientEnroll = try Yuno.apiClientEnroll(
 
 ## Step 6: Generate a vaulted token
 
-After collecting all user information, you can start the enrollment. First, you need to create a `vaulted_token` using the function `apiClientEnroll.continueEnrollment`. As it is an asynchronous function, you can use `do/catch` to ensure you will correctly handle triggered errors. Below, you will find an example of creating a  `vaulted_token`:
+After collecting all user information, you can start the enrollment. First, you need to create a `vaulted_token` using the function `apiClientEnroll.continueEnrollment`. As it is an asynchronous function, you can use `do/catch` to ensure you will correctly handle triggered errors. Below, you will find an example of creating a `vaulted_token`:
 
 ```swift
 let enrollmentCollectedData: EnrollmentCollectedData = EnrollmentCollectedData(
@@ -141,7 +141,7 @@ let enrollmentCollectedData: EnrollmentCollectedData = EnrollmentCollectedData(
 let result = try await apiClientEnroll.continueEnrollment(data: enrollmentCollectedData)
 ```
 
-After enrolling the new card, you will receive the `vaulted_token`, which you can use to make payments in the future without asking for your customer's card information. The following code block presents an example of a response from the `apiClientEnroll.continueEnrollment` function. The response is a dictionary of type `[String: String]`.
+After enrolling the new card, you will receive the `vaulted_token`. You can use it to make payments in the future without asking for your customer's card information. The following code block presents an example of a response from the `apiClientEnroll.continueEnrollment` function. The response is a dictionary of type `[String: String]`.
 
 ```swift
 [
@@ -167,7 +167,7 @@ After enrolling the new card, you will receive the `vaulted_token`, which you ca
 <Info>
 **Using Webhooks for Enrollment Status**
 
-Consider using the enrollment status received via [Webhooks](/docs/webhooks/index). Yuno recommends always using this status to base and make business decisions on your platform.
+Consider using the enrollment status received via [Webhooks](/docs/webhooks/index). Yuno recommends always basing business decisions on your platform on this status.
 </Info>
 
 <Info>
@@ -178,5 +178,5 @@ In addition to the code examples provided, you can access the [Yuno repository](
 
 ## Error handling
 
-Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
+Handle errors returned by the SDK in your app, such as failed payments or validation errors. For HTTP status and response codes, see [Status and response codes](/reference/payments/status-and-response-codes/payment) in the API reference.
 

--- a/docs/sdks/headless-web/enrollment.mdx
+++ b/docs/sdks/headless-web/enrollment.mdx
@@ -16,7 +16,7 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 <GenericOrientation />
 Yuno's Headless SDK lets you enroll in payment methods and tokenize cards, saving them for future usage.
 
-The following steps describe creating a payment using Yuno's Headless SDK.
+The following steps describe enrolling a payment method using Yuno's Headless SDK.
 
 ## Requirements
 
@@ -35,7 +35,7 @@ The integration guide provides three flexible methods:
 2. Dynamic JavaScript injection
 3. NPM module installation
 
-Choose the integration method that best suits your development workflow and technical requirements. After completing the SDK integration, you can proceed with the following steps to implement the headless enrollment functionality.
+Choose the integration method that best suits your development workflow and technical requirements. After completing the SDK integration, you can proceed with the following steps to implement the headless enrollment capability.
 
 <Note>
 **TypeScript Library**
@@ -45,7 +45,7 @@ If you are using TypeScript, Yuno provides a [library](https://www.npmjs.com/pac
 
 ## Step 2: Initialize Headless SDK with the public key
 
-In your JavaScript application, create an instance of the `Yuno` class by providing a valid `PUBLIC_API_KEY`.
+In your JavaScript app, create an instance of the `Yuno` class by providing a valid `PUBLIC_API_KEY`.
 
 ```javascript
 const yuno = await Yuno.initialize(PUBLIC_API_KEY);
@@ -70,7 +70,7 @@ You need an enrollment payment method object to set Headless SDK integration for
 <Warning>
 **Verify Card**
 
-If you want to verify cards (zero value authorization) before enrollment, you need to provide the `verify` object when creating the payment method object for the customer session.
+If you want to verify cards (zero value authorization) before enrollment, you need to provide the `verify` object. Include it when creating the payment method object for the customer session.
 </Warning>
 
 ## Step 5: Start the enrollment process
@@ -118,7 +118,7 @@ const vaultedTokenResponse = await apiClientEnroll.continueEnrollment({
 });
 ```
 
-After enrolling the new card, you will receive the `vaulted_token`, which you can use to make payments in the future without asking for your customer's card information. The following code block shows an example of a response from the `apiClientEnroll.continueEnrollment` function:
+After enrolling the new card, you will receive the `vaulted_token`. You can use it to make payments in the future without asking for your customer's card information. The following code block shows an example of a response from the `apiClientEnroll.continueEnrollment` function:
 
 ```json
 {
@@ -157,8 +157,8 @@ In addition to the code examples provided, you can access the [Demo App](https:/
 
 ## Error handling
 
-Handle errors returned by the SDK in your app (e.g. failed enrollment, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/getting-started/response-codes) in the API reference.
+Handle errors returned by the SDK in your app, such as failed enrollment or validation errors. For HTTP status and response codes, see [Status and response codes](/reference/getting-started/response-codes) in the API reference.
 
-## Stay Updated
+## Stay updated
 
 Visit the [changelog](/changelog/web#v1-6-0) for the latest SDK updates and version history.

--- a/docs/sdks/headless-web/payment.mdx
+++ b/docs/sdks/headless-web/payment.mdx
@@ -17,7 +17,7 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 <br />
 
 
-Yuno's Headless SDK lets you create payments. Note that when using the Headless SDK, you will need to request and send via API all the mandatory fields the payment provider requires to generate payment in their API.
+Yuno's Headless SDK lets you create payments. When using the Headless SDK, note that you will need to request and send via API all the mandatory fields the payment provider requires. These fields are needed to generate the payment in their API.
 
 Yuno's Headless SDK enables you to create payments in two different scenarios:
 
@@ -36,7 +36,7 @@ The integration guide provides three flexible methods:
 2. Dynamic JavaScript injection
 3. NPM module installation
 
-Choose the integration method that best suits your development workflow and technical requirements. After completing the SDK integration, you can proceed with the following steps to implement the Headless checkout functionality.
+Choose the integration method that best suits your development workflow and technical requirements. After completing the SDK integration, you can proceed with the following steps to implement the Headless checkout capability.
 
 <Note>
 **TypeScript Library**
@@ -46,7 +46,7 @@ If you are using TypeScript, Yuno provides a [library](https://www.npmjs.com/pac
 
 ## Step 2: Initialize Headless SDK with the public key
 
-In your JavaScript application, create an instance of the `Yuno` class by providing a valid `PUBLIC_API_KEY`.
+In your JavaScript app, create an instance of the `Yuno` class by providing a valid `PUBLIC_API_KEY`.
 
 ```javascript
 const yuno = await Yuno.initialize(PUBLIC_API_KEY);
@@ -80,7 +80,7 @@ const apiClientPayment = await yuno.apiClientPayment({
 
 ### Preloading fraud fingerprints
 
-If your account uses [fraud screening](/docs/basic-concepts/fraud) with a provider whose fingerprinting script can take longer than the configured fraud timeout, call `executeFraudCheck` when the payment form renders, not at the moment your customer clicks "Pay". Some providers' fingerprinting scripts take longer than the timeout to load in certain regions. Calling `apiClientPayment` and `generateToken` back to back at click time can generate the one-time token before the fingerprint finishes loading, so the token is created without a device fingerprint.
+If your account uses [fraud screening](/docs/basic-concepts/fraud) with a provider whose fingerprinting script can take longer than the configured fraud timeout, call `executeFraudCheck` when the payment form renders, not at the moment your customer clicks "Pay." Some providers' fingerprinting scripts take longer than the timeout to load in certain regions. Calling `apiClientPayment` and `generateToken` back to back at click time can generate the one-time token before the fingerprint finishes loading. This means the token would be created without a device fingerprint.
 
 ```javascript
 // Wrong: calling everything at "Pay" click time
@@ -113,7 +113,7 @@ After collecting all user information, you can start the payment. First, you nee
 <Note>
 **Benefits of Using a Vaulted Token**
 
-When you use a vaulted token with the SDK, all the fraud information from the providers you configured in your card routing is collected and attached to the one-time token. In addition, you can add installment information and a security code if the provider requires it.
+When you use a vaulted token with the SDK, all the fraud information from the providers you configured in your card routing is collected. This information is attached to the one-time token. In addition, you can add installment information and a security code if the provider requires it.
 </Note>
 
 ```javascript Example 1
@@ -361,9 +361,9 @@ window.addEventListener('message', (event) => {
 });
 ```
 
-You are responsible for redirecting your customers to the URL provided by the `redirect_url` to complete the challenge. Once the customer successfully completes the 3DS challenge, they will be automatically redirected to the `callback_url`, which you provided when creating the `checkout_session` with the [Create Checkout Session](/reference/checkout-sessions/create-checkout-session) endpoint.
+You are responsible for redirecting your customers to the URL provided by the `redirect_url` to complete the challenge. Once the customer successfully completes the 3DS challenge, they will be automatically redirected to the `callback_url`. You provided this `callback_url` when creating the `checkout_session` with the [Create Checkout Session](/reference/checkout-sessions/create-checkout-session) endpoint.
 
-To complete the Headless SDK payment flow, you need to use [Yuno Webhooks](/docs/webhooks/configure-webhooks), which will promptly notify you about the outcome of the 3DS challenge and the final payment status. Using webhooks ensures that you receive real-time updates on the progress of the payment transaction. In addition to the webhooks, you can retrieve the payment information using the [Retrieve Payment by ID](/reference/payments/retrieve-payment-by-id) endpoint.
+To complete the Headless SDK payment flow, you need to use [Yuno Webhooks](/docs/webhooks/configure-webhooks). Webhooks promptly notify you about the outcome of the 3DS challenge and the final payment status, ensuring you receive real-time updates on the progress of the payment transaction. In addition to the webhooks, you can retrieve the payment information using the [Retrieve Payment by ID](/reference/payments/retrieve-payment-by-id) endpoint.
 
 ## Step 7: Get payment actions
 
@@ -373,7 +373,7 @@ Sometimes the payment may require an extra action to continue the payment flow. 
 const data = await apiClientPayment.getContinuePaymentAction({ checkoutSession: string }): Promise<ContinuePaymentAction>
 ```
 
-The `getContinuePaymentAction` method returns a `ContinuePaymentAction` object that describes the specific action required to continue the payment flow, depending on the provider and the specific step required.
+The `getContinuePaymentAction` method returns a `ContinuePaymentAction` object. This object describes the specific action required to continue the payment flow, depending on the provider and the specific step required.
 
 ### `ContinuePaymentAction` response structure
 
@@ -474,18 +474,18 @@ type ContinuePaymentAction = {
 
 | Field                     | Description                                                                      |
 | ------------------------- | -------------------------------------------------------------------------------- |
-| `type`                    | Type of payment provider (e.g., MERCADO_PAGO, DLOCAL, etc.)                      |
-| `action`                  | Specific action required to continue the payment (e.g., REDIRECT_URL, OTP, etc.) |
+| `type`                    | Type of payment provider (for example, MERCADO_PAGO, DLOCAL, etc.)                      |
+| `action`                  | Specific action required to continue the payment (for example, REDIRECT_URL, OTP, etc.) |
 | `payment_code`            | Used when the payment provider issues a payment code for cash-based payments     |
-| `image`                   | Used when an image (e.g., QR code) must be displayed to the user                 |
+| `image`                   | Used when an image (for example, QR code) must be displayed to the user                 |
 | `redirect`                | Used when a redirect is required for 3rd-party payment flows                     |
 | `otp`                     | Used when the flow requires OTP (One-Time Password) validation                   |
 | `three_d_secure_redirect` | Used for 3DS flows that redirect the user to a secure verification step          |
 | `transaction_id`          | Unique transaction ID, if available                                              |
 | `request_html`            | Used to render a payment form with dynamic HTML and headers                      |
-| `sdk_provider`            | Used for SDK-based providers (e.g., Apple Pay, Google Pay)                       |
+| `sdk_provider`            | Used for SDK-based providers (for example, Apple Pay, Google Pay)                       |
 | `render_html`             | Used to display HTML content directly in the app                                 |
-| `info`                    | General information or messaging (e.g., show confirmation message)               |
+| `info`                    | General information or messaging (for example, show confirmation message)               |
 | `render_iframe`           | Used when the provider needs to render an iframe for user interaction            |
 
 ### Provider Types and Actions
@@ -526,7 +526,7 @@ export declare namespace Provider {
 }
 ```
 
-### Provider Types and Actions
+### Provider Types and Actions Reference
 
 | Provider Type     | Description                   |
 | ----------------- | ----------------------------- |
@@ -547,7 +547,7 @@ export declare namespace Provider {
 | Action Type                   | Description                         |
 | ----------------------------- | ----------------------------------- |
 | `PAYMENT_CODE`                | Show payment code to user           |
-| `IMAGE`                       | Show image (e.g., QR code)          |
+| `IMAGE`                       | Show image (for example, QR code)          |
 | `REDIRECT_URL`                | Redirect the user to external page  |
 | `FORM`                        | Render a form to collect user input |
 | `INFO`                        | Display informational screen        |
@@ -596,8 +596,8 @@ In addition to the code examples provided, you can access the [Demo App](https:/
 
 ## Error handling
 
-Handle errors returned by the SDK in your app (e.g. failed payments, validation errors). For HTTP status and response codes, see [Status and response codes](/reference/getting-started/response-codes) in the API reference. To refund a payment, see [Refund payments](/docs/direct-integration-use-cases/refund-payments) and the [Refund payment](/reference/payments/refund-payment) API.
+Handle errors returned by the SDK in your app, such as failed payments or validation errors. For HTTP status and response codes, see [Status and response codes](/reference/getting-started/response-codes) in the API reference. To refund a payment, see [Refund payments](/docs/direct-integration-use-cases/refund-payments) and the [Refund payment](/reference/payments/refund-payment) API.
 
-## Stay Updated
+## Stay updated
 
 Visit the [changelog](/changelog/web#v1-6-0) for the latest SDK updates and version history.


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged grammar, voice-consistency, structural, and link issues across the Headless SDK guides. This PR applies the confirmed text-only fixes. No code samples, code-fence language tags, or method/variable/constant names were touched — every report item that touched those was explicitly excluded from scope (see "Not included" below).

## Changes
- **docs/sdks/headless-web/payment.mdx**: replaced "functionality"/"application" with "capability"/"app"; expanded 7 "e.g." occurrences to "for example"; split 7 long sentences; fixed a period placed outside a closing quote ("Pay".→"Pay."); renamed the second duplicate `### Provider Types and Actions` heading to avoid an anchor collision; standardized `## Stay Updated` → `## Stay updated`.
- **docs/sdks/headless-web/enrollment.mdx**: same functionality/app and e.g./sentence-split fixes; fixed a copy-paste leftover ("describe creating a payment" → "describe enrolling a payment method", since this page is about enrollment); standardized the "Stay updated" heading casing.
- **docs/sdks/headless-android/checkout.mdx**: "our" → "Yuno's"; "above" → "preceding" for the one backward-reference (left the version-threshold "X or above" mentions untouched); reworded the one genuine prose em dash (the other 3 flagged instances are inside the ProGuard code block, left untouched); expanded "e.g."; split a long sentence; added a specific one-line frontmatter description (previously generic boilerplate, now matches the Web page's descriptive style).
- **docs/sdks/headless-android/enrollment.mdx**: same "our"→"Yuno's" fix; expanded "e.g."; reworded the confusing "recommends...to base and make business decisions on" sentence (kept the `/docs/webhooks/index` link exactly as-is — verified against `docs.json`, it's already the correct page); removed a stray `<br />` sitting alone before "Error handling"; added a specific frontmatter description.
- **docs/sdks/headless-ios/checkout.mdx**: replaced "application" with "app"; expanded "e.g."; split 4 long sentences; turned the plain-text "Parameters" label into a real `### Parameters` heading; reworded the confusing "back-to-back payment creation" sentence.
- **docs/sdks/headless-ios/enrollment.mdx**: split 2 long sentences; expanded "e.g."; fixed 4 double-space typos in prose; turned "Parameters" into a real heading; reworded the same webhook-status sentence as the Android enrollment page (link left untouched, same reasoning).

## Not included (out of scope — code/behavior, needs engineering)
- headless-web/payment.mdx: the two fake-TypeScript "call signature" lines (`getThreeDSecureChallenge(...)`, `getContinuePaymentAction(...)`); the unquoted UUID in the Example 2 JSON block; the stray space inside `` `THREE_D_SECURE ` ``.
- headless-android/checkout.mdx: the `javascript`→`kotlin` code-fence language tag on Example 2; the duplicated `lastName = "lastName"` argument.
- headless-android/enrollment.mdx: `config: YunoConfig,` → `config = YunoConfig(),`; the wrong receiver `apiClientPayment.continueEnrollment(...)` → `apiClientEnroll...`; the typo variable `vauldtedtoken` → `vaultedToken`; renaming the `ENROLLMENT_STATE_CANCELED_BY_USER` constant.
- headless-ios/enrollment.mdx: `import Yuno` → `import YunoSDK`.

## Corrected report assumption
The report suggested the `/docs/webhooks/index` link (on both the Android and iOS enrollment pages) was broken and "probably should be `/docs/webhooks/webhooks`". Checked against `docs.json`'s navigation — `docs/webhooks/index` is a real, current page, and `docs/webhooks/webhooks` doesn't exist. Left both links unchanged; only the confusing sentence next to them was reworded.