### PR TITLE
docs(payment-links): document hosted payment page customization

### DIFF
--- a/docs/using-yuno/dashboard-overview/payment-links.mdx
+++ b/docs/using-yuno/dashboard-overview/payment-links.mdx
@@ -53,6 +53,16 @@ When customers open payment links, they will be greeted with a clean interface i
 
 <Frame><img src="/images/reference/payment-links/image2.png" alt="Payment link checkout page showing the order review and card payment form" /></Frame>
 
+### Hosted payment page customization
+
+Match your brand's look and feel on the hosted payment page from the Checkout Builder: add your logo as a thumbnail and set your brand colors.
+
+The hosted payment page shows in the customer's browser language by default. Customers can change it at any time using the language selector.
+
+<Note>
+  Express payment buttons (PayPal, Apple Pay, Google Pay) are also available on the hosted payment page, available since Web SDK v1.6.
+</Note>
+
 <Note>
   Want customers to open the payment link under your own domain, with no Yuno branding? See [Payment Link White Label](/docs/sdks/customization/web/payment-link-white-label).
 </Note>


### PR DESCRIPTION
## Summary

Closes a documentation gap found while reviewing the internal SDK/Checkout demo meetings, cross-checked against the published docs. This item was shared in the Apr 24, 2026 demo.

- Documents hosted payment page customization: logo and brand colors from the Checkout Builder, browser-language default with a manual language selector, and express payment buttons (available since Web SDK v1.6).

### Files changed
- `docs/using-yuno/dashboard-overview/payment-links.mdx`
