### PR TITLE
docs(checkout-sessions): apply docs-evaluation fixes

### DIFF
--- a/reference/checkout-sessions/the-checkout-session-object.mdx
+++ b/reference/checkout-sessions/the-checkout-session-object.mdx
@@ -46,7 +46,7 @@ This object represents a checkout session that can be created to make a payment.
 </ParamField>
 
 <ParamField body="country" type="enum">
-  Country where the transaction must be processed (MAX 2; MIN 2; <a href="/reference/country-reference">ISO 3166-1</a> ).
+  Country where the transaction must be processed (MAX 2; MIN 2; <a href="https://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> ).
 
   Possible enum values: Check the <a href="/reference/country-reference">Country reference</a>.
 </ParamField>
@@ -63,7 +63,7 @@ This object represents a checkout session that can be created to make a payment.
   <Expandable title="properties">
 
     <ParamField body="currency" type="enum">
-      The currency used to make the payment (MAX 3; MIN 3; <a href="/reference/country-reference">ISO 4217</a> ).
+      The currency used to make the payment (MAX 3; MIN 3; <a href="https://en.wikipedia.org/wiki/ISO_4217">ISO 4217</a> ).
 
       Possible enum values: Check the <a href="/reference/country-reference">Country reference</a>.
     </ParamField>
@@ -88,13 +88,13 @@ This object represents a checkout session that can be created to make a payment.
       <Expandable title="properties">
 
         <ParamField body="key" type="string">
-          Specifies one metadata key.
+          Specifies one metadata key (MAX 48).
 
           Example: age
         </ParamField>
 
         <ParamField body="value" type="string">
-          Specifies the value for the defined metadata key.
+          Specifies the value for the defined metadata key (MAX 512).
 
           Example: 28
         </ParamField>
@@ -106,18 +106,16 @@ This object represents a checkout session that can be created to make a payment.
 </ParamField>
 
 <ParamField body="installments" type="array of objects">
-  [Optional] The object to send the installment plan created in Yuno to show your customers and let them choose from. This optional field is used in case a particular installments plan needs to be used in the session. if not sent, we will display the installment plan created for the account for each scenario, if any.
+  [Optional] The object to send the installment plan created in Yuno to show customers and let them choose from. This optional field is used in case a particular installments plan needs to be used in the session. If not sent, the installment plan created for the account is displayed for each scenario, if any.
 
   <Expandable title="properties">
 
     <ParamField body="plan_id" type="string">
-      Specifies a plan id created in Yuno to show your customer in the checkout session. If not defined, we will use the ones created for the account, if applicable. (MAX 64 ; MIN 64).
-
-      Possible enum values: Check the <a href="/reference/country-reference">Country reference</a>.
+      Specifies a plan id created in Yuno to show your customer in the checkout session. If not defined, the ones created for the account are used, if applicable (MAX 64; MIN 64).
     </ParamField>
 
     <ParamField body="plan" type="array of objects">
-      Installments to show the customer in with the checkout_session. This optional struct is used in case a particular installments plan needs to be used in the session and does not have an installments plan created for it. if not sent, we will display the installment plan created for the account for each scenario, if any.
+      Installments to show the customer in with the checkout_session. This optional struct is used in case a particular installments plan needs to be used in the session and does not have an installments plan created for it.
 
       <Expandable title="properties">
 


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged voice, redundancy, missing-field, and inconsistent-link issues on the Checkout Session object reference page. This PR applies the confirmed fixes to the prose .mdx page.

## Changes
- **reference/checkout-sessions/the-checkout-session-object.mdx**: removed first-person "we" wording and split a long sentence in the installments/plan field descriptions; removed an erroneous "Possible enum values: Check the Country reference" line copied onto plan_id (not a country/currency enum); added the missing metadata key (MAX 48) and value (MAX 512) size constraints, matching create-checkout-session.json; standardized the ISO 3166-1 and ISO 4217 links to point to Wikipedia, matching the convention used elsewhere in the guide; fixed the "MAX 64 ; MIN 64" spacing; removed a fallback sentence duplicated between the installments and nested plan field descriptions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a reference MDX page; no API, auth, or runtime behavior changes.
> 
> **Overview**
> Tightens the Checkout Session object reference: ISO 3166-1 and ISO 4217 now link to Wikipedia, metadata `key`/`value` document MAX 48 and MAX 512, and installments copy drops first-person voice, a duplicated fallback sentence, and a mistaken country-enum note on `plan_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f751c2a983f5b062f43336b9e62f3bcfbabcff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->