### PR TITLE
docs(customer-sessions-enrollment): apply docs-evaluation fixes

### DIFF
--- a/reference/customer-sessions-enrollment/create-customer-session.mdx
+++ b/reference/customer-sessions-enrollment/create-customer-session.mdx
@@ -4,4 +4,4 @@ openapi: "/openapi/customer-sessions-enrollment/create-customer-session.json POS
 description: "Creates a customer session for enrolling and managing saved payment methods for future use"
 ---
 
-Creates a customer session for enrolling and managing payment methods. Use this to save cards, wallets, and other payment methods for future use. Requires a `customer_id` from [Create Customer](/reference/create-customer) .
+Creates a customer session for enrolling and managing payment methods. Use this to save cards, wallets, and other payment methods for future use. Requires a `customer_id` from [Create Customer](/reference/customers/create-customer).

--- a/reference/customer-sessions-enrollment/enrollment-workflow.mdx
+++ b/reference/customer-sessions-enrollment/enrollment-workflow.mdx
@@ -3,11 +3,11 @@ title: "Enrollment Status"
 description: "Lists the possible statuses a payment method can have during the enrollment process"
 ---
 
-Yuno gives customers the possibility to enroll a payment method to use it for future purchases and have a seamless payment experience. That payment method enrollment can be used either in our [Full](/docs/sdks/overview/understanding-flows) or [Lite](/docs/sdks/overview/quickstart) payment implementation and could have one of the following statuses.
+Yuno gives customers the possibility to enroll a payment method to use it for future purchases and have a seamless payment experience. That payment method enrollment can be used either in Yuno's [Full](/docs/sdks/overview/understanding-flows) or [Lite](/docs/sdks/overview/quickstart) payment implementation. It could have one of the following statuses.
 
 ## Workflow
 
-<Frame><img src="/images/reference/enrollment-workflow/image1.png" /></Frame>
+<Frame><img src="/images/reference/enrollment-workflow/image1.png" alt="Enrollment workflow diagram showing payment method status transitions" /></Frame>
 
 ## Payment method status
 

--- a/reference/customer-sessions-enrollment/the-customer-session-object.mdx
+++ b/reference/customer-sessions-enrollment/the-customer-session-object.mdx
@@ -6,7 +6,7 @@ description: "Describes the customer session object and its attributes used for 
 
 ## Attributes
 
-This object represents a customer session that can be created in order to enroll a customer's payment methods.
+This object represents a customer session that can be created to enroll a customer's payment methods.
 
 
 <ParamField body="customer_session" type="string">
@@ -24,11 +24,11 @@ This object represents a customer session that can be created in order to enroll
 <ParamField body="country" type="enum">
   The customer's country (MAX 2; MIN 2; <a href="https://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> ).
 
-  Possible enum values: Check the  <a href="/reference/country-reference">Country reference</a>.
+  Possible enum values: Check the <a href="/reference/country-reference">Country reference</a>.
 </ParamField>
 
 <ParamField body="callback_url" type="string">
-  The URL to redirect your customer after the enrollment is made in the provider´s environment (MAX 526; MIN 3).
+  The URL to redirect your customer after the enrollment is made in the provider's environment (MAX 526; MIN 3).
 
   Example: www.your-url.com
 </ParamField>
@@ -37,5 +37,11 @@ This object represents a customer session that can be created in order to enroll
   Customer Session creation date and time (MAX 27; MIN 27; <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> ).
 
   Example: 2022-05-09T20:46:54.786342Z
+</ParamField>
+
+<ParamField body="checkout_id" type="string">
+  The unique identifier of the Custom Checkout used for this enrollment session.
+
+  Example: 6822f80c-684e-41a3-8628-78963d3d60f7
 </ParamField>
 


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged voice, accessibility, filler-word, typo, missing-field, and broken-link issues across the Customer Sessions (Enrollment) reference pages. This PR applies the confirmed fixes to the three prose `.mdx` pages.

## Changes
- **reference/customer-sessions-enrollment/enrollment-workflow.mdx**: replaced "our" with "Yuno's" and split a run-on sentence covering two different topics; added `alt` text to the enrollment workflow diagram image.
- **reference/customer-sessions-enrollment/the-customer-session-object.mdx**: cut the filler phrase "in order to"; fixed a double space before an inline link; fixed a wrong apostrophe character in "provider´s"; added the missing `checkout_id` field, which the `create-customer-session` endpoint's `201` response actually returns (verified against the OpenAPI spec's example and schema) but wasn't documented on this object page.
- **reference/customer-sessions-enrollment/create-customer-session.mdx**: fixed the broken `[Create Customer](/reference/create-customer)` link to `/reference/customers/create-customer`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX edits with no API, auth, or runtime behavior changes.
> 
> **Overview**
> Applies docs-evaluation fixes across the Customer Sessions (Enrollment) reference pages: copy/voice, accessibility, a broken link, and a missing field.
> 
> Documents `checkout_id` on the customer session object so it matches the create-session OpenAPI response. Fixes the Create Customer link to `/reference/customers/create-customer`, adds alt text on the enrollment workflow diagram, and tightens a few phrasing/typo issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869ae7fbb91702d83fe4ce4b1b81d4534cdd4937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->