### PR TITLE
docs(C2-18187): VERIFY in the event_type enum + all values described + valid minimal example

### DIFF
--- a/openapi/reporting/report-transactions.json
+++ b/openapi/reporting/report-transactions.json
@@ -173,10 +173,11 @@
                           "type": "string",
                           "enum": [
                             "PURCHASE",
-                            "AUTHORIZE"
+                            "AUTHORIZE",
+                            "VERIFY"
                           ],
                           "default": "PURCHASE",
-                          "description": "Optional. The operation you performed at the provider. Defaults to `PURCHASE` when omitted. `VERIFY` reports a card verification (zero-dollar authorization)."
+                          "description": "Optional. The operation you performed at the provider: `PURCHASE` — a direct charge (authorization and capture in one step; the default when omitted); `AUTHORIZE` — an authorization to be captured later (the payment lands `PENDING` with sub-status `AUTHORIZED`); `VERIFY` — a card verification / zero-dollar authorization (the payment lands `SUCCEEDED` with sub-status `VERIFIED`)."
                         },
                         "occurred_at": {
                           "type": "string",
@@ -210,7 +211,8 @@
                         "amount": {
                           "currency": "USD",
                           "value": 99.0
-                        }
+                        },
+                        "provider_id": "ADYEN"
                       }
                     ]
                   }
@@ -299,7 +301,7 @@
                           "report_id": "merchant-rpt-000124",
                           "code": "INVALID_EVENT",
                           "messages": [
-                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZE."
+                            "The field 'event_type' must be one of: PURCHASE, AUTHORIZE, VERIFY."
                           ]
                         }
                       ]


### PR DESCRIPTION
Fixes four gaps on the reporting reference (silent replace failures in #760's first commit, caught by Andrea on the rendered page):

1. `VERIFY` was missing from the `event_type` **enum** — the description mentioned it but "Available options" showed only two values.
2. `event_type` description now explains **all three values** (`AUTHORIZE` was the only one undocumented), each with its status mapping.
3. The **minimal example** now includes `provider_id` — it is required, so the example was an invalid request.
4. The rejection-message example now says `PURCHASE, AUTHORIZE, VERIFY` — matching the live API message.

Verified by asserting against the parsed JSON (enum, description, example, message), not by string counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)