### PR TITLE
chore: web sdk changelog 1.10.6

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,37 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.6",
+      "release_date": "2026-08-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.6",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Point at sdk-web-card 1.87.2, which validates the card number by default when the BIN lookup fails or returns an unknown IIN",
+          "description": "Previously, an unknown or failed card BIN lookup silently skipped Luhn validation, letting structurally invalid card numbers through to tokenization. The card form now defaults to validating unless the backend explicitly says not to.",
+          "group": "Card Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Carry the SRC card type (maskedCard.paymentCardType) into the Click to Pay one-time token when the shopper made no card-type selection",
+          "description": "Previously, non-dual enrolled cards left the OTT cardType empty, so the backend derived the type from the network token BIN against the card-iin table, which misclassifies credit cards as debit and gets payments rejected by the acquirer (kind DEBIT + installments, returnCode 54).",
+          "group": "Click to Pay",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-17694",
+        "CORECM-19203",
+        "YSHUB-6551"
+      ]
+    },
+    {
       "version": "1.10.5",
       "release_date": "2026-08-14",
       "upgrade": {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -11,7 +11,7 @@
       "entries": [
         {
           "type": "FIXED",
-          "title": "Point at sdk-web-card 1.87.2, which validates the card number by default when the BIN lookup fails or returns an unknown IIN",
+          "title": "Card number validation on unknown or failed BIN lookup",
           "description": "Previously, an unknown or failed card BIN lookup silently skipped Luhn validation, letting structurally invalid card numbers through to tokenization. The card form now defaults to validating unless the backend explicitly says not to.",
           "group": "Card Payments",
           "migration_guide": null,
@@ -19,7 +19,7 @@
         },
         {
           "type": "FIXED",
-          "title": "Carry the SRC card type (maskedCard.paymentCardType) into the Click to Pay one-time token when the shopper made no card-type selection",
+          "title": "Fixed Missing Card Type in Click to Pay One-Time Token",
           "description": "Previously, non-dual enrolled cards left the OTT cardType empty, so the backend derived the type from the network token BIN against the card-iin table, which misclassifies credit cards as debit and gets payments rejected by the acquirer (kind DEBIT + installments, returnCode 54).",
           "group": "Click to Pay",
           "migration_guide": null,

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,19 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.6
+*August 19, 2026*
+
+**Card Payments**
+
+- <ChangelogBadge type="fixed" /> **Card number validation on unknown or failed BIN lookup**  
+  Previously, an unknown or failed card BIN lookup silently skipped Luhn validation, letting structurally invalid card numbers through to tokenization. The card form now defaults to validating unless the backend explicitly says not to.
+
+**Click to Pay**
+
+- <ChangelogBadge type="fixed" /> **Fixed Missing Card Type in Click to Pay One-Time Token**  
+  Previously, non-dual enrolled cards left the OTT cardType empty, so the backend derived the type from the network token BIN against the card-iin table, which misclassifies credit cards as debit and gets payments rejected by the acquirer (kind DEBIT + installments, returnCode 54).
+
 ## v1.10.5
 *August 14, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.6`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.7

2 entries.