### PR TITLE
docs(sdk): onInstallmentSelected controller page (CORECM-18672)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -888,7 +888,8 @@
               "docs/yuno-sdk/controllers/on-status",
               "docs/yuno-sdk/controllers/show-view",
               "docs/yuno-sdk/controllers/show-loading",
-              "docs/yuno-sdk/controllers/create-payment"
+              "docs/yuno-sdk/controllers/create-payment",
+              "docs/yuno-sdk/controllers/on-installment-selected"
             ]
           },
           {

--- a/docs/yuno-sdk/controllers/on-installment-selected.mdx
+++ b/docs/yuno-sdk/controllers/on-installment-selected.mdx
@@ -1,0 +1,49 @@
+---
+hidden: true
+title: "onInstallmentSelected"
+sidebarTitle: "Installment selection (onInstallmentSelected)"
+description: "Invoked when the buyer picks an installment option in the card form."
+---
+
+`onInstallmentSelected` is invoked when the buyer picks an installment option in the card form — including the automatic selection of the first option when the list loads. It is informational: the selection travels with the payment either way, so overriding it is optional. Use it to reflect the chosen financing in your own UI (for example, updating an order summary).
+
+Available on Android. iOS support is planned; on Web the equivalent callback exists on the current (non-Universal) SDK.
+
+## What you receive
+
+| Field | Type | Description |
+|---|---|---|
+| `installment` | Int | Number of installments picked. |
+| `label` | String | The option label exactly as rendered to the buyer. |
+| `amount.currency` | String | Currency code of the amounts. |
+| `amount.value` | String | Per-installment amount. |
+| `amount.totalValue` | String | Total amount across all installments. |
+| `additionalData` | Map? | Reserved; currently `null`. |
+| `isMerchantInstallment` | Boolean? | Reserved; currently `null`. |
+
+`amount` is `null` when the backend did not provide amounts for the option.
+
+## The `null` delivery
+
+The controller receives `null` when a previously reported selection stops being valid — the available installments changed, typically because the buyer edited the card number and the new card has no installment plans. Treat it as "no installment is selected anymore". It fires at most once per invalidation; a new selection re-arms it.
+
+## Signature
+
+<Tabs>
+  <Tab title="Android">
+
+```kotlin
+override fun onInstallmentSelected(installment: InstallmentSelected?) {
+    installment?.let {
+        orderSummary.showFinancing(it.label)
+    } ?: orderSummary.clearFinancing()
+}
+```
+
+  </Tab>
+</Tabs>
+
+## Related
+
+- [`onStatus`](/docs/yuno-sdk/controllers/on-status). The final outcome of the transaction.
+- [Controllers overview](/docs/yuno-sdk/controllers/overview). How controllers are wired per platform.

--- a/docs/yuno-sdk/controllers/overview.mdx
+++ b/docs/yuno-sdk/controllers/overview.mdx
@@ -15,6 +15,7 @@ Controllers are how your code receives the SDK's events and, when needed, overri
 | [`showView`](/docs/yuno-sdk/controllers/show-view) (iOS, Android) | SDK presents forms and action views (e.g. 3DS) full-screen. | SDK hands you the view and a `TransactionProcess`; embed it and call `process.onSubmit()`. |
 | [`showLoading`](/docs/yuno-sdk/controllers/show-loading) | SDK shows its own full-screen loader. | SDK suppresses its loader and emits `isLoading: true/false`. |
 | [`createPayment`](/docs/yuno-sdk/controllers/create-payment) | SDK creates the payment after tokenization. | SDK delivers the One-Time Token; you create the payment from your backend and resolve. |
+| [`onInstallmentSelected`](/docs/yuno-sdk/controllers/on-installment-selected) (Android) | Nothing happens — the selection still travels with the payment. | Receives the installment option the buyer picks in the card form, and `null` when that selection stops being valid. |
 
 Implement `onStatus` in every integration. The others are optional.
 
@@ -33,3 +34,4 @@ On iOS and Android, every controller method is invoked on the main thread. You c
 - [`showView`](/docs/yuno-sdk/controllers/show-view) (iOS, Android)
 - [`showLoading`](/docs/yuno-sdk/controllers/show-loading)
 - [`createPayment`](/docs/yuno-sdk/controllers/create-payment)
+- [`onInstallmentSelected`](/docs/yuno-sdk/controllers/on-installment-selected) (Android)


### PR DESCRIPTION
## Summary
Documents the new `onInstallmentSelected` controller shipped for Android in [CORECM-18672](https://yunopayments.atlassian.net/browse/CORECM-18672) (android-sdk PR yuno-payments/android-sdk#1833):

- New page `docs/yuno-sdk/controllers/on-installment-selected.mdx`: payload fields, the `null` (selection no longer valid) delivery semantics, Android signature example; marked Android-only with iOS planned (CORECM-18673).
- `controllers/overview.mdx`: row in the Defaults table + per-controller list entry.
- `docs.json`: page registered in the "Listen and take over" group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-18672]: https://yunopayments.atlassian.net/browse/CORECM-18672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ