### PR TITLE
[FIX] | [CORECM-19093] | strip internal references from public changelog pages

### DIFF
--- a/changelog/android.mdx
+++ b/changelog/android.mdx
@@ -20,61 +20,49 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="changed" /> **Installment dropdown now shows the per-installment value and the total amount**  
   Aligned the card installment dropdown with the Web SDK: each option now shows the per-installment value and the total amount (for example '2x of R$ 500,31 - Total R$ 1.000,61'). The same template is applied to every option regardless of whether financial_costs is present, since its amount is already reflected in the rendered total. If the total is not available the option falls back to the previous per-installment format, and if no amount is available it falls back to the installment count only.
-  *See also: [CORECM-17537](https://yunopayments.atlassian.net/browse/CORECM-17537)*
 
 - <ChangelogBadge type="added" /> **NuPay renders expanded in the unfolded payment method list**  
   When the unfolded payment method list is enabled, NuPay now expands directly in the list like other alternative payment methods, matching the iOS SDK. The inline form shows the buyer's fields together with the NuPay payment types banner, which loads the available options as soon as the buyer enters their document. With the setting off, NuPay keeps opening its separate form screen as before.
-  *See also: [CORECM-18227](https://yunopayments.atlassian.net/browse/CORECM-18227)*
 
 - <ChangelogBadge type="added" /> **NuPay one-click renders expanded in the unfolded payment method list**  
   The NuPay one-click experience now also expands directly in the payment method list when the unfolded list is enabled, completing the parity with the iOS SDK. The inline form shows the credit or debit selector and the selectable payment conditions with their installment options; the chosen condition travels with the payment exactly as it does from the full form screen, and paying without choosing a condition is blocked with an inline message. With the setting off, the one-click flow keeps opening its separate form screen as before.
-  *See also: [CORECM-18227](https://yunopayments.atlassian.net/browse/CORECM-18227)*
 
 - <ChangelogBadge type="added" /> **Unfolded payment method list for alternative payment methods**  
   The payment method list can now show the payment form for alternative payment methods (such as PSE, Nequi, or Boleto) expanded directly in the list, matching the existing behavior for cards and the Web SDK. When a buyer selects one of these methods, its fields unfold inline, and startPayment() charges with the data entered in the list without opening a separate form screen. Saved (enrolled) methods and methods without a form keep their current collapsed behavior. This reuses the existing unfolded payment method list setting and is turned on by Yuno per account; when it is off, the list behaves exactly as before.
 
 - <ChangelogBadge type="breaking" /> **Payment method selection indicator moved to the leading edge of each row**  
   The selection indicator in the payment method list now appears at the leading edge of each row (before the payment method logo) instead of the trailing edge, matching the placement used by major checkouts. The position mirrors automatically for right-to-left languages such as Arabic and Urdu, while card number, expiration date, and CVC inputs keep left-to-right formatting. Each row is now also announced to screen readers as a selectable option within the list, improving accessibility. This is a global visual change applied to all merchants by default across Yuno SDKs.  
-  [Migration guide →](No code changes are required. If your UI tests or visual snapshots assert the position of the selection indicator in the payment method list, update them to expect it at the leading edge of the row.)
-  *See also: [CORECM-17649](https://yunopayments.atlassian.net/browse/CORECM-17649)*
+  *Migration:* No code changes are required. If your UI tests or visual snapshots assert the position of the selection indicator in the payment method list, update them to expect it at the leading edge of the row.
 
 - <ChangelogBadge type="added" /> **OTP codes received by SMS can be filled in automatically**  
   When a buyer is asked for a one-time password during a payment or enrollment, the SDK can now read the code from the incoming SMS and fill the OTP field for them, matching the experience already offered on iOS. The buyer sees a one-tap system prompt asking for permission before any message is read, so nothing happens without their consent, and a code they have already started typing is never overwritten. The SDK does not request any SMS permissions, works with codes sent from any sender, and silently falls back to manual entry on devices without Google Play services.
-  *See also: [CORECM-18295](https://yunopayments.atlassian.net/browse/CORECM-18295)*
 
 - <ChangelogBadge type="changed" /> **Secure payment badge copy changed to "Powered by Yuno"**  
   The badge shown on checkout and enrollment surfaces now reads "Powered by" followed by the Yuno wordmark logo instead of "Secure payment with YUNO". The copy is translated in every language that already localized the badge; the few locales that never localized it keep their existing English fallback.
-  *See also: [CORECM-17338](https://yunopayments.atlassian.net/browse/CORECM-17338)*
 
 - <ChangelogBadge type="added" /> **Privacy link next to the Powered by Yuno badge**  
   A localized "Privacy" link is rendered next to the Powered by Yuno wordmark and opens the privacy policy URL from the account configuration in a Chrome Custom Tab (with an in-app browser fallback); when the configuration provides no URL, the link performs no action. The link is announced to screen readers as a button and is hidden together with the badge when the merchant configuration disables the tag.
-  *See also: [CORECM-17338](https://yunopayments.atlassian.net/browse/CORECM-17338)*
 
 - <ChangelogBadge type="removed" /> **Inline data-privacy disclosure removed from all payment forms**  
   The "By paying, you agree to the Personal Data Processing Policy" sentence no longer appears anywhere: it is removed from the one-step, enrolled-card, and step-by-step card forms and from every alternative payment method form. The privacy disclosure is now the "Privacy" link rendered next to the Powered by Yuno badge on the payment form and list surfaces. Mid-action legacy screens (OTP and bank-instruction views, which never carried the inline disclosure) keep the badge without the link.  
-  [Migration guide →](If UI tests assert the terms_and_conditions_text test tag, remove that assertion; the tag no longer exists on any form.)
-  *See also: [CORECM-17338](https://yunopayments.atlassian.net/browse/CORECM-17338)*
+  *Migration:* If UI tests assert the terms_and_conditions_text test tag, remove that assertion; the tag no longer exists on any form.
 
 - <ChangelogBadge type="added" /> **privacy_tag_displayed consent signal on completion telemetry**  
   The SDK completion telemetry now includes params.privacy_tag_displayed=true when the Powered by Yuno badge actually rendered during the session (the parameter is omitted when the badge was hidden), and enrollment completion now emits the enrollCheckoutSdk_completed event with enrollment_status. This supports privacy-compliance reporting; merchant-facing behavior and integration contracts are unchanged.
-  *See also: [CORECM-17338](https://yunopayments.atlassian.net/browse/CORECM-17338) · [CORECM-17340](https://yunopayments.atlassian.net/browse/CORECM-17340)*
 
 - <ChangelogBadge type="added" /> **Powered by Yuno badge below the payment method list and on render forms**  
   The payment method list component now shows the Powered by Yuno badge with the Privacy link once, centered below the full list of methods (never inside each method row or expanded form). Forms rendered with a merchant-side pay button (render flows) also show the badge below the form, where the removed inline disclosure used to appear. Both placements follow the existing secure-payment-tag merchant setting: disabling it hides the badge and the link everywhere.
-  *See also: [CORECM-17338](https://yunopayments.atlassian.net/browse/CORECM-17338)*
 
 - <ChangelogBadge type="fixed" /> **Host app no longer crashes when a Google Pay Pix result arrives after the checkout screen is closed**  
   Fixed a crash that could occur during Google Pay Pix payments when the payment availability or payment result callback arrived after the user had already left the checkout screen (for example by navigating back while the payment was processing). The SDK now silently ignores results delivered after the screen is gone instead of raising an exception in the host app.
 
 - <ChangelogBadge type="added" /> **Account type and account holder type fields for ACH bank transfers**  
   The ACH bank-transfer form now shows two additional dropdowns — account type (checking or savings) and account holder type (individual or company) — rendered between the routing number and the beneficiary name. In addition, the whole bank-transfer block (account number, routing number, account type, account holder type, beneficiary name) now renders at the top of the form, before the customer fields, for any payment method whose configuration requires those bank fields. The new dropdowns appear only when the merchant configuration requires them, and the selected values are sent with the bank_transfer data on both the create-payment token and the enrollment request. Forms whose configuration requires none of the bank-transfer fields are unchanged.
-  *See also: [CORECM-18130](https://yunopayments.atlassian.net/browse/CORECM-18130)*
 
 **Enrollment**
 
 - <ChangelogBadge type="fixed" /> **enrollment_status no longer dropped from enrollment telemetry**  
   The event reporter silently dropped params.enrollment_status when rebuilding event payloads, so enrollStatus_* events reached the backend without it. The field is now forwarded.
-  *See also: [CORECM-17338](https://yunopayments.atlassian.net/browse/CORECM-17338)*
 
 ## v2.20.1
 *July 28, 2026*
@@ -91,7 +79,6 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="added" /> **onInstallmentSelected card callback (Web parity)**  
   `startCheckout` now accepts an optional `onInstallmentSelected` callback that fires every time the shopper selects or changes an installment option in the card form — including the default pre-selection at render and recalculations after a BIN change — so merchants can keep the cart total in sync with the selected installment. The payload mirrors the Web SDK's `OnInstallmentSelectedArgs`: `installment` (Int), `label` (String), `amount` { `currency`, `value`, `totalValue` } as strings, `additionalData` (reserved), and `isMerchantInstallment` (nullable, reserved for the merchant-installments feature). When installments stop being available after a selection was reported (e.g. the shopper switches to a card without installments), the callback fires once with null so the merchant knows the previous installment information is no longer valid. Fully backwards compatible: with no callback registered there is no behavior change, and an exception inside the merchant's callback never affects the payment flow.
-  *See also: [CORECM-18470](https://yunopayments.atlassian.net/browse/CORECM-18470)*
 
 ## v2.19.1
 *July 28, 2026*
@@ -143,7 +130,6 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 - <ChangelogBadge type="changed" /> **Installment dropdown now shows the per-installment value and the total amount**  
   Aligned the card installment dropdown with the Web SDK: each option now shows the per-installment value and the total amount (for example '2x of R$ 500,31 - Total R$ 1.000,61'). The same template is applied to every option regardless of whether financial_costs is present, since its amount is already reflected in the rendered total. If the total is not available the option falls back to the previous per-installment format, and if no amount is available it falls back to the installment count only.
-  *See also: [CORECM-17537](https://yunopayments.atlassian.net/browse/CORECM-17537)*
 
 ## v2.17.3
 *June 30, 2026*
@@ -264,7 +250,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
   Enrollment now supports the same dynamic action screens used in payments, including PIN, image, payment code, OTP, and info screens.
 
 - <ChangelogBadge type="added" /> **Installment Details on Tokenization**  
-  When a card is tokenized with installments selected, the installment information — plan, rate, amount, and selected option — is now returned alongside the one-time token. 
+  When a card is tokenized with installments selected, the installment information — plan, rate, amount, and selected option — is now returned alongside the one-time token.
 
 ## v2.14.0
 *April 30, 2026*

--- a/changelog/react-native.mdx
+++ b/changelog/react-native.mdx
@@ -71,7 +71,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
   Aligned Android status values with the TypeScript `YunoStatus` enum and kept render flow status mappings separate from shared mappings.
 
 - <ChangelogBadge type="security" /> **fast-xml-parser DoS Vulnerability**  
-  Upgraded `fast-xml-parser` to address denial-of-service advisories (VULS-1511 and CVE-2026-25128).
+  Upgraded `fast-xml-parser` to address denial-of-service advisories (CVE-2026-25128).
 
 ## v1.1.0
 *March 10, 2026*

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -375,7 +375,7 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="added" /> **Per-Scheme Card Number Length Validation**  
   Card number length is now validated per card scheme using backend-driven rules combined with the Luhn check, reducing false rejections of valid cards. Gated behind a feature flag.
 
-- <ChangelogBadge type="fixed" /> **FIXED: Route sdk-web-card iframe assets (secure-field pages, card form, mediator) through the asset host in whitelabel mode. They were resolved against `apiUrl`, so when a merchant set a distinct `assetUrl` carrying a proxy sub-path (e.g. `/hosted-payment-methods/orchestrator`) the sub-path was dropped and secure fields loaded from the wrong path in enrollment and enrolled-card flows (CORECM-17901).**  
+- <ChangelogBadge type="fixed" /> **FIXED: Route sdk-web-card iframe assets (secure-field pages, card form, mediator) through the asset host in whitelabel mode. They were resolved against `apiUrl`, so when a merchant set a distinct `assetUrl` carrying a proxy sub-path (e.g. `/hosted-payment-methods/orchestrator`) the sub-path was dropped and secure fields loaded from the wrong path in enrollment and enrolled-card flows.**  
   
 
 ## v1.9.7

--- a/scripts/generate_changelog.js
+++ b/scripts/generate_changelog.js
@@ -34,18 +34,48 @@ function badge(typeStr) {
   return `<ChangelogBadge type="${typeStr.toLowerCase()}" />`;
 }
 
+const INTERNAL_URL = /atlassian\.net|github\.com\/yuno-payments/i;
+const INTERNAL_KEY = /\b(?:CORECM|YSHUB|MX|VULS)-\d+\b/g;
+const INTERNAL_KEY_SINGLE = /\b(?:CORECM|YSHUB|MX|VULS)-\d+\b/;
+
+function normalizeLink(link) {
+  if (typeof link === 'string') return { label: link, url: link };
+  return link || {};
+}
+
+function isInternalLink(link) {
+  return INTERNAL_URL.test(link.url || '') || INTERNAL_KEY_SINGLE.test(link.label || '');
+}
+
+function scrubInternalRefs(text) {
+  if (!text) return text;
+  return text
+    .replace(/\[([^\]]*)\]\([^)]*atlassian\.net[^)]*\)/gi, '$1')
+    .replace(/\s*\((?:see\s+)?(?:CORECM|YSHUB|MX|VULS)-\d+\)/gi, '')
+    .replace(INTERNAL_KEY, '')
+    .replace(/\(\s*(?:and|,|·|\/)\s+/gi, '(')
+    .replace(/\s+(?:and|,|·|\/)\s*\)/gi, ')')
+    .replace(/(^|\s)\(\s*\)/g, '$1')
+    .replace(/ {2,}(?=\S)/g, ' ')
+    .replace(/\s+([.,;:])/g, '$1')
+    .trim();
+}
+
 function renderEntry(entry) {
   const lines = [];
   const migration = entry.migration_guide;
-  const links = entry.links || [];
+  const links = (entry.links || []).map(normalizeLink).filter(l => !isInternalLink(l));
 
-  lines.push(`- ${badge(entry.type)} **${entry.title}**  `);
+  lines.push(`- ${badge(entry.type)} **${scrubInternalRefs(entry.title)}**  `);
 
-  if (migration) {
-    lines.push(`  ${entry.description}  `);
-    lines.push(`  [Migration guide →](${migration})`);
+  if (migration && /^(https?:\/\/|\/)/i.test(migration.trim())) {
+    lines.push(`  ${scrubInternalRefs(entry.description)}  `);
+    lines.push(`  [Migration guide →](${migration.trim()})`);
+  } else if (migration) {
+    lines.push(`  ${scrubInternalRefs(entry.description)}  `);
+    lines.push(`  *Migration:* ${scrubInternalRefs(migration)}`);
   } else {
-    lines.push(`  ${entry.description}`);
+    lines.push(`  ${scrubInternalRefs(entry.description)}`);
   }
 
   if (links.length > 0) {


### PR DESCRIPTION
## Summary
Implements the render-time guard from [CORECM-19093](https://yunopayments.atlassian.net/browse/CORECM-19093): internal identifiers never reach the public changelog pages, while `links` in the per-release source JSON keep carrying Jira URLs for internal traceability.

Changes in `scripts/generate_changelog.js`:
- Links whose URL points to `atlassian.net` (or `github.com/yuno-payments`) are dropped at render; the *See also* line disappears when nothing public remains.
- Jira keys (`CORECM/YSHUB/MX/VULS-\d+`) are scrubbed from rendered titles, descriptions and migration notes as a safety net, with punctuation cleanup.
- Plain-text `migration_guide` values now render as `*Migration:* <text>` instead of producing a broken `[Migration guide →](<sentence>)` link; URL values (absolute or root-relative) keep rendering as links.
- `links` tolerates both shapes: `{label, url}` objects (docs-native) and plain strings (android-sdk `changelog/schema.json`).

Regenerated pages with the new generator (this also applies the pending manual cleanup for Android v2.18.0/v2.20.0/v2.21.0 — 9 internal Jira links removed):
- `changelog/android.mdx` — internal *See also* lines removed, broken migration links fixed
- `changelog/web.mdx`, `changelog/react-native.mdx` — internal VULS reference scrubbed

Since `sync-changelogs.yml` regenerates every platform page through this script, the guard covers iOS/Web/Flutter/RN/API/plugins automatically going forward. The authoring-time lint on the android-sdk side ships separately (same ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-19093]: https://yunopayments.atlassian.net/browse/CORECM-19093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ