### PR TITLE
docs(C2-18187): INVALID_EVENT error row shows 202 instead of an empty dash

### DIFF
--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -57,4 +57,4 @@ Errors return a `code` and a `messages` array.
 | 400 | `INVALID_ACCOUNT_ID` | The `account_id` does not exist or does not belong to your organization. |
 | 401 | `NOT_AUTHENTICATED` / `INVALID_CREDENTIALS` | Missing or invalid `PUBLIC-API-KEY` / `PRIVATE-SECRET-KEY` headers. |
 | 403 | `PRODUCT_NOT_ENABLED` | "The Transaction Reporting API is enabled per organization. Contact your Key Account Manager (KAM) to activate it." |
-| — | `INVALID_EVENT` (per event, in `rejected[]`) | Invalid enum value, wrong field type, unknown field, or `raw_provider_response` over 64 KB. |
+| 202 | `INVALID_EVENT` (per event, in `rejected[]`) | Not an HTTP error: the batch is accepted (`202`) and invalid events are returned individually inside `rejected[]`. Causes: invalid enum value, wrong field type, unknown field, or `raw_provider_response` over 64 KB. |


### PR DESCRIPTION
The `INVALID_EVENT` row in the errors table had `—` in the HTTP column (it is a per-event code, not an HTTP error), which rendered like a broken cell. Now shows `202` — the status of the batch response that carries `rejected[]` — with a one-line clarification. Presentation only; no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)