### PR TITLE
docs(payment-links): remove incorrect COL-only restriction on taxes field

### DIFF
--- a/openapi/payment-links/create-payment-link.json
+++ b/openapi/payment-links/create-payment-link.json
@@ -140,7 +140,7 @@
                   },
                   "taxes": {
                     "type": "array",
-                    "description": "Specifies the payment taxes list. **Only available for COL**.",
+                    "description": "Specifies the payment taxes list.",
                     "items": {
                       "properties": {
                         "type": {


### PR DESCRIPTION
## PR Description
Aleksandra (product) reported that the `taxes` field on Create Payment Link incorrectly states it's "Only available for COL" — she confirmed the taxes list is accepted for any country and currency. This removes the incorrect restriction from the field description.

## Changes
- `openapi/payment-links/create-payment-link.json` — removed "**Only available for COL**." from the `taxes` field description, keeping "Specifies the payment taxes list."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only OpenAPI description tweak with no API or runtime behavior change.
> 
> **Overview**
> Corrects the Create Payment Link OpenAPI spec so `taxes` is no longer described as Colombia-only. The field is accepted for any country and currency; the description now just says it specifies the payment taxes list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc29d499b1cd6b72b50211278bfee155f3163b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->