### PR TITLE
[CORECM-18693] Fix iOS APPLE_PAY doc samples: .APPLE_PAY() enum-case form

### DIFF
--- a/docs/yuno-sdk/features/payment-methods-list.mdx
+++ b/docs/yuno-sdk/features/payment-methods-list.mdx
@@ -67,7 +67,7 @@ Each view in the returned object exposes a `.mount({ elementSelector, ...config 
 var selectedPayment: SdkPayments.PaymentMethodSelected?
 
 let views = transaction.getPaymentMethodsViews(
-    types: [.APPLE_PAY, .PAYMENT_METHOD_LIST],
+    types: [.APPLE_PAY(), .PAYMENT_METHOD_LIST],
     controller: self
 )
 
@@ -111,7 +111,7 @@ selectedPayment?.let { transaction.start(paymentSelected = it) }
 
 | Value | Available on | What you get |
 |---|---|---|
-| `APPLE_PAY` | iOS, Web | The native Apple Pay button, wired to start the payment flow. |
+| `APPLE_PAY` | iOS, Web | The native Apple Pay button, wired to start the payment flow. On iOS this is an enum case with associated values — write it as `.APPLE_PAY()`, or pass `type:` / `style:` to customize the button. |
 | `GOOGLE_PAY` | Android, Web | The native Google Pay button, wired to start the payment flow. |
 | `PAYPAL` | Web | The native PayPal button, wired to start the payment flow. |
 | `PAYMENT_METHOD_LIST` | iOS, Android, Web | Full list of payment methods enabled in your Yuno dashboard. |
@@ -120,6 +120,8 @@ If a requested type does not apply to the current platform or configuration, the
 
 <Note>
 On Android, `PaymentMethodType` is a sealed interface rather than a set of string constants: `GOOGLE_PAY` corresponds to `PaymentMethodType.GooglePay(...)`, which also carries the button customization (`cta`, `theme`, `cornerRadius`), and `PAYMENT_METHOD_LIST` corresponds to `PaymentMethodType.PaymentMethodList`. `APPLE_PAY` does not exist on Android.
+
+On iOS, `APPLE_PAY` is an enum case with associated values, both optional: `.APPLE_PAY(type: .buy, style: .black)` takes a `PKPaymentButtonType` and a `PKPaymentButtonStyle` (defaults `.plain` and `.automatic`), which carry the Apple Pay button customization. The bare spelling `.APPLE_PAY` does not compile — always write `.APPLE_PAY()`.
 </Note>
 
 ### Express buttons

--- a/docs/yuno-sdk/migration/ios/payment/full.mdx
+++ b/docs/yuno-sdk/migration/ios/payment/full.mdx
@@ -182,7 +182,7 @@ struct CheckoutView: View {
 
 | Before (Full) | After (unified) | Notes |
 |---|---|---|
-| `Yuno.getPaymentMethodViewAsync(delegate:) async -> some View` | `transaction.getPaymentMethodsViews(types:controller:) -> [SdkPayments.PaymentMethodType: AnyView]` | Returns a dictionary keyed by type. Pass `[.PAYMENT_METHOD_LIST]` for the equivalent of Full. You can also request `.APPLE_PAY` in the same call to get the wallet button. |
+| `Yuno.getPaymentMethodViewAsync(delegate:) async -> some View` | `transaction.getPaymentMethodsViews(types:controller:) -> [SdkPayments.PaymentMethodType: AnyView]` | Returns a dictionary keyed by type. Pass `[.PAYMENT_METHOD_LIST]` for the equivalent of Full. You can also request `.APPLE_PAY()` in the same call to get the wallet button. |
 | `Yuno.startPayment(showPaymentStatus:)` | `transaction.start(paymentSelected:)` | The SDK no longer remembers the selection internally. Pass it explicitly from your model. The `showPaymentStatus` argument moved to `SdkPayments.TransactionConfig.showStatusScreen`. |
 
 ## Behavior changes


### PR DESCRIPTION
## What

Fixes [CORECM-18693](https://yunopayments.atlassian.net/browse/CORECM-18693): the documented `getPaymentMethodsViews` call with `types: [.APPLE_PAY, .PAYMENT_METHOD_LIST]` does not compile.

## Why

Verified against the `SdkPayments.xcframework` swiftinterface from the 3.0.0-alpha.1 release of `yuno-sdk-ios`:

```swift
case APPLE_PAY(type: PassKit.PKPaymentButtonType = .plain, style: PassKit.PKPaymentButtonStyle = .automatic)
```

`APPLE_PAY` is an enum case with associated values, so the bare `.APPLE_PAY` spelling is rejected by the compiler. The correct form is `.APPLE_PAY()` — both arguments have defaults.

## Changes

- `docs/yuno-sdk/features/payment-methods-list.mdx`: iOS sample `.APPLE_PAY` → `.APPLE_PAY()`; PaymentMethodType table notes the iOS enum-case spelling; the platform Note (next to the existing Android sealed-interface note) now documents iOS button customization via the case's `type:`/`style:` arguments (`PKPaymentButtonType` / `PKPaymentButtonStyle`)
- `docs/yuno-sdk/migration/ios/payment/full.mdx`: same bare-case fix in the API mapping table

Replaces yuno-sdk-docs#8, which targeted the temporary docs mirror by mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-18693]: https://yunopayments.atlassian.net/browse/CORECM-18693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and sample-code fixes; no runtime, API, or security changes.
> 
> **Overview**
> Corrects iOS samples that used the bare `.APPLE_PAY` spelling, which does not compile because `APPLE_PAY` is an enum case with associated values.
> 
> The payment-methods list sample now uses `.APPLE_PAY()`, and the type table plus platform note document optional `type:` / `style:` (`PKPaymentButtonType` / `PKPaymentButtonStyle`) customization. The iOS Full-mode migration table is updated the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022e2a371f1b441df0db76cba9fb5ebf3b8cdce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->