### PR TITLE
docs(external-native-modules): apply docs-evaluation text fixes to iOS and Android Netcetera 3DS guides

### DIFF
--- a/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
@@ -1,14 +1,14 @@
 ---
 title: "3DS Native SDKs (Android)"
 sidebarTitle: "Netcetera 3DS (Android)"
-description: "Run 3-D Secure challenges natively in your Android app with Netcetera's 3DS SDK."
+description: "Run 3D Secure challenges natively in your Android app with Netcetera's 3DS SDK."
 robots: index
 ---
 
-The Yuno Android SDK supports running 3-D Secure (3DS) challenges natively inside your app using **Netcetera's 3DS SDK**. Native 3DS gives a smoother UX than the WebView-based fallback (no in-app browser jump) and is required by some acquirers for frictionless authentication.
+The Yuno Android SDK supports running 3D Secure (3DS) challenges natively inside your app using **Netcetera's 3DS SDK**. Native 3DS gives a smoother UX than the WebView-based fallback (no in-app browser jump) and may be required by some acquirers for frictionless authentication.
 
 <Warning>
-  **Payment flows only** — Native 3DS via Netcetera is currently supported for **payment** flows only. It does not apply to enrollment flows.
+  **Payment flows only**: Native 3DS via Netcetera is currently supported for **payment** flows only. It does not apply to enrollment flows.
 </Warning>
 
 <Note>
@@ -23,7 +23,7 @@ The Yuno Android SDK supports running 3-D Secure (3DS) challenges natively insid
 
 ## Compatibility
 
-Each release of this module is built and tested against a minimum version of the Yuno Payments SDK. The module's POM does not pin a specific core version, leaving you in full control of which `com.yuno.payments:android-sdk` version your app runs against — but versions below the minimum may not expose the APIs this module relies on and can fail at runtime with `NoSuchMethodError` / `NoSuchFieldError`.
+Each release of this module is built and tested against a minimum version of the Yuno Payments SDK. The module's POM does not pin a specific core version. Versions below the minimum may not expose the APIs this module relies on and can fail at runtime with `NoSuchMethodError` / `NoSuchFieldError`.
 
 | Yuno 3DS Netcetera | Requires Yuno Payments SDK |
 |---|---|
@@ -72,7 +72,7 @@ Add the entry to your project's settings file inside `dependencyResolutionManage
 </Tabs>
 
 <Info>
-  If you are using the legacy `allprojects { repositories { … } }` block in your root `build.gradle`, add the same Netcetera `maven { url "…" }` line there instead.
+  You may still be using the legacy `allprojects { repositories { … } }` block in your root `build.gradle`. If so, add the same Netcetera `maven { url "…" }` line there instead.
 </Info>
 
 ## Step 2: Add the dependency
@@ -103,11 +103,11 @@ Add the Yuno 3DS Netcetera dependency to your app module's build file:
   </Tab>
 </Tabs>
 
-The Netcetera 3DS SDK and its required `androidx.startup` dependency are pulled in transitively — you don't need to declare them yourself.
+The upstream Netcetera 3DS SDK wrapped by `yuno-sdk-3ds-netcetera` and its required `androidx.startup` dependency are pulled in transitively. You don't need to declare them yourself.
 
 ## Activating the 3DS provider
 
-The module **auto-registers** with the Yuno Payments SDK when your app process starts (via [Jetpack App Startup](https://developer.android.com/topic/libraries/app-startup)). **No extra code is required** — just initialize the Yuno SDK as usual:
+The module **auto-registers** with the Yuno Payments SDK when your app process starts (via [Jetpack App Startup](https://developer.android.com/topic/libraries/app-startup)). **No extra code is required**: just initialize the Yuno SDK as usual:
 
 ```kotlin
 import com.yuno.payments.Yuno
@@ -119,9 +119,9 @@ Yuno.initialize(
 ```
 
 <Tip>
-  Once registered, the Yuno Payments SDK automatically routes any 3DS challenge during checkout through the Netcetera provider. **You don't need to change any of your payment code.**
+  Once registered, the Yuno Payments SDK automatically routes any 3DS challenge during checkout through the Netcetera provider.
 </Tip>
 
 ### Permissions
 
-`android.permission.INTERNET` is declared by the module's manifest and merged into your app automatically — no action required.
+`android.permission.INTERNET` is declared by the module's manifest and merged into your app automatically. No action required.

--- a/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
@@ -96,7 +96,7 @@ The Yuno iOS SDK supports running 3D Secure (3DS) challenges natively inside you
 When testing against the Yuno sandbox environment, the Netcetera SDK requires a Visa test root certificate (`acq-root-certeq-prev-environment.crt`) to be present in your app's main bundle.
 
 <Info>
-  **Contact your Yuno TAM (Technical Account Manager) or [Yuno's support team](mailto:support@y.uno) to obtain the certificate.** It is not distributed publicly.
+  **Contact your Yuno TAM (Technical Account Manager) to obtain the certificate.** It is not distributed publicly.
 </Info>
 
 Once you have the file:

--- a/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
@@ -1,14 +1,14 @@
 ---
 title: "3DS Native SDKs (iOS)"
 sidebarTitle: "Netcetera 3DS (iOS)"
-description: "Run 3-D Secure challenges natively in your iOS app with Netcetera's 3DS SDK."
+description: "Run 3D Secure challenges natively in your iOS app with Netcetera's 3DS SDK."
 robots: index
 ---
 
-The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside your app using **Netcetera's 3DS SDK**. Native 3DS gives a smoother UX than web-based challenges (no Safari View Controller jump) and is required by some acquirers for frictionless authentication.
+The Yuno iOS SDK supports running 3D Secure (3DS) challenges natively inside your app using **Netcetera's 3DS SDK**. Native 3DS gives a smoother UX than web-based challenges (no Safari View Controller jump) and may be required by some acquirers for frictionless authentication.
 
 <Warning>
-  **Payment flows only** — Native 3DS via Netcetera is currently supported for **payment** flows only. It does not apply to enrollment flows.
+  **Payment flows only**: Native 3DS via Netcetera is currently supported for **payment** flows only. It does not apply to enrollment flows.
 </Warning>
 
 <Note>
@@ -20,6 +20,10 @@ The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside yo
 - iOS **15.0** or higher.
 - **YunoSDK 2.17.0 or higher** already installed in your app.
 - The Netcetera 3DS provider package ([`Yuno3DSNetcetera`](https://github.com/yuno-payments/yuno-3DS-netcetera-iOS)), installed via Swift Package Manager or CocoaPods (see below).
+
+<Note>
+  This module requires iOS 15.0, higher than the iOS 14.0 minimum documented for the base SDK elsewhere. Adding native 3DS raises your app's overall deployment target.
+</Note>
 
 ## Installation
 
@@ -60,7 +64,7 @@ The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside yo
 
 <Tabs>
   <Tab title="Swift Package Manager">
-    The provider **auto-registers** when the framework loads. No extra code is required — just `import Yuno3DSNetcetera` somewhere in your app:
+    The provider **auto-registers** when the framework loads. No extra code is required: just `import Yuno3DSNetcetera` somewhere in your app:
 
     ```swift
     import YunoSDK
@@ -71,7 +75,7 @@ The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside yo
   </Tab>
 
   <Tab title="CocoaPods">
-    The CocoaPods variant ships as a **static** framework, so the auto-register bootstrap is not included. Call `Yuno3DSNetcetera.register()` **once**, before `Yuno.initialize(...)`:
+    Unlike the Swift Package Manager variant above, the CocoaPods build ships as a **static** framework, so it does not auto-register. Call `Yuno3DSNetcetera.register()` **once**, before `Yuno.initialize(...)`:
 
     ```swift
     import YunoSDK
@@ -92,7 +96,7 @@ The Yuno iOS SDK supports running 3-D Secure (3DS) challenges natively inside yo
 When testing against the Yuno sandbox environment, the Netcetera SDK requires a Visa test root certificate (`acq-root-certeq-prev-environment.crt`) to be present in your app's main bundle.
 
 <Info>
-  **Contact your Yuno TAM (Technical Account Manager) to obtain the certificate.** It is not distributed publicly.
+  **Contact your Yuno TAM (Technical Account Manager) or [Yuno's support team](mailto:support@y.uno) to obtain the certificate.** It is not distributed publicly.
 </Info>
 
 Once you have the file:


### PR DESCRIPTION
## PR Description
Applies the text/prose-only fixes from a docs-evaluation pass on the External Native Modules section: the iOS and Android guides for running native 3DS challenges via Netcetera's SDK. Fixes cover terminology standardization, em dash cleanup, a version-requirement clarification, a self-contained CocoaPods note, and wording that either contradicted itself or asserted an unverifiable claim.

## Changes

**netcetera-3ds-ios.mdx**
- Standardized "3-D Secure"/"3-D" to "3D Secure"/"3D" in the frontmatter description and intro paragraph
- Rewrote 2 prose em dashes (Warning box, Swift Package Manager tab) to colons
- Added a note after Requirements clarifying this module needs iOS 15.0, higher than the iOS 14.0 minimum documented for the base SDK elsewhere
- Reworded the CocoaPods tab to explicitly name the contrast with the Swift Package Manager tab ("Unlike the Swift Package Manager variant above...") instead of assuming the reader saw it
- Softened "is required by some acquirers" to "may be required by some acquirers" (no acquirer is named or verifiable)
- Left the "your Yuno TAM" contact as plain text — no verified TAM-specific contact link/email exists in the docs to point to instead

**netcetera-3ds-android.mdx**
- Standardized "3-D Secure"/"3-D" to "3D Secure"/"3D" in the frontmatter description and intro paragraph
- Rewrote 5 prose em dashes (Warning box, Compatibility paragraph, transitive-dependency sentence, auto-register sentence, Permissions section) to colons/periods
- Split 2 over-25-word sentences: the Compatibility paragraph and the legacy `allprojects` Info box under Step 1
- Cut the "leaving you in full control" framing in the Compatibility paragraph — it undercut the runtime-failure risk described right after it
- Disambiguated "The Netcetera 3DS SDK" from the `yuno-sdk-3ds-netcetera` module added in Step 2, clarifying it's the upstream SDK the module wraps, not a separate dependency
- Cut the redundant "You don't need to change any of your payment code" line from the Tip box, which restated "No extra code is required" from the sentence directly above it
- Softened "is required by some acquirers" to "may be required by some acquirers"

No code blocks, Gradle/Podfile snippets, or module/class names were changed on either page.