### PR TITLE
docs: describe alphanumeric CNPJ format support (CORECM-18442)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -99,7 +99,7 @@
           },
           "document_number": {
             "type": "string",
-            "description": "Document number (digits only). CPF: 11 digits, CNPJ: 14 digits.",
+            "description": "Document number. CPF: 11 numeric digits. CNPJ: 14 characters \u2014 numeric, or alphanumeric for CNPJs issued from July 2026 (letters A\u2013Z may appear in the first 12 positions; the last 2 check digits are always numeric), e.g. 12.ABC.345/01DE-35. Existing numeric CNPJs remain valid.",
             "example": "12345678901"
           }
         },

--- a/reference/country-reference.mdx
+++ b/reference/country-reference.mdx
@@ -23,6 +23,8 @@ On this page, you will find the country's information you need when using Yuno A
 
 **(1)** *The number of digits after the decimal separator*
 
+**(2)** *CNPJ accepts both formats: the legacy 14-digit numeric format and, for CNPJs issued from July 2026, an alphanumeric format where the first 12 positions may contain uppercase letters (A–Z) or digits, while the last 2 check digits are always numeric — for example, `12.ABC.345/01DE-35`. Yuno SDK document validation and API document fields accept both formats.*
+
 <table>
   <thead>
     <tr>
@@ -386,7 +388,7 @@ On this page, you will find the country's information you need when using Yuno A
       <td style={{ textAlign: "left" }}>
         * **RG** (Registro Geral (Carteira de Identidade))
         * **CPF** (Cadastro de Pessoas Físicas)
-        * **CNPJ** (Cadastro Nacional da Pessoa Jurídica)
+        * **CNPJ** (Cadastro Nacional da Pessoa Jurídica) **(2)**
         * **CNH** (Carteira Nacional de Habilitação)
         * **PAS** (Passaporte)
       </td>


### PR DESCRIPTION
## What

Brazil's Receita Federal introduced an alphanumeric CNPJ format for registrations starting July 2026. All SDKs already validate it (shipped Feb–May 2026, CORECM-15653 & siblings) — but the docs never said so, and one spot still claimed digits-only.

- **openapi.json** — `CustomerDocument.document_number` said *"Document number (digits only). CPF: 11 digits, CNPJ: 14 digits."* This was the only numeric-only claim on the site. Now describes both formats. (No page binds this root spec — the reference pages use `openapi/<section>/*.json`, which are already format-neutral — but it is served to AI/MCP consumers.)
- **reference/country-reference.mdx** — added a **(2)** footnote on the Brazil row (same idiom as the existing **(1)** footnote) describing both CNPJ formats, with the official example `12.ABC.345/01DE-35`.

Legacy numeric CNPJ documentation is unchanged — the numeric format remains valid.

## Verification

- `sdk-web-core` master: `validateCNPJ` delegates to `cpf-cnpj-validator@^2.1.1`; the alphanumeric test suite accepts `12.ABC.345/01DE-35` and rejects letter check-digits.
- Swept all 409 published pages (via `llms.txt`) — no other numeric-only claims exist.
- Android/iOS changelogs already announce alphanumeric CNPJ validation (auto-ingested; untouched).

Jira: [CORECM-18442](https://yunopayments.atlassian.net/browse/CORECM-18442)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-18442]: https://yunopayments.atlassian.net/browse/CORECM-18442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy updates; no API, validation, or runtime behavior changes.
> 
> **Overview**
> Documents Brazil’s alphanumeric **CNPJ** format (issued from July 2026) alongside the still-valid 14-digit numeric format.
> 
> Updates `CustomerDocument.document_number` in `openapi.json` so it no longer says digits-only, and adds a **(2)** footnote on the Brazil row in `country-reference.mdx` with the official example `12.ABC.345/01DE-35`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0e111d62ff4155e46ec8626467f3a5ac576bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->