### PR TITLE
docs(C2-18056): external_subscription object on payment creation and retrieval

### DIFF
--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -12522,8 +12522,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -13549,8 +13552,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -14801,8 +14807,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -15905,8 +15914,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -16990,8 +17002,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -18007,8 +18022,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -19024,8 +19042,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -20073,8 +20094,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -21087,8 +21111,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -22108,8 +22135,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -23141,8 +23171,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -23724,8 +23757,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -24820,8 +24856,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -25488,8 +25527,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -26418,8 +26460,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -29111,8 +29156,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }

--- a/openapi/payments/create-payment.json
+++ b/openapi/payments/create-payment.json
@@ -3110,6 +3110,25 @@
                       ],
                       "type": "object"
                     }
+                  },
+                  "external_subscription": {
+                    "type": "object",
+                    "description": "Identifies the subscription in the billing platform that manages the recurring plan, when that platform is not Yuno. Send either `external_subscription` or `subscription`, never both: a request carrying both is rejected with `400` before any charge.",
+                    "required": [
+                      "id"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the subscription in the merchant's billing platform. Any string is accepted, with no platform specific format required. The length is measured after trimming surrounding whitespace, and the value is stored and returned exactly as sent (MAX 255; MIN 3).",
+                        "example": "sub_1QwZzz"
+                      },
+                      "customer_id": {
+                        "type": "string",
+                        "description": "The unique identifier of the customer in the merchant's billing platform. The length is measured after trimming surrounding whitespace (MAX 255; MIN 3).",
+                        "example": "cus_RplXYZ"
+                      }
+                    }
                   }
                 }
               },
@@ -4880,6 +4899,33 @@
                     "simplified_mode": false,
                     "subscription": {
                       "id": "1c9f0b2e-7d5a-4c3b-8e1f-9a0b1c2d3e4f"
+                    }
+                  }
+                },
+                "Card - Payment for an external subscription": {
+                  "value": {
+                    "description": "Monthly plan renewal",
+                    "account_id": "<account_id>",
+                    "merchant_order_id": "0000023",
+                    "country": "US",
+                    "amount": {
+                      "currency": "USD",
+                      "value": 20000
+                    },
+                    "customer_payer": {
+                      "id": "<customer_id>",
+                      "first_name": "John",
+                      "last_name": "Doe",
+                      "email": "johndoe@example.com"
+                    },
+                    "workflow": "DIRECT",
+                    "payment_method": {
+                      "type": "CARD",
+                      "vaulted_token": "<vaulted_token>"
+                    },
+                    "external_subscription": {
+                      "id": "sub_1QwZzz",
+                      "customer_id": "cus_RplXYZ"
                     }
                   }
                 },
@@ -12466,6 +12512,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -13476,6 +13538,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",
@@ -14713,6 +14791,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -15801,6 +15895,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -16870,6 +16980,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -17871,6 +17997,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -18871,6 +19013,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",
@@ -19905,6 +20063,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -20902,6 +21076,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",
@@ -21907,6 +22097,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",
@@ -22925,6 +23131,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -23491,6 +23713,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",
@@ -24572,6 +24810,22 @@
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
                         },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        },
                         "routing_rules": {
                           "type": "object",
                           "properties": {
@@ -25223,6 +25477,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -26137,6 +26407,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",
@@ -28814,6 +29100,22 @@
                           "format": "uuid",
                           "nullable": true,
                           "description": "Identifier of the subscription created or charged by this payment. Null when the payment carries no subscription."
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         },
                         "routing_rules": {
                           "type": "object",

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -4164,8 +4164,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -4877,8 +4880,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -5847,8 +5853,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -6519,8 +6528,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -7268,8 +7280,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -8089,8 +8104,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -8847,8 +8865,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -9605,8 +9626,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -10366,8 +10390,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -11138,8 +11165,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -11910,8 +11940,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -12626,8 +12659,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -13126,8 +13162,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -13627,8 +13666,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -14127,8 +14169,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }
@@ -14916,8 +14961,11 @@
                                   "example": "sub_1QwZzz"
                                 },
                                 "customer_id": {
-                                  "type": "string",
-                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ],
+                                  "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                   "example": "cus_RplXYZ"
                                 }
                               }

--- a/openapi/payments/retrieve-payment-by-id-v2.json
+++ b/openapi/payments/retrieve-payment-by-id-v2.json
@@ -4154,6 +4154,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "routing_rules": {
                               "type": "object",
                               "example": null,
@@ -4850,6 +4866,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "account_code": {
                               "type": "string",
@@ -5805,6 +5837,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "account_code": {
                               "type": "string",
                               "example": "64761a45-6e49-4ea5-a6ff-6b52030b92ac"
@@ -6460,6 +6508,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "routing_rules": {
                               "type": "object",
@@ -7193,6 +7257,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "account_code": {
                               "type": "string",
@@ -7999,6 +8079,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "account_code": {
                               "type": "string",
                               "example": "493e9374-510a-4201-9e09-de669d75f256"
@@ -8741,6 +8837,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "account_code": {
                               "type": "string",
                               "example": "493e9374-510a-4201-9e09-de669d75f256"
@@ -9482,6 +9594,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "account_code": {
                               "type": "string",
@@ -10227,6 +10355,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "account_code": {
                               "type": "string",
@@ -10984,6 +11128,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "account_code": {
                               "type": "string",
                               "example": "493e9374-510a-4201-9e09-de669d75f256"
@@ -11740,6 +11900,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "account_code": {
                               "type": "string",
                               "example": "493e9374-510a-4201-9e09-de669d75f256"
@@ -12440,6 +12616,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "routing_rules": {
                               "type": "object",
                               "example": null,
@@ -12923,6 +13115,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "routing_rules": {
                               "type": "object",
@@ -13409,6 +13617,22 @@
                               "type": "string",
                               "example": ""
                             },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
+                            },
                             "routing_rules": {
                               "type": "object",
                               "example": null,
@@ -13892,6 +14116,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "routing_rules": {
                               "type": "object",
@@ -14665,6 +14905,22 @@
                             "payment_link_code": {
                               "type": "string",
                               "example": ""
+                            },
+                            "external_subscription": {
+                              "type": "object",
+                              "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                  "example": "sub_1QwZzz"
+                                },
+                                "customer_id": {
+                                  "type": "string",
+                                  "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                  "example": "cus_RplXYZ"
+                                }
+                              }
                             },
                             "routing_rules": {
                               "type": "object",

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -3783,6 +3783,22 @@
                         },
                         "metadata": {
                           "type": "array"
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -4447,6 +4463,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -5359,6 +5391,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -5973,6 +6021,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -6673,6 +6737,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -7440,6 +7520,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -8140,6 +8236,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -8840,6 +8952,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -9543,6 +9671,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -10257,6 +10401,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -10971,6 +11131,22 @@
                         "payment_link_code": {
                           "type": "string",
                           "example": ""
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -11611,6 +11787,22 @@
                         },
                         "metadata": {
                           "type": "array"
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -12049,7 +12241,23 @@
                         "metadata": {
                           "type": "array"
                         },
-                        "fraud_screening": {}
+                        "fraud_screening": {},
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
+                        }
                       }
                     },
                     {
@@ -12483,6 +12691,22 @@
                         },
                         "metadata": {
                           "type": "array"
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     },
@@ -12916,6 +13140,22 @@
                         },
                         "metadata": {
                           "type": "array"
+                        },
+                        "external_subscription": {
+                          "type": "object",
+                          "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                              "example": "sub_1QwZzz"
+                            },
+                            "customer_id": {
+                              "type": "string",
+                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "example": "cus_RplXYZ"
+                            }
+                          }
                         }
                       }
                     }

--- a/openapi/payments/retrieve-payment-by-id.json
+++ b/openapi/payments/retrieve-payment-by-id.json
@@ -3794,8 +3794,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -4474,8 +4477,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -5402,8 +5408,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -6032,8 +6041,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -6748,8 +6760,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -7531,8 +7546,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -8247,8 +8265,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -8963,8 +8984,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -9682,8 +9706,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -10412,8 +10439,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -11142,8 +11172,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -11798,8 +11831,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -12252,8 +12288,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -12702,8 +12741,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }
@@ -13151,8 +13193,11 @@
                               "example": "sub_1QwZzz"
                             },
                             "customer_id": {
-                              "type": "string",
-                              "description": "The unique identifier of the customer in the merchant's billing platform.",
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                               "example": "cus_RplXYZ"
                             }
                           }

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -3841,8 +3841,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -4512,8 +4515,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -5151,8 +5157,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -5772,8 +5781,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -6461,8 +6473,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -7213,8 +7228,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -8035,8 +8053,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -8724,8 +8745,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -9416,8 +9440,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -10119,8 +10146,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -10822,8 +10852,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -11464,8 +11497,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -11856,8 +11892,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -12334,8 +12373,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -12809,8 +12851,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }
@@ -13254,8 +13299,11 @@
                                 "example": "sub_1QwZzz"
                               },
                               "customer_id": {
-                                "type": "string",
-                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "description": "The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it.",
                                 "example": "cus_RplXYZ"
                               }
                             }

--- a/openapi/payments/retrieve-payment-by-merchant-order-id.json
+++ b/openapi/payments/retrieve-payment-by-merchant-order-id.json
@@ -3830,6 +3830,22 @@
                           },
                           "metadata": {
                             "type": "array"
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -4485,6 +4501,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -5108,6 +5140,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -5713,6 +5761,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -6386,6 +6450,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -7122,6 +7202,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -7928,6 +8024,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -8601,6 +8713,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -9277,6 +9405,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -9964,6 +10108,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -10651,6 +10811,22 @@
                           "payment_link_code": {
                             "type": "string",
                             "example": ""
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -11277,6 +11453,22 @@
                           },
                           "metadata": {
                             "type": "array"
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -11653,7 +11845,23 @@
                           "metadata": {
                             "type": "array"
                           },
-                          "fraud_screening": {}
+                          "fraud_screening": {},
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
+                          }
                         }
                       }
                     },
@@ -12115,6 +12323,22 @@
                           },
                           "metadata": {
                             "type": "array"
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -12574,6 +12798,22 @@
                           },
                           "metadata": {
                             "type": "array"
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }
@@ -13003,6 +13243,22 @@
                           },
                           "metadata": {
                             "type": "array"
+                          },
+                          "external_subscription": {
+                            "type": "object",
+                            "description": "Returned when the payment was created with `external_subscription`, carrying the same values that were sent. Omitted for payments created without it.",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "The unique identifier of the subscription in the merchant's billing platform.",
+                                "example": "sub_1QwZzz"
+                              },
+                              "customer_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the customer in the merchant's billing platform.",
+                                "example": "cus_RplXYZ"
+                              }
+                            }
                           }
                         }
                       }

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -99,6 +99,28 @@ This object represents the payment created after generating the checkout session
   Example: null
 </ParamField>
 
+<ParamField body="external_subscription" type="object">
+  optional
+
+  Present when the payment was created with an `external_subscription`; the subscription and customer identifiers from the merchant's billing platform.
+
+  <Expandable title="properties">
+
+    <ParamField body="id" type="string">
+      The unique identifier of the subscription in the merchant's billing platform (MAX 255; MIN 3).
+
+      Example: sub_1QwZzz
+    </ParamField>
+
+    <ParamField body="customer_id" type="string">
+      The unique identifier of the customer in the merchant's billing platform (MAX 255; MIN 3).
+
+      Example: cus_RplXYZ
+    </ParamField>
+
+  </Expandable>
+</ParamField>
+
 <ParamField body="simplified_mode" type="boolean">
   optional
 

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -112,8 +112,8 @@ This object represents the payment created after generating the checkout session
       Example: sub_1QwZzz
     </ParamField>
 
-    <ParamField body="customer_id" type="string">
-      The unique identifier of the customer in the merchant's billing platform (MAX 255; MIN 3).
+    <ParamField body="customer_id" type="string | null">
+      The unique identifier of the customer in the merchant's billing platform. Null when the payment was created without it (MAX 255; MIN 3).
 
       Example: cus_RplXYZ
     </ParamField>


### PR DESCRIPTION
Documents the optional `external_subscription` object added in C2-18056, for merchants whose recurring plans are managed by their own billing platform instead of by Yuno.

### What changed

- **Create Payment** (`openapi/payments/create-payment.json`): the object in the request body, with `id` required, `customer_id` optional, both bounded to 3 to 255 characters measured after trimming surrounding whitespace, and the rule that `external_subscription` and `subscription` cannot be sent together (`400` before any charge).
- **Payment responses**: the object added to every response variant of Create Payment, Retrieve Payment by ID (both specs) and Retrieve Payment by Merchant Order ID. It is returned with the same values that were sent, omitted when the payment carries none, and `customer_id` comes back as `null` when it was not sent.
- **The Payment Object** (`reference/payments/the-payment-object.mdx`): the field and its two properties. The webhook page points at this page for the `data` attribute, so this also covers the payment webhook payload.
- A Create Payment request example carrying the object.

Request:

```json
{
  "description": "Monthly plan renewal",
  "account_id": "<account_id>",
  "merchant_order_id": "0000023",
  "country": "US",
  "amount": { "currency": "USD", "value": 20000 },
  "customer_payer": { "id": "<customer_id>" },
  "workflow": "DIRECT",
  "payment_method": { "type": "CARD", "vaulted_token": "<vaulted_token>" },
  "external_subscription": { "id": "sub_1QwZzz", "customer_id": "cus_RplXYZ" }
}
```

Response (same shape on create, on both retrieve endpoints and on the payment webhook):

```json
"external_subscription": { "id": "sub_1QwZzz", "customer_id": "cus_RplXYZ" }
```

### Verified against staging

Every claim on the pages was exercised on `api-staging.y.uno`, not taken from the spec:

| Documented | Observed |
|---|---|
| returned on create | payment `7f8e16f7-6dc1-4072-b81e-acfe20d22ca8`, `201`, object at the top level |
| returned on retrieve by ID and by merchant order ID | both carry it |
| omitted when not sent | payment `0e15ed01-1fd0-4f80-b17d-b296af201a81`, key absent on create and on retrieve |
| `id` required when the object is present | `400 INVALID_REQUEST`, "external_subscription.id is required." |
| 3 to 255 characters | `400` at 2 and at 256 characters |
| length measured after trimming | `"   "` gives `400` "can not be empty."; `"  sub_pad  "` is accepted |
| value stored and returned as sent | comes back as `"  sub_pad  "`, untrimmed |
| no platform specific format | `"anything-not-stripe-shaped"` is accepted |
| cannot be sent with `subscription` | `400 INVALID_REQUEST`, "external_subscription and subscription can not be sent together." |
| `customer_id` optional | accepted without it, returned as `null` |

### Notes for the reviewer

- No format rule is documented for `id`: the value belongs to the merchant's billing platform, so pinning a prefix or a length would tie the public contract to one provider. No provider is named anywhere in the pages.
- Left out on purpose: the **Authorize Payment** page. It documents the same endpoint but with a curated body that already omits `subscription`, so adding a subscription object only to its responses would read as incoherent. Happy to add it if you prefer full parity with `subscription_code`.
- Two pre-existing mismatches found while verifying, **not touched here** because they are outside this change: `retrieve-payment-by-merchant-order-id.json` models an array of flat payment objects while the endpoint returns an array of `{"payment": {...}}`, and `retrieve-payment-by-id.json` models the flat shape (that page is `hidden: true` and out of the nav, so the visible page is already the correct one). Worth its own ticket.
- Public surface scan run on the diff: no versioned internal path, no internal service name, no behavior note that depends on Yuno internals.
- Checks: `check-descriptions.cjs` green (409 pages), Mintlify link-rot green, `redocly lint` adds no error and one warning identical to the one every sibling request example already produces (`checkout` marked required while the DIRECT examples omit it), render reviewed on `mint dev` and on the preview.

Jira: https://yunopayments.atlassian.net/browse/C2-18056
