### PR TITLE
docs(C2-17931): add connection_data to operation responses

### DIFF
--- a/openapi/payments/cancel-or-refund-a-payment.json
+++ b/openapi/payments/cancel-or-refund-a-payment.json
@@ -571,6 +571,10 @@
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
                       },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
+                      },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
                       "payment": {
@@ -693,6 +697,10 @@
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
                       },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
+                      },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
                       "payment": {
@@ -814,6 +822,10 @@
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
+                      },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
                       },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
@@ -938,6 +950,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {
@@ -1358,6 +1383,19 @@
                             "third_party_account_id": {}
                           }
                         },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
+                          }
+                        },
                         "response_code": {
                           "type": "string",
                           "example": "SUCCEEDED"
@@ -1774,6 +1812,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {

--- a/openapi/payments/cancel-or-refund-payment-with-transaction.json
+++ b/openapi/payments/cancel-or-refund-payment-with-transaction.json
@@ -578,6 +578,10 @@
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
                       },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
+                      },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
                       "payment": {
@@ -700,6 +704,10 @@
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
                       },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
+                      },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
                       "payment": {
@@ -821,6 +829,10 @@
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
+                      },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
                       },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
@@ -945,6 +957,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {
@@ -1359,6 +1384,19 @@
                             "third_party_account_id": {}
                           }
                         },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
+                          }
+                        },
                         "response_code": {
                           "type": "string",
                           "example": "SUCCEEDED"
@@ -1769,6 +1807,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {

--- a/openapi/payments/cancel-payment.json
+++ b/openapi/payments/cancel-payment.json
@@ -180,6 +180,10 @@
                         "iso8583_response_code": "00",
                         "iso8583_response_message": "Approved or completed successfully"
                       },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
+                      },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
                       "payment": {
@@ -319,6 +323,19 @@
                         "iso8583_response_message": {
                           "type": "string",
                           "example": "Approved or completed successfully"
+                        }
+                      }
+                    },
+                    "connection_data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Stripe BM US"
                         }
                       }
                     },

--- a/openapi/payments/capture-authorization.json
+++ b/openapi/payments/capture-authorization.json
@@ -832,6 +832,10 @@
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
                       },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
+                      },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
                       "payment": {
@@ -886,6 +890,10 @@
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
+                      },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
                       },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
@@ -995,6 +1003,10 @@
                         "raw_response": null,
                         "third_party_transaction_id": null,
                         "third_party_account_id": null
+                      },
+                      "connection_data": {
+                        "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                        "name": "Stripe BM US"
                       },
                       "response_code": "SUCCEEDED",
                       "response_message": "Transaction successful",
@@ -1127,6 +1139,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {
@@ -1314,6 +1339,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {
@@ -1690,6 +1728,19 @@
                             "raw_response": {},
                             "third_party_transaction_id": {},
                             "third_party_account_id": {}
+                          }
+                        },
+                        "connection_data": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Stripe BM US"
+                            }
                           }
                         },
                         "response_code": {

--- a/openapi/payments/refund-payment.json
+++ b/openapi/payments/refund-payment.json
@@ -748,7 +748,10 @@
                           "iso8583_response_code": null,
                           "iso8583_response_message": null
                         },
-                        "connection_data": null,
+                        "connection_data": {
+                          "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                          "name": "Stripe BM US"
+                        },
                         "created_at": "2025-04-14T17:52:07.768528Z",
                         "updated_at": "2025-04-14T17:52:07.862912Z"
                       },
@@ -962,7 +965,10 @@
                           "iso8583_response_code": null,
                           "iso8583_response_message": null
                         },
-                        "connection_data": null,
+                        "connection_data": {
+                          "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
+                          "name": "Stripe BM US"
+                        },
                         "created_at": "2025-04-14T17:51:23.232152Z",
                         "updated_at": "2025-04-14T17:51:23.322335Z"
                       },
@@ -1605,7 +1611,19 @@
                                 "iso8583_response_message": {}
                               }
                             },
-                            "connection_data": {},
+                            "connection_data": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Stripe BM US"
+                                }
+                              }
+                            },
                             "created_at": {
                               "type": "string",
                               "example": "2025-04-14T17:52:07.768528Z"
@@ -2261,7 +2279,19 @@
                                 "iso8583_response_message": {}
                               }
                             },
-                            "connection_data": {},
+                            "connection_data": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "example": "58cc35f4-faef-4107-8e09-d18d60121d38"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Stripe BM US"
+                                }
+                              }
+                            },
                             "created_at": {
                               "type": "string",
                               "example": "2025-04-14T17:51:23.232152Z"


### PR DESCRIPTION
## docs(C2-17931): connection_data on operation responses

Adds `connection_data { id, name }` to the synchronous operation response reference pages, matching what `GET /v1/payments/{id}` and `create-payment` already document. Field sits at the transaction root, next to `provider_data`; same forward-only nullability semantics as the rest.

**Pages / endpoints updated** (`openapi/payments/`):
| Page | Endpoint |
|---|---|
| capture-authorization | `POST /v1/payments/{id}/transactions/{txn}/capture` |
| cancel-payment | `POST /v1/payments/{id}/transactions/{txn}/cancel` |
| cancel-or-refund-a-payment | `POST /v1/payments/{id}/cancel-or-refund` |
| cancel-or-refund-payment-with-transaction | `POST /v1/payments/{id}/transactions/{txn}/cancel-or-refund` |
| refund-payment | `POST /v1/payments/{id}/transactions/{txn}/refund` |

**Field** — schema + response examples:
```json
"connection_data": {
  "id": "58cc35f4-faef-4107-8e09-d18d60121d38",
  "name": "Stripe BM US"
}
```
`refund-payment` already carried the field but with an empty `{}` schema and `null` examples — normalized to the shaped `{id, name}` block for consistency.

**Scope notes**
- **transfer-reversal** — descoped from C2-17931 by Andrea (product), so `reverse-standalone-transfer` is intentionally **not** touched here.
- **complete** — no dedicated reference page exists in yuno-docs (no `/complete` path in `openapi/`), so there's nothing to update for it. Flagging in case a page is expected.
- Navigation (`docs.json`) unchanged — these are existing pages, only a field was added.

**Backing code** (all merged): payment-rx-orc #119, payment-api #120, public-api #2093.

@andrea — ready for your copy review before merge (wording / gating notes / example values). Not merging until you've validated.
