### PR TITLE
docs(network-tokens): apply docs-evaluation text fixes

### DIFF
--- a/reference/network-tokens/generate-network-token-cryptogram.mdx
+++ b/reference/network-tokens/generate-network-token-cryptogram.mdx
@@ -4,37 +4,37 @@ openapi: "/openapi/network-tokens/generate-network-token-cryptogram.json POST /n
 description: "Generates a fresh, single-use network token cryptogram for a vaulted card so it can be authorized on an external PSP."
 ---
 
-This endpoint returns an on-demand **network token cryptogram** for a vaulted card and, by default, the card's current network token (DPAN). A card's network token alone cannot authorize a payment — card schemes require a single-use cryptogram per transaction, and only Yuno can request it because Yuno holds the Token Requestor ID. Use this endpoint when you want to take a Yuno network token and authorize the transaction on your own PSP.
+This endpoint returns an on-demand **network token cryptogram** for a vaulted card and, by default, the card's current network token (DPAN). A card's network token alone cannot authorize a payment. Card schemes require a single-use cryptogram per transaction, and only Yuno can request it because Yuno holds the Token Requestor ID. Use this endpoint when you want to take a Yuno network token and authorize the transaction on your own PSP.
 
-You identify the card with its `vaulted_token` — the same identifier you use in [Create Payment](/reference/create-payment). Yuno resolves the card's current network token internally and absorbs token rotation, so you always receive a consistent, current `(DPAN, cryptogram, ECI)` set.
+You identify the card with its `vaulted_token`, the same identifier you use in [Create Payment](/reference/payments/create-payment). Yuno resolves the card's current network token internally and absorbs token rotation, so you always receive a consistent, current `(DPAN, cryptogram, ECI)` set.
 
 <Warning>
-**The DPAN requires PCI certification — the cryptogram does not**
+**The DPAN requires PCI certification: the cryptogram does not**
 
-The full network token (DPAN) is PAN-equivalent data, so the default response — which includes it — is only available to PCI-certified merchants. The cryptogram itself is not PAN-equivalent: it is single-use, short-lived, and bound to a specific DPAN, so it cannot authorize anything on its own.
+The full network token (DPAN) is PAN-equivalent data, so the default response, which includes it, is only available to PCI-certified merchants. The cryptogram itself is not PAN-equivalent: it is single-use, short-lived, and bound to a specific DPAN, so it cannot authorize anything on its own.
 
-If your organization is not PCI-certified, send `include_network_token: false` to receive the cryptogram only — see [Cryptogram-only mode](#cryptogram-only-mode) below. To enable the product, contact your Key Account Manager (KAM).
+If your organization is not PCI-certified, send `include_network_token: false` to receive the cryptogram only. See [Cryptogram-only mode](#cryptogram-only-mode) below. To enable the product, contact your Key Account Manager (KAM).
 </Warning>
 
 <Warning>
-**Always submit a consistent pair.** A cryptogram is bound to a specific network token. Submit the `network_token.number` (DPAN) returned in the **same response** together with its `cryptogram` and `eci`. Never pair a returned cryptogram with a previously stored DPAN — after a token rotation, a stored DPAN will no longer match. In [cryptogram-only mode](#cryptogram-only-mode) the same rule applies through the proxy: forward immediately after requesting the cryptogram, so the DPAN the proxy resolves is the one the cryptogram was generated for.
+**Always submit a consistent pair.** A cryptogram is bound to a specific network token. Submit the `network_token.number` (DPAN) returned in the **same response** together with its `cryptogram` and `eci`. Never pair a returned cryptogram with a previously stored DPAN. After a token rotation, a stored DPAN will no longer match. In [cryptogram-only mode](#cryptogram-only-mode) the same rule applies through the proxy: forward immediately after requesting the cryptogram, so the DPAN the proxy resolves is the one the cryptogram was generated for.
 </Warning>
 
 ## How it works
 
-1. Request a cryptogram right before you authorize. Every call generates a **fresh, single-use** cryptogram from the scheme — there is no idempotency, and duplicate calls simply return new cryptograms (no money moves).
+1. Request a cryptogram right before you authorize. Every call generates a **fresh, single-use** cryptogram from the scheme: there is no idempotency, and duplicate calls return new cryptograms (no money moves).
 2. Submit `network_token.number` (DPAN), `cryptogram`, and `eci` to your PSP as a network-token transaction.
-3. If the authorization is declined and you retry, request a **new** cryptogram first — a used or stale cryptogram cannot be replayed.
+3. If the authorization is declined and you retry, request a **new** cryptogram first. A used or stale cryptogram cannot be replayed.
 
 ## Cryptogram-only mode
 
-Send `include_network_token: false` and the response omits `network_token.number` (the DPAN) and `network_token.token_data` entirely — the `network_token` object keeps its non-PAN-equivalent metadata (`network`, `status`, `par`, `network_token_id`), and the response carries `cryptogram` and `eci` as usual. Because no PAN-equivalent data is returned, this mode does not require PCI certification.
+Send `include_network_token: false` and the response omits `network_token.number` (the DPAN) and `network_token.token_data` entirely. The `network_token` object keeps its non-PAN-equivalent metadata (`network`, `status`, `par`, `network_token_id`), and the response carries `cryptogram` and `eci` as usual. Because no PAN-equivalent data is returned, this mode does not require PCI certification.
 
 Pair it with the [Forward Proxy](/docs/security-and-compliance/pci-proxy/forward-proxy) to run a network-token transaction end-to-end without PAN-equivalent data ever entering your systems:
 
 1. Request the cryptogram with `include_network_token: false`.
-2. Build the forward request with the `{{vaulted_token.<TOKEN>.network_token_number}}` expression (and the `network_token_expiration_*` expressions) where the destination expects the DPAN, and include the `cryptogram` value directly in the body — cryptograms are generated per transaction, so the proxy does not resolve them as expressions.
-3. Send it through the proxy **immediately**: the proxy resolves the card's current DPAN at forward time, and the cryptogram is bound to a specific DPAN. Requesting the cryptogram right before the forward keeps the pair consistent — a delay spanning a token rotation would make them mismatch.
+2. Build the forward request with the `{{vaulted_token.<TOKEN>.network_token_number}}` expression (and the `network_token_expiration_*` expressions) where the destination expects the DPAN. Include the `cryptogram` value directly in the body, since cryptograms are generated per transaction and the proxy does not resolve them as expressions.
+3. Send it through the proxy **immediately**: the proxy resolves the card's current DPAN at forward time, and the cryptogram is bound to a specific DPAN. Requesting the cryptogram right before the forward keeps the pair consistent. A delay spanning a token rotation would make them mismatch.
 
 The complete gate matrix:
 
@@ -65,7 +65,7 @@ Supported networks: **Visa** and **Mastercard**.
 
 ## Cryptogram lifetime
 
-The cryptogram is single-use — request it immediately before you authorize, and do not cache it.
+The cryptogram is single-use. Request it immediately before you authorize, and do not cache it.
 
 ## Errors
 
@@ -80,10 +80,10 @@ Errors return a `code` and a `messages` array. The exact `messages` value per `c
 | 400 | `TOKEN_NOT_ACTIVE` | "Network token is not active." |
 | 400 | `NETWORK_NOT_SUPPORTED` | "Network token brand is not supported." |
 | 400 | `COUNTRY_NOT_SUPPORTED` | "Country is not supported for this organization." |
-| 400 | `INVALID_REQUEST` | The specific invalid field, e.g. "The field 'vaulted_token' must be a valid uuid v4." |
+| 400 | `INVALID_REQUEST` | The specific invalid field, for example "The field 'vaulted_token' must be a valid uuid v4." |
 | 403 | `PCI_MERCHANT_REQUIRED` | "This endpoint is only available to PCI-certified merchants." |
 | 403 | `NETWORK_TOKEN_RETURN_NOT_ALLOWED` | "Returning the network token requires PCI certification. Send include_network_token: false to receive the cryptogram only, or contact your Key Account Manager (KAM)." |
 | 403 | `PRODUCT_NOT_ENABLED` | "The Network Token Cryptogram API is enabled per organization. Contact your Key Account Manager (KAM) to activate it." |
 | 502 | `PROVIDER_ERROR` | "The network token cryptogram service is temporarily unavailable, please retry." |
 
-A `vaulted_token` that doesn't exist and one that belongs to another organization both return the same `PAYMENT_METHOD_NOT_FOUND` — no existence leak.
+A `vaulted_token` that doesn't exist and one that belongs to another organization both return the same `PAYMENT_METHOD_NOT_FOUND`, so there is no existence leak.


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged heavy em-dash usage, a filler word, an abbreviation, overlong sentences, and a broken link on the Generate Network Token Cryptogram reference page. This PR applies the confirmed text-only fixes to the prose `.mdx` page.

## Changes
- **reference/network-tokens/generate-network-token-cryptogram.mdx**: rewrote ~14 prose em dashes into plain punctuation; cut the filler word "simply"; expanded "e.g." to "for example" in the `INVALID_REQUEST` error-table row; split several overlong sentences; fixed the broken `[Create Payment](/reference/create-payment)` link to `/reference/payments/create-payment`.