### PR TITLE
docs(wallets): document BIN promo caveat, Google Pay contact fields, cardholder name defaults, and Android autofill

### DIFF
--- a/docs/sdks/seamless-sdk/android-payments.mdx
+++ b/docs/sdks/seamless-sdk/android-payments.mdx
@@ -335,6 +335,14 @@ Use the `YunoConfig` data class, described in Step 5, to use the `styles` custom
 
 The loader functionality is controlled through the `keepLoader` parameter in the `YunoConfig` data class, which is documented inline in the preceding SDK configuration section.
 
+### Google Autofill
+
+Since Android SDK version 2.16.0, the card number, cardholder name, expiration date, and CVV fields are eligible for Google Autofill. When a buyer focuses on any of these fields, the Google keyboard can suggest a card saved in their Google account, and selecting it fills in the form automatically.
+
+<Note>
+  This applies to any Android user paying with a card, it isn't tied to the Google Pay payment method. No feature flag or extra configuration is needed, it's active automatically once you update to 2.16.0 or later.
+</Note>
+
 ### Save card for future payments
 
 You can also display a checkbox to save or enroll cards using `cardSaveEnable: true`. The following examples show the checkbox for both card form renders:

--- a/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-sdk-integration.mdx
@@ -83,6 +83,10 @@ When any of these fields are enabled as required in the Checkout Builder, the Ap
   Each additional required field adds an extra step to the Apple Pay payment sheet, increasing friction for the customer. This can negatively impact conversion rates. Yuno recommends enabling only the fields that are strictly necessary for your business or regulatory requirements.
 </Note>
 
+<Note>
+  Holder name (cardholder name) is disabled by default for Apple Pay, unlike cards, where it's enabled by default. Enable it from the Checkout Builder if your integration needs it.
+</Note>
+
 | Platform | Minimum version |
 |----------|-----------------|
 | Web      | 1.8.0           |
@@ -257,7 +261,11 @@ Monitor payment status through [webhooks](/docs/webhooks) to handle edge cases a
 
 When a payment is completed with Apple Pay, the iOS SDK returns the full OTT (One-Time Token) service response. Within this response, the `card_data` object contains card-related information associated with the Apple Pay payment, including the DPAN BIN (the first digits of the Device Primary Account Number used in the transaction).
 
-Merchants can use this object to retrieve card details such as brand, type, issuer, and the `iin` field, which represents the DPAN BIN.
+Merchants can use this object to retrieve card details such as brand, type, issuer, and the `iin` field, which represents the DPAN BIN. This lets you show BIN-based promotions and discounts before the shopper pays, for the wallet's default card.
+
+<Note>
+  **Limitation**: the `iin` reflects the default card selected in the payment sheet at the time the payment is created. If the shopper switches to a different card in the payment sheet, the promotion you showed may no longer apply, there's no intermediate step between changing the card and paying where you could show a different promotion.
+</Note>
 
 ### Example OTT response (iOS SDK)
 

--- a/docs/wallets/google-pay/google-pay-sdk-integration.mdx
+++ b/docs/wallets/google-pay/google-pay-sdk-integration.mdx
@@ -69,6 +69,31 @@ The SDK handles the rest. When the customer selects Google Pay:
 
 The SDK returns the payment result. You can also monitor payment status through [webhooks](/docs/webhooks) for asynchronous confirmation.
 
+## Requesting contact information
+
+You can configure which fields the Google Pay payment sheet requests from the customer directly from the [Checkout Builder](/docs/using-yuno/dashboard-overview/checkout-builder#required-fields). The available fields are:
+
+- Email
+- Phone
+- Cardholder name
+- Billing address
+- Shipping address
+
+When any of these fields are enabled as required in the Checkout Builder, the Google Pay payment sheet prompts the customer to provide that information before completing the payment.
+
+<Note>
+  This used to be configured at the connection level. It's now unified under Required Fields in the Checkout Builder, the same way it works for Apple Pay.
+</Note>
+
+<Note>
+  Cardholder name is disabled by default for Google Pay, unlike cards, where it's enabled by default. Enable it from the Checkout Builder if your integration needs it.
+</Note>
+
+| Platform | Minimum version |
+|----------|-----------------|
+| Web      | 1.8.0           |
+| Android  | 2.16.0          |
+
 ## Create a payment with the SDK workflow
 
 If you need to call the payment API directly while using the SDK checkout flow, set the `workflow` to `SDK_CHECKOUT` and include the checkout session:


### PR DESCRIPTION
## Summary

Closes 4 documentation gaps found while reviewing the internal SDK/Checkout demo meetings, cross-checked against the published docs. These items were shared in the Mar 27, 2026 and May 29, 2026 demos.

- Adds the promo/BIN limitation note for Apple Pay: if the shopper switches cards in the payment sheet, a shown promotion may no longer apply.
- Documents Google Pay's contact information fields (email, phone, cardholder name, billing and shipping address), now unified under Checkout Builder Required Fields, the same way it works for Apple Pay.
- Documents that cardholder name is disabled by default for both wallets, unlike cards, where it's enabled by default.
- Promotes Google Autofill on Android card fields (available since SDK 2.16.0) from the changelog into the SDK guide.

### Files changed
- `docs/wallets/apple-pay/apple-pay-sdk-integration.mdx`
- `docs/wallets/google-pay/google-pay-sdk-integration.mdx`
- `docs/sdks/seamless-sdk/android-payments.mdx`
