### PR TITLE
docs:[CORECM-19310] pin Web SDK to v1.10 and stop pairing SRI with global paths

### DIFF
--- a/docs/sdks/full-checkout/web-payments.mdx
+++ b/docs/sdks/full-checkout/web-payments.mdx
@@ -46,25 +46,23 @@ const yuno = await loadScript({
 
 ```html
 <script 
-  src="https://sdk-web.y.uno/v1.9/main.js"
-  integrity="sha384-..."
-  crossorigin="anonymous"
+  src="https://sdk-web.y.uno/v1.10/main.js"
   async
   defer
 ></script>
 ```
 
 <Note>
-Find the latest SRI hashes for each version in [versions-sri.json](https://sdk-web.y.uno/versions-sri.json).
+`v1.10` is a global path: it receives every patch released on that line, so you get fixes without changing your integration.
+
+Do not add an `integrity` attribute to this URL. Because the file is republished on each patch release, any hash you pin to it stops matching and the browser blocks the script. Subresource Integrity requires the immutable full-version URL instead — see [Subresource Integrity](/docs/sdks/resources/references/web#subresource-integrity-sri).
 </Note>
 
 **Option 3: Dynamic JavaScript**
 
 ```javascript
 const script = document.createElement('script');
-script.src = 'https://sdk-web.y.uno/v1.9/main.js';
-script.integrity = 'sha384-...';
-script.crossOrigin = 'anonymous';
+script.src = 'https://sdk-web.y.uno/v1.10/main.js';
 script.async = true;
 script.defer = true;
 document.head.appendChild(script);

--- a/docs/sdks/overview/quickstart.mdx
+++ b/docs/sdks/overview/quickstart.mdx
@@ -22,7 +22,7 @@ Choose your platform and follow the steps to start processing your first payment
     Or include via CDN:
 
     ```html
-    <script src="https://sdk-web.y.uno/v1.9/main.js"></script>
+    <script src="https://sdk-web.y.uno/v1.10/main.js"></script>
     ```
 
     ### 2. Initialize and process payment

--- a/docs/sdks/resources/references/web.mdx
+++ b/docs/sdks/resources/references/web.mdx
@@ -40,7 +40,11 @@ The hash can be found in [versions-sri.json](https://sdk-web.y.uno/versions-sri.
   crossorigin="anonymous"></script>
 ```
 
-`src` for production is `https://sdk-web.y.uno/versions-sri.json`.
+The example above targets sandbox. For production, use the `url` published alongside the hash in [versions-sri.json](https://sdk-web.y.uno/versions-sri.json) — each entry pairs a full-version `url` with the `integrity` that matches it, for example `https://prod.y.uno/sdk-static-bundles-ms/sdk-web/v1.10.6/main.js`.
+
+<Note>
+SRI only works with these full-version URLs. The global paths such as `https://sdk-web.y.uno/v1.10/main.js` are republished on every patch release, so no hash stays valid for them and none is published.
+</Note>
 
 ### Using NPM package
 


### PR DESCRIPTION
## The bug

`web-payments.mdx` tells merchants to load the SDK like this:

```html
<script src="https://sdk-web.y.uno/v1.9/main.js"
        integrity="sha384-..."
        crossorigin="anonymous"></script>
```

…with a Note pointing at `versions-sri.json` for the hash. That combination cannot work. Verified against production today:

| Check | Result |
|---|---|
| `versions-sri.json` entries | only full-version URLs on **another host**: `https://prod.y.uno/sdk-static-bundles-ms/sdk-web/v1.10.6/main.js` |
| That URL | `HTTP 200`, and its sha384 matches the published `integrity` exactly ✅ |
| Real hash of `sdk-web.y.uno/v1.9/main.js` | `sha384-EypHvpeSksexxqk9Lc5yflo1K80G227sWnAtd22azBoWaOzSIYK+ey6JMnGHgcwS` — published nowhere |
| `last-modified` on that global path | `Tue, 18 Aug 2026 17:25:44 GMT` — rewritten yesterday |

So a merchant who follows Option 2 or 3 pastes a hash that can never match, the browser blocks the script, and the SDK never loads. Even a self-computed hash would break on our next patch release of that line, since global paths are republished each time.

## What changed

- **`full-checkout/web-payments.mdx`** — drops `integrity`/`crossorigin` from the global-path snippets, bumps them to `v1.10`, and replaces the Note with one that explains why SRI does not belong on a global path, linking to the SRI reference.
- **`overview/quickstart.mdx`** — `v1.9` → `v1.10`. Plain CDN, no SRI, so this one was only stale.
- **`resources/references/web.mdx`** — replaces the line "`src` for production is `https://sdk-web.y.uno/versions-sri.json`". That file is the hash manifest, not a script `src`. Now points at the `url` + `integrity` pair each manifest entry publishes, and states that SRI works only with full-version URLs.

The SRI reference page was otherwise already correct — it documents Full (immutable) vs Partial (mutable) URLs properly. The defect was the integration page contradicting it.

## Deliberately not touched

`changelog/archive/**` and `changelog/migration-guides/web/**` still carry `v1.1`–`v1.6` pins. Those record what each version's integration looked like at the time; rewriting them would falsify the history.

Worth noting for whoever automates pin bumps later: any such automation must be scoped to `docs/**` for exactly this reason.

## One thing I did not fix

Option 1 on `web-payments.mdx` still reads:

```javascript
const yuno = await loadScript({
  apiKey: 'YOUR_PUBLIC_KEY',
  integrity: 'sha384-...', // Find the hash in our GitHub repository
});
```

In `sdk-web-package@master`, `LoadScriptProps` is `{ env?, sri?, baseUrl? }` — neither `apiKey` nor `integrity` is a valid prop, and the hashes are in `versions-sri.json`, not GitHub. The SRI reference documents `loadScript({ sri: true })` instead.

I left it alone because that repo has no `7.x` tags and these docs target a different npm major than `master`, so I could not confirm the signature for the version this page covers. Flagging rather than guessing — someone who knows which major applies should correct it.

## Context

Follows the Aligosta incident: a merchant failed card certification after pinning an exact SDK version copied from our examples. Companion PRs: yuno-payments/yuno-sdk-web#160 (examples repo pin + CI guard) and yuno-payments/sdk-web-demo#397 (automatic pin bump on release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)