### PR TITLE
docs(sdk): Android tab on the styling page (CORECM-19314)

### DIFF
--- a/docs/yuno-sdk/features/styling.mdx
+++ b/docs/yuno-sdk/features/styling.mdx
@@ -73,6 +73,72 @@ SdkPayments.Transaction(config: config)
 ```
 
   </Tab>
+
+  <Tab title="Android">
+
+Build an `Appearance` with the fields you want to override and pass it to `TransactionConfig(appearance = ...)`. Every field is optional; unset fields fall back to the SDK default.
+
+## Appearance fields
+
+| Field | Description |
+|---|---|
+| `fontFamily` | Font family used across the SDK. Resolved against the system fonts and the fonts configured in your dashboard; a name that cannot be resolved keeps the SDK typography. |
+| `accentColor` | Accent color used on focus strokes and cursors. It does not cascade into checkboxes or secondary button borders — those have their own fields. |
+| `buttonBackgroundColor` | Background color of primary buttons. |
+| `buttonTitleColor` | Text color of primary buttons. |
+| `buttonBorderColor` | Border color of primary buttons. |
+| `secondaryButtonBackgroundColor` | Background color of secondary buttons. |
+| `secondaryButtonTitleColor` | Text color of secondary buttons. |
+| `secondaryButtonBorderColor` | Border color of secondary buttons. |
+| `disableButtonBackgroundColor` | Background color of disabled buttons. |
+| `disableButtonTitleColor` | Text color of disabled buttons. |
+| `checkboxColor` | Color of checkboxes shown in the SDK (e.g. save card). |
+
+<Note>
+All colors are `@ColorInt` integers — use `Color.parseColor("#FFD600")`, `ContextCompat.getColor(context, R.color.brand)`, or the `android.graphics.Color` constants.
+</Note>
+
+## How styles are resolved
+
+Setting **any** `Appearance` field makes it the active style source for the transaction: dashboard styles are then ignored entirely — resolution is all-or-nothing per source, never a field-by-field merge. An empty `Appearance()` does not count as custom, so dashboard styles still apply. Any custom appearance (in code or from the dashboard) renders in light mode.
+
+## Usage
+
+Appearance is per-transaction: pass it on each `TransactionConfig`, not at `initialize`.
+
+```kotlin
+import android.graphics.Color
+import com.yuno.payments.sdk.api.Appearance
+import com.yuno.payments.sdk.api.Transaction
+import com.yuno.payments.sdk.api.TransactionConfig
+
+val appearance = Appearance(
+    fontFamily = "Climate Crisis",
+    accentColor = Color.parseColor("#E65100"),
+    buttonBackgroundColor = Color.parseColor("#FFD600"),
+    buttonTitleColor = Color.BLACK,
+    buttonBorderColor = Color.BLACK,
+    secondaryButtonBackgroundColor = Color.parseColor("#FFD600"),
+    secondaryButtonTitleColor = Color.BLACK,
+    secondaryButtonBorderColor = Color.BLACK,
+    disableButtonBackgroundColor = Color.GRAY,
+    disableButtonTitleColor = Color.BLACK,
+    checkboxColor = Color.BLACK,
+)
+
+val transaction = Transaction(
+    TransactionConfig(
+        countryCode = "US",
+        checkoutSession = "session-from-backend",
+        appearance = appearance,
+        controller = this,
+    ),
+)
+
+transaction.start(paymentSelected = paymentSelected)
+```
+
+  </Tab>
 </Tabs>
 
 ## Related


### PR DESCRIPTION
## Summary
The styling page (`docs/yuno-sdk/features/styling.mdx`) only documented iOS — Android was absent even though its v3 API is an exact mirror. Fixes [CORECM-19314](https://yunopayments.atlassian.net/browse/CORECM-19314) (flagged by Viviana).

Adds the **Android** tab, verified against `release/3.0.0-alpha`:
- Fields table — same 11 fields as iOS (`fontFamily` + 10 colors), typed as `@ColorInt Int`, with the `Color.parseColor` / `ContextCompat.getColor` note.
- Kotlin usage snippet: `Appearance` passed per-transaction on `TransactionConfig(appearance = ...)` (never at initialize — `YunoConfig.styles` was removed by CORECM-18302).
- **"How styles are resolved"** section the page didn't cover: setting any field makes the merchant appearance the active source and dashboard styles are ignored entirely (all-or-nothing, no field-by-field merge; empty `Appearance()` doesn't count), and any custom appearance renders in light mode. `fontFamily` resolves against system + dashboard fonts, with fallback to SDK typography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-19314]: https://yunopayments.atlassian.net/browse/CORECM-19314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to SDK styling docs; no runtime or security impact.
> 
> **Overview**
> Adds an **Android** tab to the SDK styling page so merchants can customize checkout appearance in code, matching the existing iOS coverage.
> 
> Documents the 11 `Appearance` fields (`fontFamily` plus 10 colors as `@ColorInt`), that styles are passed per-transaction on `TransactionConfig` (not at initialize), and that setting any field is all-or-nothing versus dashboard styles. Includes a Kotlin usage snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e5581bbf828463201abfbaf8166482c11080f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->