### PR TITLE
chore: web sdk changelog 1.10.8

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,81 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.10.8",
+      "release_date": "2026-08-22",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.10.8",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Yuno Pay Button",
+          "description": "The SDK can now render its own Pay button, controlled by the yuno_pay_button_position setting: FLOATING places it at the end of the payment method list, STICKY keeps it fixed at the bottom of the screen on mobile (falling back to FLOATING on desktop), and ACCORDION renders it inside each payment method. A new stickyPayButton.lastElementSelector option in startCheckout lets merchants tell the SDK which element to pad so the sticky bar never overlaps their page content.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Google Pay sheet now offers a shipping method selector",
+          "description": "The Google Pay payment sheet can display the merchant's shipping methods so the buyer picks one directly on the sheet, with amounts updated on each selection.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Google Pay payment sheet now shows the order breakdown",
+          "description": "Google Pay displays the order line-item breakdown (subtotal, shipping, tax, discounts) on the payment sheet when the checkout session provides summary items.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Google Pay notifies shipping address changes in real time",
+          "description": "Merchants can register an onShippingAddressChanged callback to receive the shipping address selected on the Google Pay sheet and return updated amounts while the buyer checks out.",
+          "group": "Google Pay",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "ADDED",
+          "title": "Shipping Callbacks for Apple Pay",
+          "description": "The Apple Pay sheet can now open with your delivery options and price breakdown already in place, and tell you when the customer picks or changes a shipping address. When the checkout session carries `shipping_methods` or `summary_items`, the sheet renders them as-is — the first delivery option is preselected and its breakdown drives the total, and your labels are shown exactly as you wrote them. Set `externalButtons.onShippingAddressChanged` to be called with the address the wallet exposes (city, state, postal code and country) and answer with new totals, new delivery options, or an error message that rejects the address. Switching between delivery options is answered from the SDK's own cache, so your handler is only called when the address itself changes, and the option the customer chose travels with the one time token alongside the shipping address. Checkout sessions without these fields and integrations without the handler behave exactly as before.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Worldpay 3DS Device Data Collection",
+          "description": "Card payments routed through Worldpay's own 3DS now run the device data collection step and report the resulting device fingerprint back to the provider, so the authentication challenge behaves correctly instead of being silently degraded. The same fix applies to the headless flow, and other 3DS providers now also forward the device session they collect.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "CHANGED",
+          "title": "Live Form Validation Feedback",
+          "description": "Payment forms now validate continuously as the customer types, errors appear only after leaving a field, and pay buttons look disabled until the form is complete while staying clickable to reveal pending errors.",
+          "group": "Core SDK",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-15264",
+        "CORECM-16512",
+        "CORECM-16514",
+        "CORECM-16516",
+        "CORECM-16532",
+        "CORECM-19283",
+        "CORECM-19317"
+      ]
+    },
+    {
       "version": "1.10.7",
       "release_date": "2026-08-19",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -5,6 +5,36 @@ description: "Latest updates and version history for the Yuno Web SDK"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v1.10.8
+*August 22, 2026*
+
+**Core SDK**
+
+- <ChangelogBadge type="added" /> **Yuno Pay Button**  
+  The SDK can now render its own Pay button, controlled by the yuno_pay_button_position setting: FLOATING places it at the end of the payment method list, STICKY keeps it fixed at the bottom of the screen on mobile (falling back to FLOATING on desktop), and ACCORDION renders it inside each payment method. A new stickyPayButton.lastElementSelector option in startCheckout lets merchants tell the SDK which element to pad so the sticky bar never overlaps their page content.
+
+- <ChangelogBadge type="changed" /> **Live Form Validation Feedback**  
+  Payment forms now validate continuously as the customer types, errors appear only after leaving a field, and pay buttons look disabled until the form is complete while staying clickable to reveal pending errors.
+
+**Google Pay**
+
+- <ChangelogBadge type="added" /> **Google Pay sheet now offers a shipping method selector**  
+  The Google Pay payment sheet can display the merchant's shipping methods so the buyer picks one directly on the sheet, with amounts updated on each selection.
+
+- <ChangelogBadge type="added" /> **Google Pay payment sheet now shows the order breakdown**  
+  Google Pay displays the order line-item breakdown (subtotal, shipping, tax, discounts) on the payment sheet when the checkout session provides summary items.
+
+- <ChangelogBadge type="added" /> **Google Pay notifies shipping address changes in real time**  
+  Merchants can register an onShippingAddressChanged callback to receive the shipping address selected on the Google Pay sheet and return updated amounts while the buyer checks out.
+
+**Payment Actions**
+
+- <ChangelogBadge type="added" /> **Shipping Callbacks for Apple Pay**  
+  The Apple Pay sheet can now open with your delivery options and price breakdown already in place, and tell you when the customer picks or changes a shipping address. When the checkout session carries `shipping_methods` or `summary_items`, the sheet renders them as-is — the first delivery option is preselected and its breakdown drives the total, and your labels are shown exactly as you wrote them. Set `externalButtons.onShippingAddressChanged` to be called with the address the wallet exposes (city, state, postal code and country) and answer with new totals, new delivery options, or an error message that rejects the address. Switching between delivery options is answered from the SDK's own cache, so your handler is only called when the address itself changes, and the option the customer chose travels with the one time token alongside the shipping address. Checkout sessions without these fields and integrations without the handler behave exactly as before.
+
+- <ChangelogBadge type="fixed" /> **Worldpay 3DS Device Data Collection**  
+  Card payments routed through Worldpay's own 3DS now run the device data collection step and report the resulting device fingerprint back to the provider, so the authentication challenge behaves correctly instead of being silently degraded. The same fix applies to the headless flow, and other 3DS providers now also forward the device session they collect.
+
 ## v1.10.7
 *August 19, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.10.8`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v14.0.9

7 entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no code, auth, or runtime behavior changes.
> 
> **Overview**
> Publishes **Web SDK v1.10.8** (August 22, 2026) in `changelog/source/web.json` and `changelog/web.mdx`.
> 
> Highlights: SDK-rendered Pay button (`FLOATING` / `STICKY` / `ACCORDION`), Google Pay shipping methods, order breakdown, and `onShippingAddressChanged`, Apple Pay shipping callbacks, live form validation, and a Worldpay 3DS device-data collection fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9cbc680ccf942b5c47100ca62670075045f248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->