### PR TITLE
docs(reference): apply Reference lists docs-evaluation text fixes

### DIFF
--- a/reference/airline-information.mdx
+++ b/reference/airline-information.mdx
@@ -15,7 +15,9 @@ On this page, you will find airline information you may need when using Yuno API
 
 ## Fare class code
 
-The values can be a letter (A-Z) but may vary depending on the airline's definition. Type: String (MAX:1; MIN:1).
+| `fare_class_code` | Description                                     |
+| ------------------ | ------------------------------------------------ |
+| Letter (A-Z)        | Varies by airline definition. Max 1 character.   |
 
 ## Loyalty tier
 

--- a/reference/api-enums.mdx
+++ b/reference/api-enums.mdx
@@ -10,7 +10,7 @@ This page serves as the **Single Source of Truth (SSOT)** for all key enums and 
 These are the primary standard identifiers used for transaction routing, payment method processing, and integration strategy selection across Yuno.
 
 <Note>
-  For an exhaustive, category-by-category mapping of which **Payment Method Types** are supported by which **Providers**, please refer directly to our comprehensive [Payment Catalog](/reference/payment-type-list). The tables below serve as flat lookup references for individual enum parameter values.
+  For an exhaustive, category-by-category mapping of which **Payment Method Types** are supported by which **Providers**, please refer directly to the comprehensive [Payment Catalog](/reference/payment-type-list). The tables below serve as flat lookup references for individual enum parameter values.
 </Note>
 
 ### Provider ID (`provider_id`)
@@ -154,7 +154,7 @@ Identifies the payment service provider (PSP) or gateway. This value is used in 
 
 ### Payment Method Type (`payment_method_type`)
 
-Specifies the payment instrument or channel used (e.g., credit card, bank transfer, digital wallet, BNPL).
+Specifies the payment instrument or channel used (for example, credit card, bank transfer, digital wallet, BNPL).
 
 <Accordion title="View 180+ Supported Payment Methods" icon="credit-card">
   <div className="code-nowrap-table dense-table">
@@ -265,7 +265,6 @@ Specifies the payment instrument or channel used (e.g., credit card, bank transf
   | `KLARNA_PAY_NOW_ENROLLMENT` | Klarna Pay Now Enrollment |
   | `KLARNA_PAY_OVER_TIME` | Klarna Pay Over Time |
   | `KLARNA_PAY_OVER_TIME_ENROLLMENT` | Klarna Pay Over Time Enrollment |
-  | `COOPERATIVA_LA_ALTAGRACIA` | Cooperativa La Altagracia |
   | `LAMASBARATA` | La Mas Barata |
   | `LAWSON` | Lawson Cash |
   | `LINK_TO_PAY` | Link to Pay identifier |

--- a/reference/eci-indicators-list.mdx
+++ b/reference/eci-indicators-list.mdx
@@ -3,8 +3,6 @@ title: "ECI Indicators List"
 description: "Lists ECI response codes returned by card networks during 3D Secure authentication attempts"
 ---
 
-import { HTMLBlock } from "/snippets/HTMLBlock.jsx";
-
 An Electronic Commerce Indicator (ECI) is a response code used in 3D Secure transactions, specifically in EMV 3D Secure. It helps merchants determine the next steps to take in a transaction — proceed, reject the purchase, or try again. Below you will find the possible responses and ECI values you can receive.
 
 ## Successful authentication
@@ -187,7 +185,7 @@ The authentication request encountered obstacles that prevented its completion f
   <thead>
     <tr>
       <th>Card type</th>
-      <th>Supported Version(s)</th>
+      <th>ECI indicator</th>
     </tr>
   </thead>
   <tbody>

--- a/reference/industry-category-list.mdx
+++ b/reference/industry-category-list.mdx
@@ -25,7 +25,7 @@ On this page, you will find the industry category information you need when usin
 | `ELECTRONICS`               | Audio & Surveillance, Video & GPS, Others.                                                                                                                                  |
 | `ENTERTAINMENT`             | Music, Movies & Series, Magazines & Comics.                                                                                                                                 |
 | `EDUCATION`                 | Education services.                                                                                                                                                         |
-| `FASHION`                   | Men’s, Women’s, Kids & baby, Handbags & Accessories, Health & Beauty, Shoes, Jewelry & Watches.                                                                             |
+| `FASHION`                   | Men's, Women's, Kids & baby, Handbags & Accessories, Health & Beauty, Shoes, Jewelry & Watches.                                                                             |
 | `GAMES`                     | Online Games & Credits.                                                                                                                                                     |
 | `GARDEN_&_OUTDOOR`        | Outdoor Décor, Patio Furniture & Accessories, Outdoor Lighting Products, Pest Control Products.                                                                             |
 | `GROCERY_&_GOURMET_FOOD` | Alcoholic Beverages, Baby Foods, Frozen Foods, Fresh Produce.                                                                                                               |

--- a/reference/items-category-list.mdx
+++ b/reference/items-category-list.mdx
@@ -25,7 +25,7 @@ On this page, you will find the items category information you need when using Y
 | `AUTOMOTIVE`                | Parts & Accessories.                                                                                                                                                        |
 | `TOYS_&_GAMES`            | Board Games & Toys.                                                                                                                                                         |
 | `MUSICAL_INSTRUMENTS`      | Guitars, Ukuleles, Drums & Percussion, Musical Instrument Keyboards.                                                                                                        |
-| `HANDMADE`                  | Accesories, jewerly, decorations.                                                                                                                                           |
+| `HANDMADE`                  | Accessories, jewelry, decorations.                                                                                                                                           |
 | `GARDEN_&_OUTDOOR`        | Outdoor Décor, Patio Furniture & Accessories, Outdoor Lighting Products, Pest Control Products.                                                                             |
 | `ENTERTAINMENT`             | Music, Movies & Series, Magazines & Comics.                                                                                                                                 |
 | `INDUSTRIAL&_SCIENTIFIC`   | Scales & Balances, Industrial Magnets.                                                                                                                                      |

--- a/reference/reference-lists.mdx
+++ b/reference/reference-lists.mdx
@@ -3,7 +3,7 @@ title: "Reference"
 description: "Indexes all reference lists for enums, payment methods, countries, and other Yuno API data"
 ---
 
-Discover a comprehensive collection of essential data the Yuno API utilizes on this page. Effortlessly access the following categories through the provided links:
+This page indexes essential reference data used by the Yuno API. Use the links below to find each category:
 
 <CardGroup cols={3}>
   <Card arrow title="API Enums" icon="brackets-curly" href="/reference/api-enums">
@@ -46,5 +46,3 @@ Discover a comprehensive collection of essential data the Yuno API utilizes on t
     Standard groupings for classifying transactions and payment methods.
   </Card>
 </CardGroup>
-
-Each link will redirect you to a corresponding information list, granting you quick access to the required details.

--- a/reference/transaction-category-list.mdx
+++ b/reference/transaction-category-list.mdx
@@ -12,6 +12,6 @@ Yuno organizes the available payment methods into distinct transaction categorie
 | `BNPL`                | Buy Now Pay Later.                                 |
 | `WALLET`              | Wallet payments.                                   |
 | `TICKET`              | Cash payments.                                     |
-| `PAYMENT_LINK`        | Payment links that accept multiple payment methods |
+| `PAYMENT_LINK`        | Payment links that accept multiple payment methods. |
 
 To access the list of available payment methods on the Yuno API, refer to the [Payment type](/reference/payment-type-list) page.


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged grammar, voice, consistency, and dead-code issues across the Reference lookup pages. This PR applies the confirmed text-only fixes. No enum values or code were touched — one item that touched an enum value was explicitly excluded.

## Changes
- **reference-lists.mdx**: rewrote the promotional opening ("Effortlessly access..."); cut the generic closing sentence that just restated the CardGroup above it.
- **api-enums.mdx**: replaced "our" with neutral third person; expanded "e.g." to "for example"; removed a duplicate `COOPERATIVA_LA_ALTAGRACIA` table row (identical value and description appeared twice).
- **airline-information.mdx**: reformatted the "Fare class code" section as a 2-column table to match its sibling subsections ("Passenger type", "Loyalty tier"), instead of a lone sentence.
- **transaction-category-list.mdx**: added the missing trailing period to the `PAYMENT_LINK` row for consistency with every other row.
- **industry-category-list.mdx**: standardized the `FASHION` row's free-text description to straight apostrophes, matching `items-category-list.mdx` and the docs' default style.
- **items-category-list.mdx**: fixed 2 spelling typos in the `HANDMADE` row's description ("Accesories" → "Accessories", "jewerly" → "jewelry").
- **eci-indicators-list.mdx**: removed the unused `HTMLBlock` MDX import (verified it's never referenced in the file, same pattern already fixed on `response-codes.mdx`); fixed the "Not permitted authentication codes" table's misleading column header ("Supported Version(s)" → "ECI indicator") to match the three preceding tables, whose data columns hold the same kind of ECI code values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits; no API enum values or product behavior change.
> 
> **Overview**
> Applies docs-evaluation copy and consistency fixes across Reference lookup pages. No documented enum values were changed.
> 
> Tightens intro copy on `reference-lists.mdx`, uses third-person voice in `api-enums.mdx`, and drops a duplicate `COOPERATIVA_LA_ALTAGRACIA` payment-method row. Fare class is now a table like the other airline fields. ECI “not permitted” column header is `ECI indicator` (matching sibling tables), and an unused `HTMLBlock` import is removed.
> 
> Also fixes typos (`HANDMADE` accessories/jewelry), apostrophes in `FASHION`, and a missing period on `PAYMENT_LINK`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2937dc1d9caf9d3d54d28d46d025a4d82268af00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->