### PR TITLE
docs(additional-platforms): apply docs-evaluation text fixes to Flutter and React Native guides

### DIFF
--- a/docs/sdks/additional-platforms/flutter.mdx
+++ b/docs/sdks/additional-platforms/flutter.mdx
@@ -6,7 +6,7 @@ metadata:
   robots: index
 description: "Integrate Yuno's Flutter SDK for payment and enrollment flows, including styling, customization, and troubleshooting"
 ---
-Integrate Yuno's Flutter SDK Lite payment and enrollment flows by following these steps.
+Integrate Yuno's Flutter SDK for Lite payment and enrollment flows by following these steps.
 
 ## Requirements
 
@@ -74,11 +74,11 @@ Then register the application class in `AndroidManifest.xml`:
 
 ### iOS configuration
 
-No additional iOS-specific configuration is required beyond the Flutter package installation. iOS appearance customization is configured through `IosConfig` during SDK initialization (see customizations section).
+No additional iOS-specific configuration is required beyond the Flutter package installation. iOS appearance customization is configured through `IosConfig` during SDK initialization (see the [Customizations](#customizations) section).
 
 ## Payment
 
-Follow these steps to integrate the Yuno payment flow in your Flutter application.
+Follow these steps to integrate the Yuno payment flow in your Flutter app.
 
 <Steps>
   <Step title="Create a customer and checkout session">
@@ -155,7 +155,7 @@ Follow these steps to integrate the Yuno payment flow in your Flutter applicatio
 
 ### Payment status validation
 
-The SDK manages the relationship between frontend SDK status and backend payment status when users interact with payment flows. Understanding this distinction helps you handle payment states correctly in your application.
+The SDK manages the relationship between frontend SDK status and backend payment status when users interact with payment flows. Understanding this distinction helps you handle payment states correctly in your app.
 
 #### Sync payment methods (Apple Pay and Google Pay)
 
@@ -164,8 +164,6 @@ For synchronous payment methods like Apple Pay and Google Pay, when a user cance
 * **SDK status**: Returns `cancelByUser` (CANCELLED_BY_USER)
 * **Backend payment status**: Remains `PENDING` until PSP timeout or merchant cancellation
 * **Important**: The SDK will not return `reject` or `processing` in this scenario
-
-This ensures that the backend payment remains in a pending state and can be properly handled by the merchant's system.
 
 #### Async payment methods (PIX and QR-based methods)
 
@@ -176,8 +174,6 @@ For asynchronous payment methods like PIX, when a user closes the QR code window
 * **Checkout session reuse**: Re-opening the same checkout session can display the same valid QR code
 * **No automatic cancellation**: The PIX payment is not automatically cancelled when the user closes the QR window
 
-This behavior allows users to return to the payment flow and complete the transaction using the same QR code before it expires.
-
 #### Expired async payments
 
 If a PIX QR code expires naturally:
@@ -185,11 +181,9 @@ If a PIX QR code expires naturally:
 * **Backend status**: Updated to `EXPIRED`
 * **SDK status**: SDK callbacks and polling endpoints return `EXPIRED` consistently
 
-This ensures merchants receive accurate status information when a payment method has expired.
-
 ## Enrollment
 
-Follow these steps to enroll payment methods in your Flutter application.
+Follow these steps to enroll payment methods in your Flutter app.
 
 <Steps>
   <Step title="Create customer and session">
@@ -302,23 +296,7 @@ For the full list of parameters and options, see the subsections that follow.
 
 | Parameter    | Description                                                                                                                                                  |
 | :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `appearance` | iOS-only appearance customization. See [`Appearance`](#appearance-ios) below and the [customizations](#customizations) section for detailed styling options. |
-
-### `Appearance` (iOS)
-
-| Parameter                              | Description                                      |
-| :------------------------------------- | :----------------------------------------------- |
-| `fontFamily`                           | iOS font family name.                            |
-| `accentColor`                          | Accent color for highlights and active elements. |
-| `buttonBackgrounColor`                | Primary button background color.                 |
-| `buttonTitleBackgrounColor`           | Primary button title color.                      |
-| `buttonBorderBackgrounColor`          | Primary button border color.                     |
-| `secondaryButtonBackgrounColor`       | Secondary button background color.               |
-| `secondaryButtonTitleBackgrounColor`  | Secondary button title color.                    |
-| `secondaryButtonBorderBackgrounColor` | Secondary button border color.                   |
-| `disableButtonBackgrounColor`         | Disabled button background color.                |
-| `disableButtonTitleBackgrounColor`    | Disabled button title color.                     |
-| `checkboxColor`                        | Checkbox color.                                  |
+| `appearance` | iOS-only appearance customization. See [Available iOS customization options](#available-ios-customization-options) in the [Customizations](#customizations) section for the full parameter list. |
 
 ### `StartPayment` (Lite)
 
@@ -343,7 +321,7 @@ For the full list of parameters and options, see the subsections that follow.
 | `showPaymentStatus` | Controls whether the SDK displays its built-in enrollment status screens after enrollment completion. Set to `false` if you want to handle status display in your own UI. Default: `true`.                           |
 | `countryCode`       | Optional country code override for this enrollment. If not provided, the SDK uses the country code from `Yuno.init()`. See [Country coverage](/docs/sdks/resources/country-coverage) for supported countries.                               |
 
-## customizations
+## Customizations
 
 You can customize SDK behavior and appearance using the configuration options:
 
@@ -377,7 +355,7 @@ For more iOS customization options, see [SDK customizations (iOS)](/docs/sdks/cu
 
 ### Android customization
 
-For Android, the Flutter SDK uses the native Android SDK's styling system. customization is performed in the native Android layer using Kotlin/Java code when initializing the SDK through `YunoSdkAndroidPlugin.initSdk()`.
+For Android, the Flutter SDK uses the native Android SDK's styling system. Customization is performed in the native Android layer using Kotlin/Java code when initializing the SDK through `YunoSdkAndroidPlugin.initSdk()`.
 
 #### YunoConfig (Android)
 
@@ -458,7 +436,7 @@ Then read it in Dart:
 const apiKey = String.fromEnvironment('YUNO_API_KEY', defaultValue: '');
 ```
 
-If you also need the key on the Android native side, map `dart-defines` into `BuildConfig` and read `BuildConfig.YUNO_API_KEY` in `MyApp` (see the Flutter SDK README for the full snippet).
+If you also need the key on the Android native side, map `dart-defines` into `BuildConfig`. Then read `BuildConfig.YUNO_API_KEY` in `MyApp` (see the Flutter SDK README for the full snippet).
 
 ## Troubleshooting
 

--- a/docs/sdks/additional-platforms/flutter.mdx
+++ b/docs/sdks/additional-platforms/flutter.mdx
@@ -296,7 +296,23 @@ For the full list of parameters and options, see the subsections that follow.
 
 | Parameter    | Description                                                                                                                                                  |
 | :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `appearance` | iOS-only appearance customization. See [Available iOS customization options](#available-ios-customization-options) in the [Customizations](#customizations) section for the full parameter list. |
+| `appearance` | iOS-only appearance customization. See [`Appearance`](#appearance-ios) below and the [Customizations](#customizations) section for detailed styling options. |
+
+### `Appearance` (iOS)
+
+| Parameter                              | Description                                      |
+| :------------------------------------- | :----------------------------------------------- |
+| `fontFamily`                           | iOS font family name.                            |
+| `accentColor`                          | Accent color for highlights and active elements. |
+| `buttonBackgrounColor`                | Primary button background color.                 |
+| `buttonTitleBackgrounColor`           | Primary button title color.                      |
+| `buttonBorderBackgrounColor`          | Primary button border color.                     |
+| `secondaryButtonBackgrounColor`       | Secondary button background color.               |
+| `secondaryButtonTitleBackgrounColor`  | Secondary button title color.                    |
+| `secondaryButtonBorderBackgrounColor` | Secondary button border color.                   |
+| `disableButtonBackgrounColor`         | Disabled button background color.                |
+| `disableButtonTitleBackgrounColor`    | Disabled button title color.                     |
+| `checkboxColor`                        | Checkbox color.                                  |
 
 ### `StartPayment` (Lite)
 

--- a/docs/sdks/additional-platforms/react-native/advanced-features.mdx
+++ b/docs/sdks/additional-platforms/react-native/advanced-features.mdx
@@ -8,11 +8,9 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 
 <GenericOrientation />
 
-Explore advanced configurations and custom integrations for the React Native SDK.
-
 ## Deep linking / external browser return
 
-Handle users returning to your app after external payment flows like 3DS authentication challenges, bank transfer redirects, PIX payments, and alternative payment methods that redirect to external browsers.
+Some payment flows redirect users to an external browser, including 3DS authentication challenges, bank transfer redirects, PIX payments, and other alternative payment methods. Handle their return to your app with the following steps.
 
 ### 1. Set callback_url in checkout session
 

--- a/docs/sdks/additional-platforms/react-native/code-examples.mdx
+++ b/docs/sdks/additional-platforms/react-native/code-examples.mdx
@@ -8,7 +8,7 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 
 <GenericOrientation />
 
-Explore these examples to quickly implement Yuno in your React Native application.
+Explore these examples to quickly implement Yuno in your React Native app.
 
 ## Basic payment flow
 

--- a/docs/sdks/additional-platforms/react-native/headless.mdx
+++ b/docs/sdks/additional-platforms/react-native/headless.mdx
@@ -8,7 +8,7 @@ import GenericOrientation from '/snippets/GenericOrientation.mdx'
 
 <GenericOrientation />
 
-Build completely custom payment forms with full UI control when you need complete control over every UI element, highly custom checkout experiences, or have development resources for custom UI.
+Build fully custom payment forms when you need complete control over every UI element, a highly tailored checkout experience, or have the development resources to build your own UI.
 
 ## Integration workflow
 

--- a/docs/sdks/additional-platforms/react-native/index.mdx
+++ b/docs/sdks/additional-platforms/react-native/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: React Native SDK
 sidebarTitle: Overview
-description: Integrate Yuno into your React Native application to accept payments and save payment methods.
+description: Integrate Yuno into your React Native app to accept payments and save payment methods.
 ---
 
 import GenericOrientation from '/snippets/GenericOrientation.mdx'
@@ -32,7 +32,7 @@ The SDK includes TypeScript definitions out of the box.
 
 ## Initialize
 
-Initialize the SDK as early as possible in your application, typically in `App.tsx`.
+Initialize the SDK as early as possible in your app, typically in `App.tsx`.
 
 ```typescript
 import { YunoSdk } from '@yuno-payments/yuno-sdk-react-native';

--- a/docs/sdks/additional-platforms/react-native/lite.mdx
+++ b/docs/sdks/additional-platforms/react-native/lite.mdx
@@ -12,7 +12,7 @@ The Lite SDK allows you to build your own payment method selection screen while 
 
 ## Alternative mounting options
 
-The basic flow uses automatic payment method display. For more control, use these alternatives:
+The [basic payment flow](/docs/sdks/additional-platforms/react-native#basic-payment-flow-full-checkout) uses automatic payment method display. For more control, use these alternatives:
 
 ### Custom payment method selection (`startPaymentLite`)
 
@@ -74,7 +74,7 @@ await YunoSdk.startPaymentLite({
 | Parameter | Description |
 | --------- | ----------- |
 | `checkoutSession` | Checkout session ID from your backend. |
-| `methodSelected.paymentMethodType` | Payment method type (e.g. `CARD`, `PIX`). |
+| `methodSelected.paymentMethodType` | Payment method type (for example, `CARD`, `PIX`). |
 | `methodSelected.vaultedToken` | Saved payment method token, or `null` for new card. |
 | `showPaymentStatus` | When `true`, SDK shows payment result UI. |
-| `countryCode` | Optional ISO country code override (e.g. `US`). |
+| `countryCode` | Optional ISO country code override (for example, `US`). |

--- a/docs/sdks/additional-platforms/react-native/styling.mdx
+++ b/docs/sdks/additional-platforms/react-native/styling.mdx
@@ -31,6 +31,8 @@ YunoSdk.initialize({
 });
 ```
 
+Available `theme` options depend on the native SDK versions bundled with the React Native SDK. See [Android Customization](/docs/sdks/customization/android) and [iOS Customization](/docs/sdks/customization/ios) for the full list of tokens.
+
 ## Platform-specific styling
 
 Since the React Native SDK wraps native iOS and Android SDKs, some styling options might be platform-specific.


### PR DESCRIPTION
## PR Description
Applies the text/prose-only fixes from a docs-evaluation pass across the Additional Platforms section (Flutter and React Native guides): grammar and wording fixes, broken anchor/link cleanup, and generic "application" → "app" replacements. Per the team's standing rule, any item touching a code sample, a method/property/class name, or a product/flow-naming question was intentionally left unchanged and flagged for engineering/product confirmation instead of being applied directly.

## Changes

**Flutter**
- Fixed the missing "for" in "Integrate Yuno's Flutter SDK for Lite payment and enrollment flows..."
- Turned "(see customizations section)" into a real anchor link to `## Customizations`, and capitalized that heading and the "Customization is performed..." sentence
- Cut 3 closing sentences that only restated the bullets above them (Sync/Async/Expired payment status sections)
- Replaced "application" with "app" (3 instances) and split one over-25-word sentence in the environment variables section

**React Native Overview**
- Replaced "application" with "app" in the frontmatter description and the Initialize section

**React Native Lite**
- Linked "the basic flow" to the Overview page's "Basic payment flow (Full Checkout)" section
- Expanded both "e.g." occurrences to "for example" in the parameters table

**React Native Headless**
- Tightened the opening sentence that repeated "custom"/"control" 5 times across "custom payment forms," "full UI control," "complete control," "custom checkout experiences," and "custom UI"

**React Native Styling**
- Added a direct link to the Android/iOS Customization docs next to the "depends on native SDK versions" theme warning, instead of only at the end of the page

**Advanced Features**
- Cut the redundant "Explore advanced configurations..." opening line
- Split the long deep-linking intro sentence into two

**Code Examples**
- Replaced "application" with "app" in the intro line

**Flagged, not changed** (per the no-code/no-behavior-change rule, even though some items were reported as "Bug"):
- Flutter: the two Appearance/iOS-styling tables (`### Appearance (iOS)` under Parameters and "Available iOS customization options" under Customizations) are NOT duplicates — the first follows the page's own pattern of expanding every referenced type inline in the Parameters section, the second documents usage for styling. Left both as-is after review.
- Flutter: `YunoConfig` vs `YunoStyles`/`YunoButtonStyles` styling claim; the requested new example listing required Lite payment methods
- React Native Overview: renaming "Basic payment flow (Full Checkout)" (overlaps a distinct product/flow name)
- React Native Headless: the unconditional `getThreeDSecureChallenge` call in the code sample; the "fraud routing data collection" phrase (not found verbatim in the current file)
- Advanced Features: explaining the unexplained `continuePayment` arguments
- Code Examples: the missing `Alert` import, the undefined `SuccessScreen` component, and the `card.vaultedToken` origin pointer
- Flutter: "above" (5x, all legitimate "version X or above" usage) and "disabled" (2x, legitimate UI-state adjective) — verified as not matching the reported anti-pattern, left unchanged