### PR TITLE
docs(checkout-builder): fix Fetch Checkout Configuration response example and schema

### DIFF
--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -78,25 +78,102 @@
                         "payment_methods": [
                           {
                             "payment_method_type": "CARD",
+                            "name": "Card",
+                            "description": "Card",
+                            "icon": "https://sdk.prod.y.uno/brands/card_logosimbolo.png",
+                            "category": "CARD",
+                            "short_name": "Card",
+                            "hint": "",
                             "order_to_show": 1,
                             "is_active": true,
-                            "active_enrollment_type": "BOTH",
-                            "conditions_to_override": [],
-                            "required_fields_to_override": null
+                            "type": "PAYMENT_METHOD",
+                            "has_enrollment": true,
+                            "conditions_quantity": 1,
+                            "active_enrollment_type": "BOTH"
                           }
                         ],
                         "general_settings": {
                           "country_documents": [
                             { "country_code": "AR", "documents": ["DNI", "CUIT"] }
                           ]
+                        },
+                        "feature_flags": {
+                          "custom_required_fields": true,
+                          "custom_logo_icon": true
                         }
                       },
                       "styling": {
                         "styles": {
-                          "global": { "accent_color": "#282A30", "font_family": "Inter" }
+                          "global": {
+                            "accent_color": "#282A30",
+                            "primary_background_color": "#FFFFFF",
+                            "primary_text_color": "#282A30",
+                            "primary_button_text_color": "#FFFFFF",
+                            "secondary_background_color": "#ECEFF2",
+                            "secondary_text_color": "#84807F",
+                            "secondary_button_background_color": "#FFFFFF",
+                            "secondary_button_text_color": "#282A30",
+                            "font_family": "Inter"
+                          },
+                          "header": {
+                            "logo_border_size": 0,
+                            "logo_border_color": "#282A30",
+                            "logo_corner_radius": 8,
+                            "font_size": 18,
+                            "font_weight": 700
+                          },
+                          "button": {
+                            "corner_radius": 8,
+                            "border_size": 0,
+                            "primary_border_color": "#282A30",
+                            "secondary_border_color": "#282A30",
+                            "font_size": 18,
+                            "font_weight": 400
+                          }
                         },
-                        "settings": {},
-                        "flags": { "force_default_styles": false }
+                        "settings": {
+                          "sdk_type": { "web": "SEAMLESS", "mobile": "SEAMLESS" },
+                          "card": {
+                            "save_on_success": true,
+                            "visualization_mode": "ONE_STEP",
+                            "enable_ocr": false,
+                            "credit_card_only_processing": false,
+                            "default_network": "DOM"
+                          },
+                          "web_sdk": { "render_mode": "MODAL", "hide_pay_button": false },
+                          "payment_method_list": {
+                            "unfolded_display": false,
+                            "preselected_payment_method": false,
+                            "condensed_checkout_view": false,
+                            "edit_payment_method_list": false
+                          },
+                          "ui": { "dark_mode": false, "show_secure_payment_tag": true },
+                          "payment_link": { "show_result_screen": false }
+                        },
+                        "external_fonts": [
+                          {
+                            "family_name": "Inter",
+                            "files": [
+                              { "weight": 400, "url": "https://staging.y.uno/sdk-static-bundles-ms/v1/static/fonts/Inter-Regular.ttf" }
+                            ]
+                          }
+                        ],
+                        "payment_link_styles": {
+                          "panel": {
+                            "left": {
+                              "background": { "color": "#ECEFF2" },
+                              "logo": "data:image/jpeg;base64,..."
+                            }
+                          },
+                          "checkbox": { "color": "#282A30" },
+                          "border": { "color": "#282A30" },
+                          "radio_button": { "color": "#282A30" },
+                          "button": {
+                            "text": { "color": "#876E6E" },
+                            "background": { "color": "#282A30" }
+                          },
+                          "published_at": "2026-05-14T19:34:06Z"
+                        }
                       }
                     }
                   }
@@ -117,7 +194,7 @@
                       "properties": {
                         "payment_methods": {
                           "type": "array",
-                          "description": "Payment methods configured for this checkout. Order is driven by `order_to_show` (lower = first).",
+                          "description": "Payment methods configured for this checkout. Order is driven by `order_to_show` (lower = first). Returns the full payment-method catalog available to the account (approximately 210 items), not only the ones active for this checkout — filter by `is_active: true` to get only the enabled ones.",
                           "items": { "type": "object" }
                         },
                         "general_settings": {
@@ -128,7 +205,7 @@
                     },
                     "styling": {
                       "type": "object",
-                      "description": "Checkout styling and SDK settings: `styles`, `settings`, `flags`, `external_fonts`, `payment_link_styles`."
+                      "description": "Checkout styling and SDK settings: `styles`, `settings`, `external_fonts`, `payment_link_styles`."
                     }
                   }
                 }

--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -200,6 +200,10 @@
                         "general_settings": {
                           "type": "object",
                           "description": "General checkout settings, including accepted document types per country (`country_documents`)."
+                        },
+                        "feature_flags": {
+                          "type": "object",
+                          "description": "Feature toggles for this checkout, including `custom_required_fields` and `custom_logo_icon`."
                         }
                       }
                     },

--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -194,7 +194,7 @@
                       "properties": {
                         "payment_methods": {
                           "type": "array",
-                          "description": "Payment methods configured for this checkout. Order is driven by `order_to_show` (lower = first). Returns the full payment-method catalog available to the account (approximately 210 items), not only the ones active for this checkout — filter by `is_active: true` to get only the enabled ones.",
+                          "description": "Payment methods configured for this checkout. Order is driven by `order_to_show` (lower = first). Returns the full payment-method catalog available to the account, not only the ones active for this checkout — filter by `is_active: true` to get only the enabled ones.",
                           "items": { "type": "object" }
                         },
                         "general_settings": {

--- a/reference/checkout-builder/fetch-checkout-configuration.mdx
+++ b/reference/checkout-builder/fetch-checkout-configuration.mdx
@@ -5,3 +5,5 @@ description: "Retrieves the configuration of a checkout session by its checkout 
 ---
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>
+
+<Note>`styling.payment_link_styles.panel.left.logo` returns the merchant logo as an embedded base64 data URI (e.g. `data:image/jpeg;base64,...`), not a URL.</Note>


### PR DESCRIPTION
## PR Description
Mirola validated the Fetch Checkout Configuration page against real GET `/checkouts/{checkout_code}` responses in staging, sandbox, and production, and found the documented example was built from the PUT request body shape instead of the actual response. This corrects the OpenAPI example and schema descriptions to match the real payload, and adds two clarifying notes for behavior that isn't obvious from the field names alone.

## Changes

**openapi/checkout-builder/fetch-checkout-configuration.json**
- Removed `conditions_to_override` and `required_fields_to_override` from the `config.payment_methods[]` example item — confirmed these belong to the PUT request body (they're declared in `publish-checkout-configuration.json`), not the GET response
- Added the 9 missing `payment_methods[]` fields to the example: `name`, `description`, `icon`, `category`, `short_name`, `hint`, `type`, `has_enrollment`, `conditions_quantity`
- Added `config.feature_flags` to both the example (`custom_required_fields`, `custom_logo_icon`) and the schema's `config.properties`, previously missing entirely from both
- Replaced the `styling` example: dropped the nonexistent `flags`/`force_default_styles` key, added the real `settings`, `external_fonts`, and `payment_link_styles` keys, and expanded `styles.global` from 2 fields to the full color palette plus the new `styles.header` and `styles.button` objects
- Updated the `config.payment_methods` schema description to note the response returns the full payment-method catalog, not only the active ones, and that consumers should filter by `is_active: true` (kept count-agnostic to match house style — sibling files avoid stating specific numbers that could go stale)
- Updated the `styling` schema description to drop the nonexistent `flags` key from the listed sub-objects

**reference/checkout-builder/fetch-checkout-configuration.mdx**
- Added a `<Note>` documenting that `styling.payment_link_styles.panel.left.logo` returns the merchant logo as an embedded base64 data URI, not a URL

Source: Mirola's Slack report, cross-checked against the OpenAPI spec directly (not the rendered page). Verified no leftover references to the removed fields remain anywhere in the file, the JSON still parses, and the new/edited content matches this repo's OpenAPI house style (checked against `create-checkout.json`, `list-checkouts.json`, and `publish-checkout-configuration.json`).