### PR TITLE
docs: fix stale payment_method_type / country enums on enroll-payment-method-checkout

### DIFF
--- a/openapi/customer-sessions-enrollment/create-customer-session.json
+++ b/openapi/customer-sessions-enrollment/create-customer-session.json
@@ -57,26 +57,7 @@
                   },
                   "country": {
                     "type": "string",
-                    "description": "The customer's country  (MAX 2; MIN 2; [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).",
-                    "enum": [
-                      "AR",
-                      "BO",
-                      "BR",
-                      "CL",
-                      "CO",
-                      "CR",
-                      "EC",
-                      "SV",
-                      "GT",
-                      "HN",
-                      "MX",
-                      "NI",
-                      "PA",
-                      "PY",
-                      "PE",
-                      "US",
-                      "UY"
-                    ]
+                    "description": "The customer's country. Accepts any valid ISO 3166-1 alpha-2 country code ([ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2))."
                   },
                   "customer_id": {
                     "type": "string",

--- a/openapi/payment-methods-checkout/enroll-payment-method-checkout.json
+++ b/openapi/payment-methods-checkout/enroll-payment-method-checkout.json
@@ -75,37 +75,11 @@
                   },
                   "payment_method_type": {
                     "type": "string",
-                    "description": "The payment method type (MAX 255; MIN 3; [Payment Type List](/reference/payment-type-list)).",
-                    "enum": [
-                      "CARD",
-                      "MERCADO_PAGO_WALLET",
-                      "NEQUI",
-                      "BANCOLOMBIA_TOKENBOX",
-                      "NU_PAY_ENROLLMENT"
-                    ]
+                    "description": "The payment method type (MAX 255; MIN 3; [Payment Type List](/reference/payment-type-list)). Accepted values depend on the payment methods connected to your account; common examples include `CARD`, `MERCADO_PAGO_WALLET`, `NEQUI`, `BANCOLOMBIA_TOKENBOX`, `NU_PAY_ENROLLMENT`, and `PAYPAL_ENROLLMENT`."
                   },
                   "country": {
                     "type": "string",
-                    "description": "The transaction's country code (MAX 2; MIN 2; [ISO 3166-1](/reference/country-reference)).",
-                    "enum": [
-                      "AR",
-                      "BO",
-                      "BR",
-                      "CL",
-                      "CO",
-                      "CR",
-                      "EC",
-                      "SV",
-                      "GT",
-                      "HN",
-                      "MX",
-                      "NI",
-                      "PA",
-                      "PY",
-                      "PE",
-                      "US",
-                      "UY"
-                    ]
+                    "description": "The transaction's country code. Accepts any valid ISO 3166-1 alpha-2 country code ([ISO 3166-1](/reference/country-reference))."
                   },
                   "account_updater": {
                     "type": "boolean",


### PR DESCRIPTION
## What

Fixes two verified documentation gaps found while investigating the Nutrameg PAYPAL_ENROLLMENT issue (YSHUB-6567), unrelated to that bug's fix — both confirmed against the live API, not just read from code.

**`country` (both `enroll-payment-method-checkout.json` and `create-customer-session.json`)**

Docs list a 17-code enum (LatAm + US). The API actually validates against the full ISO 3166-1 alpha-2 list. Tested 6 codes outside the documented enum on the Montmartre sandbox test account (`41971fb9`): `LV, ES, DE, GB, DO, VE` all returned 201 at both `create-customer-session` and `enroll-payment-method-checkout`. Genuinely invalid codes (`ZZ`, `XYZ`) were correctly rejected with a real validation message, confirming the field is checked, just against a bigger list than documented.

**`payment_method_type` (`enroll-payment-method-checkout.json`)**

This field isn't validated against a fixed enum at all — it's a lookup against the account's connected payment providers. Proof: on Montmartre, a nonsense value (`TOTALLY_BOGUS_TYPE`) and a real-but-unconnected value (e.g. `PAYPAL_ENROLLMENT`, which Montmartre has no PayPal connection for) both return the byte-identical generic 400 (`"Invalid parameters: list - [%s]"`). Only `CARD` and `NU_PAY_ENROLLMENT`, the two providers Montmartre actually has, returned 201.

The 5-value enum here implied a closed list that doesn't match how the field works. Reworded the description to say accepted values depend on the account's connected providers, and added `PAYPAL_ENROLLMENT` as a named example since it's independently verified end-to-end on a merchant account that does have PayPal connected (Nutrameg, trace `ad71e4a6`/`185a007c`).

## What this does NOT fix

`enroll-payment-methods.mdx` separately lists 9 supported types for this same workflow (`DAVIPLATA_ENROLLMENT`, `WALLET_CONNECT`, `YAPE_ENROLLMENT`, `SMART_PIX`, `ASTROPAY_ENROLLABLE`, `PIX_BIOMETRICO`, plus the ones covered here), and disagrees with this endpoint's old enum on which types are supported at all. Those 6 remain unverified — no test account was available with those providers connected — and are intentionally left out of this PR rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI description/enum updates; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Aligns enrollment OpenAPI specs with live API behavior by dropping closed enums that were too narrow.
> 
> `country` on **Create Customer Session** and **Enroll Payment Method** is no longer a 17-code LatAm+US list; docs now say any valid ISO 3166-1 alpha-2 code is accepted.
> 
> `payment_method_type` on enroll is no longer a 5-value enum. The description now states accepted types depend on providers connected to the account, and lists common examples including `PAYPAL_ENROLLMENT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ca3b76240d2e068b9f66aed71558bd7e3c3268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->