### PR TITLE
docs(3ds): document iFrame challenge experience and Netcetera native module details

### DIFF
--- a/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-android.mdx
@@ -15,6 +15,10 @@ The Yuno Android SDK supports running 3D Secure (3DS) challenges natively inside
   Native 3DS is **opt-in**: you only need to install the provider module if your integration runs 3DS challenges in-app. If you are not enabling 3DS, you can skip this guide.
 </Note>
 
+<Note>
+  This is a separate module (roughly 3-4 MB) so you only add it if you need native 3DS. If your app already customizes the Yuno SDK's styles, those styles propagate automatically to the challenge screen, no additional UI configuration is needed.
+</Note>
+
 ## Requirements
 
 - Android **API level 21** (Lollipop) or higher.
@@ -125,3 +129,13 @@ Yuno.initialize(
 ### Permissions
 
 `android.permission.INTERNET` is declared by the module's manifest and merged into your app automatically. No action required.
+
+## Sandbox certificate
+
+When testing against the Yuno sandbox environment, the Netcetera SDK requires a card scheme certificate to be present in your app.
+
+<Info>
+  **Contact your Yuno TAM (Technical Account Manager) to obtain the certificate.** It is not distributed publicly.
+</Info>
+
+This is only required for sandbox testing, not for production.

--- a/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
+++ b/docs/sdks/external-native-modules/netcetera-3ds-ios.mdx
@@ -15,6 +15,10 @@ The Yuno iOS SDK supports running 3D Secure (3DS) challenges natively inside you
   Native 3DS is **opt-in**: you only need to install the provider package if your integration runs 3DS challenges in-app. If you are not enabling 3DS, you can skip this guide.
 </Note>
 
+<Note>
+  This is a separate module (roughly 3-4 MB) so you only add it if you need native 3DS. If your app already customizes the Yuno SDK's styles, those styles propagate automatically to the challenge screen, no additional UI configuration is needed.
+</Note>
+
 ## Requirements
 
 - iOS **15.0** or higher.

--- a/docs/security-and-compliance/3d-secure.mdx
+++ b/docs/security-and-compliance/3d-secure.mdx
@@ -89,6 +89,10 @@ Adding the 3DS2 verification step to the checkout process changes the normal wor
 With SDK v1.1, 3DS logic is handled automatically using the `continuePayment()` method - no separate 3DS setup is required. For more information, see the [Yuno Web SDK documentation](/docs/sdks/full-checkout/web-payments).
 </Note>
 
+<Note>
+  **Yuno 3DS challenge experience**: for merchants using Yuno's own 3DS provider, the challenge is presented in an iFrame instead of a full-page redirect, on both desktop and mobile web. This reduces drop-off compared to redirecting to a separate URL. This iFrame experience is currently web only, an embedded challenge for native mobile apps is in development.
+</Note>
+
 You decide if your system will implement the 3DS2 or not. The 3DS2 verification step is added while defining your cards [dynamic routing](/docs/routing#configuring-the-dynamic-routing). When starting your card routes, you can add the 3DS2 step before defining the payment provider. When adding the 3DS2 verification step, when a payment using a card is initialized, the Yuno system will analyze if the card needs an extra challenge. If an extra challenge is necessary, the user will be redirected to the bank environment to complete the authorization. On the other hand, the payment process will proceed normally.
 
 To create payments with the 3DS DIRECT workflow, you need to fulfill some requirements.


### PR DESCRIPTION
## Summary

Closes 2 documentation gaps found while reviewing the internal SDK/Checkout demo meetings, cross-checked against the published docs. These items were shared in the Feb 27, 2026 and May 29, 2026 demos.

- Documents the Yuno 3DS iFrame challenge experience (desktop and mobile web), reducing drop-off compared to a full-page redirect.
- Adds module size and style-propagation notes to both native 3DS module guides (iOS and Android).
- Adds a sandbox certificate section to the Android native 3DS guide, matching the existing iOS guide.

### Files changed
- `docs/security-and-compliance/3d-secure.mdx`
- `docs/sdks/external-native-modules/netcetera-3ds-ios.mdx`
- `docs/sdks/external-native-modules/netcetera-3ds-android.mdx`