### PR TITLE
Add Routing Recommendations API reference (POST /v1/routing/recommendations)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -484,6 +484,13 @@
             ]
           },
           {
+            "group": "Routing Recommendations",
+            "tag": "Beta",
+            "pages": [
+              "reference/routing/recommendations"
+            ]
+          },
+          {
             "group": "Payment Links",
             "pages": [
               "reference/payment-links/status-payment-links",

--- a/openapi/routing/routing-recommendations.json
+++ b/openapi/routing/routing-recommendations.json
@@ -1,0 +1,313 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Yuno Routing Recommendations API",
+    "version": "1.0"
+  },
+  "servers": [
+    { "url": "https://api-sandbox.y.uno/v1" },
+    { "url": "https://api.y.uno/v1" },
+    { "url": "https://api.eu.y.uno/v1" }
+  ],
+  "security": [],
+  "paths": {
+    "/routing/recommendations": {
+      "post": {
+        "summary": "Request Routing Recommendations",
+        "description": "Send a payment context and your candidate providers; Yuno returns the recommended candidate and a full ranking built from your own reported transaction history.",
+        "operationId": "createRoutingRecommendation",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "PUBLIC-API-KEY",
+            "schema": { "type": "string" },
+            "description": "Your public API key."
+          },
+          {
+            "in": "header",
+            "name": "PRIVATE-SECRET-KEY",
+            "schema": { "type": "string" },
+            "description": "Your private secret key. Never expose it client-side."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["account_id", "payment", "candidates"],
+                "properties": {
+                  "account_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The Yuno account whose reported transaction history feeds the statistics. Must belong to your organization."
+                  },
+                  "merchant_order_id": {
+                    "type": "string",
+                    "description": "Your own order reference. Echoed in the response. When you later report the payment outcome with the same `merchant_order_id` (same account), Yuno attributes it to the recommendation — you never need to store `recommendation_id`."
+                  },
+                  "payment": {
+                    "type": "object",
+                    "required": ["amount", "country", "payment_method"],
+                    "description": "The payment you are about to route.",
+                    "properties": {
+                      "amount": {
+                        "type": "object",
+                        "required": ["currency", "value"],
+                        "properties": {
+                          "currency": {
+                            "type": "string",
+                            "description": "ISO 4217 currency code.",
+                            "example": "USD"
+                          },
+                          "value": {
+                            "type": "number",
+                            "description": "Decimal amount.",
+                            "example": 99.0
+                          }
+                        }
+                      },
+                      "country": {
+                        "type": "string",
+                        "description": "ISO 3166-1 alpha-2 country code.",
+                        "example": "US"
+                      },
+                      "payment_method": {
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "Payment method type, e.g. `CARD`.",
+                            "example": "CARD"
+                          },
+                          "details": {
+                            "type": "object",
+                            "description": "Optional container keyed by method type, mirroring the create-payment shape. For cards, `card.bin` refines the statistics per issuer.",
+                            "properties": {
+                              "card": {
+                                "type": "object",
+                                "properties": {
+                                  "bin": {
+                                    "type": "string",
+                                    "description": "The card BIN (first 6–8 digits).",
+                                    "example": "457173"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "initiation": {
+                        "type": "string",
+                        "enum": ["CIT", "MIT"],
+                        "description": "Whether the payment is customer-initiated (`CIT`) or merchant-initiated (`MIT`)."
+                      }
+                    }
+                  },
+                  "candidates": {
+                    "type": "array",
+                    "minItems": 2,
+                    "description": "The providers you can actually route this payment to. The recommendation is always one of these — Yuno never proposes a provider you did not list. Minimum 2.",
+                    "items": {
+                      "type": "object",
+                      "required": ["provider_id"],
+                      "properties": {
+                        "provider_id": {
+                          "type": "string",
+                          "description": "Provider identifier — the statistics key. Must match the `provider_id` values you use when reporting transactions.",
+                          "example": "ADYEN"
+                        },
+                        "connection_id": {
+                          "type": "string",
+                          "description": "Optional passthrough identifier for your own connection bookkeeping. Not validated; returned as sent.",
+                          "example": "con_xxx"
+                        }
+                      }
+                    }
+                  },
+                  "optimize_for": {
+                    "type": "string",
+                    "enum": ["APPROVAL_RATE", "LATENCY", "BALANCED"],
+                    "default": "APPROVAL_RATE",
+                    "description": "The objective the ranking is ordered by. Defaults to `APPROVAL_RATE`."
+                  }
+                }
+              },
+              "example": {
+                "account_id": "11111111-2222-3333-4444-555555555555",
+                "merchant_order_id": "order_45678",
+                "payment": {
+                  "amount": { "currency": "USD", "value": 99.0 },
+                  "country": "US",
+                  "payment_method": {
+                    "type": "CARD",
+                    "details": { "card": { "bin": "457173" } }
+                  },
+                  "initiation": "CIT"
+                },
+                "candidates": [
+                  { "provider_id": "ADYEN", "connection_id": "con_xxx" },
+                  { "provider_id": "STRIPE", "connection_id": "con_yyy" },
+                  { "provider_id": "DLOCAL" }
+                ],
+                "optimize_for": "APPROVAL_RATE"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The recommendation. `recommended` is always present, and `ranking` always contains every candidate — even when there is not enough history yet (`decision_source: INSUFFICIENT_DATA`).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "recommendation_id": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Unique id of this recommendation. Every call computes a fresh recommendation with a new id."
+                    },
+                    "merchant_order_id": {
+                      "type": ["string", "null"],
+                      "description": "Echo of the request value; `null` when not sent."
+                    },
+                    "optimized_for": {
+                      "type": "string",
+                      "enum": ["APPROVAL_RATE", "LATENCY", "BALANCED"],
+                      "description": "The objective the ranking is ordered by."
+                    },
+                    "recommended": {
+                      "type": "object",
+                      "description": "The candidate Yuno recommends. Always one of your `candidates`, and always present — under `INSUFFICIENT_DATA` it falls back to the best partial data, or request order as a last resort.",
+                      "properties": {
+                        "provider_id": { "type": "string" },
+                        "connection_id": { "type": ["string", "null"] }
+                      }
+                    },
+                    "decision_source": {
+                      "type": "string",
+                      "enum": ["MERCHANT_HISTORY", "INSUFFICIENT_DATA"],
+                      "description": "`MERCHANT_HISTORY`: the ranking is backed by statistics over your reported payments. `INSUFFICIENT_DATA`: no candidate has enough recent history — the ranking is returned with `null` metrics and you decide."
+                    },
+                    "ranking": {
+                      "type": "array",
+                      "description": "Every candidate, ordered by the objective. Use it to cascade: if the recommended candidate declines, take the next entry — no second call needed.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "provider_id": { "type": "string" },
+                          "connection_id": { "type": ["string", "null"] },
+                          "approval_rate": {
+                            "type": ["number", "null"],
+                            "description": "Approved / (approved + declined) over your reported payments in the statistics window. `null` when there is no data."
+                          },
+                          "avg_latency_ms": {
+                            "type": ["number", "null"],
+                            "description": "Average provider latency in milliseconds over the same window. `null` when there is no data."
+                          },
+                          "sample_size": {
+                            "type": "integer",
+                            "description": "How many reported payments back this candidate's metrics — the honesty of the recommendation."
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "merchant_history": {
+                    "summary": "Ranking backed by your reported history",
+                    "value": {
+                      "recommendation_id": "984b115b-f0b5-4891-a35d-aed995d6d2d1",
+                      "merchant_order_id": "order_45678",
+                      "optimized_for": "APPROVAL_RATE",
+                      "recommended": { "provider_id": "ADYEN", "connection_id": "con_xxx" },
+                      "decision_source": "MERCHANT_HISTORY",
+                      "ranking": [
+                        { "provider_id": "ADYEN", "connection_id": "con_xxx", "approval_rate": 0.94, "avg_latency_ms": 180, "sample_size": 1250 },
+                        { "provider_id": "STRIPE", "connection_id": "con_yyy", "approval_rate": 0.91, "avg_latency_ms": 150, "sample_size": 3400 },
+                        { "provider_id": "DLOCAL", "connection_id": null, "approval_rate": null, "avg_latency_ms": null, "sample_size": 0 }
+                      ]
+                    }
+                  },
+                  "insufficient_data": {
+                    "summary": "Not enough history yet — ranking returned with nulls",
+                    "value": {
+                      "recommendation_id": "32df2552-4c29-4162-b6fa-97ca4fcea6e2",
+                      "merchant_order_id": null,
+                      "optimized_for": "APPROVAL_RATE",
+                      "recommended": { "provider_id": "ADYEN", "connection_id": "con_xxx" },
+                      "decision_source": "INSUFFICIENT_DATA",
+                      "ranking": [
+                        { "provider_id": "ADYEN", "connection_id": "con_xxx", "approval_rate": null, "avg_latency_ms": null, "sample_size": 0 },
+                        { "provider_id": "STRIPE", "connection_id": "con_yyy", "approval_rate": null, "avg_latency_ms": null, "sample_size": 0 }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                },
+                "examples": {
+                  "invalid_parameters": {
+                    "summary": "A field is missing or has an invalid value",
+                    "value": { "code": "INVALID_PARAMETERS", "messages": ["The field 'payment.country' is required."] }
+                  },
+                  "invalid_account": {
+                    "summary": "account_id does not exist or is not in your organization",
+                    "value": { "code": "INVALID_ACCOUNT_ID", "messages": ["Account id is invalid"] }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API keys.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                },
+                "example": { "code": "INVALID_CREDENTIALS", "messages": ["Invalid Credentials"] }
+              }
+            }
+          },
+          "403": {
+            "description": "The Routing Recommendations API is not enabled for your organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string" },
+                    "messages": { "type": "array", "items": { "type": "string" } }
+                  }
+                },
+                "example": { "code": "PRODUCT_NOT_ENABLED", "messages": ["The Routing Recommendations API is enabled per organization. Contact your Key Account Manager (KAM) to activate it."] }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/routing/recommendations.mdx
+++ b/reference/routing/recommendations.mdx
@@ -1,0 +1,53 @@
+---
+title: "Request Routing Recommendations"
+openapi: "/openapi/routing/routing-recommendations.json POST /routing/recommendations"
+description: "Send a payment context and your candidate providers — Yuno returns the best route, ranked by your own transaction history."
+---
+
+This endpoint recommends which of **your own provider accounts** to route a payment to, based on the outcome history you send Yuno through the [Transaction Reporting API](/reference/reporting/report-transactions). You send the payment context and the candidates you can actually use; Yuno returns the recommended candidate, a full ranking with per-candidate metrics, and a `recommendation_id`.
+
+The transaction itself never passes through Yuno. **Yuno recommends; you decide and process.**
+
+<Note>
+**Enabled per organization**
+
+This API requires activation for your organization. Contact your Key Account Manager (KAM) to enable it.
+</Note>
+
+## How it works
+
+1. You report your off-Yuno transaction outcomes through the [Transaction Reporting API](/reference/reporting/report-transactions). Only payments with `origin: REPORTED` feed the statistics — Yuno-processed traffic is a different population and is deliberately kept out.
+2. Before routing a payment, you call this endpoint with the payment context and your candidate providers.
+3. Yuno computes statistics per candidate — approval rate, average provider latency, sample size — over a rolling window of your recent reported payments, segmented by provider, country and payment method (and BIN, when you send it), and returns the ranking ordered by your objective.
+4. You route the payment yourself and report its outcome. If the reported event carries the same `merchant_order_id` you sent here, Yuno attributes the outcome to this recommendation automatically — closing the loop without you storing `recommendation_id`.
+
+## Reading the response
+
+- **`recommended` is always present** — even without enough history. You never need a special branch: `decision_source` tells you how much to trust it.
+- **`decision_source: MERCHANT_HISTORY`** — the ranking is backed by statistics over your reported payments.
+- **`decision_source: INSUFFICIENT_DATA`** — no candidate has accumulated enough recent reported events yet. The full ranking still comes back with `null` metrics, and the recommendation falls back to the best partial data, or request order as a last resort.
+- **`sample_size`** on each candidate tells you how many reported payments back its metrics — the honesty of the recommendation. A high approval rate over 12 events is not the same signal as one over 12,000.
+- **The full `ranking` always comes back**, ordered by your objective. If the recommended candidate declines, take the next entry — cascade retry without a second call.
+
+## Choosing an objective
+
+`optimize_for` orders the ranking: `APPROVAL_RATE` (default), `LATENCY`, or `BALANCED` (a weighted blend of both). There is no cost objective yet — the Reporting API does not collect fees, and Yuno does not rank on data it does not have.
+
+## Candidates are your constraint layer
+
+The recommendation is always one of the `candidates` you send — Yuno never proposes a provider you did not list. Send only the providers this payment is genuinely allowed to use (eligibility, contracts, committed volumes), and the recommendation respects those constraints by construction. `connection_id` is an optional passthrough for your own bookkeeping: it is returned exactly as sent and not validated.
+
+## Retries
+
+There is no idempotency header on this endpoint, and none is needed: each call computes a fresh recommendation with a new `recommendation_id`, and requesting a recommendation changes no state. Retrying after a network failure is always safe.
+
+## Errors
+
+Errors return a `code` and a `messages` array.
+
+| HTTP | `code` | When |
+| ---- | ------ | ---- |
+| 400 | `INVALID_PARAMETERS` | Malformed body, missing required field, fewer than 2 candidates, or an invalid enum value (`optimize_for`, `initiation`). |
+| 400 | `INVALID_ACCOUNT_ID` | The `account_id` does not exist or does not belong to your organization. |
+| 401 | `INVALID_CREDENTIALS` | Missing or invalid `PUBLIC-API-KEY` / `PRIVATE-SECRET-KEY` headers. |
+| 403 | `PRODUCT_NOT_ENABLED` | The Routing Recommendations API is not enabled for your organization. Contact your KAM. |


### PR DESCRIPTION
## What

New API reference page **Request Routing Recommendations** (`reference/routing/recommendations`) + OpenAPI spec + nav entry (new "Routing Recommendations" Beta group, next to Transaction Reporting).

Written from **PRD v1.3** (Confluence 3047391241) and verified against **live sandbox behavior**: 24-case contract audit run 2026-08-19 22:32 CEST (script: `yuno-workspace/scripts/spacex_routing_recommendations_audit.sh`). 22/24 cases match the PRD; the page documents observed behavior where they diverge.

## Verified against sandbox

- Required fields, min-2 candidates, enum validation (optimize_for, initiation) → 400
- merchant_order_id echo (null when omitted); recommended always present; full ranking with nulls under INSUFFICIENT_DATA; fresh recommendation_id per call
- Unknown/future fields tolerated
- Real error codes: `INVALID_PARAMETERS`, `INVALID_ACCOUNT_ID`, `INVALID_CREDENTIALS` (documented instead of the PRD's flat `INVALID_REQUEST`)

## Needs @Andrea's validation before merge (do not merge until confirmed)

1. **Statistics wording**: page says "rolling window of your recent reported payments" without hard numbers — PRD's 30-day window and 50-event minimum are marked *proposal*. Confirm whether to state them.
2. **403 PRODUCT_NOT_ENABLED**: text taken from PRD; not observable on an enabled org. Confirm code + message.
3. **PRD deviation**: `details` key mismatched with `payment_method.type` returns 200 (ignored) in sandbox, PRD says 400. Page currently documents neither — decide enforce-vs-ignore and I'll add a line.
4. Zero amount is accepted (200); Reporting API rejects it. Aligning them is a product call; page is silent on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)