### PR TITLE
docs(checkout-builder): document list styling options and published badge behavior

### DIFF
--- a/docs/using-yuno/dashboard-overview/checkout-builder.mdx
+++ b/docs/using-yuno/dashboard-overview/checkout-builder.mdx
@@ -22,6 +22,10 @@ This module lets you configure and customize the payment methods used in the che
 
 You must click **Publish settings** on the Checkout Builder to apply all changes to the checkout.
 
+<Note>
+  **Published status**: next to **Publish settings**, the Checkout Builder shows a status badge with two possible values, **Published** or **Not published**. It reflects your actual publish state: changes you save show as **Not published** until you click **Publish settings**, and switch to **Published** once they're live on the checkout.
+</Note>
+
 ### Conditions
 
 You can control when a payment method appears at checkout by setting display conditions based on criteria such as the order’s country, amount, currency, or integration metadata. To configure these settings:
@@ -95,6 +99,17 @@ No additional SDK parameters are required in the merchant's integration: as long
 
 In the Required fields, you can also configure the behavior for enrolled cards. You can configure whether to request the CVV for every transaction or only during the customer's first payment.
 
+### Payment method list style
+
+Beyond display conditions and required fields, the Checkout Builder lets you control how the payment method list itself behaves for your customers:
+
+- **Unfolded display**: renders the card form fields directly inline in the payment method list instead of opening a separate modal, so customers can complete a card payment with fewer clicks.
+- **Pre-selected payment method**: automatically pre-selects the last payment method a returning customer used, instead of showing the list with nothing selected.
+- **Condensed view**: when a checkout has many enabled payment methods, the list can be condensed behind a **More options** control, showing only the top methods until the customer expands it.
+- **Edit payment method list**: lets customers view their own enrolled payment methods and delete them directly from the list.
+
+These options are available from the Checkout Builder's Styling section. Toggle the setting you want and click **Publish settings** for it to take effect on the live checkout.
+
 ### Edit name and logo
 
 The name and logo settings control how a payment methods appear during checkout. This option is unavailable for enrolled payment methods. To adjust these settings:
@@ -121,6 +136,10 @@ The General Styling section allows you to adjust key visual elements, creating a
 | **Secondary Text Color**      | Choose a secondary text color for supporting text elements. This color applies to:<ul><li>Field descriptions</li><li>Placeholder text</li><li>Help text for additional form guidance</li></ul>                                                                                               |
 | **Primary Button Text Color** | Set the text color for the primary button to ensure the call-to-action is noticeable and accessible.                                                                                                                                                                                         |
 | **Typography**                | Select your preferred font.                                                                                                                                                                                                                                                                  |
+
+<Note>
+  **Dark mode**: Checkout styling includes a toggle to automatically switch to a dark color scheme when the customer's device or browser has dark mode enabled, inheriting the end user's system preference instead of always applying the light theme configured above.
+</Note>
 
 ## Real-time checkout preview
 

--- a/docs/using-yuno/dashboard-overview/checkout-builder.mdx
+++ b/docs/using-yuno/dashboard-overview/checkout-builder.mdx
@@ -23,7 +23,7 @@ This module lets you configure and customize the payment methods used in the che
 You must click **Publish settings** on the Checkout Builder to apply all changes to the checkout.
 
 <Note>
-  **Published status**: next to **Publish settings**, the Checkout Builder shows a status badge with two possible values, **Published** or **Not published**. It reflects your actual publish state: changes you save show as **Not published** until you click **Publish settings**, and switch to **Published** once they're live on the checkout.
+  **Published status**: next to **Publish settings**, the Checkout Builder shows a status badge with two possible values, **Published** or **Not published**. It reflects your actual publish state: changes you save show as **Not published** until you click **Publish settings**, and switch to **Published** after the publish completes and the changes are deployed to the checkout.
 </Note>
 
 ### Conditions
@@ -108,7 +108,7 @@ Beyond display conditions and required fields, the Checkout Builder lets you con
 - **Condensed view**: when a checkout has many enabled payment methods, the list can be condensed behind a **More options** control, showing only the top methods until the customer expands it.
 - **Edit payment method list**: lets customers view their own enrolled payment methods and delete them directly from the list.
 
-These options are available from the Checkout Builder's Styling section. Toggle the setting you want and click **Publish settings** for it to take effect on the live checkout.
+These options are available from the Checkout Builder's Styling section. **Unfolded display** applies to card payments, **Pre-selected payment method** and **Condensed view** affect the overall payment method list, and **Edit payment method list** is only relevant when the customer has enrolled payment methods available to manage. Toggle the setting you want and click **Publish settings** for it to take effect on the live checkout.
 
 ### Edit name and logo
 
@@ -138,7 +138,7 @@ The General Styling section allows you to adjust key visual elements, creating a
 | **Typography**                | Select your preferred font.                                                                                                                                                                                                                                                                  |
 
 <Note>
-  **Dark mode**: Checkout styling includes a toggle to automatically switch to a dark color scheme when the customer's device or browser has dark mode enabled, inheriting the end user's system preference instead of always applying the light theme configured above.
+  **Dark mode**: Checkout styling includes a toggle to automatically switch to a dark color scheme when the customer's device or browser has dark mode enabled, inheriting the end user's system preference instead of always applying the light theme configured above. Dark mode does not create a separate merchant-configurable dark palette or automatically invert every color you set. Instead, Yuno applies its built-in dark theme for dark surfaces while continuing to use the styling settings configured here where supported, especially your **Accent Color**, **Primary Button Text Color**, and **Typography**. Background and text colors should therefore be reviewed in the preview with dark mode enabled to confirm the final appearance.
 </Note>
 
 ## Real-time checkout preview


### PR DESCRIPTION
## Summary

Closes 3 documentation gaps found while reviewing the internal SDK/Checkout demo meetings, cross-checked against the published docs.

- Documents Payment Method List Style options: unfolded display, pre-selected payment method, condensed "more options" view, edit payment method list. Shared in the Dec 19, 2025 demo.
- Adds a note on the dark mode toggle for merchant styling (inherits the end user's OS/browser dark mode preference). Shared in the Dec 19, 2025 demo.
- Documents the corrected "Published"/"Not published" badge behavior (2 possible states, reflecting actual publish status). Shared in the Jul 3, 2026 demo.

### Files changed
- `docs/using-yuno/dashboard-overview/checkout-builder.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to Checkout Builder docs; no product, auth, or data-handling code changes.
> 
> **Overview**
> Fills three Checkout Builder documentation gaps in `checkout-builder.mdx`.
> 
> Adds a **Published / Not published** badge note so saved-but-unpublished changes are distinguished from a live publish.
> 
> Documents **Payment method list style** options from Styling: unfolded card fields, last-used pre-selection, condensed **More options**, and customer-side enrolled-method editing.
> 
> Clarifies **dark mode**: it follows the customer’s OS/browser preference and Yuno’s built-in dark theme, not a separate merchant palette, while still applying accent, primary button text, and typography where supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0ad17adce807e28c0d3881b7bf83bf858e0290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->