### PR TITLE
docs(subscriptions): hidden Usage-Based Billing (Meters) guide, API reference and OpenAPI specs

### DIFF
--- a/docs/payment-features/subscriptions/usage-based-billing.mdx
+++ b/docs/payment-features/subscriptions/usage-based-billing.mdx
@@ -1,0 +1,274 @@
+---
+title: "Usage-Based Billing"
+hidden: true
+description: "Meter any action your product performs, price it on a plan with included credits and a per-unit overage, and let Yuno bill the usage on each subscription's renewal"
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. Everything on this page — objects, endpoints, field names and error codes — may change before general availability. Contact your Yuno representative to enable it on your account, and pin your integration to the behavior described here rather than assuming forward compatibility.
+</Warning>
+
+Subscriptions bill a fixed price on a fixed cadence. Usage-based billing adds a variable part on top: you tell Yuno *what* to count (a **meter**), *how much of it* a plan includes and what extra units cost (a **metered price**), and then report *how much each subscriber consumed* (**usage events**). Yuno aggregates the usage per subscription and billing cycle and bills anything beyond the included allowance together with the subscription's regular renewal charge.
+
+Typical uses: an AI product that includes 10,000 tokens a month and bills the rest per token, an API that includes 1,000 requests and bills per extra call, a storage product billed per gigabyte held.
+
+## How the pieces fit
+
+1. **Meter** — a named, countable action: `tokens_consumed`, `api_request`, `storage_gb`. It defines the `event_name` your systems send and the aggregation (`SUM`, `COUNT` or `LAST`). A meter has no price of its own — at most a `default_price` in USD that plans can inherit. See [The Meter Object](/reference/meters/the-meter-object).
+2. **Metered price** — the meter attached to a [plan](/docs/payment-features/subscriptions/plans): how many units are included per cycle (`credits`) and what each unit beyond that costs (`price_per_credit`, optionally per country). A plan can carry any number of metered prices next to its flat price. See [The Metered Price Object](/reference/meters/the-metered-price-object).
+3. **Subscription** — created on that plan as usual. It inherits every metered price; nothing changes in [Create Subscription](/reference/subscriptions/create-subscription).
+4. **Usage events** — one call per unit of work, carrying the `event_name`, the `subscription_id`, a `value` and your own `event_id` for idempotency. See [Report Usage Event](/reference/meters/report-usage-event).
+5. **Renewal** — at the end of the billing cycle, Yuno computes the billable quantity (`max(0, usage − credits)`) and adds `billable × price_per_credit` to the subscription's renewal charge.
+
+<Note>
+**Meters are generic**
+
+Nothing here is specific to AI. A meter can count deliveries, minutes, messages, seats or gigabytes just as well as tokens — the meter's `unit_label` / `plural_unit_label` are what usage is displayed in.
+</Note>
+
+## Quick start
+
+The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 tokens and bills \$0.002 per token beyond that.
+
+<Steps>
+  <Step title="Create the meter">
+    Choose an `event_name` your systems will send (lowercase, `_` and `.` allowed) and the aggregation. `default_price` is optional and must be USD; it saves you from repeating the unit price on every USD plan.
+
+    ```bash
+    curl -X POST https://api-sandbox.y.uno/v1/subscriptions/meters \
+      -H 'Content-Type: application/json' \
+      -H 'public-api-key: <Your public-api-key>' \
+      -H 'private-secret-key: <Your private-secret-key>' \
+      -H 'X-Idempotency-Key: 5f1c2c1e-1a2b-4c3d-9e8f-0a1b2c3d4e5f' \
+      -d '{
+        "name": "Tokens Consumed",
+        "description": "Meters LLM token consumption per billing cycle",
+        "event_name": "tokens_consumed",
+        "aggregation": "SUM",
+        "unit_label": "token",
+        "plural_unit_label": "tokens",
+        "default_price": { "currency": "USD", "value": 0.002 }
+      }'
+    ```
+
+    Keep the `id` from the response — you need it to attach the meter to a plan.
+  </Step>
+
+  <Step title="Attach it to a plan">
+    Either create the plan with the meter inline, or attach it to a plan that already exists. Both take the same metered-price body: `meter_id`, `credits` (included units per cycle), `pricing_strategy` and, unless inherited, `price_per_credit`.
+
+    <CodeGroup>
+    ```bash New plan
+    curl -X POST https://api-sandbox.y.uno/v1/plans \
+      -H 'Content-Type: application/json' \
+      -H 'public-api-key: <Your public-api-key>' \
+      -H 'private-secret-key: <Your private-secret-key>' \
+      -H 'X-Idempotency-Key: 8d5c9a3e-4b7f-4a2c-b1d0-2e3f4a5b6c7d' \
+      -d '{
+        "name": "Copilot Pro",
+        "base_amount": { "currency": "USD", "value": 200.0 },
+        "frequency": { "type": "MONTH", "value": 1 },
+        "meters": [
+          {
+            "meter_id": "55555555-5555-5555-5555-555555555555",
+            "credits": 10000,
+            "pricing_strategy": "PER_UNIT"
+          }
+        ]
+      }'
+    ```
+
+    ```bash Existing plan
+    curl -X POST https://api-sandbox.y.uno/v1/subscriptions/plans/00000000-0000-4000-8000-000000000001/meters \
+      -H 'Content-Type: application/json' \
+      -H 'public-api-key: <Your public-api-key>' \
+      -H 'private-secret-key: <Your private-secret-key>' \
+      -H 'X-Idempotency-Key: 9e6d0b4f-5c8a-4b3d-a2e1-3f4a5b6c7d8e' \
+      -d '{
+        "meter_id": "55555555-5555-5555-5555-555555555555",
+        "credits": 10000,
+        "pricing_strategy": "PER_UNIT",
+        "price_per_credit": { "currency": "USD", "value": 0.002 }
+      }'
+    ```
+    </CodeGroup>
+
+    In the "New plan" example `price_per_credit` is omitted: the plan is USD and the meter has a `default_price`, so \$0.002 is inherited. [Retrieve Plan](/reference/plans/retrieve-plan) now returns the metered price under `meters[]`.
+
+    <Note>
+    Attaching a meter to a live plan does not change the plan's flat price or any existing subscriber's base amount — it only adds a variable line for usage beyond `credits`. Sending `{ "meters": [ ... ] }` to `PATCH /subscriptions/plans/{plan_id}` does the same for several meters at once and accepts no other plan field.
+    </Note>
+  </Step>
+
+  <Step title="Subscribe customers to the plan">
+    Nothing new here: call [Create Subscription](/reference/subscriptions/create-subscription) with the `plan_id`. The subscription inherits the plan's metered prices. Store the subscription `id` — every usage event references it.
+  </Step>
+
+  <Step title="Report usage as it happens">
+    Send one event per unit of work. `event_id` is your idempotency key; `value` is required for `SUM` and `LAST` meters and defaults to 1 for `COUNT`.
+
+    ```bash
+    curl -X POST https://api-sandbox.y.uno/v1/subscriptions/meters/events \
+      -H 'Content-Type: application/json' \
+      -H 'public-api-key: <Your public-api-key>' \
+      -H 'private-secret-key: <Your private-secret-key>' \
+      -d '{
+        "event_id": "11111111-1111-1111-1111-111111111111",
+        "event_name": "tokens_consumed",
+        "subscription_id": "33333333-3333-3333-3333-333333333333",
+        "value": 42.5,
+        "timestamp": "2026-08-18T09:00:04Z",
+        "metadata": [{ "key": "model", "value": "kimi-k2" }]
+      }'
+    ```
+
+    A `201` confirms the event was validated and stored:
+
+    ```json
+    {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "event_id": "11111111-1111-1111-1111-111111111111",
+      "event_name": "tokens_consumed",
+      "meter_id": "55555555-5555-5555-5555-555555555555",
+      "subscription_id": "33333333-3333-3333-3333-333333333333",
+      "value": 42.5,
+      "received_at": "2026-08-18T09:00:04.000000Z"
+    }
+    ```
+
+    Retrying the same request (same `event_id`) returns this same response and never counts the 42.5 tokens twice.
+  </Step>
+</Steps>
+
+## Choosing an aggregation
+
+The aggregation is fixed when you create the meter and decides what a cycle's quantity means:
+
+<Tabs>
+  <Tab title="SUM — consumption">
+    Adds every event's `value`. Report the amount consumed by each unit of work.
+
+    ```json
+    { "event_id": "resp_8f3k2", "event_name": "tokens_consumed", "subscription_id": "3333…", "value": 1280 }
+    ```
+
+    Three events of 1,280 / 640 / 2,100 tokens → cycle quantity 4,020 tokens. Use for tokens, minutes transcribed, messages sent, deliveries completed.
+  </Tab>
+  <Tab title="COUNT — per call">
+    Counts events; `value` is ignored (each event counts as 1, so you can omit it).
+
+    ```json
+    { "event_id": "req_01J5Y3Q9K8ZC5G6E4Y2W7X8N9M", "event_name": "api_request", "subscription_id": "3333…" }
+    ```
+
+    1,432 events → cycle quantity 1,432 requests. Use for API calls, jobs, exports.
+  </Tab>
+  <Tab title="LAST — gauge">
+    Keeps the most recent `value` in the cycle by `timestamp`. Report the current level, not the delta.
+
+    ```json
+    { "event_id": "storage-2026-08-18T09:00-sub-3333", "event_name": "storage_gb", "subscription_id": "3333…", "value": 128.4, "timestamp": "2026-08-18T09:00:00Z" }
+    ```
+
+    Reports of 96.0 → 110.2 → 128.4 GB → cycle quantity 128.4 GB. Use for storage held, seats in use, active devices.
+  </Tab>
+</Tabs>
+
+## Pricing a meter on a plan
+
+A metered price has three pricing knobs:
+
+- **`credits`** — the units included in the plan each billing cycle. Think "allowance": the first `credits` units are covered by the plan's flat price. `0` bills every unit. `credits` is measured in the meter's unit (tokens, requests, GB) and resets each cycle — it is **not** a prepaid balance or wallet.
+- **`price_per_credit`** — the price of each unit beyond `credits`, in the plan's base currency. On a USD plan you can omit it if the meter has a `default_price`; the default is inherited and echoed back on the metered price. On a non-USD plan, or when the meter has no default, it is required. The currency must always match the plan's `base_amount` currency.
+- **`country_prices`** — optional per-unit prices by subscriber country, same shape as the plan's own `country_prices`. A subscriber whose country is not listed pays `price_per_credit`.
+
+`pricing_strategy` selects how overage is rated. Only **`PER_UNIT`** (billable units × unit price) is priced in this preview. `PACKAGE` (price per bundle of N units) and `TIERED` (graduated rates) are accepted enum values reserved for an upcoming release — their configuration fields and rating are not available yet, so use `PER_UNIT`.
+
+You can change `credits`, `price_per_credit` and `country_prices` on a live plan with [Update Plan Meter](/reference/meters/update-plan-meter); the new values apply to usage rated from the next billing cycle onward. The plan's flat price stays [immutable](/docs/payment-features/subscriptions/plans) as before.
+
+## What happens at renewal
+
+<Note>
+Usage rating and the usage line items on the renewal charge are being rolled out during the preview. The model below is how billing works; the exact shape of usage on the charge and its webhooks will be documented as it lands.
+</Note>
+
+For each subscription and each metered price on its plan, at the end of the billing cycle:
+
+1. **Quantity** — events whose `timestamp` falls in the cycle are aggregated with the meter's `aggregation` (SUM / COUNT / LAST).
+2. **Billable units** — `max(0, quantity − credits)`. Unused credits do not roll over.
+3. **Amount** — `billable × price_per_credit` (or the subscriber's `country_prices` entry).
+4. **Charge** — the amount is added to the subscription's renewal charge alongside the plan's flat price. One charge, one payment, as today. A subscription with usage under its credits pays only the flat price.
+
+Example, on the Copilot Pro plan (10,000 tokens included, \$0.002 per extra token): a subscriber consumes 13,500 tokens in August → 3,500 billable → \$7.00 usage, so the renewal charges \$207.00. Another subscriber consumes 8,000 → \$200.00.
+
+## Idempotency and timestamps
+
+- **`event_id` is required and is your idempotency key.** Make it unique per event — a UUID, or the id of the request/response/job it came from — and reuse it on every retry. Yuno stores the first event under that id and answers every replay with the same response, including the original `value`. Usage is never double counted, however many times you retry.
+- **Report close to real time**, but you can backdate. `timestamp` defaults to the receive time and can be up to **35 days** in the past; older events are rejected with `400`. The `timestamp` (not the receive time) decides which billing cycle the event lands in.
+- **`X-Idempotency-Key`** on the HTTP request works as on the rest of the Yuno API and is a good belt-and-braces for network retries, but `event_id` is what protects billing.
+- **One event per request.** Aggregate on your side if you produce many small events (for example, sum tokens per response rather than per token) — a `SUM` meter is designed for that.
+
+## Error handling
+
+Validation is synchronous: a rejected event returns `400` or `404` immediately and is never counted, so treat non-`201` responses as "not recorded" and retry with the same `event_id` after fixing the request. The codes you will meet most often:
+
+| Situation | Response |
+| --- | --- |
+| `event_name` does not match an `ACTIVE` meter of your account | `404 METER_NOT_FOUND` |
+| `subscription_id` unknown | `404 SUBSCRIPTION_NOT_FOUND` |
+| `value` missing on a `SUM`/`LAST` meter | `400 INVALID_PARAMETERS` — "The value is required for a SUM meter" |
+| `timestamp` older than 35 days | `400 INVALID_PARAMETERS` |
+| Second `ACTIVE` meter with the same `event_name` | `409 METER_EVENT_NAME_CONFLICT` |
+| Same meter attached to a plan twice | `409 PLAN_METER_ALREADY_ASSIGNED` |
+| `price_per_credit` in the wrong currency / missing on a non-USD plan | `400 INVALID_PARAMETERS` |
+
+The full list, with every message, is on [Meter Error Codes](/reference/meters/meter-error-codes).
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Do I need a new plan to add usage pricing to an existing one?">
+    No. Attach the meter to the live plan with [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) (or the attach-only `PATCH /subscriptions/plans/{plan_id}` with `meters[]`). The flat price and existing subscribers' base amount are unchanged; usage beyond `credits` starts being billed on their next renewal.
+  </Accordion>
+  <Accordion title="Can a plan have several meters?">
+    Yes, any number — for example tokens (`SUM`) plus API requests (`COUNT`) plus storage (`LAST`), each with its own `credits` and unit price. Each meter can be attached to a given plan once.
+  </Accordion>
+  <Accordion title="Are credits shared across subscriptions or across meters?">
+    Neither. `credits` apply per subscription, per meter, per billing cycle. Two subscribers on the same plan each get the full allowance; unused credits do not carry over.
+  </Accordion>
+  <Accordion title="What happens if I report usage for a subscription that isn't on a plan with that meter?">
+    In this preview the event is validated against the meter and the subscription only, so it is accepted and stored — but only usage against a metered price on the subscription's plan is rated and billed. Check the plan's `meters[]` if usage isn't showing up on the renewal.
+  </Accordion>
+  <Accordion title="Can I change a meter's event_name or aggregation?">
+    No — both are immutable because your systems and past events depend on them. Create a new meter and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archiving frees the `event_name` for the new meter, and archived meters reject new events with `404 METER_NOT_FOUND`.
+  </Accordion>
+  <Accordion title="Can I remove a metered price from a plan?">
+    Not in this preview. Archive the meter to stop ingestion, or raise `credits` so no overage is billed.
+  </Accordion>
+  <Accordion title="Can I price the meter in a currency other than USD?">
+    Yes, per plan. The meter's `default_price` is USD-only, but a metered price on a BRL plan takes `price_per_credit` in BRL (required — nothing is inherited for non-USD plans), and `country_prices` lets you set per-country unit prices in each country's currency.
+  </Accordion>
+  <Accordion title="Can I meter usage without a subscription?">
+    Not in this preview. Every event needs a `subscription_id`; usage is billed on that subscription's renewal.
+  </Accordion>
+</AccordionGroup>
+
+## What's next
+
+The preview covers meters, metered prices and per-event ingestion. Coming next, in rough order:
+
+- **Usage visibility** — endpoints and Dashboard views for running usage per subscription and per plan mid-cycle (quantity, included, billable, amount).
+- **Usage on the renewal charge** — usage as its own line items on the charge breakdown and in the renewal webhooks.
+- **Batch ingestion** — many events per request.
+- **`PACKAGE` and `TIERED` pricing** — bundle and graduated rates on top of `PER_UNIT`.
+- **Dashboard** — create and manage meters, attach metered prices to plans, see usage per subscriber.
+
+## Reference
+
+- [The Meter Object](/reference/meters/the-meter-object) · [Create](/reference/meters/create-meter) · [List](/reference/meters/list-meters) · [Retrieve](/reference/meters/retrieve-meter) · [Update](/reference/meters/update-meter)
+- [Report Usage Event](/reference/meters/report-usage-event)
+- [The Metered Price Object](/reference/meters/the-metered-price-object) · [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) · [List Plan Meters](/reference/meters/list-plan-meters) · [Update Plan Meter](/reference/meters/update-plan-meter)
+- [Meter Error Codes](/reference/meters/meter-error-codes)
+- [Plans](/docs/payment-features/subscriptions/plans) · [The Plan Object](/reference/plans/the-plan-object)

--- a/docs/payment-features/subscriptions/usage-based-billing.mdx
+++ b/docs/payment-features/subscriptions/usage-based-billing.mdx
@@ -16,7 +16,7 @@ Typical uses: an AI product that includes 10,000 tokens a month and bills the re
 
 ## How the pieces fit
 
-1. **Meter** — a named, countable action: `tokens_consumed`, `api_request`, `storage_gb`. It defines the `event_name` your systems send and the aggregation (`SUM`, `COUNT` or `LAST`). A meter has no price of its own — at most a `default_price` in USD that plans can inherit. See [The Meter Object](/reference/meters/the-meter-object).
+1. **Meter** — a named, countable action: `ai_tokens`, `api_request`, `storage_gb`. It defines the `event_name` your systems send and the aggregation (`SUM`, `COUNT` or `LAST`). A meter has no price of its own — at most a `default_price` in USD that plans can inherit. See [The Meter Object](/reference/meters/the-meter-object).
 2. **Metered price** — the meter attached to a [plan](/docs/payment-features/subscriptions/plans): how many units are included per cycle (`credits`) and what each unit beyond that costs (`price_per_credit`, optionally per country). A plan can carry any number of metered prices next to its flat price. See [The Metered Price Object](/reference/meters/the-metered-price-object).
 3. **Subscription** — created on that plan as usual. It inherits every metered price; nothing changes in [Create Subscription](/reference/subscriptions/create-subscription).
 4. **Usage events** — one call per unit of work, carrying the `event_name`, the `subscription_id`, a `value` and your own `event_id` for idempotency. See [Report Usage Event](/reference/meters/report-usage-event).
@@ -30,7 +30,7 @@ Nothing here is specific to AI. A meter can count deliveries, minutes, messages,
 
 ## Quick start
 
-The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 tokens and bills \$0.002 per token beyond that.
+The example builds a "Max" plan at \$200/month that includes 10,000 AI tokens and bills \$0.002 per token beyond that. Requests use the standard `public-api-key` / `private-secret-key` headers; `X-Idempotency-Key` is optional.
 
 <Steps>
   <Step title="Create the meter">
@@ -43,9 +43,10 @@ The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 toke
       -H 'private-secret-key: <Your private-secret-key>' \
       -H 'X-Idempotency-Key: 5f1c2c1e-1a2b-4c3d-9e8f-0a1b2c3d4e5f' \
       -d '{
-        "name": "Tokens Consumed",
-        "description": "Meters LLM token consumption per billing cycle",
-        "event_name": "tokens_consumed",
+        "account_id": "00000000-0000-4000-8000-000000000002",
+        "name": "AI tokens",
+        "description": "LLM tokens consumed by model responses, reported once per response",
+        "event_name": "ai_tokens",
         "aggregation": "SUM",
         "unit_label": "token",
         "plural_unit_label": "tokens",
@@ -53,7 +54,7 @@ The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 toke
       }'
     ```
 
-    Keep the `id` from the response — you need it to attach the meter to a plan.
+    The response is `201` with the meter, always `ACTIVE`. Keep its `id` — you need it to attach the meter to a plan.
   </Step>
 
   <Step title="Attach it to a plan">
@@ -67,7 +68,8 @@ The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 toke
       -H 'private-secret-key: <Your private-secret-key>' \
       -H 'X-Idempotency-Key: 8d5c9a3e-4b7f-4a2c-b1d0-2e3f4a5b6c7d' \
       -d '{
-        "name": "Copilot Pro",
+        "account_id": "00000000-0000-4000-8000-000000000002",
+        "name": "Max",
         "base_amount": { "currency": "USD", "value": 200.0 },
         "frequency": { "type": "MONTH", "value": 1 },
         "meters": [
@@ -95,10 +97,10 @@ The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 toke
     ```
     </CodeGroup>
 
-    In the "New plan" example `price_per_credit` is omitted: the plan is USD and the meter has a `default_price`, so \$0.002 is inherited. [Retrieve Plan](/reference/plans/retrieve-plan) now returns the metered price under `meters[]`.
+    In the "New plan" example `price_per_credit` is omitted: the plan is USD and the meter has a `default_price`, so \$0.002 applies and the metered price comes back with `price_per_credit: null`. The plan response and [Retrieve Plan](/reference/plans/retrieve-plan) now carry the metered price under `meters[]` (an empty array on plans without meters).
 
     <Note>
-    Attaching a meter to a live plan does not change the plan's flat price or any existing subscriber's base amount — it only adds a variable line for usage beyond `credits`. Sending `{ "meters": [ ... ] }` to `PATCH /subscriptions/plans/{plan_id}` does the same for several meters at once and accepts no other plan field.
+    Attaching a meter to a live plan does not change the plan's flat price or any existing subscriber's base amount — it only adds a variable line for usage beyond `credits`. Sending `{ "meters": [ ... ] }` to `PATCH /subscriptions/plans/{plan_id}` does the same for several meters at once — atomically (one bad entry and nothing is attached) — and ignores every other plan field.
     </Note>
   </Step>
 
@@ -116,11 +118,11 @@ The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 toke
       -H 'private-secret-key: <Your private-secret-key>' \
       -d '{
         "event_id": "11111111-1111-1111-1111-111111111111",
-        "event_name": "tokens_consumed",
+        "event_name": "ai_tokens",
         "subscription_id": "33333333-3333-3333-3333-333333333333",
-        "value": 42.5,
+        "value": 1500,
         "timestamp": "2026-08-18T09:00:04Z",
-        "metadata": [{ "key": "model", "value": "kimi-k2" }]
+        "metadata": [{ "key": "model", "value": "llm-large" }]
       }'
     ```
 
@@ -130,15 +132,15 @@ The example builds a "Copilot Pro" plan at \$200/month that includes 10,000 toke
     {
       "id": "22222222-2222-2222-2222-222222222222",
       "event_id": "11111111-1111-1111-1111-111111111111",
-      "event_name": "tokens_consumed",
+      "event_name": "ai_tokens",
       "meter_id": "55555555-5555-5555-5555-555555555555",
       "subscription_id": "33333333-3333-3333-3333-333333333333",
-      "value": 42.5,
+      "value": 1500,
       "received_at": "2026-08-18T09:00:04.000000Z"
     }
     ```
 
-    Retrying the same request (same `event_id`) returns this same response and never counts the 42.5 tokens twice.
+    Retrying the same request (same `event_id`) returns this same response and never counts the 1,500 tokens twice — even if the retry carries a different `value`, the original is kept.
   </Step>
 </Steps>
 
@@ -151,7 +153,7 @@ The aggregation is fixed when you create the meter and decides what a cycle's qu
     Adds every event's `value`. Report the amount consumed by each unit of work.
 
     ```json
-    { "event_id": "resp_8f3k2", "event_name": "tokens_consumed", "subscription_id": "3333…", "value": 1280 }
+    { "event_id": "resp_8f3k2", "event_name": "ai_tokens", "subscription_id": "3333…", "value": 1280 }
     ```
 
     Three events of 1,280 / 640 / 2,100 tokens → cycle quantity 4,020 tokens. Use for tokens, minutes transcribed, messages sent, deliveries completed.
@@ -181,8 +183,8 @@ The aggregation is fixed when you create the meter and decides what a cycle's qu
 A metered price has three pricing knobs:
 
 - **`credits`** — the units included in the plan each billing cycle. Think "allowance": the first `credits` units are covered by the plan's flat price. `0` bills every unit. `credits` is measured in the meter's unit (tokens, requests, GB) and resets each cycle — it is **not** a prepaid balance or wallet.
-- **`price_per_credit`** — the price of each unit beyond `credits`, in the plan's base currency. On a USD plan you can omit it if the meter has a `default_price`; the default is inherited and echoed back on the metered price. On a non-USD plan, or when the meter has no default, it is required. The currency must always match the plan's `base_amount` currency.
-- **`country_prices`** — optional per-unit prices by subscriber country, same shape as the plan's own `country_prices`. A subscriber whose country is not listed pays `price_per_credit`.
+- **`price_per_credit`** — the price of each unit beyond `credits`, in the plan's base currency. On a USD plan you can omit it if the meter has a `default_price`; the meter's default then applies and the metered price is returned with `price_per_credit: null`. On a non-USD plan, or when the meter has no default, it is required. The currency must always match the plan's `base_amount` currency.
+- **`country_prices`** — optional per-unit prices by subscriber country (one entry per country), same shape as the plan's own `country_prices`. A subscriber whose country is not listed pays `price_per_credit`.
 
 `pricing_strategy` selects how overage is rated. Only **`PER_UNIT`** (billable units × unit price) is priced in this preview. `PACKAGE` (price per bundle of N units) and `TIERED` (graduated rates) are accepted enum values reserved for an upcoming release — their configuration fields and rating are not available yet, so use `PER_UNIT`.
 
@@ -201,11 +203,11 @@ For each subscription and each metered price on its plan, at the end of the bill
 3. **Amount** — `billable × price_per_credit` (or the subscriber's `country_prices` entry).
 4. **Charge** — the amount is added to the subscription's renewal charge alongside the plan's flat price. One charge, one payment, as today. A subscription with usage under its credits pays only the flat price.
 
-Example, on the Copilot Pro plan (10,000 tokens included, \$0.002 per extra token): a subscriber consumes 13,500 tokens in August → 3,500 billable → \$7.00 usage, so the renewal charges \$207.00. Another subscriber consumes 8,000 → \$200.00.
+Example, on the Max plan (10,000 tokens included, \$0.002 per extra token): a subscriber consumes 13,500 tokens in August → 3,500 billable → \$7.00 usage, so the renewal charges \$207.00. Another subscriber consumes 8,000 → \$200.00.
 
 ## Idempotency and timestamps
 
-- **`event_id` is required and is your idempotency key.** Make it unique per event — a UUID, or the id of the request/response/job it came from — and reuse it on every retry. Yuno stores the first event under that id and answers every replay with the same response, including the original `value`. Usage is never double counted, however many times you retry.
+- **`event_id` is required and is your idempotency key.** Make it unique per event — a UUID, or the id of the request/response/job it came from — and reuse it on every retry. Yuno stores the first event under that id and answers every replay with the same response, including the original `value` (a different `value` on the retry is discarded). Usage is never double counted, however many times you retry. A request without `event_id` is rejected with `400`.
 - **Report close to real time**, but you can backdate. `timestamp` defaults to the receive time and can be up to **35 days** in the past; older events are rejected with `400`. The `timestamp` (not the receive time) decides which billing cycle the event lands in.
 - **`X-Idempotency-Key`** on the HTTP request works as on the rest of the Yuno API and is a good belt-and-braces for network retries, but `event_id` is what protects billing.
 - **One event per request.** Aggregate on your side if you produce many small events (for example, sum tokens per response rather than per token) — a `SUM` meter is designed for that.
@@ -217,11 +219,12 @@ Validation is synchronous: a rejected event returns `400` or `404` immediately a
 | Situation | Response |
 | --- | --- |
 | `event_name` does not match an `ACTIVE` meter of your account | `404 METER_NOT_FOUND` |
-| `subscription_id` unknown | `404 SUBSCRIPTION_NOT_FOUND` |
+| `subscription_id` unknown | `400 SUBSCRIPTION_NOT_FOUND` |
 | `value` missing on a `SUM`/`LAST` meter | `400 INVALID_PARAMETERS` — "The value is required for a SUM meter" |
 | `timestamp` older than 35 days | `400 INVALID_PARAMETERS` |
-| Second `ACTIVE` meter with the same `event_name` | `409 METER_EVENT_NAME_CONFLICT` |
+| Second meter with the same `event_name` (even if the first is archived) | `409 METER_EVENT_NAME_CONFLICT` |
 | Same meter attached to a plan twice | `409 PLAN_METER_ALREADY_ASSIGNED` |
+| Attaching an archived (`INACTIVE`) meter | `404 METER_NOT_FOUND` |
 | `price_per_credit` in the wrong currency / missing on a non-USD plan | `400 INVALID_PARAMETERS` |
 
 The full list, with every message, is on [Meter Error Codes](/reference/meters/meter-error-codes).
@@ -242,7 +245,7 @@ The full list, with every message, is on [Meter Error Codes](/reference/meters/m
     In this preview the event is validated against the meter and the subscription only, so it is accepted and stored — but only usage against a metered price on the subscription's plan is rated and billed. Check the plan's `meters[]` if usage isn't showing up on the renewal.
   </Accordion>
   <Accordion title="Can I change a meter's event_name or aggregation?">
-    No — both are immutable because your systems and past events depend on them. Create a new meter and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archiving frees the `event_name` for the new meter, and archived meters reject new events with `404 METER_NOT_FOUND`.
+    No — both are immutable because your systems and past events depend on them; a PATCH that includes them is silently ignored. Create a new meter (with a new `event_name` — names stay reserved even after archiving) and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archived meters reject new events with `404 METER_NOT_FOUND`, can't be attached to plans, and their existing metered prices are frozen; you can reactivate one at any time with `status: ACTIVE`.
   </Accordion>
   <Accordion title="Can I remove a metered price from a plan?">
     Not in this preview. Archive the meter to stop ingestion, or raise `credits` so no overage is billed.

--- a/docs/payment-features/subscriptions/usage-based-billing.mdx
+++ b/docs/payment-features/subscriptions/usage-based-billing.mdx
@@ -4,11 +4,11 @@ hidden: true
 description: "Meter any action your product performs, price it on a plan with included credits and a per-unit overage, and let Yuno bill the usage on each subscription's renewal"
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. Everything on this page — objects, endpoints, field names and error codes — may change before general availability. Contact your Yuno representative to enable it on your account, and pin your integration to the behavior described here rather than assuming forward compatibility.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 Subscriptions bill a fixed price on a fixed cadence. Usage-based billing adds a variable part on top: you tell Yuno *what* to count (a **meter**), *how much of it* a plan includes and what extra units cost (a **metered price**), and then report *how much each subscriber consumed* (**usage events**). Yuno aggregates the usage per subscription and billing cycle and bills anything beyond the included allowance together with the subscription's regular renewal charge.
 
@@ -19,7 +19,7 @@ Typical uses: an AI product that includes 10,000 tokens a month and bills the re
 1. **Meter** — a named, countable action: `ai_tokens`, `api_request`, `storage_gb`. It defines the `event_name` your systems send and the aggregation (`SUM`, `COUNT` or `LAST`). A meter has no price of its own — at most a `default_price` in USD that plans can inherit. See [The Meter Object](/reference/meters/the-meter-object).
 2. **Metered price** — the meter attached to a [plan](/docs/payment-features/subscriptions/plans): how many units are included per cycle (`credits`) and what each unit beyond that costs (`price_per_credit`, optionally per country). A plan can carry any number of metered prices next to its flat price. See [The Metered Price Object](/reference/meters/the-metered-price-object).
 3. **Subscription** — created on that plan as usual. It inherits every metered price; nothing changes in [Create Subscription](/reference/subscriptions/create-subscription).
-4. **Usage events** — one call per unit of work, carrying the `event_name`, the `subscription_id`, a `value` and your own `event_id` for idempotency. See [Report Usage Event](/reference/meters/report-usage-event).
+4. **Usage events** — one call per unit of work, carrying the `event_name`, the `subscription_id`, a `consumed_value` and your own `event_id` for idempotency. See [Report Usage Event](/reference/meters/report-usage-event).
 5. **Renewal** — at the end of the billing cycle, Yuno computes the billable quantity (`max(0, usage − credits)`) and adds `billable × price_per_credit` to the subscription's renewal charge.
 
 <Note>
@@ -30,7 +30,7 @@ Nothing here is specific to AI. A meter can count deliveries, minutes, messages,
 
 ## Quick start
 
-The example builds a "Max" plan at \$200/month that includes 10,000 AI tokens and bills \$0.002 per token beyond that. Requests use the standard `public-api-key` / `private-secret-key` headers; `X-Idempotency-Key` is optional.
+The example builds a "Max" plan at \$200/month that includes 10,000 AI tokens and bills \$0.002 per token beyond that. Requests use the standard `public-api-key` / `private-secret-key` headers, and every write request must carry a unique `X-Idempotency-Key`.
 
 <Steps>
   <Step title="Create the meter">
@@ -109,19 +109,20 @@ The example builds a "Max" plan at \$200/month that includes 10,000 AI tokens an
   </Step>
 
   <Step title="Report usage as it happens">
-    Send one event per unit of work. `event_id` is your idempotency key; `value` is required for `SUM` and `LAST` meters and defaults to 1 for `COUNT`.
+    Send one event per unit of work. `event_id` is your idempotency key; `consumed_value` is required for `SUM` and `LAST` meters and defaults to 1 for `COUNT`. The subscription must be `ACTIVE` or `TRIALING`.
 
     ```bash
     curl -X POST https://api-sandbox.y.uno/v1/subscriptions/meters/events \
       -H 'Content-Type: application/json' \
       -H 'public-api-key: <Your public-api-key>' \
       -H 'private-secret-key: <Your private-secret-key>' \
+      -H 'X-Idempotency-Key: 3c7e8f10-2b4d-4e6a-9c1f-5a7b9d2e4f60' \
       -d '{
         "event_id": "11111111-1111-1111-1111-111111111111",
         "event_name": "ai_tokens",
         "subscription_id": "33333333-3333-3333-3333-333333333333",
-        "value": 1500,
-        "timestamp": "2026-08-18T09:00:04Z",
+        "consumed_value": 1500,
+        "occurred_at": "2026-08-18T09:00:04Z",
         "metadata": [{ "key": "model", "value": "llm-large" }]
       }'
     ```
@@ -135,12 +136,12 @@ The example builds a "Max" plan at \$200/month that includes 10,000 AI tokens an
       "event_name": "ai_tokens",
       "meter_id": "55555555-5555-5555-5555-555555555555",
       "subscription_id": "33333333-3333-3333-3333-333333333333",
-      "value": 1500,
+      "consumed_value": 1500,
       "received_at": "2026-08-18T09:00:04.000000Z"
     }
     ```
 
-    Retrying the same request (same `event_id`) returns this same response and never counts the 1,500 tokens twice — even if the retry carries a different `value`, the original is kept.
+    Retrying the same request (same `event_id`) returns this same response and never counts the 1,500 tokens twice — even if the retry carries a different `consumed_value`, the original is kept.
   </Step>
 </Steps>
 
@@ -150,16 +151,16 @@ The aggregation is fixed when you create the meter and decides what a cycle's qu
 
 <Tabs>
   <Tab title="SUM — consumption">
-    Adds every event's `value`. Report the amount consumed by each unit of work.
+    Adds every event's `consumed_value`. Report the amount consumed by each unit of work.
 
     ```json
-    { "event_id": "resp_8f3k2", "event_name": "ai_tokens", "subscription_id": "3333…", "value": 1280 }
+    { "event_id": "resp_8f3k2", "event_name": "ai_tokens", "subscription_id": "3333…", "consumed_value": 1280 }
     ```
 
     Three events of 1,280 / 640 / 2,100 tokens → cycle quantity 4,020 tokens. Use for tokens, minutes transcribed, messages sent, deliveries completed.
   </Tab>
   <Tab title="COUNT — per call">
-    Counts events; `value` is ignored (each event counts as 1, so you can omit it).
+    Counts events; `consumed_value` is ignored (each event counts as 1, so you can omit it).
 
     ```json
     { "event_id": "req_01J5Y3Q9K8ZC5G6E4Y2W7X8N9M", "event_name": "api_request", "subscription_id": "3333…" }
@@ -168,10 +169,10 @@ The aggregation is fixed when you create the meter and decides what a cycle's qu
     1,432 events → cycle quantity 1,432 requests. Use for API calls, jobs, exports.
   </Tab>
   <Tab title="LAST — gauge">
-    Keeps the most recent `value` in the cycle by `timestamp`. Report the current level, not the delta.
+    Keeps the most recent `consumed_value` in the cycle by `occurred_at`. Report the current level, not the delta.
 
     ```json
-    { "event_id": "storage-2026-08-18T09:00-sub-3333", "event_name": "storage_gb", "subscription_id": "3333…", "value": 128.4, "timestamp": "2026-08-18T09:00:00Z" }
+    { "event_id": "storage-2026-08-18T09:00-sub-3333", "event_name": "storage_gb", "subscription_id": "3333…", "consumed_value": 128.4, "occurred_at": "2026-08-18T09:00:00Z" }
     ```
 
     Reports of 96.0 → 110.2 → 128.4 GB → cycle quantity 128.4 GB. Use for storage held, seats in use, active devices.
@@ -184,21 +185,21 @@ A metered price has three pricing knobs:
 
 - **`credits`** — the units included in the plan each billing cycle. Think "allowance": the first `credits` units are covered by the plan's flat price. `0` bills every unit. `credits` is measured in the meter's unit (tokens, requests, GB) and resets each cycle — it is **not** a prepaid balance or wallet.
 - **`price_per_credit`** — the price of each unit beyond `credits`, in the plan's base currency. On a USD plan you can omit it if the meter has a `default_price`; the meter's default then applies and the metered price is returned with `price_per_credit: null`. On a non-USD plan, or when the meter has no default, it is required. The currency must always match the plan's `base_amount` currency.
-- **`country_prices`** — optional per-unit prices by subscriber country (one entry per country), same shape as the plan's own `country_prices`. A subscriber whose country is not listed pays `price_per_credit`.
+- **`country_prices`** — optional per-unit prices by subscriber country (one entry per country), same shape as the plan's own `country_prices`. A subscriber whose country is not listed pays `price_per_credit`. The subscriber's country comes from the subscription — usage events carry no `country` or `account_id` — so `country_prices` are resolved automatically per subscriber.
 
-`pricing_strategy` selects how overage is rated. Only **`PER_UNIT`** (billable units × unit price) is priced in this preview. `PACKAGE` (price per bundle of N units) and `TIERED` (graduated rates) are accepted enum values reserved for an upcoming release — their configuration fields and rating are not available yet, so use `PER_UNIT`.
+`pricing_strategy` selects how overage is rated. Only **`PER_UNIT`** (billable units × unit price) is priced today. `PACKAGE` and `TIERED` are accepted enum values but are not priced and have no configuration fields, so use `PER_UNIT`.
 
 You can change `credits`, `price_per_credit` and `country_prices` on a live plan with [Update Plan Meter](/reference/meters/update-plan-meter); the new values apply to usage rated from the next billing cycle onward. The plan's flat price stays [immutable](/docs/payment-features/subscriptions/plans) as before.
 
 ## What happens at renewal
 
 <Note>
-Usage rating and the usage line items on the renewal charge are being rolled out during the preview. The model below is how billing works; the exact shape of usage on the charge and its webhooks will be documented as it lands.
+Usage is billed on the subscription's renewal charge, together with the plan's flat price — there is no separate usage invoice.
 </Note>
 
 For each subscription and each metered price on its plan, at the end of the billing cycle:
 
-1. **Quantity** — events whose `timestamp` falls in the cycle are aggregated with the meter's `aggregation` (SUM / COUNT / LAST).
+1. **Quantity** — events whose `occurred_at` falls in the cycle are aggregated with the meter's `aggregation` (SUM / COUNT / LAST).
 2. **Billable units** — `max(0, quantity − credits)`. Unused credits do not roll over.
 3. **Amount** — `billable × price_per_credit` (or the subscriber's `country_prices` entry).
 4. **Charge** — the amount is added to the subscription's renewal charge alongside the plan's flat price. One charge, one payment, as today. A subscription with usage under its credits pays only the flat price.
@@ -208,23 +209,26 @@ Example, on the Max plan (10,000 tokens included, \$0.002 per extra token): a su
 ## Idempotency and timestamps
 
 - **`event_id` is required and is your idempotency key.** Make it unique per event — a UUID, or the id of the request/response/job it came from — and reuse it on every retry. Yuno stores the first event under that id and answers every replay with the same response, including the original `value` (a different `value` on the retry is discarded). Usage is never double counted, however many times you retry. A request without `event_id` is rejected with `400`.
-- **Report close to real time**, but you can backdate. `timestamp` defaults to the receive time and can be up to **35 days** in the past; older events are rejected with `400`. The `timestamp` (not the receive time) decides which billing cycle the event lands in.
-- **`X-Idempotency-Key`** on the HTTP request works as on the rest of the Yuno API and is a good belt-and-braces for network retries, but `event_id` is what protects billing.
+- **Report close to real time**, but you can backdate. `occurred_at` defaults to the receive time (returned as `received_at`) and can be up to **35 days** in the past; older events are rejected with `400`. The `occurred_at` (not the receive time) decides which billing cycle the event lands in.
+- **`X-Idempotency-Key`** is required on every write request of this feature and works as on the rest of the Yuno API (same key + same body → same response). It protects the HTTP call; `event_id` is what protects billing across calls, so send both.
 - **One event per request.** Aggregate on your side if you produce many small events (for example, sum tokens per response rather than per token) — a `SUM` meter is designed for that.
+- **The subscription must be active.** Only `ACTIVE` and `TRIALING` subscriptions accept usage; events for a `PAUSED`, `PAST_DUE`, `CANCELED` or `COMPLETED` subscription are rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted.
 
 ## Error handling
 
-Validation is synchronous: a rejected event returns `400` or `404` immediately and is never counted, so treat non-`201` responses as "not recorded" and retry with the same `event_id` after fixing the request. The codes you will meet most often:
+Validation is synchronous: a rejected event returns `400` immediately (lookup failures are `400` too, never `404`) and is never counted, so treat non-`201` responses as "not recorded" and retry with the same `event_id` after fixing the request. The codes you will meet most often:
 
 | Situation | Response |
 | --- | --- |
-| `event_name` does not match an `ACTIVE` meter of your account | `404 METER_NOT_FOUND` |
+| `event_name` does not match an `ACTIVE` meter of your account | `400 METER_NOT_FOUND` |
 | `subscription_id` unknown | `400 SUBSCRIPTION_NOT_FOUND` |
-| `value` missing on a `SUM`/`LAST` meter | `400 INVALID_PARAMETERS` — "The value is required for a SUM meter" |
-| `timestamp` older than 35 days | `400 INVALID_PARAMETERS` |
+| Subscription is `PAUSED`, `CANCELED`, `COMPLETED` or otherwise not active | `400 SUBSCRIPTION_NOT_ACTIVE` — "The subscription is not active" |
+| Usage-based billing not enabled for your organization | `403 PRODUCT_NOT_ENABLED` |
+| `consumed_value` missing on a `SUM`/`LAST` meter | `400 INVALID_PARAMETERS` — "The consumed_value is required for a SUM meter" |
+| `occurred_at` older than 35 days | `400 INVALID_PARAMETERS` |
 | Second meter with the same `event_name` (even if the first is archived) | `409 METER_EVENT_NAME_CONFLICT` |
 | Same meter attached to a plan twice | `409 PLAN_METER_ALREADY_ASSIGNED` |
-| Attaching an archived (`INACTIVE`) meter | `404 METER_NOT_FOUND` |
+| Attaching an archived (`INACTIVE`) meter | `400 METER_NOT_FOUND` |
 | `price_per_credit` in the wrong currency / missing on a non-USD plan | `400 INVALID_PARAMETERS` |
 
 The full list, with every message, is on [Meter Error Codes](/reference/meters/meter-error-codes).
@@ -242,31 +246,24 @@ The full list, with every message, is on [Meter Error Codes](/reference/meters/m
     Neither. `credits` apply per subscription, per meter, per billing cycle. Two subscribers on the same plan each get the full allowance; unused credits do not carry over.
   </Accordion>
   <Accordion title="What happens if I report usage for a subscription that isn't on a plan with that meter?">
-    In this preview the event is validated against the meter and the subscription only, so it is accepted and stored — but only usage against a metered price on the subscription's plan is rated and billed. Check the plan's `meters[]` if usage isn't showing up on the renewal.
+    The event is validated against the meter and the subscription only, so it is accepted and stored — but only usage against a metered price on the subscription's plan is rated and billed. Check the plan's `meters[]` if usage isn't showing up on the renewal.
   </Accordion>
   <Accordion title="Can I change a meter's event_name or aggregation?">
-    No — both are immutable because your systems and past events depend on them; a PATCH that includes them is silently ignored. Create a new meter (with a new `event_name` — names stay reserved even after archiving) and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archived meters reject new events with `404 METER_NOT_FOUND`, can't be attached to plans, and their existing metered prices are frozen; you can reactivate one at any time with `status: ACTIVE`.
+    No — both are immutable because your systems and past events depend on them; a PATCH that includes them is silently ignored. Create a new meter (with a new `event_name` — names stay reserved even after archiving) and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archived meters reject new events with `400 METER_NOT_FOUND`, can't be attached to plans, and their existing metered prices are frozen; you can reactivate one at any time with `status: ACTIVE`.
   </Accordion>
   <Accordion title="Can I remove a metered price from a plan?">
-    Not in this preview. Archive the meter to stop ingestion, or raise `credits` so no overage is billed.
+    There is no detach endpoint. Archive the meter to stop ingestion, or raise `credits` so no overage is billed.
   </Accordion>
   <Accordion title="Can I price the meter in a currency other than USD?">
     Yes, per plan. The meter's `default_price` is USD-only, but a metered price on a BRL plan takes `price_per_credit` in BRL (required — nothing is inherited for non-USD plans), and `country_prices` lets you set per-country unit prices in each country's currency.
   </Accordion>
+  <Accordion title="What happens if I report usage for a paused or canceled subscription?">
+    The event is rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted — only `ACTIVE` and `TRIALING` subscriptions accept usage. Resume the subscription first ([Resume Subscription](/reference/subscriptions/resume-subscription)), then report the usage; you can backdate `occurred_at` up to 35 days.
+  </Accordion>
   <Accordion title="Can I meter usage without a subscription?">
-    Not in this preview. Every event needs a `subscription_id`; usage is billed on that subscription's renewal.
+    No. Every event needs a `subscription_id`; usage is billed on that subscription's renewal.
   </Accordion>
 </AccordionGroup>
-
-## What's next
-
-The preview covers meters, metered prices and per-event ingestion. Coming next, in rough order:
-
-- **Usage visibility** — endpoints and Dashboard views for running usage per subscription and per plan mid-cycle (quantity, included, billable, amount).
-- **Usage on the renewal charge** — usage as its own line items on the charge breakdown and in the renewal webhooks.
-- **Batch ingestion** — many events per request.
-- **`PACKAGE` and `TIERED` pricing** — bundle and graduated rates on top of `PER_UNIT`.
-- **Dashboard** — create and manage meters, attach metered prices to plans, see usage per subscriber.
 
 ## Reference
 

--- a/docs/payment-features/subscriptions/usage-based-billing.mdx
+++ b/docs/payment-features/subscriptions/usage-based-billing.mdx
@@ -187,7 +187,11 @@ A metered price has three pricing knobs:
 - **`price_per_credit`** — the price of each unit beyond `credits`, in the plan's base currency. On a USD plan you can omit it if the meter has a `default_price`; the meter's default then applies and the metered price is returned with `price_per_credit: null`. On a non-USD plan, or when the meter has no default, it is required. The currency must always match the plan's `base_amount` currency.
 - **`country_prices`** — optional per-unit prices by subscriber country (one entry per country), same shape as the plan's own `country_prices`. A subscriber whose country is not listed pays `price_per_credit`. The subscriber's country comes from the subscription — usage events carry no `country` or `account_id` — so `country_prices` are resolved automatically per subscriber.
 
-`pricing_strategy` selects how overage is rated. Only **`PER_UNIT`** (billable units × unit price) is priced today. `PACKAGE` and `TIERED` are accepted enum values but are not priced and have no configuration fields, so use `PER_UNIT`.
+`pricing_strategy` selects how overage is rated:
+
+- **`PER_UNIT`** — billable units × unit price (`price_per_credit` or the subscriber's `country_prices` entry). The default choice for tokens, requests, minutes.
+- **`PACKAGE`** — usage is billed in bundles of N units; a partial bundle counts as a full one.
+- **`TIERED`** — graduated tiers: each band of usage is billed at its own rate.
 
 You can change `credits`, `price_per_credit` and `country_prices` on a live plan with [Update Plan Meter](/reference/meters/update-plan-meter); the new values apply to usage rated from the next billing cycle onward. The plan's flat price stays [immutable](/docs/payment-features/subscriptions/plans) as before.
 

--- a/docs/payment-features/subscriptions/usage-based-billing.mdx
+++ b/docs/payment-features/subscriptions/usage-based-billing.mdx
@@ -228,7 +228,7 @@ Validation is synchronous: a rejected event returns `400` immediately (lookup fa
 | `subscription_id` unknown | `400 SUBSCRIPTION_NOT_FOUND` |
 | Subscription is `PAUSED`, `CANCELED`, `COMPLETED` or otherwise not active | `400 SUBSCRIPTION_NOT_ACTIVE` — "The subscription is not active" |
 | Usage-based billing not enabled for your organization | `403 PRODUCT_NOT_ENABLED` |
-| `consumed_value` missing on a `SUM`/`LAST` meter | `400 INVALID_PARAMETERS` — "The consumed_value is required for a SUM meter" |
+| `consumed_value` missing on a `SUM`/`LAST` meter | `400 INVALID_PARAMETERS` — "The consumed_value is required for a SUM meter" / "…for a LAST meter" |
 | `occurred_at` older than 35 days | `400 INVALID_PARAMETERS` |
 | Second meter with the same `event_name` (even if the first is archived) | `409 METER_EVENT_NAME_CONFLICT` |
 | Same meter attached to a plan twice | `409 PLAN_METER_ALREADY_ASSIGNED` |

--- a/docs/payment-features/subscriptions/usage-based-billing.mdx
+++ b/docs/payment-features/subscriptions/usage-based-billing.mdx
@@ -109,7 +109,7 @@ The example builds a "Max" plan at \$200/month that includes 10,000 AI tokens an
   </Step>
 
   <Step title="Report usage as it happens">
-    Send one event per unit of work. `event_id` is your idempotency key; `consumed_value` is required for `SUM` and `LAST` meters and defaults to 1 for `COUNT`. The subscription must be `ACTIVE` or `TRIALING`.
+    Send one event per unit of work. `event_id` is your idempotency key; `consumed_value` is required for `SUM` and `LAST` meters and defaults to 1 for `COUNT`. The subscription must be `ACTIVE`, `TRIALING` or `PAST_DUE`.
 
     ```bash
     curl -X POST https://api-sandbox.y.uno/v1/subscriptions/meters/events \
@@ -216,7 +216,7 @@ Example, on the Max plan (10,000 tokens included, \$0.002 per extra token): a su
 - **Report close to real time**, but you can backdate. `occurred_at` defaults to the receive time (returned as `received_at`) and can be up to **35 days** in the past; older events are rejected with `400`. The `occurred_at` (not the receive time) decides which billing cycle the event lands in.
 - **`X-Idempotency-Key`** is required on every write request of this feature and works as on the rest of the Yuno API (same key + same body → same response). It protects the HTTP call; `event_id` is what protects billing across calls, so send both.
 - **One event per request.** Aggregate on your side if you produce many small events (for example, sum tokens per response rather than per token) — a `SUM` meter is designed for that.
-- **The subscription must be active.** Only `ACTIVE` and `TRIALING` subscriptions accept usage; events for a `PAUSED`, `PAST_DUE`, `CANCELED` or `COMPLETED` subscription are rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted.
+- **The subscription must be active.** `ACTIVE`, `TRIALING` and `PAST_DUE` subscriptions accept usage (a subscription in payment retries keeps metering); events for a `PAUSED`, `CANCELED` or `COMPLETED` subscription are rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted.
 
 ## Error handling
 
@@ -262,7 +262,7 @@ The full list, with every message, is on [Meter Error Codes](/reference/meters/m
     Yes, per plan. The meter's `default_price` is USD-only, but a metered price on a BRL plan takes `price_per_credit` in BRL (required — nothing is inherited for non-USD plans), and `country_prices` lets you set per-country unit prices in each country's currency.
   </Accordion>
   <Accordion title="What happens if I report usage for a paused or canceled subscription?">
-    The event is rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted — only `ACTIVE` and `TRIALING` subscriptions accept usage. Resume the subscription first ([Resume Subscription](/reference/subscriptions/resume-subscription)), then report the usage; you can backdate `occurred_at` up to 35 days.
+    The event is rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted — only `ACTIVE`, `TRIALING` and `PAST_DUE` subscriptions accept usage. Resume the subscription first ([Resume Subscription](/reference/subscriptions/resume-subscription)), then report the usage; you can backdate `occurred_at` up to 35 days.
   </Accordion>
   <Accordion title="Can I meter usage without a subscription?">
     No. Every event needs a `subscription_id`; usage is billed on that subscription's renewal.

--- a/openapi/meters/attach-meter-to-plan.json
+++ b/openapi/meters/attach-meter-to-plan.json
@@ -82,7 +82,7 @@
                       "PACKAGE",
                       "TIERED"
                     ],
-                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced today. `PACKAGE` and `TIERED` are accepted enum values but are not priced and have no configuration fields."
+                    "description": "How usage beyond `credits` is priced: `PER_UNIT` (billable units × `price_per_credit`), `PACKAGE` (bundles of N units, partial bundle counts as a full one) or `TIERED` (graduated tiers, each band at its own rate)."
                   },
                   "price_per_credit": {
                     "type": "object",

--- a/openapi/meters/attach-meter-to-plan.json
+++ b/openapi/meters/attach-meter-to-plan.json
@@ -68,7 +68,7 @@
                 "properties": {
                   "meter_id": {
                     "type": "string",
-                    "description": "The unique identifier of the meter to attach (MAX 64; MIN 36). Must be an existing meter of the account, else `404 METER_NOT_FOUND`. A meter can be attached to a plan only once, else `409 PLAN_METER_ALREADY_ASSIGNED`."
+                    "description": "The unique identifier of the meter to attach (MAX 64; MIN 36). Must be an existing `ACTIVE` meter of the account — an unknown or `INACTIVE` meter is rejected with `404 METER_NOT_FOUND`. A meter can be attached to a plan only once, else `409 PLAN_METER_ALREADY_ASSIGNED`."
                   },
                   "credits": {
                     "type": "number",
@@ -98,13 +98,13 @@
                       "value": {
                         "type": "number",
                         "format": "float",
-                        "description": "Price per unit beyond the included credits (multiple of 0.0001). Optional only when the plan's base currency is `USD` and the meter has a `default_price` — it is then inherited from the meter. Required otherwise."
+                        "description": "Price per unit beyond the included credits (multiple of 0.0001). Optional only when the plan's base currency is `USD` and the meter has a `default_price` — the meter's default then applies and the metered price is returned with `price_per_credit: null`. Required otherwise."
                       }
                     }
                   },
                   "country_prices": {
                     "type": "array",
-                    "description": "Optional explicit per-country price per unit (one entry per country). A country not listed falls back to `price_per_credit`.",
+                    "description": "Optional explicit per-country price per unit. One entry per country — a repeated country is rejected with `400 INVALID_PARAMETERS`. A country not listed falls back to `price_per_credit`.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -166,7 +166,7 @@
                   }
                 },
                 "Inherit meter default_price (USD plan)": {
-                  "summary": "USD plan — price inherited from the meter's default_price",
+                  "summary": "USD plan — price inherited from the meter's default_price (returned as null)",
                   "value": {
                     "meter_id": "55555555-5555-5555-5555-555555555555",
                     "credits": 10000,
@@ -235,6 +235,8 @@
                     },
                     "price_per_credit": {
                       "type": "object",
+                      "nullable": true,
+                      "description": "`null` when inherited from the meter's `default_price` (USD plans).",
                       "properties": {
                         "currency": {
                           "type": "string"
@@ -326,6 +328,15 @@
                         "The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED"
                       ]
                     }
+                  },
+                  "Duplicate country": {
+                    "summary": "Duplicate country",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The country_prices must not contain duplicate countries"
+                      ]
+                    }
                   }
                 },
                 "schema": {
@@ -350,12 +361,12 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Unknown meter": {
-                    "summary": "Unknown meter",
+                  "Unknown or inactive meter": {
+                    "summary": "Unknown or inactive meter",
                     "value": {
                       "code": "METER_NOT_FOUND",
                       "messages": [
-                        "The meter does not exist or is not linked to this account."
+                        "The meter does not exist, is inactive or is not linked to this account."
                       ]
                     }
                   },

--- a/openapi/meters/attach-meter-to-plan.json
+++ b/openapi/meters/attach-meter-to-plan.json
@@ -1,0 +1,436 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/plans/{plan_id}/meters": {
+      "post": {
+        "summary": "Attach Meter to Plan",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Attaches a meter to an existing plan as a metered price: how many units are included per cycle (`credits`) and what each unit beyond that costs. Attaching does not change the plan's flat price or any existing subscriber's base amount. You can also attach meters inline with `meters[]` when calling Create Plan.",
+        "operationId": "attach-meter-to-plan",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the plan.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Idempotency-Key",
+            "schema": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "meter_id": {
+                    "type": "string",
+                    "description": "The unique identifier of the meter to attach (MAX 64; MIN 36). Must be an existing meter of the account, else `404 METER_NOT_FOUND`. A meter can be attached to a plan only once, else `409 PLAN_METER_ALREADY_ASSIGNED`."
+                  },
+                  "credits": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Units included in the plan per billing cycle — the allowance a subscriber can consume before any usage is billed. Must be >= 0. `0` means every unit is billed."
+                  },
+                  "pricing_strategy": {
+                    "type": "string",
+                    "enum": [
+                      "PER_UNIT",
+                      "PACKAGE",
+                      "TIERED"
+                    ],
+                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced in this preview. `PACKAGE` and `TIERED` are accepted but reserved — their configuration fields and rating are not available yet."
+                  },
+                  "price_per_credit": {
+                    "type": "object",
+                    "required": [
+                      "currency",
+                      "value"
+                    ],
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "description": "MAX 3; MIN 3. Must equal the plan's `base_amount` currency, else `400 INVALID_PARAMETERS`."
+                      },
+                      "value": {
+                        "type": "number",
+                        "format": "float",
+                        "description": "Price per unit beyond the included credits (multiple of 0.0001). Optional only when the plan's base currency is `USD` and the meter has a `default_price` — it is then inherited from the meter. Required otherwise."
+                      }
+                    }
+                  },
+                  "country_prices": {
+                    "type": "array",
+                    "description": "Optional explicit per-country price per unit (one entry per country). A country not listed falls back to `price_per_credit`.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "country",
+                        "amount"
+                      ],
+                      "properties": {
+                        "country": {
+                          "type": "string",
+                          "description": "MAX 2; MIN 2; [ISO 3166-1](/reference/country-reference)."
+                        },
+                        "amount": {
+                          "type": "object",
+                          "required": [
+                            "currency",
+                            "value"
+                          ],
+                          "properties": {
+                            "currency": {
+                              "type": "string",
+                              "description": "MAX 3; MIN 3; [ISO 4217](/reference/country-reference)."
+                            },
+                            "value": {
+                              "type": "number",
+                              "format": "float",
+                              "description": "Multiple of 0.0001."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "meter_id",
+                  "credits",
+                  "pricing_strategy"
+                ]
+              },
+              "examples": {
+                "Metered price": {
+                  "value": {
+                    "meter_id": "66666666-6666-6666-6666-666666666666",
+                    "credits": 100.5,
+                    "pricing_strategy": "PER_UNIT",
+                    "price_per_credit": {
+                      "currency": "USD",
+                      "value": 0.05
+                    },
+                    "country_prices": [
+                      {
+                        "country": "US",
+                        "amount": {
+                          "currency": "USD",
+                          "value": 0.06
+                        }
+                      }
+                    ]
+                  }
+                },
+                "Inherit meter default_price (USD plan)": {
+                  "summary": "USD plan — price inherited from the meter's default_price",
+                  "value": {
+                    "meter_id": "55555555-5555-5555-5555-555555555555",
+                    "credits": 10000,
+                    "pricing_strategy": "PER_UNIT"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "77777777-7777-7777-7777-777777777777",
+                      "plan_id": "00000000-0000-4000-8000-000000000001",
+                      "meter_id": "66666666-6666-6666-6666-666666666666",
+                      "credits": 100.5,
+                      "pricing_strategy": "PER_UNIT",
+                      "price_per_credit": {
+                        "currency": "USD",
+                        "value": 0.05
+                      },
+                      "country_prices": [
+                        {
+                          "country": "US",
+                          "amount": {
+                            "currency": "USD",
+                            "value": 0.06
+                          }
+                        }
+                      ],
+                      "created_at": "2026-08-18T09:00:04.000000Z",
+                      "updated_at": "2026-08-18T09:00:04.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The unique identifier of the metered price (the plan-meter relation)."
+                    },
+                    "plan_id": {
+                      "type": "string"
+                    },
+                    "meter_id": {
+                      "type": "string"
+                    },
+                    "credits": {
+                      "type": "number",
+                      "description": "Units included in the plan per billing cycle."
+                    },
+                    "pricing_strategy": {
+                      "type": "string",
+                      "enum": [
+                        "PER_UNIT",
+                        "PACKAGE",
+                        "TIERED"
+                      ]
+                    },
+                    "price_per_credit": {
+                      "type": "object",
+                      "properties": {
+                        "currency": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "country_prices": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "country": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Currency mismatch": {
+                    "summary": "Currency mismatch",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The price_per_credit currency must match the plan base currency"
+                      ]
+                    }
+                  },
+                  "Missing price on non-USD plan": {
+                    "summary": "Missing price on non-USD plan",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "A price_per_credit is required when the plan base currency is not USD"
+                      ]
+                    }
+                  },
+                  "Missing price and no default": {
+                    "summary": "Missing price and no default",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "A price_per_credit is required when the meter has no default_price"
+                      ]
+                    }
+                  },
+                  "Negative credits": {
+                    "summary": "Negative credits",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The meter credits must be greater than or equal to 0"
+                      ]
+                    }
+                  },
+                  "Invalid strategy": {
+                    "summary": "Invalid strategy",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unknown meter": {
+                    "summary": "Unknown meter",
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "The meter does not exist or is not linked to this account."
+                      ]
+                    }
+                  },
+                  "Unknown plan": {
+                    "summary": "Unknown plan",
+                    "value": {
+                      "code": "PLAN_NOT_FOUND",
+                      "messages": [
+                        "The plan does not exist or is not linked to this account."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "409",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "PLAN_METER_ALREADY_ASSIGNED",
+                      "messages": [
+                        "The meter 66666666-6666-6666-6666-666666666666 is already assigned to this plan"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/attach-meter-to-plan.json
+++ b/openapi/meters/attach-meter-to-plan.json
@@ -38,7 +38,7 @@
     "/subscriptions/plans/{plan_id}/meters": {
       "post": {
         "summary": "Attach Meter to Plan",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Attaches a meter to an existing plan as a metered price: how many units are included per cycle (`credits`) and what each unit beyond that costs. Attaching does not change the plan's flat price or any existing subscriber's base amount. You can also attach meters inline with `meters[]` when calling Create Plan.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Attaches a meter to an existing plan as a metered price: how many units are included per cycle (`credits`) and what each unit beyond that costs. Attaching does not change the plan's flat price or any existing subscriber's base amount. You can also attach meters inline with `meters[]` when calling Create Plan.",
         "operationId": "attach-meter-to-plan",
         "parameters": [
           {
@@ -53,11 +53,11 @@
           {
             "in": "header",
             "name": "X-Idempotency-Key",
+            "required": true,
             "schema": {
-              "type": "string",
-              "maxLength": 64
+              "type": "string"
             },
-            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+            "description": "Unique identifier used in HTTP headers to ensure that a request is processed only once, even if it is retried due to network issues or timeouts. Required on every write request of this feature."
           }
         ],
         "requestBody": {
@@ -68,7 +68,7 @@
                 "properties": {
                   "meter_id": {
                     "type": "string",
-                    "description": "The unique identifier of the meter to attach (MAX 64; MIN 36). Must be an existing `ACTIVE` meter of the account — an unknown or `INACTIVE` meter is rejected with `404 METER_NOT_FOUND`. A meter can be attached to a plan only once, else `409 PLAN_METER_ALREADY_ASSIGNED`."
+                    "description": "The unique identifier of the meter to attach (MAX 64; MIN 36). Must be an existing `ACTIVE` meter of the account — an unknown or `INACTIVE` meter is rejected with `400 METER_NOT_FOUND`. A meter can be attached to a plan only once, else `409 PLAN_METER_ALREADY_ASSIGNED`."
                   },
                   "credits": {
                     "type": "number",
@@ -82,7 +82,7 @@
                       "PACKAGE",
                       "TIERED"
                     ],
-                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced in this preview. `PACKAGE` and `TIERED` are accepted but reserved — their configuration fields and rating are not available yet."
+                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced today. `PACKAGE` and `TIERED` are accepted enum values but are not priced and have no configuration fields."
                   },
                   "price_per_credit": {
                     "type": "object",
@@ -269,10 +269,12 @@
                       }
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on creation."
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on every update."
                     }
                   }
                 }
@@ -337,30 +339,7 @@
                         "The country_prices must not contain duplicate countries"
                       ]
                     }
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string"
-                    },
-                    "messages": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "404",
-            "content": {
-              "application/json": {
-                "examples": {
+                  },
                   "Unknown or inactive meter": {
                     "summary": "Unknown or inactive meter",
                     "value": {
@@ -385,6 +364,39 @@
                   "properties": {
                     "code": {
                       "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "Usage-based billing is not enabled for this organization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/create-meter.json
+++ b/openapi/meters/create-meter.json
@@ -38,17 +38,17 @@
     "/subscriptions/meters": {
       "post": {
         "summary": "Create Meter",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Creates a meter: a named, countable action your product performs (tokens, API requests, gigabytes held). The meter defines the `event_name` your systems send and how the reported values aggregate per billing cycle. Attach it to a plan as a metered price to bill usage.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Creates a meter: a named, countable action your product performs (tokens, API requests, gigabytes held). The meter defines the `event_name` your systems send and how the reported values aggregate per billing cycle. Attach it to a plan as a metered price to bill usage.",
         "operationId": "create-meter",
         "parameters": [
           {
             "in": "header",
             "name": "X-Idempotency-Key",
+            "required": true,
             "schema": {
-              "type": "string",
-              "maxLength": 64
+              "type": "string"
             },
-            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+            "description": "Unique identifier used in HTTP headers to ensure that a request is processed only once, even if it is retried due to network issues or timeouts. Required on every write request of this feature."
           }
         ],
         "requestBody": {
@@ -274,10 +274,12 @@
                       "example": "ACTIVE"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on creation."
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on every update."
                     }
                   }
                 }
@@ -331,6 +333,39 @@
                   "properties": {
                     "code": {
                       "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "Usage-based billing is not enabled for this organization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/create-meter.json
+++ b/openapi/meters/create-meter.json
@@ -57,11 +57,16 @@
               "schema": {
                 "type": "object",
                 "required": [
+                  "account_id",
                   "name",
                   "event_name",
                   "aggregation"
                 ],
                 "properties": {
+                  "account_id": {
+                    "type": "string",
+                    "description": "The unique identifier of the account the meter belongs to (UUID, 36 chars)."
+                  },
                   "name": {
                     "type": "string",
                     "description": "The meter display name (MAX 255; MIN 3). Leading and trailing spaces are trimmed."
@@ -72,7 +77,7 @@
                   },
                   "event_name": {
                     "type": "string",
-                    "description": "The key your systems send on every usage event to reference this meter (MAX 100; lowercase letters, digits, `_` and `.` only — `^[a-z0-9_.]+$`). Must be unique among the account's `ACTIVE` meters, else `409 METER_EVENT_NAME_CONFLICT`. Immutable after creation."
+                    "description": "The key your systems send on every usage event to reference this meter (MAX 100; lowercase letters, digits, `_` and `.` only — `^[a-z0-9_.]+$`). Must be unique across all meters of the account, `ACTIVE` or `INACTIVE`, else `409 METER_EVENT_NAME_CONFLICT`. Immutable after creation."
                   },
                   "aggregation": {
                     "type": "string",
@@ -129,15 +134,24 @@
                         }
                       }
                     }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "ACTIVE",
+                      "INACTIVE"
+                    ],
+                    "description": "Ignored on creation — a new meter is always `ACTIVE`. Use Update Meter to archive it."
                   }
                 }
               },
               "examples": {
                 "Meter": {
                   "value": {
-                    "name": "Tokens Consumed",
-                    "description": "Meters LLM token consumption per billing cycle",
-                    "event_name": "tokens_consumed",
+                    "account_id": "00000000-0000-4000-8000-000000000002",
+                    "name": "AI tokens",
+                    "description": "LLM tokens consumed by model responses, reported once per response",
+                    "event_name": "ai_tokens",
                     "aggregation": "SUM",
                     "unit_label": "token",
                     "plural_unit_label": "tokens",
@@ -167,9 +181,9 @@
                     "value": {
                       "id": "55555555-5555-5555-5555-555555555555",
                       "account_id": "00000000-0000-4000-8000-000000000002",
-                      "name": "Tokens Consumed",
-                      "description": "Meters LLM token consumption per billing cycle",
-                      "event_name": "tokens_consumed",
+                      "name": "AI tokens",
+                      "description": "LLM tokens consumed by model responses, reported once per response",
+                      "event_name": "ai_tokens",
                       "aggregation": "SUM",
                       "unit_label": "token",
                       "plural_unit_label": "tokens",
@@ -284,6 +298,15 @@
                       ]
                     }
                   },
+                  "Missing account_id": {
+                    "summary": "Missing account_id",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The account_id is required"
+                      ]
+                    }
+                  },
                   "Non-USD default_price": {
                     "summary": "Non-USD default_price",
                     "value": {
@@ -329,7 +352,7 @@
                     "value": {
                       "code": "METER_EVENT_NAME_CONFLICT",
                       "messages": [
-                        "An active meter with event_name tokens_consumed already exists for this account"
+                        "A meter with event_name ai_tokens already exists for this account"
                       ]
                     }
                   }

--- a/openapi/meters/create-meter.json
+++ b/openapi/meters/create-meter.json
@@ -1,0 +1,370 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/meters": {
+      "post": {
+        "summary": "Create Meter",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Creates a meter: a named, countable action your product performs (tokens, API requests, gigabytes held). The meter defines the `event_name` your systems send and how the reported values aggregate per billing cycle. Attach it to a plan as a metered price to bill usage.",
+        "operationId": "create-meter",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Idempotency-Key",
+            "schema": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "event_name",
+                  "aggregation"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The meter display name (MAX 255; MIN 3). Leading and trailing spaces are trimmed."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "What the meter counts and how. Optional but recommended — it is how your team and Yuno support understand the meter."
+                  },
+                  "event_name": {
+                    "type": "string",
+                    "description": "The key your systems send on every usage event to reference this meter (MAX 100; lowercase letters, digits, `_` and `.` only — `^[a-z0-9_.]+$`). Must be unique among the account's `ACTIVE` meters, else `409 METER_EVENT_NAME_CONFLICT`. Immutable after creation."
+                  },
+                  "aggregation": {
+                    "type": "string",
+                    "enum": [
+                      "SUM",
+                      "COUNT",
+                      "LAST"
+                    ],
+                    "description": "How reported events roll up into the cycle quantity. `SUM` adds every event `value` (tokens, minutes). `COUNT` counts events, ignoring `value` (API requests). `LAST` keeps the most recent `value` (a gauge such as gigabytes held). Immutable after creation."
+                  },
+                  "unit_label": {
+                    "type": "string",
+                    "description": "Singular unit label used when the usage is displayed. Example: `token`."
+                  },
+                  "plural_unit_label": {
+                    "type": "string",
+                    "description": "Plural unit label used when the usage is displayed. Example: `tokens`."
+                  },
+                  "default_price": {
+                    "type": "object",
+                    "required": [
+                      "currency",
+                      "value"
+                    ],
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "description": "MAX 3; MIN 3. Must be `USD` — any other currency is rejected with `400 INVALID_PARAMETERS`."
+                      },
+                      "value": {
+                        "type": "number",
+                        "format": "float",
+                        "description": "Default price per unit beyond the included credits (multiple of 0.0001). Inherited by USD plans that attach this meter without an explicit `price_per_credit`."
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "type": "array",
+                    "description": "Optional key-value pairs attached to the meter (MAX 48 entries; keys must be unique per meter).",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "description": "MAX 48."
+                        },
+                        "value": {
+                          "type": "string",
+                          "description": "MAX 512."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "Meter": {
+                  "value": {
+                    "name": "Tokens Consumed",
+                    "description": "Meters LLM token consumption per billing cycle",
+                    "event_name": "tokens_consumed",
+                    "aggregation": "SUM",
+                    "unit_label": "token",
+                    "plural_unit_label": "tokens",
+                    "default_price": {
+                      "currency": "USD",
+                      "value": 0.002
+                    },
+                    "metadata": [
+                      {
+                        "key": "team",
+                        "value": "platform"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "55555555-5555-5555-5555-555555555555",
+                      "account_id": "00000000-0000-4000-8000-000000000002",
+                      "name": "Tokens Consumed",
+                      "description": "Meters LLM token consumption per billing cycle",
+                      "event_name": "tokens_consumed",
+                      "aggregation": "SUM",
+                      "unit_label": "token",
+                      "plural_unit_label": "tokens",
+                      "default_price": {
+                        "currency": "USD",
+                        "value": 0.002
+                      },
+                      "metadata": [
+                        {
+                          "key": "team",
+                          "value": "platform"
+                        }
+                      ],
+                      "status": "ACTIVE",
+                      "created_at": "2026-08-18T09:00:04.000000Z",
+                      "updated_at": "2026-08-18T09:00:04.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The unique identifier of the meter."
+                    },
+                    "account_id": {
+                      "type": "string",
+                      "description": "The unique identifier of the account that owns the meter."
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "event_name": {
+                      "type": "string"
+                    },
+                    "aggregation": {
+                      "type": "string",
+                      "enum": [
+                        "SUM",
+                        "COUNT",
+                        "LAST"
+                      ]
+                    },
+                    "unit_label": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "plural_unit_label": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "default_price": {
+                      "type": "object",
+                      "properties": {
+                        "currency": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ACTIVE",
+                        "INACTIVE"
+                      ],
+                      "example": "ACTIVE"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Invalid event_name": {
+                    "summary": "Invalid event_name",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The event_name must match ^[a-z0-9_.]+$"
+                      ]
+                    }
+                  },
+                  "Non-USD default_price": {
+                    "summary": "Non-USD default_price",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The default_price currency must be USD"
+                      ]
+                    }
+                  },
+                  "Invalid aggregation": {
+                    "summary": "Invalid aggregation",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The aggregation must be one of SUM, COUNT, LAST"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "409",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "METER_EVENT_NAME_CONFLICT",
+                      "messages": [
+                        "An active meter with event_name tokens_consumed already exists for this account"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/create-meter.json
+++ b/openapi/meters/create-meter.json
@@ -86,7 +86,7 @@
                       "COUNT",
                       "LAST"
                     ],
-                    "description": "How reported events roll up into the cycle quantity. `SUM` adds every event `value` (tokens, minutes). `COUNT` counts events, ignoring `value` (API requests). `LAST` keeps the most recent `value` (a gauge such as gigabytes held). Immutable after creation."
+                    "description": "How reported events roll up into the cycle quantity. `SUM` adds every event `consumed_value` (tokens, minutes). `COUNT` counts events, ignoring `consumed_value` (API requests). `LAST` keeps the most recent `consumed_value` (a gauge such as gigabytes held). Immutable after creation."
                   },
                   "unit_label": {
                     "type": "string",

--- a/openapi/meters/list-meters.json
+++ b/openapi/meters/list-meters.json
@@ -42,23 +42,31 @@
         "operationId": "list-meters",
         "parameters": [
           {
-            "name": "page",
+            "name": "account_id",
             "in": "query",
-            "description": "1-indexed page number. Must be >= 1, else `400 INVALID_PARAMETERS`.",
+            "description": "The unique identifier of the account whose meters to list (UUID, 36 chars).",
             "schema": {
-              "type": "integer",
-              "default": 1,
-              "minimum": 1
+              "type": "string"
             }
           },
           {
-            "name": "size",
+            "name": "limit",
             "in": "query",
-            "description": "Page size. Must be >= 1, else `400 INVALID_PARAMETERS`. Defaults to 20.",
+            "description": "Maximum number of meters to return. Must be >= 1, else `400 INVALID_PARAMETERS`. Defaults to 20.",
             "schema": {
               "type": "integer",
               "default": 20,
               "minimum": 1
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of meters to skip. Must be >= 0. Defaults to 0.",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
             }
           }
         ],
@@ -70,13 +78,13 @@
                 "examples": {
                   "Result": {
                     "value": {
-                      "items": [
+                      "data": [
                         {
                           "id": "55555555-5555-5555-5555-555555555555",
                           "account_id": "00000000-0000-4000-8000-000000000002",
-                          "name": "Tokens Consumed",
-                          "description": "Meters LLM token consumption per billing cycle",
-                          "event_name": "tokens_consumed",
+                          "name": "AI tokens",
+                          "description": "LLM tokens consumed by model responses, reported once per response",
+                          "event_name": "ai_tokens",
                           "aggregation": "SUM",
                           "unit_label": "token",
                           "plural_unit_label": "tokens",
@@ -114,10 +122,10 @@
                         }
                       ],
                       "pagination": {
-                        "page": 1,
-                        "size": 20,
                         "total": 2,
-                        "total_pages": 1
+                        "limit": 20,
+                        "offset": 0,
+                        "has_more": false
                       }
                     }
                   }
@@ -125,7 +133,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "items": {
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -209,17 +217,19 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer"
-                        },
-                        "size": {
-                          "type": "integer"
-                        },
                         "total": {
+                          "type": "integer",
+                          "description": "Total number of items."
+                        },
+                        "limit": {
                           "type": "integer"
                         },
-                        "total_pages": {
+                        "offset": {
                           "type": "integer"
+                        },
+                        "has_more": {
+                          "type": "boolean",
+                          "description": "`true` when more items exist beyond `offset + limit`."
                         }
                       }
                     }
@@ -237,7 +247,7 @@
                     "value": {
                       "code": "INVALID_PARAMETERS",
                       "messages": [
-                        "The page must be greater than or equal to 1"
+                        "The limit must be greater than or equal to 1"
                       ]
                     }
                   }

--- a/openapi/meters/list-meters.json
+++ b/openapi/meters/list-meters.json
@@ -38,7 +38,7 @@
     "/subscriptions/meters": {
       "get": {
         "summary": "List Meters",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Returns a paginated list of the meters that belong to the authenticated account, including `INACTIVE` (archived) meters. 1-indexed pagination.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Returns a paginated list of the meters that belong to the authenticated account, including `INACTIVE` (archived) meters. 1-indexed pagination.",
         "operationId": "list-meters",
         "parameters": [
           {
@@ -206,10 +206,12 @@
                             "example": "ACTIVE"
                           },
                           "created_at": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Set by Yuno on creation."
                           },
                           "updated_at": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Set by Yuno on every update."
                           }
                         }
                       }
@@ -257,6 +259,39 @@
                   "properties": {
                     "code": {
                       "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "Usage-based billing is not enabled for this organization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/list-meters.json
+++ b/openapi/meters/list-meters.json
@@ -1,0 +1,278 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/meters": {
+      "get": {
+        "summary": "List Meters",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Returns a paginated list of the meters that belong to the authenticated account, including `INACTIVE` (archived) meters. 1-indexed pagination.",
+        "operationId": "list-meters",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-indexed page number. Must be >= 1, else `400 INVALID_PARAMETERS`.",
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Page size. Must be >= 1, else `400 INVALID_PARAMETERS`. Defaults to 20.",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "items": [
+                        {
+                          "id": "55555555-5555-5555-5555-555555555555",
+                          "account_id": "00000000-0000-4000-8000-000000000002",
+                          "name": "Tokens Consumed",
+                          "description": "Meters LLM token consumption per billing cycle",
+                          "event_name": "tokens_consumed",
+                          "aggregation": "SUM",
+                          "unit_label": "token",
+                          "plural_unit_label": "tokens",
+                          "default_price": {
+                            "currency": "USD",
+                            "value": 0.002
+                          },
+                          "metadata": [
+                            {
+                              "key": "team",
+                              "value": "platform"
+                            }
+                          ],
+                          "status": "ACTIVE",
+                          "created_at": "2026-08-18T09:00:04.000000Z",
+                          "updated_at": "2026-08-18T09:00:04.000000Z"
+                        },
+                        {
+                          "id": "66666666-6666-6666-6666-666666666666",
+                          "account_id": "00000000-0000-4000-8000-000000000002",
+                          "name": "API Requests",
+                          "description": "Calls to the public API, one event per authenticated request",
+                          "event_name": "api_request",
+                          "aggregation": "COUNT",
+                          "unit_label": "request",
+                          "plural_unit_label": "requests",
+                          "default_price": {
+                            "currency": "USD",
+                            "value": 0.001
+                          },
+                          "metadata": [],
+                          "status": "ACTIVE",
+                          "created_at": "2026-08-18T09:00:04.000000Z",
+                          "updated_at": "2026-08-18T09:00:04.000000Z"
+                        }
+                      ],
+                      "pagination": {
+                        "page": 1,
+                        "size": 20,
+                        "total": 2,
+                        "total_pages": 1
+                      }
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "The unique identifier of the meter."
+                          },
+                          "account_id": {
+                            "type": "string",
+                            "description": "The unique identifier of the account that owns the meter."
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "event_name": {
+                            "type": "string"
+                          },
+                          "aggregation": {
+                            "type": "string",
+                            "enum": [
+                              "SUM",
+                              "COUNT",
+                              "LAST"
+                            ]
+                          },
+                          "unit_label": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "plural_unit_label": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "default_price": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "ACTIVE",
+                              "INACTIVE"
+                            ],
+                            "example": "ACTIVE"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "page": {
+                          "type": "integer"
+                        },
+                        "size": {
+                          "type": "integer"
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "total_pages": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The page must be greater than or equal to 1"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/list-plan-meters.json
+++ b/openapi/meters/list-plan-meters.json
@@ -1,0 +1,227 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/plans/{plan_id}/meters": {
+      "get": {
+        "summary": "List Plan Meters",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Returns every metered price attached to a plan. The same list is embedded as `meters[]` on Retrieve Plan.",
+        "operationId": "list-plan-meters",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the plan.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "items": [
+                        {
+                          "id": "77777777-7777-7777-7777-777777777777",
+                          "plan_id": "00000000-0000-4000-8000-000000000001",
+                          "meter_id": "66666666-6666-6666-6666-666666666666",
+                          "credits": 100.5,
+                          "pricing_strategy": "PER_UNIT",
+                          "price_per_credit": {
+                            "currency": "USD",
+                            "value": 0.05
+                          },
+                          "country_prices": [
+                            {
+                              "country": "US",
+                              "amount": {
+                                "currency": "USD",
+                                "value": 0.06
+                              }
+                            }
+                          ],
+                          "created_at": "2026-08-18T09:00:04.000000Z",
+                          "updated_at": "2026-08-18T09:00:04.000000Z"
+                        },
+                        {
+                          "id": "88888888-8888-8888-8888-888888888888",
+                          "plan_id": "00000000-0000-4000-8000-000000000001",
+                          "meter_id": "55555555-5555-5555-5555-555555555555",
+                          "credits": 10000,
+                          "pricing_strategy": "PER_UNIT",
+                          "price_per_credit": {
+                            "currency": "USD",
+                            "value": 0.002
+                          },
+                          "country_prices": [],
+                          "created_at": "2026-08-18T09:00:04.000000Z",
+                          "updated_at": "2026-08-18T09:00:04.000000Z"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "The unique identifier of the metered price (the plan-meter relation)."
+                          },
+                          "plan_id": {
+                            "type": "string"
+                          },
+                          "meter_id": {
+                            "type": "string"
+                          },
+                          "credits": {
+                            "type": "number",
+                            "description": "Units included in the plan per billing cycle."
+                          },
+                          "pricing_strategy": {
+                            "type": "string",
+                            "enum": [
+                              "PER_UNIT",
+                              "PACKAGE",
+                              "TIERED"
+                            ]
+                          },
+                          "price_per_credit": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "country_prices": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "country": {
+                                  "type": "string"
+                                },
+                                "amount": {
+                                  "type": "object",
+                                  "properties": {
+                                    "currency": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "number"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "PLAN_NOT_FOUND",
+                      "messages": [
+                        "The plan does not exist or is not linked to this account."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/list-plan-meters.json
+++ b/openapi/meters/list-plan-meters.json
@@ -38,7 +38,7 @@
     "/subscriptions/plans/{plan_id}/meters": {
       "get": {
         "summary": "List Plan Meters",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Returns every metered price attached to a plan. The same list is embedded as `meters[]` on Retrieve Plan.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Returns every metered price attached to a plan. The same list is embedded as `meters[]` on Retrieve Plan.",
         "operationId": "list-plan-meters",
         "parameters": [
           {
@@ -169,10 +169,12 @@
                             }
                           },
                           "created_at": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Set by Yuno on creation."
                           },
                           "updated_at": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Set by Yuno on every update."
                           }
                         }
                       }
@@ -201,8 +203,8 @@
               }
             }
           },
-          "404": {
-            "description": "404",
+          "400": {
+            "description": "400",
             "content": {
               "application/json": {
                 "examples": {
@@ -220,6 +222,39 @@
                   "properties": {
                     "code": {
                       "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "Usage-based billing is not enabled for this organization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/list-plan-meters.json
+++ b/openapi/meters/list-plan-meters.json
@@ -59,7 +59,7 @@
                 "examples": {
                   "Result": {
                     "value": {
-                      "items": [
+                      "data": [
                         {
                           "id": "77777777-7777-7777-7777-777777777777",
                           "plan_id": "00000000-0000-4000-8000-000000000001",
@@ -88,22 +88,25 @@
                           "meter_id": "55555555-5555-5555-5555-555555555555",
                           "credits": 10000,
                           "pricing_strategy": "PER_UNIT",
-                          "price_per_credit": {
-                            "currency": "USD",
-                            "value": 0.002
-                          },
+                          "price_per_credit": null,
                           "country_prices": [],
                           "created_at": "2026-08-18T09:00:04.000000Z",
                           "updated_at": "2026-08-18T09:00:04.000000Z"
                         }
-                      ]
+                      ],
+                      "pagination": {
+                        "total": 2,
+                        "limit": 20,
+                        "offset": 0,
+                        "has_more": false
+                      }
                     }
                   }
                 },
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "items": {
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -132,6 +135,8 @@
                           },
                           "price_per_credit": {
                             "type": "object",
+                            "nullable": true,
+                            "description": "`null` when inherited from the meter's `default_price` (USD plans).",
                             "properties": {
                               "currency": {
                                 "type": "string"
@@ -169,6 +174,25 @@
                           "updated_at": {
                             "type": "string"
                           }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer",
+                          "description": "Total number of items."
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        },
+                        "has_more": {
+                          "type": "boolean",
+                          "description": "`true` when more items exist beyond `offset + limit`."
                         }
                       }
                     }

--- a/openapi/meters/report-usage-event.json
+++ b/openapi/meters/report-usage-event.json
@@ -38,7 +38,7 @@
     "/subscriptions/meters/events": {
       "post": {
         "summary": "Report Usage Event",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected in the response (`400`/`404`) and never counted. Replaying the same `event_id` returns the original response and never double counts. One event per request — there is no batch endpoint in this preview.",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected in the response (`400`/`404`) and never counted. Replaying the same `event_id` returns the original response — including the original `value`, even if the retry sent a different one — and never double counts. One event per request — there is no batch endpoint in this preview.",
         "operationId": "report-usage-event",
         "parameters": [
           {
@@ -72,7 +72,7 @@
                   },
                   "subscription_id": {
                     "type": "string",
-                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your organization. Usage is metered per subscription and billed on that subscription's renewal."
+                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your account, else `400 SUBSCRIPTION_NOT_FOUND`. Usage is metered per subscription and billed on that subscription's renewal."
                   },
                   "value": {
                     "type": "number",
@@ -109,17 +109,16 @@
                   "summary": "SUM meter — tokens consumed",
                   "value": {
                     "event_id": "11111111-1111-1111-1111-111111111111",
-                    "event_name": "tokens_consumed",
+                    "event_name": "ai_tokens",
                     "subscription_id": "33333333-3333-3333-3333-333333333333",
-                    "value": 42.5,
+                    "value": 1500,
                     "timestamp": "2026-08-18T09:00:04Z",
                     "metadata": [
                       {
-                        "key": "team",
-                        "value": "platform"
+                        "key": "model",
+                        "value": "llm-large"
                       }
-                    ],
-                    "meter_id": "55555555-5555-5555-5555-555555555555"
+                    ]
                   }
                 },
                 "Count meter (API request)": {
@@ -154,10 +153,10 @@
                     "value": {
                       "id": "22222222-2222-2222-2222-222222222222",
                       "event_id": "11111111-1111-1111-1111-111111111111",
-                      "event_name": "tokens_consumed",
+                      "event_name": "ai_tokens",
                       "meter_id": "55555555-5555-5555-5555-555555555555",
                       "subscription_id": "33333333-3333-3333-3333-333333333333",
-                      "value": 42.5,
+                      "value": 1500,
                       "received_at": "2026-08-18T09:00:04.000000Z"
                     }
                   }
@@ -197,6 +196,24 @@
             "content": {
               "application/json": {
                 "examples": {
+                  "Missing event_id": {
+                    "summary": "Missing event_id",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The event_id is required"
+                      ]
+                    }
+                  },
+                  "Unknown subscription": {
+                    "summary": "Unknown subscription",
+                    "value": {
+                      "code": "SUBSCRIPTION_NOT_FOUND",
+                      "messages": [
+                        "The subscription does not exist or is not linked to this account."
+                      ]
+                    }
+                  },
                   "Missing value on SUM meter": {
                     "summary": "Missing value on SUM meter",
                     "value": {
@@ -247,23 +264,14 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Unknown or inactive meter": {
-                    "summary": "Unknown or inactive meter",
+                  "Result": {
                     "value": {
                       "code": "METER_NOT_FOUND",
                       "messages": [
-                        "No active meter with event_name tokens_consumed exists for this account"
+                        "No active meter with event_name ai_tokens exists for this account"
                       ]
-                    }
-                  },
-                  "Unknown subscription": {
-                    "summary": "Unknown subscription",
-                    "value": {
-                      "code": "SUBSCRIPTION_NOT_FOUND",
-                      "messages": [
-                        "The subscription does not exist or is not linked to this organization."
-                      ]
-                    }
+                    },
+                    "summary": "Unknown or inactive meter"
                   }
                 },
                 "schema": {

--- a/openapi/meters/report-usage-event.json
+++ b/openapi/meters/report-usage-event.json
@@ -38,7 +38,7 @@
     "/subscriptions/meters/events": {
       "post": {
         "summary": "Report Usage Event",
-        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected with `400` and never counted. Replaying the same `event_id` returns the original response — including the original `consumed_value`, even if the retry sent a different one — and never double counts. Only `ACTIVE` and `TRIALING` subscriptions accept usage; any other status is rejected with `400 SUBSCRIPTION_NOT_ACTIVE`. One event per request.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected with `400` and never counted. Replaying the same `event_id` returns the original response — including the original `consumed_value`, even if the retry sent a different one — and never double counts. `ACTIVE`, `TRIALING` and `PAST_DUE` subscriptions accept usage; any other status is rejected with `400 SUBSCRIPTION_NOT_ACTIVE`. One event per request.",
         "operationId": "report-usage-event",
         "parameters": [
           {
@@ -72,7 +72,7 @@
                   },
                   "subscription_id": {
                     "type": "string",
-                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your account (`400 SUBSCRIPTION_NOT_FOUND`) and be `ACTIVE` or `TRIALING` (`400 SUBSCRIPTION_NOT_ACTIVE`). Usage is metered per subscription and billed on that subscription's renewal."
+                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your account (`400 SUBSCRIPTION_NOT_FOUND`) and be `ACTIVE`, `TRIALING` or `PAST_DUE` (`400 SUBSCRIPTION_NOT_ACTIVE`). Usage is metered per subscription and billed on that subscription's renewal."
                   },
                   "consumed_value": {
                     "type": "number",

--- a/openapi/meters/report-usage-event.json
+++ b/openapi/meters/report-usage-event.json
@@ -1,0 +1,302 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/meters/events": {
+      "post": {
+        "summary": "Report Usage Event",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected in the response (`400`/`404`) and never counted. Replaying the same `event_id` returns the original response and never double counts. One event per request — there is no batch endpoint in this preview.",
+        "operationId": "report-usage-event",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Idempotency-Key",
+            "schema": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "event_id",
+                  "event_name",
+                  "subscription_id"
+                ],
+                "properties": {
+                  "event_id": {
+                    "type": "string",
+                    "description": "Your unique identifier for this event — the idempotency key. Unique per account. Re-sending the same `event_id` returns the same response (including the original `value`) and never counts the usage twice, regardless of retries."
+                  },
+                  "event_name": {
+                    "type": "string",
+                    "description": "The `event_name` of the meter this event belongs to. Resolves the meter within your account; an unknown or `INACTIVE` meter is rejected with `404 METER_NOT_FOUND`."
+                  },
+                  "subscription_id": {
+                    "type": "string",
+                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your organization. Usage is metered per subscription and billed on that subscription's renewal."
+                  },
+                  "value": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "The numeric value of the event (decimals allowed). Required for `SUM` and `LAST` meters (\"The value is required for a SUM meter\"). Optional for `COUNT` meters — defaults to 1."
+                  },
+                  "timestamp": {
+                    "type": "string",
+                    "description": "When the usage happened (ISO 8601 with offset). Defaults to the time the event is received. Backdating is accepted up to 35 days in the past; older timestamps are rejected with `400 INVALID_PARAMETERS`."
+                  },
+                  "metadata": {
+                    "type": "array",
+                    "description": "Optional key-value pairs stored with the event (MAX 48 entries; value MAX 512).",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "meter_id": {
+                    "type": "string",
+                    "description": "Optional guard. When sent, it must match the meter resolved from `event_name`, else `400 INVALID_PARAMETERS`."
+                  }
+                }
+              },
+              "examples": {
+                "Sum meter (tokens)": {
+                  "summary": "SUM meter — tokens consumed",
+                  "value": {
+                    "event_id": "11111111-1111-1111-1111-111111111111",
+                    "event_name": "tokens_consumed",
+                    "subscription_id": "33333333-3333-3333-3333-333333333333",
+                    "value": 42.5,
+                    "timestamp": "2026-08-18T09:00:04Z",
+                    "metadata": [
+                      {
+                        "key": "team",
+                        "value": "platform"
+                      }
+                    ],
+                    "meter_id": "55555555-5555-5555-5555-555555555555"
+                  }
+                },
+                "Count meter (API request)": {
+                  "summary": "COUNT meter — value omitted, counts as 1",
+                  "value": {
+                    "event_id": "req_01J5Y3Q9K8ZC5G6E4Y2W7X8N9M",
+                    "event_name": "api_request",
+                    "subscription_id": "33333333-3333-3333-3333-333333333333"
+                  }
+                },
+                "Last meter (storage)": {
+                  "summary": "LAST meter — current gigabytes held",
+                  "value": {
+                    "event_id": "storage-2026-08-18T09:00-sub-3333",
+                    "event_name": "storage_gb",
+                    "subscription_id": "33333333-3333-3333-3333-333333333333",
+                    "value": 128.4,
+                    "timestamp": "2026-08-18T09:00:00Z"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "22222222-2222-2222-2222-222222222222",
+                      "event_id": "11111111-1111-1111-1111-111111111111",
+                      "event_name": "tokens_consumed",
+                      "meter_id": "55555555-5555-5555-5555-555555555555",
+                      "subscription_id": "33333333-3333-3333-3333-333333333333",
+                      "value": 42.5,
+                      "received_at": "2026-08-18T09:00:04.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Yuno's identifier for the stored event."
+                    },
+                    "event_id": {
+                      "type": "string"
+                    },
+                    "event_name": {
+                      "type": "string"
+                    },
+                    "meter_id": {
+                      "type": "string"
+                    },
+                    "subscription_id": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "number"
+                    },
+                    "received_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Missing value on SUM meter": {
+                    "summary": "Missing value on SUM meter",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The value is required for a SUM meter"
+                      ]
+                    }
+                  },
+                  "Timestamp too old": {
+                    "summary": "Timestamp too old",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The timestamp cannot be more than 35 days in the past"
+                      ]
+                    }
+                  },
+                  "meter_id mismatch": {
+                    "summary": "meter_id mismatch",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The meter_id does not match the meter resolved from event_name"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Unknown or inactive meter": {
+                    "summary": "Unknown or inactive meter",
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "No active meter with event_name tokens_consumed exists for this account"
+                      ]
+                    }
+                  },
+                  "Unknown subscription": {
+                    "summary": "Unknown subscription",
+                    "value": {
+                      "code": "SUBSCRIPTION_NOT_FOUND",
+                      "messages": [
+                        "The subscription does not exist or is not linked to this organization."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/report-usage-event.json
+++ b/openapi/meters/report-usage-event.json
@@ -38,17 +38,17 @@
     "/subscriptions/meters/events": {
       "post": {
         "summary": "Report Usage Event",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected in the response (`400`/`404`) and never counted. Replaying the same `event_id` returns the original response — including the original `value`, even if the retry sent a different one — and never double counts. One event per request — there is no batch endpoint in this preview.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Reports one usage event against a subscription. The meter is resolved from `event_name`. Validation is synchronous: a malformed or unresolvable event is rejected with `400` and never counted. Replaying the same `event_id` returns the original response — including the original `consumed_value`, even if the retry sent a different one — and never double counts. Only `ACTIVE` and `TRIALING` subscriptions accept usage; any other status is rejected with `400 SUBSCRIPTION_NOT_ACTIVE`. One event per request.",
         "operationId": "report-usage-event",
         "parameters": [
           {
             "in": "header",
             "name": "X-Idempotency-Key",
+            "required": true,
             "schema": {
-              "type": "string",
-              "maxLength": 64
+              "type": "string"
             },
-            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+            "description": "Unique identifier used in HTTP headers to ensure that a request is processed only once, even if it is retried due to network issues or timeouts. Required on every write request of this feature."
           }
         ],
         "requestBody": {
@@ -68,20 +68,20 @@
                   },
                   "event_name": {
                     "type": "string",
-                    "description": "The `event_name` of the meter this event belongs to. Resolves the meter within your account; an unknown or `INACTIVE` meter is rejected with `404 METER_NOT_FOUND`."
+                    "description": "The `event_name` of the meter this event belongs to. Resolves the meter within your account; an unknown or `INACTIVE` meter is rejected with `400 METER_NOT_FOUND`."
                   },
                   "subscription_id": {
                     "type": "string",
-                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your account, else `400 SUBSCRIPTION_NOT_FOUND`. Usage is metered per subscription and billed on that subscription's renewal."
+                    "description": "The unique identifier of the subscription the usage is attributed to (MAX 64; MIN 36). Must exist in your account (`400 SUBSCRIPTION_NOT_FOUND`) and be `ACTIVE` or `TRIALING` (`400 SUBSCRIPTION_NOT_ACTIVE`). Usage is metered per subscription and billed on that subscription's renewal."
                   },
-                  "value": {
+                  "consumed_value": {
                     "type": "number",
                     "format": "float",
-                    "description": "The numeric value of the event (decimals allowed). Required for `SUM` and `LAST` meters (\"The value is required for a SUM meter\"). Optional for `COUNT` meters — defaults to 1."
+                    "description": "The numeric value of the event (decimals allowed). Required for `SUM` and `LAST` meters (\"The consumed_value is required for a SUM meter\"). Optional for `COUNT` meters — defaults to 1."
                   },
-                  "timestamp": {
+                  "occurred_at": {
                     "type": "string",
-                    "description": "When the usage happened (ISO 8601 with offset). Defaults to the time the event is received. Backdating is accepted up to 35 days in the past; older timestamps are rejected with `400 INVALID_PARAMETERS`."
+                    "description": "When the usage happened (ISO 8601 with offset). Defaults to the time the event is received. Backdating is accepted up to 35 days in the past; older values are rejected with `400 INVALID_PARAMETERS`. `occurred_at` decides which billing cycle the event lands in."
                   },
                   "metadata": {
                     "type": "array",
@@ -111,8 +111,8 @@
                     "event_id": "11111111-1111-1111-1111-111111111111",
                     "event_name": "ai_tokens",
                     "subscription_id": "33333333-3333-3333-3333-333333333333",
-                    "value": 1500,
-                    "timestamp": "2026-08-18T09:00:04Z",
+                    "consumed_value": 1500,
+                    "occurred_at": "2026-08-18T09:00:04Z",
                     "metadata": [
                       {
                         "key": "model",
@@ -122,7 +122,7 @@
                   }
                 },
                 "Count meter (API request)": {
-                  "summary": "COUNT meter — value omitted, counts as 1",
+                  "summary": "COUNT meter — consumed_value omitted, counts as 1",
                   "value": {
                     "event_id": "req_01J5Y3Q9K8ZC5G6E4Y2W7X8N9M",
                     "event_name": "api_request",
@@ -135,8 +135,8 @@
                     "event_id": "storage-2026-08-18T09:00-sub-3333",
                     "event_name": "storage_gb",
                     "subscription_id": "33333333-3333-3333-3333-333333333333",
-                    "value": 128.4,
-                    "timestamp": "2026-08-18T09:00:00Z"
+                    "consumed_value": 128.4,
+                    "occurred_at": "2026-08-18T09:00:00Z"
                   }
                 }
               }
@@ -156,7 +156,7 @@
                       "event_name": "ai_tokens",
                       "meter_id": "55555555-5555-5555-5555-555555555555",
                       "subscription_id": "33333333-3333-3333-3333-333333333333",
-                      "value": 1500,
+                      "consumed_value": 1500,
                       "received_at": "2026-08-18T09:00:04.000000Z"
                     }
                   }
@@ -180,11 +180,12 @@
                     "subscription_id": {
                       "type": "string"
                     },
-                    "value": {
+                    "consumed_value": {
                       "type": "number"
                     },
                     "received_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "When Yuno received the event."
                     }
                   }
                 }
@@ -214,21 +215,30 @@
                       ]
                     }
                   },
-                  "Missing value on SUM meter": {
-                    "summary": "Missing value on SUM meter",
+                  "Missing consumed_value on SUM meter": {
+                    "summary": "Missing consumed_value on SUM meter",
                     "value": {
                       "code": "INVALID_PARAMETERS",
                       "messages": [
-                        "The value is required for a SUM meter"
+                        "The consumed_value is required for a SUM meter"
                       ]
                     }
                   },
-                  "Timestamp too old": {
-                    "summary": "Timestamp too old",
+                  "Subscription not active": {
+                    "summary": "Subscription not active",
+                    "value": {
+                      "code": "SUBSCRIPTION_NOT_ACTIVE",
+                      "messages": [
+                        "The subscription is not active"
+                      ]
+                    }
+                  },
+                  "occurred_at too old": {
+                    "summary": "occurred_at too old",
                     "value": {
                       "code": "INVALID_PARAMETERS",
                       "messages": [
-                        "The timestamp cannot be more than 35 days in the past"
+                        "The occurred_at cannot be more than 35 days in the past"
                       ]
                     }
                   },
@@ -240,6 +250,15 @@
                         "The meter_id does not match the meter resolved from event_name"
                       ]
                     }
+                  },
+                  "Result": {
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "No active meter with event_name ai_tokens exists for this account"
+                      ]
+                    },
+                    "summary": "Unknown or inactive meter"
                   }
                 },
                 "schema": {
@@ -259,26 +278,27 @@
               }
             }
           },
-          "404": {
-            "description": "404",
+          "403": {
+            "description": "403",
             "content": {
               "application/json": {
                 "examples": {
-                  "Result": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
                     "value": {
-                      "code": "METER_NOT_FOUND",
+                      "code": "PRODUCT_NOT_ENABLED",
                       "messages": [
-                        "No active meter with event_name ai_tokens exists for this account"
+                        "Usage-based billing is not enabled for this organization"
                       ]
-                    },
-                    "summary": "Unknown or inactive meter"
+                    }
                   }
                 },
                 "schema": {
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/report-usage-event.json
+++ b/openapi/meters/report-usage-event.json
@@ -64,7 +64,7 @@
                 "properties": {
                   "event_id": {
                     "type": "string",
-                    "description": "Your unique identifier for this event — the idempotency key. Unique per account. Re-sending the same `event_id` returns the same response (including the original `value`) and never counts the usage twice, regardless of retries."
+                    "description": "Your unique identifier for this event — the idempotency key. Unique per account. Re-sending the same `event_id` returns the same response (including the original `consumed_value`) and never counts the usage twice, regardless of retries."
                   },
                   "event_name": {
                     "type": "string",

--- a/openapi/meters/retrieve-meter.json
+++ b/openapi/meters/retrieve-meter.json
@@ -61,9 +61,9 @@
                     "value": {
                       "id": "55555555-5555-5555-5555-555555555555",
                       "account_id": "00000000-0000-4000-8000-000000000002",
-                      "name": "Tokens Consumed",
-                      "description": "Meters LLM token consumption per billing cycle",
-                      "event_name": "tokens_consumed",
+                      "name": "AI tokens",
+                      "description": "LLM tokens consumed by model responses, reported once per response",
+                      "event_name": "ai_tokens",
                       "aggregation": "SUM",
                       "unit_label": "token",
                       "plural_unit_label": "tokens",

--- a/openapi/meters/retrieve-meter.json
+++ b/openapi/meters/retrieve-meter.json
@@ -38,7 +38,7 @@
     "/subscriptions/meters/{meter_id}": {
       "get": {
         "summary": "Retrieve Meter",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Retrieves a meter by its `id`.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Retrieves a meter by its `id`.",
         "operationId": "retrieve-meter",
         "parameters": [
           {
@@ -154,18 +154,20 @@
                       "example": "ACTIVE"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on creation."
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on every update."
                     }
                   }
                 }
               }
             }
           },
-          "404": {
-            "description": "404",
+          "400": {
+            "description": "400",
             "content": {
               "application/json": {
                 "examples": {
@@ -183,6 +185,39 @@
                   "properties": {
                     "code": {
                       "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
+                    "value": {
+                      "code": "PRODUCT_NOT_ENABLED",
+                      "messages": [
+                        "Usage-based billing is not enabled for this organization"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/retrieve-meter.json
+++ b/openapi/meters/retrieve-meter.json
@@ -1,0 +1,214 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/meters/{meter_id}": {
+      "get": {
+        "summary": "Retrieve Meter",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Retrieves a meter by its `id`.",
+        "operationId": "retrieve-meter",
+        "parameters": [
+          {
+            "name": "meter_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the meter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "55555555-5555-5555-5555-555555555555",
+                      "account_id": "00000000-0000-4000-8000-000000000002",
+                      "name": "Tokens Consumed",
+                      "description": "Meters LLM token consumption per billing cycle",
+                      "event_name": "tokens_consumed",
+                      "aggregation": "SUM",
+                      "unit_label": "token",
+                      "plural_unit_label": "tokens",
+                      "default_price": {
+                        "currency": "USD",
+                        "value": 0.002
+                      },
+                      "metadata": [
+                        {
+                          "key": "team",
+                          "value": "platform"
+                        }
+                      ],
+                      "status": "ACTIVE",
+                      "created_at": "2026-08-18T09:00:04.000000Z",
+                      "updated_at": "2026-08-18T09:00:04.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The unique identifier of the meter."
+                    },
+                    "account_id": {
+                      "type": "string",
+                      "description": "The unique identifier of the account that owns the meter."
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "event_name": {
+                      "type": "string"
+                    },
+                    "aggregation": {
+                      "type": "string",
+                      "enum": [
+                        "SUM",
+                        "COUNT",
+                        "LAST"
+                      ]
+                    },
+                    "unit_label": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "plural_unit_label": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "default_price": {
+                      "type": "object",
+                      "properties": {
+                        "currency": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ACTIVE",
+                        "INACTIVE"
+                      ],
+                      "example": "ACTIVE"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "The meter does not exist or is not linked to this account."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/update-meter.json
+++ b/openapi/meters/update-meter.json
@@ -38,7 +38,7 @@
     "/subscriptions/meters/{meter_id}": {
       "patch": {
         "summary": "Update Meter",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates the descriptive fields, default price or status of a meter. Send at least one field. `event_name` and `aggregation` are immutable — to change how a meter counts, create a new meter and archive this one (`status: INACTIVE`). An `INACTIVE` meter stops accepting usage events (`404 METER_NOT_FOUND` on ingestion) and frees its `event_name` for a new meter.",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates the descriptive fields, default price or status of a meter. Send at least one field. `event_name` and `aggregation` are immutable: if you send them they are silently ignored (no error) and the response shows the original values. Set `status: INACTIVE` to archive a meter — it stops accepting usage events (`404 METER_NOT_FOUND`), cannot be attached to plans, and its existing metered prices can no longer be edited (`404`); set `status: ACTIVE` to reactivate it. Archiving does not free the `event_name`: it stays reserved by the archived meter.",
         "operationId": "update-meter",
         "parameters": [
           {
@@ -106,7 +106,7 @@
                       "ACTIVE",
                       "INACTIVE"
                     ],
-                    "description": "Set to `INACTIVE` to archive the meter. There is no delete. Archiving does not detach the meter from plans it is already attached to."
+                    "description": "Set to `INACTIVE` to archive the meter, `ACTIVE` to reactivate it. There is no delete. Archiving does not detach the meter from plans it is already attached to, and its `event_name` remains reserved."
                   }
                 }
               },
@@ -141,9 +141,9 @@
                     "value": {
                       "id": "55555555-5555-5555-5555-555555555555",
                       "account_id": "00000000-0000-4000-8000-000000000002",
-                      "name": "Tokens Consumed",
-                      "description": "Meters LLM token consumption per billing cycle",
-                      "event_name": "tokens_consumed",
+                      "name": "AI tokens",
+                      "description": "LLM tokens consumed by model responses, reported once per response",
+                      "event_name": "ai_tokens",
                       "aggregation": "SUM",
                       "unit_label": "token",
                       "plural_unit_label": "tokens",

--- a/openapi/meters/update-meter.json
+++ b/openapi/meters/update-meter.json
@@ -256,7 +256,7 @@
                     "value": {
                       "code": "INVALID_PARAMETERS",
                       "messages": [
-                        "At least one field must be provided"
+                        "At least one field must be provided to update the meter"
                       ]
                     }
                   },

--- a/openapi/meters/update-meter.json
+++ b/openapi/meters/update-meter.json
@@ -1,0 +1,335 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/meters/{meter_id}": {
+      "patch": {
+        "summary": "Update Meter",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates the descriptive fields, default price or status of a meter. Send at least one field. `event_name` and `aggregation` are immutable — to change how a meter counts, create a new meter and archive this one (`status: INACTIVE`). An `INACTIVE` meter stops accepting usage events (`404 METER_NOT_FOUND` on ingestion) and frees its `event_name` for a new meter.",
+        "operationId": "update-meter",
+        "parameters": [
+          {
+            "name": "meter_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the meter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Idempotency-Key",
+            "schema": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The meter display name (MAX 255; MIN 3)."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "What the meter counts and how."
+                  },
+                  "unit_label": {
+                    "type": "string",
+                    "description": "Singular unit label."
+                  },
+                  "plural_unit_label": {
+                    "type": "string",
+                    "description": "Plural unit label."
+                  },
+                  "default_price": {
+                    "type": "object",
+                    "required": [
+                      "currency",
+                      "value"
+                    ],
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "description": "Must be `USD`, else `400 INVALID_PARAMETERS`."
+                      },
+                      "value": {
+                        "type": "number",
+                        "format": "float",
+                        "description": "Default price per unit beyond the included credits (multiple of 0.0001)."
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "ACTIVE",
+                      "INACTIVE"
+                    ],
+                    "description": "Set to `INACTIVE` to archive the meter. There is no delete. Archiving does not detach the meter from plans it is already attached to."
+                  }
+                }
+              },
+              "examples": {
+                "Archive": {
+                  "summary": "Archive the meter",
+                  "value": {
+                    "status": "INACTIVE"
+                  }
+                },
+                "Rename": {
+                  "summary": "Rename and change the default price",
+                  "value": {
+                    "name": "LLM Tokens",
+                    "default_price": {
+                      "currency": "USD",
+                      "value": 0.0025
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "55555555-5555-5555-5555-555555555555",
+                      "account_id": "00000000-0000-4000-8000-000000000002",
+                      "name": "Tokens Consumed",
+                      "description": "Meters LLM token consumption per billing cycle",
+                      "event_name": "tokens_consumed",
+                      "aggregation": "SUM",
+                      "unit_label": "token",
+                      "plural_unit_label": "tokens",
+                      "default_price": {
+                        "currency": "USD",
+                        "value": 0.002
+                      },
+                      "metadata": [
+                        {
+                          "key": "team",
+                          "value": "platform"
+                        }
+                      ],
+                      "status": "INACTIVE",
+                      "created_at": "2026-08-18T09:00:04.000000Z",
+                      "updated_at": "2026-08-18T12:15:00.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The unique identifier of the meter."
+                    },
+                    "account_id": {
+                      "type": "string",
+                      "description": "The unique identifier of the account that owns the meter."
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "event_name": {
+                      "type": "string"
+                    },
+                    "aggregation": {
+                      "type": "string",
+                      "enum": [
+                        "SUM",
+                        "COUNT",
+                        "LAST"
+                      ]
+                    },
+                    "unit_label": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "plural_unit_label": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "default_price": {
+                      "type": "object",
+                      "properties": {
+                        "currency": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ACTIVE",
+                        "INACTIVE"
+                      ],
+                      "example": "ACTIVE"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Empty body": {
+                    "summary": "Empty body",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "At least one field must be provided"
+                      ]
+                    }
+                  },
+                  "Non-USD default_price": {
+                    "summary": "Non-USD default_price",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The default_price currency must be USD"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "The meter does not exist or is not linked to this account."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/openapi/meters/update-meter.json
+++ b/openapi/meters/update-meter.json
@@ -38,7 +38,7 @@
     "/subscriptions/meters/{meter_id}": {
       "patch": {
         "summary": "Update Meter",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates the descriptive fields, default price or status of a meter. Send at least one field. `event_name` and `aggregation` are immutable: if you send them they are silently ignored (no error) and the response shows the original values. Set `status: INACTIVE` to archive a meter — it stops accepting usage events (`404 METER_NOT_FOUND`), cannot be attached to plans, and its existing metered prices can no longer be edited (`404`); set `status: ACTIVE` to reactivate it. Archiving does not free the `event_name`: it stays reserved by the archived meter.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Updates the descriptive fields, default price or status of a meter. Send at least one field. `event_name` and `aggregation` are immutable: if you send them they are silently ignored (no error) and the response shows the original values. Set `status: INACTIVE` to archive a meter — it stops accepting usage events (`400 METER_NOT_FOUND`), cannot be attached to plans, and its existing metered prices can no longer be edited (`400 PLAN_METER_NOT_FOUND`); set `status: ACTIVE` to reactivate it. Archiving does not free the `event_name`: it stays reserved by the archived meter.",
         "operationId": "update-meter",
         "parameters": [
           {
@@ -53,11 +53,11 @@
           {
             "in": "header",
             "name": "X-Idempotency-Key",
+            "required": true,
             "schema": {
-              "type": "string",
-              "maxLength": 64
+              "type": "string"
             },
-            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+            "description": "Unique identifier used in HTTP headers to ensure that a request is processed only once, even if it is retried due to network issues or timeouts. Required on every write request of this feature."
           }
         ],
         "requestBody": {
@@ -234,10 +234,12 @@
                       "example": "ACTIVE"
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on creation."
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on every update."
                     }
                   }
                 }
@@ -266,6 +268,14 @@
                         "The default_price currency must be USD"
                       ]
                     }
+                  },
+                  "Result": {
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "The meter does not exist or is not linked to this account."
+                      ]
+                    }
                   }
                 },
                 "schema": {
@@ -285,16 +295,17 @@
               }
             }
           },
-          "404": {
-            "description": "404",
+          "403": {
+            "description": "403",
             "content": {
               "application/json": {
                 "examples": {
-                  "Result": {
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
                     "value": {
-                      "code": "METER_NOT_FOUND",
+                      "code": "PRODUCT_NOT_ENABLED",
                       "messages": [
-                        "The meter does not exist or is not linked to this account."
+                        "Usage-based billing is not enabled for this organization"
                       ]
                     }
                   }
@@ -303,7 +314,8 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/update-plan-meter.json
+++ b/openapi/meters/update-plan-meter.json
@@ -267,6 +267,15 @@
             "content": {
               "application/json": {
                 "examples": {
+                  "Empty body": {
+                    "summary": "Empty body",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "At least one field must be provided"
+                      ]
+                    }
+                  },
                   "Currency mismatch": {
                     "summary": "Currency mismatch",
                     "value": {

--- a/openapi/meters/update-plan-meter.json
+++ b/openapi/meters/update-plan-meter.json
@@ -38,7 +38,7 @@
     "/subscriptions/plans/{plan_id}/meters/{meter_id}": {
       "patch": {
         "summary": "Update Plan Meter",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates a metered price already attached to a plan: included `credits`, `pricing_strategy`, `price_per_credit` and `country_prices`. Send at least one field. The change applies to usage rated from the subscription's next billing cycle onward. To stop billing a meter on a plan, archive the meter (Update Meter with `status: INACTIVE`) — there is no detach endpoint in this preview.",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates a metered price already attached to a plan: included `credits`, `pricing_strategy`, `price_per_credit` and `country_prices`. Send at least one field. The change applies to usage rated from the subscription's next billing cycle onward. If the meter is `INACTIVE` the metered price is frozen and this call returns `404`. To stop billing a meter on a plan, archive the meter (Update Meter with `status: INACTIVE`) — there is no detach endpoint in this preview.",
         "operationId": "update-plan-meter",
         "parameters": [
           {
@@ -103,13 +103,13 @@
                       "value": {
                         "type": "number",
                         "format": "float",
-                        "description": "Price per unit beyond the included credits (multiple of 0.0001). Optional only when the plan's base currency is `USD` and the meter has a `default_price` — it is then inherited from the meter. Required otherwise."
+                        "description": "Price per unit beyond the included credits (multiple of 0.0001). Optional only when the plan's base currency is `USD` and the meter has a `default_price` — the meter's default then applies and the metered price is returned with `price_per_credit: null`. Required otherwise."
                       }
                     }
                   },
                   "country_prices": {
                     "type": "array",
-                    "description": "Optional explicit per-country price per unit (one entry per country). A country not listed falls back to `price_per_credit`.",
+                    "description": "Optional explicit per-country price per unit. One entry per country — a repeated country is rejected with `400 INVALID_PARAMETERS`. A country not listed falls back to `price_per_credit`.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -216,6 +216,8 @@
                     },
                     "price_per_credit": {
                       "type": "object",
+                      "nullable": true,
+                      "description": "`null` when inherited from the meter's `default_price` (USD plans).",
                       "properties": {
                         "currency": {
                           "type": "string"
@@ -307,6 +309,15 @@
                         "The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED"
                       ]
                     }
+                  },
+                  "Duplicate country": {
+                    "summary": "Duplicate country",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The country_prices must not contain duplicate countries"
+                      ]
+                    }
                   }
                 },
                 "schema": {
@@ -331,8 +342,8 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Meter not attached to the plan": {
-                    "summary": "Meter not attached to the plan",
+                  "Meter not attached to the plan, or inactive": {
+                    "summary": "Meter not attached to the plan, or inactive",
                     "value": {
                       "code": "PLAN_METER_NOT_FOUND",
                       "messages": [

--- a/openapi/meters/update-plan-meter.json
+++ b/openapi/meters/update-plan-meter.json
@@ -38,7 +38,7 @@
     "/subscriptions/plans/{plan_id}/meters/{meter_id}": {
       "patch": {
         "summary": "Update Plan Meter",
-        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates a metered price already attached to a plan: included `credits`, `pricing_strategy`, `price_per_credit` and `country_prices`. Send at least one field. The change applies to usage rated from the subscription's next billing cycle onward. If the meter is `INACTIVE` the metered price is frozen and this call returns `404`. To stop billing a meter on a plan, archive the meter (Update Meter with `status: INACTIVE`) — there is no detach endpoint in this preview.",
+        "description": "Usage-based billing must be enabled for your organization before this endpoint accepts requests (otherwise `403 PRODUCT_NOT_ENABLED`). Updates a metered price already attached to a plan: included `credits`, `pricing_strategy`, `price_per_credit` and `country_prices`. Send at least one field. The change applies to usage rated from the subscription's next billing cycle onward. If the meter is `INACTIVE` the metered price is frozen and this call returns `400 PLAN_METER_NOT_FOUND`. To stop billing a meter on a plan, archive the meter (Update Meter with `status: INACTIVE`) — there is no detach endpoint.",
         "operationId": "update-plan-meter",
         "parameters": [
           {
@@ -62,11 +62,11 @@
           {
             "in": "header",
             "name": "X-Idempotency-Key",
+            "required": true,
             "schema": {
-              "type": "string",
-              "maxLength": 64
+              "type": "string"
             },
-            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+            "description": "Unique identifier used in HTTP headers to ensure that a request is processed only once, even if it is retried due to network issues or timeouts. Required on every write request of this feature."
           }
         ],
         "requestBody": {
@@ -87,7 +87,7 @@
                       "PACKAGE",
                       "TIERED"
                     ],
-                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced in this preview. `PACKAGE` and `TIERED` are accepted but reserved — their configuration fields and rating are not available yet."
+                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced today. `PACKAGE` and `TIERED` are accepted enum values but are not priced and have no configuration fields."
                   },
                   "price_per_credit": {
                     "type": "object",
@@ -250,10 +250,12 @@
                       }
                     },
                     "created_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on creation."
                     },
                     "updated_at": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Set by Yuno on every update."
                     }
                   }
                 }
@@ -318,6 +320,33 @@
                         "The country_prices must not contain duplicate countries"
                       ]
                     }
+                  },
+                  "Unknown or inactive meter": {
+                    "summary": "Unknown or inactive meter",
+                    "value": {
+                      "code": "METER_NOT_FOUND",
+                      "messages": [
+                        "The meter does not exist, is inactive or is not linked to this account."
+                      ]
+                    }
+                  },
+                  "Unknown plan": {
+                    "summary": "Unknown plan",
+                    "value": {
+                      "code": "PLAN_NOT_FOUND",
+                      "messages": [
+                        "The plan does not exist or is not linked to this account."
+                      ]
+                    }
+                  },
+                  "Meter not attached to the plan, or inactive": {
+                    "summary": "Meter not attached to the plan, or inactive",
+                    "value": {
+                      "code": "PLAN_METER_NOT_FOUND",
+                      "messages": [
+                        "The meter 66666666-6666-6666-6666-666666666666 is not assigned to this plan"
+                      ]
+                    }
                   }
                 },
                 "schema": {
@@ -337,26 +366,17 @@
               }
             }
           },
-          "404": {
-            "description": "404",
+          "403": {
+            "description": "403",
             "content": {
               "application/json": {
                 "examples": {
-                  "Meter not attached to the plan, or inactive": {
-                    "summary": "Meter not attached to the plan, or inactive",
+                  "Product not enabled": {
+                    "summary": "Product not enabled",
                     "value": {
-                      "code": "PLAN_METER_NOT_FOUND",
+                      "code": "PRODUCT_NOT_ENABLED",
                       "messages": [
-                        "The meter 66666666-6666-6666-6666-666666666666 is not assigned to this plan"
-                      ]
-                    }
-                  },
-                  "Unknown plan": {
-                    "summary": "Unknown plan",
-                    "value": {
-                      "code": "PLAN_NOT_FOUND",
-                      "messages": [
-                        "The plan does not exist or is not linked to this account."
+                        "Usage-based billing is not enabled for this organization"
                       ]
                     }
                   }
@@ -365,7 +385,8 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "PRODUCT_NOT_ENABLED"
                     },
                     "messages": {
                       "type": "array",

--- a/openapi/meters/update-plan-meter.json
+++ b/openapi/meters/update-plan-meter.json
@@ -87,7 +87,7 @@
                       "PACKAGE",
                       "TIERED"
                     ],
-                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced today. `PACKAGE` and `TIERED` are accepted enum values but are not priced and have no configuration fields."
+                    "description": "How usage beyond `credits` is priced: `PER_UNIT` (billable units × `price_per_credit`), `PACKAGE` (bundles of N units, partial bundle counts as a full one) or `TIERED` (graduated tiers, each band at its own rate)."
                   },
                   "price_per_credit": {
                     "type": "object",

--- a/openapi/meters/update-plan-meter.json
+++ b/openapi/meters/update-plan-meter.json
@@ -1,0 +1,386 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "meters",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "public-api-key",
+        "x-default": "<Your public-api-key>"
+      },
+      "sec1": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "private-secret-key",
+        "x-default": "<Your private-secret-key>"
+      }
+    }
+  },
+  "security": [
+    {
+      "sec0": [],
+      "sec1": []
+    }
+  ],
+  "paths": {
+    "/subscriptions/plans/{plan_id}/meters/{meter_id}": {
+      "patch": {
+        "summary": "Update Plan Meter",
+        "description": "**Early access (preview).** Usage-based billing is available on request and the contract may change before general availability. Updates a metered price already attached to a plan: included `credits`, `pricing_strategy`, `price_per_credit` and `country_prices`. Send at least one field. The change applies to usage rated from the subscription's next billing cycle onward. To stop billing a meter on a plan, archive the meter (Update Meter with `status: INACTIVE`) — there is no detach endpoint in this preview.",
+        "operationId": "update-plan-meter",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the plan.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "meter_id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the meter attached to the plan.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Idempotency-Key",
+            "schema": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "description": "Optional. Free-form string (MAX 64). Re-sending the same key with the same body returns the original response."
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credits": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Units included in the plan per billing cycle — the allowance a subscriber can consume before any usage is billed. Must be >= 0. `0` means every unit is billed."
+                  },
+                  "pricing_strategy": {
+                    "type": "string",
+                    "enum": [
+                      "PER_UNIT",
+                      "PACKAGE",
+                      "TIERED"
+                    ],
+                    "description": "How usage beyond `credits` is priced. Only `PER_UNIT` (billable units × `price_per_credit`) is priced in this preview. `PACKAGE` and `TIERED` are accepted but reserved — their configuration fields and rating are not available yet."
+                  },
+                  "price_per_credit": {
+                    "type": "object",
+                    "required": [
+                      "currency",
+                      "value"
+                    ],
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "description": "MAX 3; MIN 3. Must equal the plan's `base_amount` currency, else `400 INVALID_PARAMETERS`."
+                      },
+                      "value": {
+                        "type": "number",
+                        "format": "float",
+                        "description": "Price per unit beyond the included credits (multiple of 0.0001). Optional only when the plan's base currency is `USD` and the meter has a `default_price` — it is then inherited from the meter. Required otherwise."
+                      }
+                    }
+                  },
+                  "country_prices": {
+                    "type": "array",
+                    "description": "Optional explicit per-country price per unit (one entry per country). A country not listed falls back to `price_per_credit`.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "country",
+                        "amount"
+                      ],
+                      "properties": {
+                        "country": {
+                          "type": "string",
+                          "description": "MAX 2; MIN 2; [ISO 3166-1](/reference/country-reference)."
+                        },
+                        "amount": {
+                          "type": "object",
+                          "required": [
+                            "currency",
+                            "value"
+                          ],
+                          "properties": {
+                            "currency": {
+                              "type": "string",
+                              "description": "MAX 3; MIN 3; [ISO 4217](/reference/country-reference)."
+                            },
+                            "value": {
+                              "type": "number",
+                              "format": "float",
+                              "description": "Multiple of 0.0001."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "Raise the allowance and lower the unit price": {
+                  "value": {
+                    "credits": 250,
+                    "price_per_credit": {
+                      "currency": "USD",
+                      "value": 0.04
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": {
+                      "id": "77777777-7777-7777-7777-777777777777",
+                      "plan_id": "00000000-0000-4000-8000-000000000001",
+                      "meter_id": "66666666-6666-6666-6666-666666666666",
+                      "credits": 250,
+                      "pricing_strategy": "PER_UNIT",
+                      "price_per_credit": {
+                        "currency": "USD",
+                        "value": 0.04
+                      },
+                      "country_prices": [
+                        {
+                          "country": "US",
+                          "amount": {
+                            "currency": "USD",
+                            "value": 0.06
+                          }
+                        }
+                      ],
+                      "created_at": "2026-08-18T09:00:04.000000Z",
+                      "updated_at": "2026-08-18T12:15:00.000000Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The unique identifier of the metered price (the plan-meter relation)."
+                    },
+                    "plan_id": {
+                      "type": "string"
+                    },
+                    "meter_id": {
+                      "type": "string"
+                    },
+                    "credits": {
+                      "type": "number",
+                      "description": "Units included in the plan per billing cycle."
+                    },
+                    "pricing_strategy": {
+                      "type": "string",
+                      "enum": [
+                        "PER_UNIT",
+                        "PACKAGE",
+                        "TIERED"
+                      ]
+                    },
+                    "price_per_credit": {
+                      "type": "object",
+                      "properties": {
+                        "currency": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "country_prices": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "country": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Currency mismatch": {
+                    "summary": "Currency mismatch",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The price_per_credit currency must match the plan base currency"
+                      ]
+                    }
+                  },
+                  "Missing price on non-USD plan": {
+                    "summary": "Missing price on non-USD plan",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "A price_per_credit is required when the plan base currency is not USD"
+                      ]
+                    }
+                  },
+                  "Missing price and no default": {
+                    "summary": "Missing price and no default",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "A price_per_credit is required when the meter has no default_price"
+                      ]
+                    }
+                  },
+                  "Negative credits": {
+                    "summary": "Negative credits",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The meter credits must be greater than or equal to 0"
+                      ]
+                    }
+                  },
+                  "Invalid strategy": {
+                    "summary": "Invalid strategy",
+                    "value": {
+                      "code": "INVALID_PARAMETERS",
+                      "messages": [
+                        "The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Meter not attached to the plan": {
+                    "summary": "Meter not attached to the plan",
+                    "value": {
+                      "code": "PLAN_METER_NOT_FOUND",
+                      "messages": [
+                        "The meter 66666666-6666-6666-6666-666666666666 is not assigned to this plan"
+                      ]
+                    }
+                  },
+                  "Unknown plan": {
+                    "summary": "Unknown plan",
+                    "value": {
+                      "code": "PLAN_NOT_FOUND",
+                      "messages": [
+                        "The plan does not exist or is not linked to this account."
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "x-readme": {
+    "headers": [
+      {
+        "value": "utf-8",
+        "key": "charset"
+      }
+    ],
+    "explorer-enabled": true,
+    "proxy-enabled": true
+  },
+  "x-readme-fauxas": true
+}

--- a/reference/meters/attach-meter-to-plan.mdx
+++ b/reference/meters/attach-meter-to-plan.mdx
@@ -5,13 +5,13 @@ hidden: true
 description: "Attaches a meter to an existing plan as a metered price: included credits per cycle plus the price per unit beyond them."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
-The plan's flat price and existing subscribers' base amount never change when you attach a meter. Every subscription on the plan inherits the metered price and can start reporting usage right away.
+`X-Idempotency-Key` is required. The plan's flat price and existing subscribers' base amount never change when you attach a meter. Every subscription on the plan inherits the metered price and can start reporting usage right away.
 
 <Note>
 **Two ways to attach**
@@ -23,7 +23,7 @@ The plan's flat price and existing subscribers' base amount never change when yo
 <Note>
 **Price inheritance**
 
-If the plan's base currency is `USD` and the meter has a `default_price`, you can omit `price_per_credit`: the meter's default applies and the metered price is returned with `price_per_credit: null`. In any other case (`price_per_credit` currency must always equal the plan's base currency) send it explicitly. Only `ACTIVE` meters can be attached; an archived meter is rejected with `404 METER_NOT_FOUND`.
+If the plan's base currency is `USD` and the meter has a `default_price`, you can omit `price_per_credit`: the meter's default applies and the metered price is returned with `price_per_credit: null`. In any other case (`price_per_credit` currency must always equal the plan's base currency) send it explicitly. Only `ACTIVE` meters can be attached; an archived meter is rejected with `400 METER_NOT_FOUND`.
 </Note>
 
 See [The Metered Price Object](/reference/meters/the-metered-price-object) for every field. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/attach-meter-to-plan.mdx
+++ b/reference/meters/attach-meter-to-plan.mdx
@@ -1,0 +1,29 @@
+---
+title: "Attach Meter to Plan"
+openapi: "/openapi/meters/attach-meter-to-plan.json POST /subscriptions/plans/{plan_id}/meters"
+hidden: true
+description: "Attaches a meter to an existing plan as a metered price: included credits per cycle plus the price per unit beyond them."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+The plan's flat price and existing subscribers' base amount never change when you attach a meter. Every subscription on the plan inherits the metered price and can start reporting usage right away.
+
+<Note>
+**Two ways to attach**
+
+- **On creation:** pass `meters[]` (same shape as this request body) to [Create Plan](/reference/plans/create-plan). Duplicated `meter_id` entries are rejected with `409`.
+- **On a live plan:** call this endpoint once per meter, or send `{ "meters": [ ... ] }` to `PATCH /subscriptions/plans/{plan_id}` — that PATCH is attach-only and accepts no other plan field.
+</Note>
+
+<Note>
+**Price inheritance**
+
+If the plan's base currency is `USD` and the meter has a `default_price`, you can omit `price_per_credit` and the meter's default is used. In any other case (`price_per_credit` currency must always equal the plan's base currency) send it explicitly.
+</Note>
+
+See [The Metered Price Object](/reference/meters/the-metered-price-object) for every field. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/attach-meter-to-plan.mdx
+++ b/reference/meters/attach-meter-to-plan.mdx
@@ -17,13 +17,13 @@ The plan's flat price and existing subscribers' base amount never change when yo
 **Two ways to attach**
 
 - **On creation:** pass `meters[]` (same shape as this request body) to [Create Plan](/reference/plans/create-plan). Duplicated `meter_id` entries are rejected with `409`.
-- **On a live plan:** call this endpoint once per meter, or send `{ "meters": [ ... ] }` to `PATCH /subscriptions/plans/{plan_id}` — that PATCH is attach-only and accepts no other plan field.
+- **On a live plan:** call this endpoint once per meter, or send `{ "meters": [ ... ] }` to `PATCH /subscriptions/plans/{plan_id}` — that PATCH is attach-only and atomic: if any entry in the list is invalid (already attached, unknown or inactive meter, bad price) nothing is attached. Any other plan field in that body (`name`, `base_amount`, …) is silently ignored — plans stay immutable outside `meters[]`.
 </Note>
 
 <Note>
 **Price inheritance**
 
-If the plan's base currency is `USD` and the meter has a `default_price`, you can omit `price_per_credit` and the meter's default is used. In any other case (`price_per_credit` currency must always equal the plan's base currency) send it explicitly.
+If the plan's base currency is `USD` and the meter has a `default_price`, you can omit `price_per_credit`: the meter's default applies and the metered price is returned with `price_per_credit: null`. In any other case (`price_per_credit` currency must always equal the plan's base currency) send it explicitly. Only `ACTIVE` meters can be attached; an archived meter is rejected with `404 METER_NOT_FOUND`.
 </Note>
 
 See [The Metered Price Object](/reference/meters/the-metered-price-object) for every field. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/create-meter.mdx
+++ b/reference/meters/create-meter.mdx
@@ -5,11 +5,11 @@ hidden: true
 description: "Creates a meter — a named, countable action of your product — that plans can price and subscriptions report usage against."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 <Note>
 **`event_name` and `aggregation` are immutable**
@@ -17,4 +17,4 @@ Usage-based billing is in preview and available on request. The contract documen
 They define what your systems send and how it counts, so they can't change after creation (a PATCH that includes them is silently ignored). To change either, create a new meter with a new `event_name` and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). `event_name` is unique per account across active **and** archived meters, so pick a name you won't need to reuse. `status` sent on creation is ignored — a new meter is always `ACTIVE`.
 </Note>
 
-See [The Meter Object](/reference/meters/the-meter-object) for every field, and the [Usage-Based Billing guide](/docs/payment-features/subscriptions/usage-based-billing) for the end-to-end flow. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.
+`X-Idempotency-Key` is required. See [The Meter Object](/reference/meters/the-meter-object) for every field, and the [Usage-Based Billing guide](/docs/payment-features/subscriptions/usage-based-billing) for the end-to-end flow. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/create-meter.mdx
+++ b/reference/meters/create-meter.mdx
@@ -1,0 +1,20 @@
+---
+title: "Create Meter"
+openapi: "/openapi/meters/create-meter.json POST /subscriptions/meters"
+hidden: true
+description: "Creates a meter — a named, countable action of your product — that plans can price and subscriptions report usage against."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+<Note>
+**`event_name` and `aggregation` are immutable**
+
+They define what your systems send and how it counts, so they can't change after creation. To change either, create a new meter and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archiving frees the `event_name` for reuse.
+</Note>
+
+See [The Meter Object](/reference/meters/the-meter-object) for every field, and the [Usage-Based Billing guide](/docs/payment-features/subscriptions/usage-based-billing) for the end-to-end flow. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/create-meter.mdx
+++ b/reference/meters/create-meter.mdx
@@ -14,7 +14,7 @@ Usage-based billing is in preview and available on request. The contract documen
 <Note>
 **`event_name` and `aggregation` are immutable**
 
-They define what your systems send and how it counts, so they can't change after creation. To change either, create a new meter and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). Archiving frees the `event_name` for reuse.
+They define what your systems send and how it counts, so they can't change after creation (a PATCH that includes them is silently ignored). To change either, create a new meter with a new `event_name` and archive the old one with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`). `event_name` is unique per account across active **and** archived meters, so pick a name you won't need to reuse. `status` sent on creation is ignored — a new meter is always `ACTIVE`.
 </Note>
 
 See [The Meter Object](/reference/meters/the-meter-object) for every field, and the [Usage-Based Billing guide](/docs/payment-features/subscriptions/usage-based-billing) for the end-to-end flow. Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/list-meters.mdx
+++ b/reference/meters/list-meters.mdx
@@ -1,0 +1,16 @@
+---
+title: "List Meters"
+openapi: "/openapi/meters/list-meters.json GET /subscriptions/meters"
+hidden: true
+description: "Returns a paginated list of the meters that belong to your account, including archived ones."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+<Note>
+The list includes `INACTIVE` (archived) meters. Filter on `status` client-side if you only want the meters currently accepting usage events.
+</Note>

--- a/reference/meters/list-meters.mdx
+++ b/reference/meters/list-meters.mdx
@@ -5,11 +5,11 @@ hidden: true
 description: "Returns a paginated (limit/offset) list of the meters that belong to your account, including archived ones."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 <Note>
 The list includes `INACTIVE` (archived) meters. Filter on `status` client-side if you only want the meters currently accepting usage events. Pagination is `limit`/`offset`, and the response wraps the meters in `data` with a `pagination` object (`total`, `limit`, `offset`, `has_more`).

--- a/reference/meters/list-meters.mdx
+++ b/reference/meters/list-meters.mdx
@@ -2,7 +2,7 @@
 title: "List Meters"
 openapi: "/openapi/meters/list-meters.json GET /subscriptions/meters"
 hidden: true
-description: "Returns a paginated list of the meters that belong to your account, including archived ones."
+description: "Returns a paginated (limit/offset) list of the meters that belong to your account, including archived ones."
 ---
 
 <Warning>
@@ -12,5 +12,5 @@ Usage-based billing is in preview and available on request. The contract documen
 </Warning>
 
 <Note>
-The list includes `INACTIVE` (archived) meters. Filter on `status` client-side if you only want the meters currently accepting usage events.
+The list includes `INACTIVE` (archived) meters. Filter on `status` client-side if you only want the meters currently accepting usage events. Pagination is `limit`/`offset`, and the response wraps the meters in `data` with a `pagination` object (`total`, `limit`, `offset`, `has_more`).
 </Note>

--- a/reference/meters/list-plan-meters.mdx
+++ b/reference/meters/list-plan-meters.mdx
@@ -5,10 +5,10 @@ hidden: true
 description: "Returns every metered price attached to a plan."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 The metered prices are returned in `data` with a `pagination` object (`total`, `limit`, `offset`, `has_more`). The same list is returned as `meters[]` on [Retrieve Plan](/reference/plans/retrieve-plan) — always an array, empty for a plan without metered prices.

--- a/reference/meters/list-plan-meters.mdx
+++ b/reference/meters/list-plan-meters.mdx
@@ -1,0 +1,14 @@
+---
+title: "List Plan Meters"
+openapi: "/openapi/meters/list-plan-meters.json GET /subscriptions/plans/{plan_id}/meters"
+hidden: true
+description: "Returns every metered price attached to a plan."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+The same list is returned as `meters[]` on [Retrieve Plan](/reference/plans/retrieve-plan).

--- a/reference/meters/list-plan-meters.mdx
+++ b/reference/meters/list-plan-meters.mdx
@@ -11,4 +11,4 @@ description: "Returns every metered price attached to a plan."
 Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
 </Warning>
 
-The same list is returned as `meters[]` on [Retrieve Plan](/reference/plans/retrieve-plan).
+The metered prices are returned in `data` with a `pagination` object (`total`, `limit`, `offset`, `has_more`). The same list is returned as `meters[]` on [Retrieve Plan](/reference/plans/retrieve-plan) — always an array, empty for a plan without metered prices.

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -31,7 +31,7 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/response-
 | 400 | `PLAN_NOT_FOUND` | Attach Meter to Plan, List Plan Meters, Update Plan Meter | The `plan_id` does not exist or is not linked to your account. |
 | 400 | `PLAN_METER_NOT_FOUND` | Update Plan Meter | The meter is not attached to this plan, or the meter is `INACTIVE` (its metered prices are frozen until it is reactivated). |
 | 400 | `SUBSCRIPTION_NOT_FOUND` | Report Usage Event | The `subscription_id` does not exist in your account. |
-| 400 | `SUBSCRIPTION_NOT_ACTIVE` | Report Usage Event | The subscription is not `ACTIVE` or `TRIALING` (for example `PAUSED`, `PAST_DUE`, `CANCELED`, `COMPLETED`). The event is rejected and nothing is counted — resume the subscription first. Message: "The subscription is not active". |
+| 400 | `SUBSCRIPTION_NOT_ACTIVE` | Report Usage Event | The subscription is `PAUSED`, `CANCELED` or `COMPLETED` (only `ACTIVE`, `TRIALING` and `PAST_DUE` accept usage). The event is rejected and nothing is counted — resume the subscription first. Message: "The subscription is not active". |
 | 409 | `METER_EVENT_NAME_CONFLICT` | Create Meter | A meter with the same `event_name` already exists in the account — active or archived. Choose another name (uniqueness is status-blind, so archiving does not free the name). |
 | 409 | `PLAN_METER_ALREADY_ASSIGNED` | Attach Meter to Plan, Create Plan (`meters[]`), `PATCH /subscriptions/plans/{plan_id}` | The meter is already attached to the plan — including when the same `meter_id` appears twice in one `meters[]` list. Use Update Plan Meter to change it. |
 

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -19,7 +19,7 @@ All lookup failures in this feature (unknown meter, plan, metered price or subsc
 }
 ```
 
-For general HTTP status semantics see [HTTP Response Codes](/reference/response-codes).
+For general HTTP status semantics see [HTTP Response Codes](/reference/getting-started/response-codes).
 
 ## Codes
 

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -49,10 +49,11 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/getting-s
 | The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Send one of the three supported strategies. |
 | The country_prices must not contain duplicate countries | Attach Meter to Plan, Update Plan Meter, Create Plan | One entry per country. |
 | The event_id is required | Report Usage Event | Always send your idempotency key. |
-| The consumed_value is required for a SUM meter (or LAST) | Report Usage Event | `consumed_value` is mandatory for `SUM` and `LAST` meters; only `COUNT` defaults to 1. |
+| The consumed_value is required for a SUM meter · The consumed_value is required for a LAST meter | Report Usage Event | `consumed_value` is mandatory for `SUM` and `LAST` meters (the message names the meter's aggregation); only `COUNT` defaults to 1. |
 | The occurred_at cannot be more than 35 days in the past | Report Usage Event | Report closer to real time, or drop events older than the 35-day window. |
 | The meter_id does not match the meter resolved from event_name | Report Usage Event | Either omit `meter_id` or make sure it belongs to the meter whose `event_name` you send. |
-| At least one field must be provided | Update Meter, Update Plan Meter | Send at least one updatable field in the PATCH body. |
+| At least one field must be provided to update the meter | Update Meter | Send at least one updatable field in the PATCH body. |
+| At least one field must be provided | Update Plan Meter | Send at least one of `credits`, `pricing_strategy`, `price_per_credit`, `country_prices`. |
 
 <Note>
 Treat both the code list and the message texts as open-ended: new codes and messages can be added. Match on `code` for control flow and log `messages` for diagnostics.

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -1,0 +1,54 @@
+---
+title: "Meter Error Codes"
+hidden: true
+description: "Error codes and messages returned by the meters, metered prices and usage event endpoints."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability.
+</Warning>
+
+Every error follows the standard shape used across the Subscriptions API:
+
+```json
+{
+  "code": "INVALID_PARAMETERS",
+  "messages": ["The price_per_credit currency must match the plan base currency"]
+}
+```
+
+For general HTTP status semantics see [HTTP Response Codes](/reference/response-codes).
+
+## Codes
+
+| HTTP | `code` | Returned by | When |
+| --- | --- | --- | --- |
+| 400 | `INVALID_PARAMETERS` | All endpoints | A field failed validation. `messages` carries one human-readable reason per failure — see the list below. |
+| 404 | `METER_NOT_FOUND` | Retrieve / Update Meter, Attach Meter to Plan, Report Usage Event | The `meter_id` does not exist or is not linked to your account — or, on usage events, no `ACTIVE` meter with that `event_name` exists (archived meters count as not found). |
+| 404 | `PLAN_NOT_FOUND` | Attach Meter to Plan, List Plan Meters, Update Plan Meter | The `plan_id` does not exist or is not linked to your account. |
+| 404 | `PLAN_METER_NOT_FOUND` | Update Plan Meter | The meter is not attached to this plan. Attach it first. |
+| 404 | `SUBSCRIPTION_NOT_FOUND` | Report Usage Event | The `subscription_id` does not exist in your organization. |
+| 409 | `METER_EVENT_NAME_CONFLICT` | Create Meter | An `ACTIVE` meter with the same `event_name` already exists in the account. Archive it or choose another name. |
+| 409 | `PLAN_METER_ALREADY_ASSIGNED` | Attach Meter to Plan, Create Plan (`meters[]`), `PATCH /subscriptions/plans/{plan_id}` | The meter is already attached to the plan — including when the same `meter_id` appears twice in one `meters[]` list. Use Update Plan Meter to change it. |
+
+## `INVALID_PARAMETERS` messages
+
+| Message | Endpoint | Fix |
+| --- | --- | --- |
+| The event_name must match ^[a-z0-9_.]+$ | Create Meter | Use lowercase letters, digits, `_` and `.` only (MAX 100). |
+| The default_price currency must be USD | Create / Update Meter | Only `USD` is accepted for `default_price` in this preview. Price non-USD plans explicitly with `price_per_credit`. |
+| The price_per_credit currency must match the plan base currency | Attach Meter to Plan, Update Plan Meter, Create Plan | Send `price_per_credit` in the plan's `base_amount` currency. |
+| A price_per_credit is required when the plan base currency is not USD | Attach Meter to Plan, Create Plan | Inheritance from `default_price` only works for USD plans — send the price. |
+| A price_per_credit is required when the meter has no default_price | Attach Meter to Plan, Create Plan | Send the price, or set a `default_price` on the meter first. |
+| The meter credits must be greater than or equal to 0 | Attach Meter to Plan, Update Plan Meter, Create Plan | `credits` cannot be negative. Use `0` to bill every unit. |
+| The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Use `PER_UNIT` — the only strategy priced in this preview. |
+| The value is required for a SUM meter (or LAST) | Report Usage Event | `value` is mandatory for `SUM` and `LAST` meters; only `COUNT` defaults to 1. |
+| The timestamp cannot be more than 35 days in the past | Report Usage Event | Report closer to real time, or drop events older than the 35-day window. |
+| The meter_id does not match the meter resolved from event_name | Report Usage Event | Either omit `meter_id` or make sure it belongs to the meter whose `event_name` you send. |
+| At least one field must be provided | Update Meter, Update Plan Meter | Send at least one updatable field in the PATCH body. |
+
+<Note>
+Treat both the code list and the message texts as open-ended: new codes and messages can be added while the feature is in preview. Match on `code` for control flow and log `messages` for diagnostics.
+</Note>

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -26,11 +26,11 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/response-
 | HTTP | `code` | Returned by | When |
 | --- | --- | --- | --- |
 | 400 | `INVALID_PARAMETERS` | All endpoints | A field failed validation. `messages` carries one human-readable reason per failure — see the list below. |
-| 404 | `METER_NOT_FOUND` | Retrieve / Update Meter, Attach Meter to Plan, Report Usage Event | The `meter_id` does not exist or is not linked to your account — or, on usage events, no `ACTIVE` meter with that `event_name` exists (archived meters count as not found). |
+| 404 | `METER_NOT_FOUND` | Retrieve / Update Meter, Attach Meter to Plan, Create Plan (`meters[]`), Report Usage Event | The `meter_id` does not exist or is not linked to your account, or the meter is `INACTIVE` (archived meters cannot be attached and reject usage events) — on usage events, no `ACTIVE` meter with that `event_name` exists. |
 | 404 | `PLAN_NOT_FOUND` | Attach Meter to Plan, List Plan Meters, Update Plan Meter | The `plan_id` does not exist or is not linked to your account. |
-| 404 | `PLAN_METER_NOT_FOUND` | Update Plan Meter | The meter is not attached to this plan. Attach it first. |
-| 404 | `SUBSCRIPTION_NOT_FOUND` | Report Usage Event | The `subscription_id` does not exist in your organization. |
-| 409 | `METER_EVENT_NAME_CONFLICT` | Create Meter | An `ACTIVE` meter with the same `event_name` already exists in the account. Archive it or choose another name. |
+| 404 | `PLAN_METER_NOT_FOUND` | Update Plan Meter | The meter is not attached to this plan, or the meter is `INACTIVE` (its metered prices are frozen until it is reactivated). |
+| 400 | `SUBSCRIPTION_NOT_FOUND` | Report Usage Event | The `subscription_id` does not exist in your account. Note the status is `400` (unlike the `404` for an unknown meter). |
+| 409 | `METER_EVENT_NAME_CONFLICT` | Create Meter | A meter with the same `event_name` already exists in the account — active or archived. Choose another name (uniqueness is status-blind, so archiving does not free the name). |
 | 409 | `PLAN_METER_ALREADY_ASSIGNED` | Attach Meter to Plan, Create Plan (`meters[]`), `PATCH /subscriptions/plans/{plan_id}` | The meter is already attached to the plan — including when the same `meter_id` appears twice in one `meters[]` list. Use Update Plan Meter to change it. |
 
 ## `INVALID_PARAMETERS` messages
@@ -38,12 +38,15 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/response-
 | Message | Endpoint | Fix |
 | --- | --- | --- |
 | The event_name must match ^[a-z0-9_.]+$ | Create Meter | Use lowercase letters, digits, `_` and `.` only (MAX 100). |
+| The account_id is required | Create Meter | Send the `account_id` of the account the meter belongs to. |
 | The default_price currency must be USD | Create / Update Meter | Only `USD` is accepted for `default_price` in this preview. Price non-USD plans explicitly with `price_per_credit`. |
 | The price_per_credit currency must match the plan base currency | Attach Meter to Plan, Update Plan Meter, Create Plan | Send `price_per_credit` in the plan's `base_amount` currency. |
 | A price_per_credit is required when the plan base currency is not USD | Attach Meter to Plan, Create Plan | Inheritance from `default_price` only works for USD plans — send the price. |
 | A price_per_credit is required when the meter has no default_price | Attach Meter to Plan, Create Plan | Send the price, or set a `default_price` on the meter first. |
 | The meter credits must be greater than or equal to 0 | Attach Meter to Plan, Update Plan Meter, Create Plan | `credits` cannot be negative. Use `0` to bill every unit. |
 | The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Use `PER_UNIT` — the only strategy priced in this preview. |
+| The country_prices must not contain duplicate countries | Attach Meter to Plan, Update Plan Meter, Create Plan | One entry per country. |
+| The event_id is required | Report Usage Event | Always send your idempotency key. |
 | The value is required for a SUM meter (or LAST) | Report Usage Event | `value` is mandatory for `SUM` and `LAST` meters; only `COUNT` defaults to 1. |
 | The timestamp cannot be more than 35 days in the past | Report Usage Event | Report closer to real time, or drop events older than the 35-day window. |
 | The meter_id does not match the meter resolved from event_name | Report Usage Event | Either omit `meter_id` or make sure it belongs to the meter whose `event_name` you send. |

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -46,7 +46,7 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/response-
 | A price_per_credit is required when the plan base currency is not USD | Attach Meter to Plan, Create Plan | Inheritance from `default_price` only works for USD plans — send the price. |
 | A price_per_credit is required when the meter has no default_price | Attach Meter to Plan, Create Plan | Send the price, or set a `default_price` on the meter first. |
 | The meter credits must be greater than or equal to 0 | Attach Meter to Plan, Update Plan Meter, Create Plan | `credits` cannot be negative. Use `0` to bill every unit. |
-| The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Use `PER_UNIT` — the only strategy priced today. |
+| The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Send one of the three supported strategies. |
 | The country_prices must not contain duplicate countries | Attach Meter to Plan, Update Plan Meter, Create Plan | One entry per country. |
 | The event_id is required | Report Usage Event | Always send your idempotency key. |
 | The consumed_value is required for a SUM meter (or LAST) | Report Usage Event | `consumed_value` is mandatory for `SUM` and `LAST` meters; only `COUNT` defaults to 1. |

--- a/reference/meters/meter-error-codes.mdx
+++ b/reference/meters/meter-error-codes.mdx
@@ -4,13 +4,13 @@ hidden: true
 description: "Error codes and messages returned by the meters, metered prices and usage event endpoints."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
-Every error follows the standard shape used across the Subscriptions API:
+All lookup failures in this feature (unknown meter, plan, metered price or subscription) return HTTP `400` with a specific `code` — never `404`. Every error follows the standard shape used across the Subscriptions API:
 
 ```json
 {
@@ -25,11 +25,13 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/response-
 
 | HTTP | `code` | Returned by | When |
 | --- | --- | --- | --- |
+| 403 | `PRODUCT_NOT_ENABLED` | All endpoints | Usage-based billing is not enabled for your organization. Contact your Yuno account manager. |
 | 400 | `INVALID_PARAMETERS` | All endpoints | A field failed validation. `messages` carries one human-readable reason per failure — see the list below. |
-| 404 | `METER_NOT_FOUND` | Retrieve / Update Meter, Attach Meter to Plan, Create Plan (`meters[]`), Report Usage Event | The `meter_id` does not exist or is not linked to your account, or the meter is `INACTIVE` (archived meters cannot be attached and reject usage events) — on usage events, no `ACTIVE` meter with that `event_name` exists. |
-| 404 | `PLAN_NOT_FOUND` | Attach Meter to Plan, List Plan Meters, Update Plan Meter | The `plan_id` does not exist or is not linked to your account. |
-| 404 | `PLAN_METER_NOT_FOUND` | Update Plan Meter | The meter is not attached to this plan, or the meter is `INACTIVE` (its metered prices are frozen until it is reactivated). |
-| 400 | `SUBSCRIPTION_NOT_FOUND` | Report Usage Event | The `subscription_id` does not exist in your account. Note the status is `400` (unlike the `404` for an unknown meter). |
+| 400 | `METER_NOT_FOUND` | Retrieve / Update Meter, Attach Meter to Plan, Create Plan (`meters[]`), Report Usage Event | The `meter_id` does not exist or is not linked to your account, or the meter is `INACTIVE` (archived meters cannot be attached and reject usage events) — on usage events, no `ACTIVE` meter with that `event_name` exists. |
+| 400 | `PLAN_NOT_FOUND` | Attach Meter to Plan, List Plan Meters, Update Plan Meter | The `plan_id` does not exist or is not linked to your account. |
+| 400 | `PLAN_METER_NOT_FOUND` | Update Plan Meter | The meter is not attached to this plan, or the meter is `INACTIVE` (its metered prices are frozen until it is reactivated). |
+| 400 | `SUBSCRIPTION_NOT_FOUND` | Report Usage Event | The `subscription_id` does not exist in your account. |
+| 400 | `SUBSCRIPTION_NOT_ACTIVE` | Report Usage Event | The subscription is not `ACTIVE` or `TRIALING` (for example `PAUSED`, `PAST_DUE`, `CANCELED`, `COMPLETED`). The event is rejected and nothing is counted — resume the subscription first. Message: "The subscription is not active". |
 | 409 | `METER_EVENT_NAME_CONFLICT` | Create Meter | A meter with the same `event_name` already exists in the account — active or archived. Choose another name (uniqueness is status-blind, so archiving does not free the name). |
 | 409 | `PLAN_METER_ALREADY_ASSIGNED` | Attach Meter to Plan, Create Plan (`meters[]`), `PATCH /subscriptions/plans/{plan_id}` | The meter is already attached to the plan — including when the same `meter_id` appears twice in one `meters[]` list. Use Update Plan Meter to change it. |
 
@@ -39,19 +41,19 @@ For general HTTP status semantics see [HTTP Response Codes](/reference/response-
 | --- | --- | --- |
 | The event_name must match ^[a-z0-9_.]+$ | Create Meter | Use lowercase letters, digits, `_` and `.` only (MAX 100). |
 | The account_id is required | Create Meter | Send the `account_id` of the account the meter belongs to. |
-| The default_price currency must be USD | Create / Update Meter | Only `USD` is accepted for `default_price` in this preview. Price non-USD plans explicitly with `price_per_credit`. |
+| The default_price currency must be USD | Create / Update Meter | Only `USD` is accepted for `default_price`. Price non-USD plans explicitly with `price_per_credit`. |
 | The price_per_credit currency must match the plan base currency | Attach Meter to Plan, Update Plan Meter, Create Plan | Send `price_per_credit` in the plan's `base_amount` currency. |
 | A price_per_credit is required when the plan base currency is not USD | Attach Meter to Plan, Create Plan | Inheritance from `default_price` only works for USD plans — send the price. |
 | A price_per_credit is required when the meter has no default_price | Attach Meter to Plan, Create Plan | Send the price, or set a `default_price` on the meter first. |
 | The meter credits must be greater than or equal to 0 | Attach Meter to Plan, Update Plan Meter, Create Plan | `credits` cannot be negative. Use `0` to bill every unit. |
-| The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Use `PER_UNIT` — the only strategy priced in this preview. |
+| The meter pricing_strategy must be one of PER_UNIT, PACKAGE, TIERED | Attach Meter to Plan, Update Plan Meter, Create Plan | Use `PER_UNIT` — the only strategy priced today. |
 | The country_prices must not contain duplicate countries | Attach Meter to Plan, Update Plan Meter, Create Plan | One entry per country. |
 | The event_id is required | Report Usage Event | Always send your idempotency key. |
-| The value is required for a SUM meter (or LAST) | Report Usage Event | `value` is mandatory for `SUM` and `LAST` meters; only `COUNT` defaults to 1. |
-| The timestamp cannot be more than 35 days in the past | Report Usage Event | Report closer to real time, or drop events older than the 35-day window. |
+| The consumed_value is required for a SUM meter (or LAST) | Report Usage Event | `consumed_value` is mandatory for `SUM` and `LAST` meters; only `COUNT` defaults to 1. |
+| The occurred_at cannot be more than 35 days in the past | Report Usage Event | Report closer to real time, or drop events older than the 35-day window. |
 | The meter_id does not match the meter resolved from event_name | Report Usage Event | Either omit `meter_id` or make sure it belongs to the meter whose `event_name` you send. |
 | At least one field must be provided | Update Meter, Update Plan Meter | Send at least one updatable field in the PATCH body. |
 
 <Note>
-Treat both the code list and the message texts as open-ended: new codes and messages can be added while the feature is in preview. Match on `code` for control flow and log `messages` for diagnostics.
+Treat both the code list and the message texts as open-ended: new codes and messages can be added. Match on `code` for control flow and log `messages` for diagnostics.
 </Note>

--- a/reference/meters/report-usage-event.mdx
+++ b/reference/meters/report-usage-event.mdx
@@ -1,0 +1,28 @@
+---
+title: "Report Usage Event"
+openapi: "/openapi/meters/report-usage-event.json POST /subscriptions/meters/events"
+hidden: true
+description: "Reports one usage event for a subscription against a meter, idempotent on event_id."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+Send one event per request. Yuno resolves the meter from `event_name`, validates the event synchronously and stores it against the `subscription_id`. Usage is aggregated per subscription and billing cycle according to the meter's `aggregation`, and any usage beyond the included `credits` is billed on the subscription's renewal charge.
+
+<Note>
+**`event_id` is your idempotency key**
+
+Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `value` — and the usage is never counted twice. `event_id` is unique per account.
+</Note>
+
+<Note>
+**Timestamps**
+
+`timestamp` defaults to the time Yuno receives the event. You can backdate up to 35 days; older timestamps are rejected with `400`. Which billing cycle an event lands in is decided by its `timestamp`, not by when it was received.
+</Note>
+
+Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/report-usage-event.mdx
+++ b/reference/meters/report-usage-event.mdx
@@ -16,13 +16,17 @@ Send one event per request. Yuno resolves the meter from `event_name`, validates
 <Note>
 **`event_id` is your idempotency key**
 
-Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `value` — and the usage is never counted twice. `event_id` is unique per account.
+Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `value`, even if the retry carried a different one (the retry's value is discarded) — and the usage is never counted twice. `event_id` is unique per account and required: a request without it is rejected with `400`.
 </Note>
 
 <Note>
 **Timestamps**
 
 `timestamp` defaults to the time Yuno receives the event. You can backdate up to 35 days; older timestamps are rejected with `400`. Which billing cycle an event lands in is decided by its `timestamp`, not by when it was received.
+</Note>
+
+<Note>
+An unknown `event_name` (or an archived meter) is a `404 METER_NOT_FOUND`; an unknown `subscription_id` is a `400 SUBSCRIPTION_NOT_FOUND`. Any `organization_code` you send in the body is ignored.
 </Note>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/report-usage-event.mdx
+++ b/reference/meters/report-usage-event.mdx
@@ -11,7 +11,7 @@ description: "Reports one usage event (consumed_value, occurred_at) for an activ
 Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
 </Note>
 
-Send one event per request, with a unique `X-Idempotency-Key` header. Yuno resolves the meter from `event_name`, validates the event synchronously and stores it against the `subscription_id`. Only `ACTIVE` and `TRIALING` subscriptions accept usage — any other status is rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted. Usage is aggregated per subscription and billing cycle according to the meter's `aggregation`, and any usage beyond the included `credits` is billed on the subscription's renewal charge.
+Send one event per request, with a unique `X-Idempotency-Key` header. Yuno resolves the meter from `event_name`, validates the event synchronously and stores it against the `subscription_id`. `ACTIVE`, `TRIALING` and `PAST_DUE` subscriptions accept usage — `PAUSED`, `CANCELED` and `COMPLETED` are rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted. Usage is aggregated per subscription and billing cycle according to the meter's `aggregation`, and any usage beyond the included `credits` is billed on the subscription's renewal charge.
 
 <Note>
 **`event_id` is your idempotency key**

--- a/reference/meters/report-usage-event.mdx
+++ b/reference/meters/report-usage-event.mdx
@@ -16,7 +16,7 @@ Send one event per request, with a unique `X-Idempotency-Key` header. Yuno resol
 <Note>
 **`event_id` is your idempotency key**
 
-Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `consumed_value`, even if the retry carried a different one (the retry's value is discarded) — and the usage is never counted twice. `event_id` is unique per account and required: a request without it is rejected with `400`.
+Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `consumed_value`, even if the retry carried a different one (the retry's value is discarded) — and the usage is never counted twice. `event_id` is unique per account and required: a request without it is rejected with `400`. Send both `event_id` and `X-Idempotency-Key` on every request: the header protects the HTTP call, `event_id` protects billing.
 </Note>
 
 <Note>
@@ -26,7 +26,7 @@ Generate a unique `event_id` for every event (a UUID or your own event/request i
 </Note>
 
 <Note>
-An unknown `event_name` (or an archived meter) is a `400 METER_NOT_FOUND`; an unknown `subscription_id` is a `400 SUBSCRIPTION_NOT_FOUND`. The event carries no `country` or `account_id` — both are resolved from the subscription. Any `organization_code` you send in the body is ignored.
+An unknown `event_name` (or an archived meter) is a `400 METER_NOT_FOUND`; an unknown `subscription_id` is a `400 SUBSCRIPTION_NOT_FOUND`. The event carries no `country` or `account_id` — both are resolved from the subscription.
 </Note>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/report-usage-event.mdx
+++ b/reference/meters/report-usage-event.mdx
@@ -2,31 +2,31 @@
 title: "Report Usage Event"
 openapi: "/openapi/meters/report-usage-event.json POST /subscriptions/meters/events"
 hidden: true
-description: "Reports one usage event for a subscription against a meter, idempotent on event_id."
+description: "Reports one usage event (consumed_value, occurred_at) for an active subscription against a meter, idempotent on event_id."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
-Send one event per request. Yuno resolves the meter from `event_name`, validates the event synchronously and stores it against the `subscription_id`. Usage is aggregated per subscription and billing cycle according to the meter's `aggregation`, and any usage beyond the included `credits` is billed on the subscription's renewal charge.
+Send one event per request, with a unique `X-Idempotency-Key` header. Yuno resolves the meter from `event_name`, validates the event synchronously and stores it against the `subscription_id`. Only `ACTIVE` and `TRIALING` subscriptions accept usage — any other status is rejected with `400 SUBSCRIPTION_NOT_ACTIVE` and nothing is counted. Usage is aggregated per subscription and billing cycle according to the meter's `aggregation`, and any usage beyond the included `credits` is billed on the subscription's renewal charge.
 
 <Note>
 **`event_id` is your idempotency key**
 
-Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `value`, even if the retry carried a different one (the retry's value is discarded) — and the usage is never counted twice. `event_id` is unique per account and required: a request without it is rejected with `400`.
+Generate a unique `event_id` for every event (a UUID or your own event/request id) and reuse it on retries. A replay returns the same response as the first call — including the original `consumed_value`, even if the retry carried a different one (the retry's value is discarded) — and the usage is never counted twice. `event_id` is unique per account and required: a request without it is rejected with `400`.
 </Note>
 
 <Note>
 **Timestamps**
 
-`timestamp` defaults to the time Yuno receives the event. You can backdate up to 35 days; older timestamps are rejected with `400`. Which billing cycle an event lands in is decided by its `timestamp`, not by when it was received.
+`occurred_at` defaults to the time Yuno receives the event (returned as `received_at`). You can backdate up to 35 days; older values are rejected with `400`. Which billing cycle an event lands in is decided by `occurred_at`, not by when it was received.
 </Note>
 
 <Note>
-An unknown `event_name` (or an archived meter) is a `404 METER_NOT_FOUND`; an unknown `subscription_id` is a `400 SUBSCRIPTION_NOT_FOUND`. Any `organization_code` you send in the body is ignored.
+An unknown `event_name` (or an archived meter) is a `400 METER_NOT_FOUND`; an unknown `subscription_id` is a `400 SUBSCRIPTION_NOT_FOUND`. The event carries no `country` or `account_id` — both are resolved from the subscription. Any `organization_code` you send in the body is ignored.
 </Note>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/retrieve-meter.mdx
+++ b/reference/meters/retrieve-meter.mdx
@@ -1,0 +1,14 @@
+---
+title: "Retrieve Meter"
+openapi: "/openapi/meters/retrieve-meter.json GET /subscriptions/meters/{meter_id}"
+hidden: true
+description: "Retrieves a single meter by its id."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/retrieve-meter.mdx
+++ b/reference/meters/retrieve-meter.mdx
@@ -5,10 +5,10 @@ hidden: true
 description: "Retrieves a single meter by its id."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/the-meter-object.mdx
+++ b/reference/meters/the-meter-object.mdx
@@ -4,11 +4,11 @@ hidden: true
 description: "Documents the meter object's attributes: event name, aggregation, unit labels, default price and status."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 ## Attributes
 
@@ -48,9 +48,9 @@ A meter is a named, countable action your product performs — tokens generated,
   How reported events roll up into the cycle quantity. Immutable after creation; a PATCH that includes it is silently ignored.
 
   Possible values:
-  - `SUM` = Adds the `value` of every event in the cycle. Use for consumption: tokens, minutes, messages, deliveries.
-  - `COUNT` = Counts events, ignoring `value` (each event counts as 1). Use for per-call pricing: API requests, jobs.
-  - `LAST` = Keeps the most recent `value` reported in the cycle (by `timestamp`). Use for gauges: gigabytes held, seats in use.
+  - `SUM` = Adds the `consumed_value` of every event in the cycle. Use for consumption: tokens, minutes, messages, deliveries.
+  - `COUNT` = Counts events, ignoring `consumed_value` (each event counts as 1). Use for per-call pricing: API requests, jobs.
+  - `LAST` = Keeps the most recent `consumed_value` reported in the cycle (by `occurred_at`). Use for gauges: gigabytes held, seats in use.
 </ParamField>
 
 <ParamField body="unit_label" type="string">
@@ -70,7 +70,7 @@ A meter is a named, countable action your product performs — tokens generated,
 
   <Expandable title="properties">
     <ParamField body="currency" type="enum">
-      MAX 3; MIN 3. Must be `USD` in this preview — any other currency is rejected with `400 INVALID_PARAMETERS`.
+      MAX 3; MIN 3. Must be `USD`  — any other currency is rejected with `400 INVALID_PARAMETERS`.
     </ParamField>
 
     <ParamField body="value" type="number">
@@ -104,11 +104,15 @@ A meter is a named, countable action your product performs — tokens generated,
 
   Possible values:
   - `ACTIVE` = The meter accepts usage events and can be attached to plans.
-  - `INACTIVE` = Archived. Usage events for its `event_name` are rejected with `404 METER_NOT_FOUND`, it cannot be attached to plans, and its existing metered prices are frozen. The `event_name` stays reserved. Set through [Update Meter](/reference/meters/update-meter) and reversible (`status: ACTIVE`); there is no delete.
+  - `INACTIVE` = Archived. Usage events for its `event_name` are rejected with `400 METER_NOT_FOUND`, it cannot be attached to plans, and its existing metered prices are frozen. The `event_name` stays reserved. Set through [Update Meter](/reference/meters/update-meter) and reversible (`status: ACTIVE`); there is no delete.
 </ParamField>
 
-<ParamField body="created_at" type="Timestamp" />
-<ParamField body="updated_at" type="Timestamp" />
+<ParamField body="created_at" type="Timestamp">
+  Set by Yuno when the meter is created.
+</ParamField>
+<ParamField body="updated_at" type="Timestamp">
+  Set by Yuno on every update.
+</ParamField>
 
 ## Related
 

--- a/reference/meters/the-meter-object.mdx
+++ b/reference/meters/the-meter-object.mdx
@@ -1,0 +1,121 @@
+---
+title: "The Meter Object"
+hidden: true
+description: "Documents the meter object's attributes: event name, aggregation, unit labels, default price and status."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+## Attributes
+
+A meter is a named, countable action your product performs — tokens generated, API requests served, gigabytes held. It defines the `event_name` your systems send on every [usage event](/reference/meters/report-usage-event) and how those events aggregate into a quantity per billing cycle. A meter carries no price of its own until it is attached to a plan as a [metered price](/reference/meters/the-metered-price-object); `default_price` is only a convenience default for USD plans.
+
+<ParamField body="id" type="string">
+  The unique identifier of the meter (MAX 64; MIN 36).
+
+  Example: 55555555-5555-5555-5555-555555555555
+</ParamField>
+
+<ParamField body="account_id" type="string">
+  The unique identifier of the account that owns the meter (MAX 64; MIN 36).
+
+  Example: 00000000-0000-4000-8000-000000000002
+</ParamField>
+
+<ParamField body="name" type="string">
+  The meter display name (MAX 255; MIN 3). Leading and trailing spaces are trimmed.
+
+  Example: Tokens Consumed
+</ParamField>
+
+<ParamField body="description" type="string">
+  What the meter counts and how it is reported. Optional; `null` when not set.
+
+  Example: Meters LLM token consumption per billing cycle
+</ParamField>
+
+<ParamField body="event_name" type="string">
+  The key your systems send on every usage event to reference this meter (MAX 100). Lowercase letters, digits, `_` and `.` only (`^[a-z0-9_.]+$`). Unique among the account's `ACTIVE` meters — creating a second active meter with the same `event_name` is rejected with `409 METER_EVENT_NAME_CONFLICT`. Immutable after creation.
+
+  Example: tokens_consumed
+</ParamField>
+
+<ParamField body="aggregation" type="enum">
+  How reported events roll up into the cycle quantity. Immutable after creation.
+
+  Possible values:
+  - `SUM` = Adds the `value` of every event in the cycle. Use for consumption: tokens, minutes, messages, deliveries.
+  - `COUNT` = Counts events, ignoring `value` (each event counts as 1). Use for per-call pricing: API requests, jobs.
+  - `LAST` = Keeps the most recent `value` reported in the cycle (by `timestamp`). Use for gauges: gigabytes held, seats in use.
+</ParamField>
+
+<ParamField body="unit_label" type="string">
+  Singular label of the unit the meter counts, used when usage is displayed. Optional.
+
+  Example: token
+</ParamField>
+
+<ParamField body="plural_unit_label" type="string">
+  Plural label of the unit the meter counts. Optional.
+
+  Example: tokens
+</ParamField>
+
+<ParamField body="default_price" type="object">
+  Optional default price per unit beyond the included credits. Inherited by USD plans that attach this meter without an explicit `price_per_credit`. `null` when not set.
+
+  <Expandable title="properties">
+    <ParamField body="currency" type="enum">
+      MAX 3; MIN 3. Must be `USD` in this preview — any other currency is rejected with `400 INVALID_PARAMETERS`.
+    </ParamField>
+
+    <ParamField body="value" type="number">
+      The price per unit (multiple of 0.0001).
+
+      Example: 0.002
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="metadata" type="array of objects">
+  Key-value pairs attached to the meter (MAX 48 entries; keys unique per meter). Independent of the `metadata` you send on usage events.
+
+  <Expandable title="properties">
+    <ParamField body="key" type="string">
+      MAX 48.
+
+      Example: team
+    </ParamField>
+
+    <ParamField body="value" type="string">
+      MAX 512.
+
+      Example: platform
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="status" type="enum">
+  Status of the meter. Defaults to `ACTIVE` on creation.
+
+  Possible values:
+  - `ACTIVE` = The meter accepts usage events and can be attached to plans.
+  - `INACTIVE` = Archived. Usage events for its `event_name` are rejected with `404 METER_NOT_FOUND`, and the `event_name` becomes available for a new meter. Set through [Update Meter](/reference/meters/update-meter); there is no delete.
+</ParamField>
+
+<ParamField body="created_at" type="Timestamp" />
+<ParamField body="updated_at" type="Timestamp" />
+
+## Related
+
+* [Create Meter](/reference/meters/create-meter)
+* [Retrieve Meter](/reference/meters/retrieve-meter)
+* [List Meters](/reference/meters/list-meters)
+* [Update Meter](/reference/meters/update-meter)
+* [Report Usage Event](/reference/meters/report-usage-event)
+* [The Metered Price Object](/reference/meters/the-metered-price-object) — how a meter is priced on a plan
+* [Usage-Based Billing guide](/docs/payment-features/subscriptions/usage-based-billing)

--- a/reference/meters/the-meter-object.mdx
+++ b/reference/meters/the-meter-object.mdx
@@ -29,23 +29,23 @@ A meter is a named, countable action your product performs — tokens generated,
 <ParamField body="name" type="string">
   The meter display name (MAX 255; MIN 3). Leading and trailing spaces are trimmed.
 
-  Example: Tokens Consumed
+  Example: AI tokens
 </ParamField>
 
 <ParamField body="description" type="string">
   What the meter counts and how it is reported. Optional; `null` when not set.
 
-  Example: Meters LLM token consumption per billing cycle
+  Example: LLM tokens consumed by model responses, reported once per response
 </ParamField>
 
 <ParamField body="event_name" type="string">
-  The key your systems send on every usage event to reference this meter (MAX 100). Lowercase letters, digits, `_` and `.` only (`^[a-z0-9_.]+$`). Unique among the account's `ACTIVE` meters — creating a second active meter with the same `event_name` is rejected with `409 METER_EVENT_NAME_CONFLICT`. Immutable after creation.
+  The key your systems send on every usage event to reference this meter (MAX 100). Lowercase letters, digits, `_` and `.` only (`^[a-z0-9_.]+$`). Unique per account across all meters, `ACTIVE` or `INACTIVE` — creating another meter with the same `event_name` is rejected with `409 METER_EVENT_NAME_CONFLICT`, even if the existing one is archived. Immutable after creation; a PATCH that includes it is silently ignored.
 
-  Example: tokens_consumed
+  Example: ai_tokens
 </ParamField>
 
 <ParamField body="aggregation" type="enum">
-  How reported events roll up into the cycle quantity. Immutable after creation.
+  How reported events roll up into the cycle quantity. Immutable after creation; a PATCH that includes it is silently ignored.
 
   Possible values:
   - `SUM` = Adds the `value` of every event in the cycle. Use for consumption: tokens, minutes, messages, deliveries.
@@ -100,11 +100,11 @@ A meter is a named, countable action your product performs — tokens generated,
 </ParamField>
 
 <ParamField body="status" type="enum">
-  Status of the meter. Defaults to `ACTIVE` on creation.
+  Status of the meter. Always `ACTIVE` on creation — a `status` sent to Create Meter is ignored.
 
   Possible values:
   - `ACTIVE` = The meter accepts usage events and can be attached to plans.
-  - `INACTIVE` = Archived. Usage events for its `event_name` are rejected with `404 METER_NOT_FOUND`, and the `event_name` becomes available for a new meter. Set through [Update Meter](/reference/meters/update-meter); there is no delete.
+  - `INACTIVE` = Archived. Usage events for its `event_name` are rejected with `404 METER_NOT_FOUND`, it cannot be attached to plans, and its existing metered prices are frozen. The `event_name` stays reserved. Set through [Update Meter](/reference/meters/update-meter) and reversible (`status: ACTIVE`); there is no delete.
 </ParamField>
 
 <ParamField body="created_at" type="Timestamp" />

--- a/reference/meters/the-metered-price-object.mdx
+++ b/reference/meters/the-metered-price-object.mdx
@@ -12,7 +12,7 @@ Usage-based billing is in preview and available on request. The contract documen
 
 ## Attributes
 
-A metered price is the relation between a [meter](/reference/meters/the-meter-object) and a [plan](/reference/plans/the-plan-object). It says how many units of the meter are included in the plan each billing cycle (`credits`) and what every unit beyond that costs (`price_per_credit`, optionally per country). A plan can carry any number of metered prices alongside its flat price; every subscription on the plan inherits them. Returned by the `/subscriptions/plans/{plan_id}/meters` endpoints and embedded as `meters[]` on [Retrieve Plan](/reference/plans/retrieve-plan).
+A metered price is the relation between a [meter](/reference/meters/the-meter-object) and a [plan](/reference/plans/the-plan-object). It says how many units of the meter are included in the plan each billing cycle (`credits`) and what every unit beyond that costs (`price_per_credit`, optionally per country). A plan can carry any number of metered prices alongside its flat price; every subscription on the plan inherits them. Returned by the `/subscriptions/plans/{plan_id}/meters` endpoints and embedded as `meters[]` on [Create Plan](/reference/plans/create-plan) and [Retrieve Plan](/reference/plans/retrieve-plan) — always present, an empty array for a plan without metered prices.
 
 <Note>
 **`credits` are included units, not prepaid money**
@@ -33,7 +33,7 @@ A metered price is the relation between a [meter](/reference/meters/the-meter-ob
 </ParamField>
 
 <ParamField body="meter_id" type="string">
-  The unique identifier of the attached meter (MAX 64; MIN 36). A meter can be attached to a given plan only once (`409 PLAN_METER_ALREADY_ASSIGNED`).
+  The unique identifier of the attached meter (MAX 64; MIN 36). Must be `ACTIVE` when attaching. A meter can be attached to a given plan only once (`409 PLAN_METER_ALREADY_ASSIGNED`).
 
   Example: 66666666-6666-6666-6666-666666666666
 </ParamField>
@@ -58,7 +58,7 @@ A metered price is the relation between a [meter](/reference/meters/the-meter-ob
 
   Rules when attaching or updating:
   - `currency` must equal the plan's `base_amount` currency, else `400 INVALID_PARAMETERS`.
-  - Optional only when the plan's base currency is `USD` and the meter has a `default_price` — the meter's default is inherited and echoed back here.
+  - Optional only when the plan's base currency is `USD` and the meter has a `default_price` — the meter's default then applies and this field is returned as `null`.
   - Required when the plan's base currency is not `USD`, or when the meter has no `default_price`.
 
   <Expandable title="properties">
@@ -75,7 +75,7 @@ A metered price is the relation between a [meter](/reference/meters/the-meter-ob
 </ParamField>
 
 <ParamField body="country_prices" type="array of objects">
-  Optional explicit per-unit prices by subscriber country, one entry per country. A country not listed falls back to `price_per_credit`. Same shape as the plan-level `country_prices`.
+  Optional explicit per-unit prices by subscriber country, one entry per country (a repeated country is rejected with `400`). A country not listed falls back to `price_per_credit`. Same shape as the plan-level `country_prices`.
 
   <Expandable title="properties">
     <ParamField body="country" type="string">

--- a/reference/meters/the-metered-price-object.mdx
+++ b/reference/meters/the-metered-price-object.mdx
@@ -4,11 +4,11 @@ hidden: true
 description: "Documents the metered price (plan meter) object: included credits per cycle, pricing strategy, price per unit and per-country prices."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
 ## Attributes
 
@@ -48,7 +48,7 @@ A metered price is the relation between a [meter](/reference/meters/the-meter-ob
   How usage beyond `credits` is priced.
 
   Possible values:
-  - `PER_UNIT` = Billable units × `price_per_credit` (or the matching `country_prices` entry). The only strategy priced in this preview.
+  - `PER_UNIT` = Billable units × `price_per_credit` (or the matching `country_prices` entry). The only strategy priced.
   - `PACKAGE` = Reserved. Accepted by the API but its configuration fields (package size and price) and rating are not available yet.
   - `TIERED` = Reserved. Accepted by the API but its configuration fields (tiers) and rating are not available yet.
 </ParamField>
@@ -91,8 +91,12 @@ A metered price is the relation between a [meter](/reference/meters/the-meter-ob
   </Expandable>
 </ParamField>
 
-<ParamField body="created_at" type="Timestamp" />
-<ParamField body="updated_at" type="Timestamp" />
+<ParamField body="created_at" type="Timestamp">
+  Set by Yuno when the metered price is attached.
+</ParamField>
+<ParamField body="updated_at" type="Timestamp">
+  Set by Yuno on every update of the metered price.
+</ParamField>
 
 ## Related
 

--- a/reference/meters/the-metered-price-object.mdx
+++ b/reference/meters/the-metered-price-object.mdx
@@ -1,0 +1,104 @@
+---
+title: "The Metered Price Object"
+hidden: true
+description: "Documents the metered price (plan meter) object: included credits per cycle, pricing strategy, price per unit and per-country prices."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+## Attributes
+
+A metered price is the relation between a [meter](/reference/meters/the-meter-object) and a [plan](/reference/plans/the-plan-object). It says how many units of the meter are included in the plan each billing cycle (`credits`) and what every unit beyond that costs (`price_per_credit`, optionally per country). A plan can carry any number of metered prices alongside its flat price; every subscription on the plan inherits them. Returned by the `/subscriptions/plans/{plan_id}/meters` endpoints and embedded as `meters[]` on [Retrieve Plan](/reference/plans/retrieve-plan).
+
+<Note>
+**`credits` are included units, not prepaid money**
+
+`credits` is the usage allowance bundled in the plan's flat price — "the first 10,000 tokens each month are included". It is measured in the meter's own unit and resets every billing cycle. It is not a prepaid balance or wallet.
+</Note>
+
+<ParamField body="id" type="string">
+  The unique identifier of the metered price (MAX 64; MIN 36).
+
+  Example: 77777777-7777-7777-7777-777777777777
+</ParamField>
+
+<ParamField body="plan_id" type="string">
+  The unique identifier of the plan the meter is attached to (MAX 64; MIN 36).
+
+  Example: 00000000-0000-4000-8000-000000000001
+</ParamField>
+
+<ParamField body="meter_id" type="string">
+  The unique identifier of the attached meter (MAX 64; MIN 36). A meter can be attached to a given plan only once (`409 PLAN_METER_ALREADY_ASSIGNED`).
+
+  Example: 66666666-6666-6666-6666-666666666666
+</ParamField>
+
+<ParamField body="credits" type="number">
+  Units of the meter included in the plan per billing cycle — the allowance a subscriber can consume before any usage is billed. Must be greater than or equal to 0; `0` means every unit is billed. Decimals allowed.
+
+  Example: 100.5
+</ParamField>
+
+<ParamField body="pricing_strategy" type="enum">
+  How usage beyond `credits` is priced.
+
+  Possible values:
+  - `PER_UNIT` = Billable units × `price_per_credit` (or the matching `country_prices` entry). The only strategy priced in this preview.
+  - `PACKAGE` = Reserved. Accepted by the API but its configuration fields (package size and price) and rating are not available yet.
+  - `TIERED` = Reserved. Accepted by the API but its configuration fields (tiers) and rating are not available yet.
+</ParamField>
+
+<ParamField body="price_per_credit" type="object">
+  The price per unit beyond the included credits, in the plan's base currency. Used for every subscriber whose country has no explicit entry in `country_prices`.
+
+  Rules when attaching or updating:
+  - `currency` must equal the plan's `base_amount` currency, else `400 INVALID_PARAMETERS`.
+  - Optional only when the plan's base currency is `USD` and the meter has a `default_price` — the meter's default is inherited and echoed back here.
+  - Required when the plan's base currency is not `USD`, or when the meter has no `default_price`.
+
+  <Expandable title="properties">
+    <ParamField body="currency" type="enum">
+      MAX 3; MIN 3; <a href="/reference/country-reference">ISO 4217</a>.
+    </ParamField>
+
+    <ParamField body="value" type="number">
+      The price per unit (multiple of 0.0001).
+
+      Example: 0.05
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="country_prices" type="array of objects">
+  Optional explicit per-unit prices by subscriber country, one entry per country. A country not listed falls back to `price_per_credit`. Same shape as the plan-level `country_prices`.
+
+  <Expandable title="properties">
+    <ParamField body="country" type="string">
+      MAX 2; MIN 2; <a href="/reference/country-reference">ISO 3166-1</a>.
+    </ParamField>
+
+    <ParamField body="amount" type="object">
+      <Expandable title="properties">
+        <ParamField body="currency" type="enum" />
+        <ParamField body="value" type="number" />
+      </Expandable>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="created_at" type="Timestamp" />
+<ParamField body="updated_at" type="Timestamp" />
+
+## Related
+
+* [Attach Meter to Plan](/reference/meters/attach-meter-to-plan)
+* [List Plan Meters](/reference/meters/list-plan-meters)
+* [Update Plan Meter](/reference/meters/update-plan-meter)
+* [Create Plan](/reference/plans/create-plan) — attach meters inline with `meters[]`
+* [The Meter Object](/reference/meters/the-meter-object)
+* [Usage-Based Billing guide](/docs/payment-features/subscriptions/usage-based-billing)

--- a/reference/meters/the-metered-price-object.mdx
+++ b/reference/meters/the-metered-price-object.mdx
@@ -48,9 +48,9 @@ A metered price is the relation between a [meter](/reference/meters/the-meter-ob
   How usage beyond `credits` is priced.
 
   Possible values:
-  - `PER_UNIT` = Billable units × `price_per_credit` (or the matching `country_prices` entry). The only strategy priced.
-  - `PACKAGE` = Reserved. Accepted by the API but its configuration fields (package size and price) and rating are not available yet.
-  - `TIERED` = Reserved. Accepted by the API but its configuration fields (tiers) and rating are not available yet.
+  - `PER_UNIT` = Billable units × `price_per_credit` (or the matching `country_prices` entry).
+  - `PACKAGE` = Usage billed in bundles of N units; a partial bundle counts as a full one.
+  - `TIERED` = Graduated tiers: each band of usage is billed at its own rate.
 </ParamField>
 
 <ParamField body="price_per_credit" type="object">

--- a/reference/meters/update-meter.mdx
+++ b/reference/meters/update-meter.mdx
@@ -11,12 +11,12 @@ description: "Updates a meter's descriptive fields, default price or status; arc
 Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
 </Warning>
 
-Send at least one of `name`, `description`, `unit_label`, `plural_unit_label`, `default_price`, `status`. `event_name` and `aggregation` cannot be changed.
+Send at least one of `name`, `description`, `unit_label`, `plural_unit_label`, `default_price`, `status`. `event_name` and `aggregation` cannot be changed — if you include them they are silently ignored and the response shows the original values.
 
 <Warning>
 **Archiving stops ingestion immediately**
 
-Once a meter is `INACTIVE`, [Report Usage Event](/reference/meters/report-usage-event) rejects its `event_name` with `404 METER_NOT_FOUND`. Metered prices already attached to plans are not removed, and there is no delete — archiving is the only way to retire a meter in this preview. Make sure no live subscription still relies on the meter before you archive it.
+Once a meter is `INACTIVE`, [Report Usage Event](/reference/meters/report-usage-event) rejects its `event_name` with `404 METER_NOT_FOUND`, it can no longer be attached to plans (`404 METER_NOT_FOUND`), and its existing metered prices are frozen ([Update Plan Meter](/reference/meters/update-plan-meter) returns `404`). Metered prices already attached to plans are not removed, the `event_name` stays reserved (recreating a meter with it is `409`), and there is no delete — archiving is the only way to retire a meter in this preview. You can reactivate it at any time with `status: ACTIVE`. Make sure no live subscription still relies on the meter before you archive it.
 </Warning>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/update-meter.mdx
+++ b/reference/meters/update-meter.mdx
@@ -5,18 +5,18 @@ hidden: true
 description: "Updates a meter's descriptive fields, default price or status; archives a meter with status INACTIVE."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
-Send at least one of `name`, `description`, `unit_label`, `plural_unit_label`, `default_price`, `status`. `event_name` and `aggregation` cannot be changed — if you include them they are silently ignored and the response shows the original values.
+`X-Idempotency-Key` is required. Send at least one of `name`, `description`, `unit_label`, `plural_unit_label`, `default_price`, `status`. `event_name` and `aggregation` cannot be changed — if you include them they are silently ignored and the response shows the original values.
 
 <Warning>
 **Archiving stops ingestion immediately**
 
-Once a meter is `INACTIVE`, [Report Usage Event](/reference/meters/report-usage-event) rejects its `event_name` with `404 METER_NOT_FOUND`, it can no longer be attached to plans (`404 METER_NOT_FOUND`), and its existing metered prices are frozen ([Update Plan Meter](/reference/meters/update-plan-meter) returns `404`). Metered prices already attached to plans are not removed, the `event_name` stays reserved (recreating a meter with it is `409`), and there is no delete — archiving is the only way to retire a meter in this preview. You can reactivate it at any time with `status: ACTIVE`. Make sure no live subscription still relies on the meter before you archive it.
+Once a meter is `INACTIVE`, [Report Usage Event](/reference/meters/report-usage-event) rejects its `event_name` with `400 METER_NOT_FOUND`, it can no longer be attached to plans (`400 METER_NOT_FOUND`), and its existing metered prices are frozen ([Update Plan Meter](/reference/meters/update-plan-meter) returns `400 PLAN_METER_NOT_FOUND`). Metered prices already attached to plans are not removed, the `event_name` stays reserved (recreating a meter with it is `409`), and there is no delete — archiving is the only way to retire a meter You can reactivate it at any time with `status: ACTIVE`. Make sure no live subscription still relies on the meter before you archive it.
 </Warning>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/update-meter.mdx
+++ b/reference/meters/update-meter.mdx
@@ -1,0 +1,22 @@
+---
+title: "Update Meter"
+openapi: "/openapi/meters/update-meter.json PATCH /subscriptions/meters/{meter_id}"
+hidden: true
+description: "Updates a meter's descriptive fields, default price or status; archives a meter with status INACTIVE."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+Send at least one of `name`, `description`, `unit_label`, `plural_unit_label`, `default_price`, `status`. `event_name` and `aggregation` cannot be changed.
+
+<Warning>
+**Archiving stops ingestion immediately**
+
+Once a meter is `INACTIVE`, [Report Usage Event](/reference/meters/report-usage-event) rejects its `event_name` with `404 METER_NOT_FOUND`. Metered prices already attached to plans are not removed, and there is no delete — archiving is the only way to retire a meter in this preview. Make sure no live subscription still relies on the meter before you archive it.
+</Warning>
+
+Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/update-plan-meter.mdx
+++ b/reference/meters/update-plan-meter.mdx
@@ -1,0 +1,20 @@
+---
+title: "Update Plan Meter"
+openapi: "/openapi/meters/update-plan-meter.json PATCH /subscriptions/plans/{plan_id}/meters/{meter_id}"
+hidden: true
+description: "Updates the included credits, pricing strategy, unit price or per-country prices of a meter attached to a plan."
+---
+
+<Warning>
+**Early access — preview**
+
+Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
+</Warning>
+
+Send at least one of `credits`, `pricing_strategy`, `price_per_credit`, `country_prices`. The same currency rules as [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) apply.
+
+<Note>
+There is no detach endpoint in this preview. To stop billing a meter, archive it with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`), or set `credits` high enough that no overage is billed.
+</Note>
+
+Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.

--- a/reference/meters/update-plan-meter.mdx
+++ b/reference/meters/update-plan-meter.mdx
@@ -11,7 +11,7 @@ description: "Updates the included credits, pricing strategy, unit price or per-
 Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
 </Warning>
 
-Send at least one of `credits`, `pricing_strategy`, `price_per_credit`, `country_prices`. The same currency rules as [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) apply.
+Send at least one of `credits`, `pricing_strategy`, `price_per_credit`, `country_prices`. The same currency rules as [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) apply. If the meter has been archived (`INACTIVE`) the metered price is frozen and this call returns `404` until the meter is reactivated.
 
 <Note>
 There is no detach endpoint in this preview. To stop billing a meter, archive it with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`), or set `credits` high enough that no overage is billed.

--- a/reference/meters/update-plan-meter.mdx
+++ b/reference/meters/update-plan-meter.mdx
@@ -5,16 +5,16 @@ hidden: true
 description: "Updates the included credits, pricing strategy, unit price or per-country prices of a meter attached to a plan."
 ---
 
-<Warning>
-**Early access — preview**
+<Note>
+**Enabled per organization**
 
-Usage-based billing is in preview and available on request. The contract documented here may change before general availability. Contact your Yuno representative to enable it on your account.
-</Warning>
+Usage-based billing must be enabled for your organization before these endpoints accept requests. Contact your Yuno account manager to enable it. Requests from an organization where it is not enabled return `403 PRODUCT_NOT_ENABLED`.
+</Note>
 
-Send at least one of `credits`, `pricing_strategy`, `price_per_credit`, `country_prices`. The same currency rules as [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) apply. If the meter has been archived (`INACTIVE`) the metered price is frozen and this call returns `404` until the meter is reactivated.
+Send at least one of `credits`, `pricing_strategy`, `price_per_credit`, `country_prices`. The same currency rules as [Attach Meter to Plan](/reference/meters/attach-meter-to-plan) apply. If the meter has been archived (`INACTIVE`) the metered price is frozen and this call returns `400 PLAN_METER_NOT_FOUND` until the meter is reactivated. `X-Idempotency-Key` is required.
 
 <Note>
-There is no detach endpoint in this preview. To stop billing a meter, archive it with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`), or set `credits` high enough that no overage is billed.
+There is no detach endpoint. To stop billing a meter, archive it with [Update Meter](/reference/meters/update-meter) (`status: INACTIVE`), or set `credits` high enough that no overage is billed.
 </Note>
 
 Refer to [Meter Error Codes](/reference/meters/meter-error-codes) for the possible error outcomes.


### PR DESCRIPTION
## PR Description
Adds **hidden** documentation for the new Usage-Based Billing (Meters) feature on Subscriptions (epic SUB-96). Merchants can define meters, attach metered prices to plans and report usage events that are billed on the subscription's renewal. The pages are not linked from the navigation (`hidden: true`, `docs.json` untouched) and are reachable only by direct URL — they are needed for a merchant demo this week; the feature is enabled per organization.

Contract source: subscription-ms PR #340 / transaction-rails PR #163 / public-api PR #2127, the team's `meters-demo-suite.json` Postman suite, and the contract decisions from the Subscriptions daily on 2026-08-19 (SUB-98 comment).

## Changes

**Guide (hidden)**
- `docs/payment-features/subscriptions/usage-based-billing.mdx` — concepts (meter → metered price on a plan → subscription → usage events → renewal), quick start with curl, aggregations (SUM / COUNT / LAST), pricing (`credits`, `price_per_credit`, `country_prices`, `default_price` inheritance, PER_UNIT / PACKAGE / TIERED), renewal math, idempotency and `occurred_at` window, error handling, FAQ.

**API reference (hidden, new group `reference/meters/`)**
- `the-meter-object`, `create-meter`, `list-meters`, `retrieve-meter`, `update-meter`
- `report-usage-event`
- `the-metered-price-object`, `attach-meter-to-plan`, `list-plan-meters`, `update-plan-meter`
- `meter-error-codes`

**OpenAPI (new `openapi/meters/`)**
- 8 specs: `create-meter`, `list-meters`, `retrieve-meter`, `update-meter`, `report-usage-event`, `attach-meter-to-plan`, `list-plan-meters`, `update-plan-meter` — same `servers`/`securitySchemes` as `openapi/plans/*`; `X-Idempotency-Key` required on every write; 400/403/409 responses with codes and messages.

**Contract highlights**
- Paths under `/v1/subscriptions/meters…` and `/v1/subscriptions/plans/{plan_id}/meters…`; `POST /plans` accepts `meters[]`, `PATCH /subscriptions/plans/{plan_id}` is attach-only (atomic).
- Usage event: `event_id` (merchant idempotency key, replay returns the original), `event_name`, `subscription_id`, `consumed_value`, `occurred_at` (≤ 35 days back), `metadata[]`; one event per request; synchronous validation, 201.
- `ACTIVE`, `TRIALING` and `PAST_DUE` subscriptions accept usage; `PAUSED` / `CANCELED` / `COMPLETED` → `400 SUBSCRIPTION_NOT_ACTIVE`.
- Lookup failures are `400` (never 404); feature not enabled for the org → `403 PRODUCT_NOT_ENABLED`.

## Checks
- All 8 specs pass `mint openapi-check`; `mint broken-links` clean; `scripts/check-descriptions.cjs` passes; JSON validated.
- No existing page, redirect or navigation entry modified — additive and hidden only.

## Known follow-ups (not in this PR)
- PACKAGE / TIERED configuration fields (package size/price, tier bounds) — pending engineering confirmation.
- Published plans docs use `/v1/plans` while payment-api and the Postman suite route `/v1/subscriptions/plans`; this PR keeps meters under `/v1/subscriptions/…` and leaves the plans pages untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)