### PR TITLE
docs(checkout-builder): document multi-account editing, document type selection, and CVV metadata condition

### DIFF
--- a/docs/using-yuno/dashboard-overview/checkout-builder.mdx
+++ b/docs/using-yuno/dashboard-overview/checkout-builder.mdx
@@ -93,7 +93,30 @@ No additional SDK parameters are required in the merchant's integration: as long
 - **Configure during low-traffic periods:** Publishing changes to required fields affects all subsequent checkout sessions immediately. Customers in the middle of an in-flight session may see inconsistent forms during the propagation window. We recommend configuring and publishing this setting during low-traffic periods to minimize impact.
 
 
+#### CVV for enrolled cards
+
 In the Required fields, you can also configure the behavior for enrolled cards. You can configure whether to request the CVV for every transaction or only during the customer's first payment.
+
+Additionally, you can set a metadata condition to hide the CVV field entirely for the enrolled card flow, for example, when the customer already completed a successful biometric authentication in your app. Configure the condition from the CVV field's required fields options, using a metadata key, an operator, and a value: when the condition matches, the CVV field is not requested during enrolled card payments.
+
+#### Document type selection
+
+For countries that allow multiple document types (for example, national ID and passport), the document field shows every allowed type in a dropdown. Use document type selection to control which types are shown, per country.
+
+<Note>
+  This is a general setting: it applies across all payment methods, not to one specific method.
+</Note>
+
+1. In **Payment method settings**, click the three dots icon on the **Card (non-enrolled)** payment method and select **Set Required fields**.
+2. Below the **Document** field, click the **Document types** icon.
+3. Filter by country and select the document types you want to accept for that country.
+4. Click **Save changes**, then **Publish settings**.
+
+<Note>
+  At least one document type must remain selected per country, you cannot deselect all of them. The first time you use this setting, every document type is enabled by default for every country.
+</Note>
+
+This setting is available in web and mobile web. Mobile Native support is in development.
 
 ### Edit name and logo
 
@@ -105,6 +128,25 @@ The name and logo settings control how a payment methods appear during checkout.
 4. Optionally, you can add a description and provide a new logo URL. The URL must start with "https\://". Use a square image (JPG or PNG), 100x100 pixels in size, and up tp 10 KB.
 5. Click **Save changes**, followed by **Publish settings** to apply all changes.
 <Frame><img src="/images/reference/checkout-builder/image6.png" alt="Edit name & logo dialog with custom settings selected, showing fields for name and description, and a logo image upload area with a PNG file uploading" /></Frame>
+
+### Mass edit across accounts
+
+If you manage multiple Yuno accounts, for example, a franchise or multi-brand merchant, you can enable or disable a payment method across many accounts at once instead of configuring each account individually.
+
+1. Next to the payment method, click the three dots icon and select the option to edit the method across accounts.
+2. Select the accounts you want to apply the change to.
+3. Enable or disable the payment method for all of them at once.
+
+<Note>
+  This only copies the payment method's enabled/disabled state. Required fields and conditions are **not** copied between accounts, configure those individually per account.
+</Note>
+
+<Note>
+  You can only enable a payment method for an account if it's already configured in routing for that account. Accounts without the payment method configured in routing show an error asking you to configure routing first.
+</Note>
+
+Access to this setting follows your existing dashboard permissions: you can only edit accounts you already have access to.
+
 ## Checkout styling
 
 Match your brand's unique look and feel using the Checkout Styling module. Changes made in this module are reflected in the end-user checkout immediately after publishing.


### PR DESCRIPTION
## Summary

Closes 3 documentation gaps found while reviewing the internal SDK/Checkout demo meetings, cross-checked against the published docs. These specific items were shared in the Feb 27, 2026 demo.

- Documents mass edit of payment methods across multiple accounts, including the required fields/conditions limitation and the routing requirement.
- Brings document type selection (per country) from the API reference into the no-code guide, with the real dashboard navigation.
- Expands the CVV note for enrolled cards to document the metadata condition mechanism (hides CVV after a successful biometric authentication).

### Files changed
- `docs/using-yuno/dashboard-overview/checkout-builder.mdx`
