### PR TITLE
chore: web sdk changelog 1.10.7

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.7",
+      "release_date": "2026-08-19",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.7",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Tell the card fields when a connection prices installments per card",
+          "description": "The card secure fields now receive installments_require_full_card from the payment method, so they wait for the complete card number before quoting when a routed connection prices each term against that exact card.",
+          "group": "Installments",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-18760"
+      ]
+    },
+    {
       "version": "1.10.6",
       "release_date": "2026-08-19",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.7
+*August 19, 2026*
+
+**Installments**
+
+- <ChangelogBadge type="changed" /> **Tell the card fields when a connection prices installments per card**  
+  The card secure fields now receive installments_require_full_card from the payment method, so they wait for the complete card number before quoting when a routed connection prices each term against that exact card.
+
 ## v1.10.6
 *August 19, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.7`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.8

1 entry.