### PR TITLE
docs(plugins): add WooCommerce plugin overview page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -281,6 +281,12 @@
                   "docs/plugins/vtex/direct-sdk-integration",
                   "docs/plugins/vtex/faqs"
                 ]
+              },
+              {
+                "group": "WooCommerce",
+                "pages": [
+                  "docs/plugins/woocommerce/index"
+                ]
               }
             ]
           },

--- a/docs/plugins/woocommerce/index.mdx
+++ b/docs/plugins/woocommerce/index.mdx
@@ -1,0 +1,36 @@
+---
+title: "WooCommerce Plugin Overview"
+description: "Understand how the Yuno WooCommerce plugin works and how to set it up in your store."
+---
+
+Yuno's WooCommerce plugin integrates Yuno's payment orchestration platform directly into your WooCommerce store, through the Yuno Web SDK and a PHP REST API layer. It's the second e-commerce plugin Yuno supports, after VTEX.
+
+<Note>
+  This is an MVP release. Yuno is actively evolving the plugin based on merchant feedback. Join the `WooCommerce` channel in the shared Slack to stay updated on new releases.
+</Note>
+
+## What it is
+
+The plugin adds Yuno as a payment gateway inside WooCommerce, supporting both the legacy shortcode checkout and the WooCommerce block-based checkout. Shoppers complete their purchase without leaving your store, and order status updates automatically as Yuno reports payment events back to WooCommerce.
+
+## Order status sync
+
+Yuno keeps your WooCommerce order status in sync with the underlying payment status:
+
+| Payment outcome | WooCommerce order status |
+| :--- | :--- |
+| Payment succeeded, virtual or downloadable product | Completed |
+| Payment succeeded, product requires shipping | Processing |
+| Payment failed | Failed |
+
+## Reviewing sync logs
+
+The plugin's settings screen includes a log viewer where you can review the messages exchanged between WooCommerce and the Yuno dashboard for each order, useful for troubleshooting a payment that didn't sync as expected.
+
+## Setup
+
+1. In your WooCommerce admin, go to the Yuno payment gateway settings.
+2. Enter your Yuno API keys.
+3. Save changes and enable the gateway.
+
+For the full list of supported features and version history, see the [WooCommerce Plugin Changelog](/changelog/plugins/woocommerce).


### PR DESCRIPTION
## Summary

Adds a dedicated guide page for the WooCommerce plugin, which previously only had a changelog. This was shared in the Feb 27, 2026 demo.

- Covers what the plugin is, order status sync, sync log review, and setup (API keys).
- Links to the existing changelog for the full feature list and version history.
- Added to `docs.json` navigation under Plugins, next to VTEX.

Note: an earlier pass in this doc-gap review suspected a gap around Google Pay installments on VTEX. After checking the source demo directly, that wasn't confirmed. Only Apple Pay installments on VTEX is described anywhere, so nothing was added or claimed about Google Pay installments in this PR.

### Files changed
- `docs/plugins/woocommerce/index.mdx` (new)
- `docs.json`
