### PR TITLE
chore: web sdk changelog 1.9.36

### DIFF
--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,27 +2,6 @@
   "sdk": "web",
   "releases": [
     {
-      "version": "1.9.36",
-      "release_date": "2026-08-21",
-      "upgrade": {
-        "snippet": "npm install @yuno-payments/sdk-web@1.9.36",
-        "language": "bash"
-      },
-      "entries": [
-        {
-          "type": "FIXED",
-          "title": "Worldpay 3DS Device Data Collection",
-          "description": "Card payments routed through Worldpay's own 3DS now run the device data collection step and report the resulting device fingerprint back to the provider, so the authentication challenge behaves correctly instead of being silently degraded. The same fix applies to the headless flow, and other 3DS providers now also forward the device session they collect.",
-          "group": "Payment Actions",
-          "migration_guide": null,
-          "links": []
-        }
-      ],
-      "consumed_tickets": [
-        "CORECM-19283"
-      ]
-    },
-    {
       "version": "1.10.8",
       "release_date": "2026-08-22",
       "upgrade": {
@@ -475,6 +454,27 @@
         "CORECM-18597",
         "CORECM-18627",
         "YSHUB-6205"
+      ]
+    },
+    {
+      "version": "1.9.36",
+      "release_date": "2026-08-21",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.36",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Worldpay 3DS Device Data Collection",
+          "description": "Card payments routed through Worldpay's own 3DS now run the device data collection step and report the resulting device fingerprint back to the provider, so the authentication challenge behaves correctly instead of being silently degraded. The same fix applies to the headless flow, and other 3DS providers now also forward the device session they collect.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-19283"
       ]
     },
     {

--- a/changelog/source/web.json
+++ b/changelog/source/web.json
@@ -2,6 +2,27 @@
   "sdk": "web",
   "releases": [
     {
+      "version": "1.9.36",
+      "release_date": "2026-08-21",
+      "upgrade": {
+        "snippet": "npm install @yuno-payments/sdk-web@1.9.36",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Worldpay 3DS Device Data Collection",
+          "description": "Card payments routed through Worldpay's own 3DS now run the device data collection step and report the resulting device fingerprint back to the provider, so the authentication challenge behaves correctly instead of being silently degraded. The same fix applies to the headless flow, and other 3DS providers now also forward the device session they collect.",
+          "group": "Payment Actions",
+          "migration_guide": null,
+          "links": []
+        }
+      ],
+      "consumed_tickets": [
+        "CORECM-19283"
+      ]
+    },
+    {
       "version": "1.10.8",
       "release_date": "2026-08-22",
       "upgrade": {

--- a/changelog/web.mdx
+++ b/changelog/web.mdx
@@ -192,6 +192,14 @@ import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 - <ChangelogBadge type="breaking" /> **Full-width action button in modal footers**  
   The action button in the shared modal footer now spans the full width on every viewport, with the "Powered by Yuno" privacy tag centered above it. Lite keeps the tag below the button. Embedded forms rendered with `renderMode: element` are unchanged.
 
+## v1.9.36
+*August 21, 2026*
+
+**Payment Actions**
+
+- <ChangelogBadge type="fixed" /> **Worldpay 3DS Device Data Collection**  
+  Card payments routed through Worldpay's own 3DS now run the device data collection step and report the resulting device fingerprint back to the provider, so the authentication challenge behaves correctly instead of being silently degraded. The same fix applies to the headless flow, and other 3DS providers now also forward the device session they collect.
+
 ## v1.9.34
 *August 17, 2026*
 


### PR DESCRIPTION
Auto-generated changelog entry for **web** SDK `1.9.36`.

Source: https://github.com/yuno-payments/sdk-web/releases/tag/v13.0.36

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog and docs only; no runtime or integration code changes in the PR.
> 
> **Overview**
> Adds the **Web SDK v1.9.36** (August 21, 2026) release to the changelog pipeline: a new block in `changelog/source/web.json` (version metadata, npm upgrade snippet, `CORECM-19283`) and a matching **v1.9.36** section in `changelog/web.mdx`.
> 
> The documented fix is **Worldpay 3DS device data collection** under Payment Actions: Worldpay-native 3DS now runs device data collection and sends the device fingerprint to the provider so challenges are not silently degraded; the same behavior is noted for headless checkout, and other 3DS providers are described as forwarding collected device sessions as well. No SDK implementation changes appear in this diff—only release notes for `@yuno-payments/sdk-web@1.9.36`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6797042619a314ffd24a68b978ae5423bf3671c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->