### PR TITLE
docs(payment-methods-checkout): fix field name inconsistencies

### DIFF
--- a/reference/payment-methods-checkout/the-payment-method-object-checkout.mdx
+++ b/reference/payment-methods-checkout/the-payment-method-object-checkout.mdx
@@ -99,7 +99,7 @@ This object represents a payment method that can be associated with a customer.
       Example: 9104911d-5df9-429e-8488-ad41abea1a4b
     </ParamField>
 
-    <ParamField body="sdk_action_required" type="boolean">
+    <ParamField body="sdk_required_action" type="boolean">
       Required action to call the SDK.
 
       Possible values: `True` or `False`
@@ -125,7 +125,7 @@ This object represents a payment method that can be associated with a customer.
       Example: OK
     </ParamField>
 
-    <ParamField body="enrollment_id" type="string">
+    <ParamField body="id" type="string">
       The unique identifier of the enrollment (MAX 64; MIN 36).
 
       Example: a079d524-c3df-4470-b3c8-7f290f5a0ba4


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged two field names on the Payment Method object page that diverged from every other reference in the guide. This PR corrects both to match the terms used consistently elsewhere.

## Changes
- **reference/payment-methods-checkout/the-payment-method-object-checkout.mdx**: renamed enrollment.sdk_action_required to sdk_required_action, matching the term used consistently across all payment-methods OpenAPI specs (the unrelated sdk_action_required term belongs to the payments object, not payment methods); renamed provider.enrollment_id to id, matching every real schema and example for the provider object across the guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only field name corrections with no code, API, or security impact.
> 
> **Overview**
> Corrects two field names on the Payment Method object reference so they match the rest of the payment-methods docs and schemas.
> 
> Renames enrollment `sdk_action_required` to `sdk_required_action` (the former belongs to the payments object). Renames provider `enrollment_id` to `id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d90d4be577c77d2c983cb286df1d158a1e1151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->