### PR TITLE
docs(sdks/card-enrollment): apply docs-evaluation text fixes to Web, Android, and iOS guides

### DIFF
--- a/docs/sdks/card-enrollment/android-enrollment.mdx
+++ b/docs/sdks/card-enrollment/android-enrollment.mdx
@@ -69,18 +69,16 @@ For the full list of parameters, see the [Android SDK Common Reference](/docs/sd
 
 | Parameter | Description |
 |-----------|-------------|
-| `customerSession` | Customer session ID from Create customer session API. Required. |
-| `countryCode` | ISO country code. Required. |
+| `customerSession` | Customer session ID from Create customer session API. Required for `apiClientEnroll`. |
+| `countryCode` | ISO country code. Required for `apiClientEnroll`. |
 | `showEnrollmentStatus` | Show enrollment result screen. Optional; default true. |
 | `callbackEnrollmentState` | Callback: enrollment state. Optional; requires `initEnrollment` in onCreate. |
 | `keepLoader` | If `true`, the SDK loader persists during enrollment, preventing UI flickering. |
 | `requestCode` | Optional; use if capturing result via `onActivityResult`. |
-| `countryCode` | Country for the enrollment. Required for `apiClientEnroll`. |
-| `customerSession` | Customer session ID. Required for `apiClientEnroll`. |
 
 ## full-checkout Enrollment (Android)
 
-Yuno full-checkout for Android provides enrollment with pre-built UI, card enrollment, status handling, and basic error management. See [Requirements](#requirements) above.
+Yuno full-checkout for Android provides enrollment with pre-built UI, card enrollment, status handling, and basic error management. See the preceding [Requirements](#requirements) section.
 
 ### Step 1: Create a customer
 

--- a/docs/sdks/card-enrollment/ios-enrollment.mdx
+++ b/docs/sdks/card-enrollment/ios-enrollment.mdx
@@ -32,7 +32,7 @@ For the full list of parameters, see the [iOS SDK Common Reference](/docs/sdks/r
 | Parameter | Description |
 |-----------|-------------|
 | `customerSession` | Customer session ID from Create customer session API. Required. |
-| `countryCode` | ISO country code (e.g. `BR`). Required. |
+| `countryCode` | ISO country code (for example, `BR`). Required. |
 | `language` | Language code for the UI. Optional. |
 | `viewController` | UIViewController that presents the enrollment flow. Required for delegate. |
 | `yunoEnrollmentResult(_:)` | Delegate: enrollment finished with result. |
@@ -40,7 +40,7 @@ For the full list of parameters, see the [iOS SDK Common Reference](/docs/sdks/r
 
 ## full-checkout Enrollment (iOS)
 
-The Yuno full-checkout iOS SDK provides enrollment with pre-built UI, card enrollment, status handling, and basic error management. See [Requirements](#requirements) above.
+The Yuno full-checkout iOS SDK provides enrollment with pre-built UI, card enrollment, status handling, and basic error management. See the preceding [Requirements](#requirements) section.
 
 ### Step 1: Create a customer and customer session
 
@@ -162,7 +162,7 @@ class ViewController: UIViewController, YunoEnrollmentDelegate {
 |-----------|-------------|
 | `customerSession` | The unique identifier for the customer session. |
 | `countryCode` | Country code where the enrollment is performed. See [Country Coverage](/docs/sdks/resources/country-coverage) for supported countries. |
-| `language` | Language code for the enrollment forms (e.g., `"en"`, `"es"`, `"pt"`). See [Supported languages](/docs/sdks/resources/languages-supported). |
+| `language` | Language code for the enrollment forms (for example, `"en"`, `"es"`, `"pt"`). See [Supported languages](/docs/sdks/resources/languages-supported). |
 | `viewController` | The `UIViewController` used to present the enrollment flow. Required for proper UI presentation. |
 | `yunoEnrollmentResult(_:)` | Called when the enrollment process completes with the final result. |
 

--- a/docs/sdks/card-enrollment/web-enrollment.mdx
+++ b/docs/sdks/card-enrollment/web-enrollment.mdx
@@ -30,8 +30,8 @@ For the full list of parameters and callbacks, see the [Web SDK Common Reference
 | Parameter              | Description                                                                    |
 | ---------------------- | ------------------------------------------------------------------------------ |
 | `customerSession`      | Customer session ID from your backend (Create customer session API). Required. |
-| `countryCode`          | ISO country code (e.g. `US`).                                                  |
-| `language`             | Language code for the UI (e.g. `en`). Optional.                                |
+| `countryCode`          | ISO country code (for example, `US`).                                                  |
+| `language`             | Language code for the UI (for example, `en`). Optional.                                |
 | `showLoading`          | Show loading spinner. Optional.                                                |
 | `onLoading`            | Callback: loading state updates. Optional.                                     |
 | `elementSelector`      | CSS selector where the enrollment form mounts. Optional.                       |
@@ -42,7 +42,7 @@ For the full list of parameters and callbacks, see the [Web SDK Common Reference
 
 ## full-checkout Enrollment (Web)
 
-Use full-checkout for a seamless integration with pre-built UI. Implement enrollment as follows.
+Use full-checkout for a smooth integration with pre-built UI. Implement enrollment as follows.
 
 ### Step 1: Include the library in your project
 
@@ -54,7 +54,7 @@ See [Quickstart guide](/docs/sdks/overview/quickstart#web-sdk-integration) for i
 
 ### Step 3: Create a customer session and an enrollment payment method object
 
-Create a [customer session](/reference/customer-sessions-enrollment/create-customer-session) and an [enrollment payment method object](/reference/payment-methods-checkout/enroll-payment-method-checkout) on your **server-side** to keep private API keys secure; define which payment method the customer can enroll when creating the payment method object.
+Create a [customer session](/reference/customer-sessions-enrollment/create-customer-session) and an [enrollment payment method object](/reference/payment-methods-checkout/enroll-payment-method-checkout) on your **server-side** to keep private API keys secure. Define which payment method the customer can enroll when creating the payment method object.
 
 #### Server-side example
 
@@ -133,8 +133,8 @@ Use `await yuno.mountEnrollment()` with the parameters below.
 | `card`                            | Define specific settings for the credit card form.                                                                                                                                                                                                |
 | `yunoEnrollmentStatus`            | Callback after enrollment ends; receives `vaultedToken` and `status`. Status options: `CREATED`, `EXPIRED`, `REJECTED`, `READY_TO_ENROLL`, `ENROLL_IN_PROCESS`, `UNENROLL_IN_PROCESS`, `ENROLLED`, `DECLINED`, `CANCELED`, `ERROR`, `UNENROLLED`. |
 | `issuersFormEnable`               | Enable the issuer's form (bank list).                                                                                                                                                                                                             |
-| `texts`                           | Custom text for payment form buttons to match your application's language or branding.                                                                                                                                                            |
-| `card.isCreditCardProcessingOnly` | Optional. Forces card transactions to process as credit only—useful where cards act as both credit and debit.                                                                                                                                     |
+| `texts`                           | Custom text for payment form buttons to match your app's language or branding.                                                                                                                                                            |
+| `card.isCreditCardProcessingOnly` | Optional. Forces card transactions to process as credit only, which is useful where cards act as both credit and debit.                                                                                                                                     |
 
 The next code block presents an example of the Enrollment parameter configuration and mounting.
 
@@ -255,6 +255,8 @@ await yuno.mountEnrollment({
   },
 });
 ```
+
+The `card.isCreditCardProcessingOnly` option described above is omitted from this example for brevity; see the parameters table for details.
 
 ## Common reference
 

--- a/docs/sdks/card-enrollment/web-enrollment.mdx
+++ b/docs/sdks/card-enrollment/web-enrollment.mdx
@@ -42,7 +42,7 @@ For the full list of parameters and callbacks, see the [Web SDK Common Reference
 
 ## full-checkout Enrollment (Web)
 
-Use full-checkout for a smooth integration with pre-built UI. Implement enrollment as follows.
+Use full-checkout for a seamless integration with pre-built UI. Implement enrollment as follows.
 
 ### Step 1: Include the library in your project
 


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged grammar, voice-consistency, and table-duplication issues across the Card Enrollment guides. This PR applies the confirmed text-only fixes. No code samples were touched — every report item that touched code was explicitly excluded from scope (see "Not included" below).

## Changes
- **docs/sdks/card-enrollment/web-enrollment.mdx**: expanded 2 "e.g." occurrences to "for example"; replaced "your application's language" with "your app's language"; rewrote an em dash into plain phrasing; split a 25+ word sentence at its semicolon; added a note after the `mountEnrollment` code example clarifying that `card.isCreditCardProcessingOnly` (documented in the table above) is omitted from the example for brevity.
- **docs/sdks/card-enrollment/android-enrollment.mdx**: replaced the backward-reference "See ... above" with "See the preceding ... section"; removed two duplicate rows (`customerSession`, `countryCode`) from the Parameters table, merging their "Required for `apiClientEnroll`" detail into the surviving rows.
- **docs/sdks/card-enrollment/ios-enrollment.mdx**: same backward-reference fix ("above" → "the preceding ... section"); expanded 2 "e.g." occurrences to "for example".

## Not included (out of scope — code, needs engineering)
- web-enrollment.mdx: adding the missing comma after the `onLoading` callback in the `mountEnrollment` code example; removing the stray commas in the JSDoc union-type comment for `status`.

## Flagged, not changed
- web-enrollment.mdx: the report asked to reword "seamless integration" (potential confusion with the separate Seamless SDK product name). Left unchanged — "Seamless" is itself a Yuno product name, so rewording it without confirming intent risks guessing wrong. Needs a call from whoever owns that wording.
- android-enrollment.mdx: the report's "application" fix targets `"custom application class"`, which refers to Android's actual `Application` class (a real SDK/OS concept) — not the generic "your app" wording pattern used elsewhere. Left unchanged.
- android-enrollment.mdx: the reported em-dash/spacing issues are inside the ProGuard code block (`# Gson — R8 full mode compatibility` style comments) — code, left untouched. No genuine prose instance was found beyond what's already fixed.
- android-enrollment.mdx: the `callbackEnrollmentState` row flagged for a >25-word split is already broken into 4 short sentences, each under 25 words — no change needed.