### PR TITLE
[CORECM-18773][CORECM-18782] Web migration guides: fix addEventController typos, link orphaned secure-fields and status pages

### DIFF
--- a/docs/yuno-sdk/migration/overview.mdx
+++ b/docs/yuno-sdk/migration/overview.mdx
@@ -16,7 +16,9 @@ The unified SDK replaces all previous SDK modes (Full, Lite, Seamless, Render, H
 | **Headless**: you collect data in your own UI | [iOS](/docs/yuno-sdk/migration/ios/payment/headless) | [Android](/docs/yuno-sdk/migration/android/payment/headless) | [Web](/docs/yuno-sdk/migration/web/headless) |
 | **Seamless**: SDK-managed payment creation with merchant-triggered start | [iOS](/docs/yuno-sdk/migration/ios/payment/seamless) | [Android](/docs/yuno-sdk/migration/android/payment/seamless) | [Web](/docs/yuno-sdk/migration/web/seamless) |
 | **Seamless Lite**: Seamless with a pre-selected method | *(not applicable)* | *(not applicable)* | [Web](/docs/yuno-sdk/migration/web/seamless-lite) |
+| **Secure Fields**: card data collected in PCI-compliant iframes | *(not applicable)* | *(not applicable)* | [Web](/docs/yuno-sdk/migration/web/secure-fields) |
 | **Enrollment**: save a payment method without charging | [Lite](/docs/yuno-sdk/migration/ios/enrollment/lite) · [Render](/docs/yuno-sdk/migration/ios/enrollment/render) · [Headless](/docs/yuno-sdk/migration/ios/enrollment/headless) | [Lite](/docs/yuno-sdk/migration/android/enrollment/lite) · [Render](/docs/yuno-sdk/migration/android/enrollment/render) · [Headless](/docs/yuno-sdk/migration/android/enrollment/headless) | [Web](/docs/yuno-sdk/migration/web/enrollment) |
+| **Status**: standalone payment status screen | *(not applicable)* | *(not applicable)* | [Web](/docs/yuno-sdk/migration/web/status) |
 | **Fraud**: device fingerprinting | *(not applicable)* | *(not applicable)* | [Web](/docs/yuno-sdk/migration/web/fraud) |
 
 ## What changed

--- a/docs/yuno-sdk/migration/web/seamless-lite.mdx
+++ b/docs/yuno-sdk/migration/web/seamless-lite.mdx
@@ -35,7 +35,7 @@ await yuno.mountSeamlessCheckoutLite({
 })
 
 // Merchant's pay button triggers. SDK does everything else
-document.getElementById('pay').addEventController('click', () => {
+document.getElementById('pay').addEventListener('click', () => {
     yuno.startPayment()
 })
 ```
@@ -52,7 +52,7 @@ const transaction = sdkPayments.transaction({
     onStatus: (result) => console.log('done:', result.status),
 })
 
-document.getElementById('pay').addEventController('click', async () => {
+document.getElementById('pay').addEventListener('click', async () => {
     await transaction.start({
         paymentMethod: { type: 'PIX' },
     })

--- a/docs/yuno-sdk/migration/web/seamless.mdx
+++ b/docs/yuno-sdk/migration/web/seamless.mdx
@@ -33,7 +33,7 @@ await yuno.startSeamlessCheckout({
 await yuno.mountSeamlessCheckout()
 
 // Merchant's pay button triggers. SDK does everything else
-document.getElementById('pay').addEventController('click', () => {
+document.getElementById('pay').addEventListener('click', () => {
     yuno.startPayment()
 })
 ```


### PR DESCRIPTION
## What

Two small Web 2.0.0-alpha.2 docs-feedback fixes bundled in one PR (both under `/docs/yuno-sdk/migration/`):

### CORECM-18773 — `addEventController` typo → dead pay button
Replaced `addEventController` with `addEventListener` in 3 code snippets:
- `migration/web/seamless-lite.mdx` — legacy ("before") snippet
- `migration/web/seamless-lite.mdx` — new-SDK ("after") snippet
- `migration/web/seamless.mdx` — legacy ("before") snippet

Copy-pasting the "after" snippet previously threw `TypeError: addEventController is not a function`, leaving the pay button dead. Verified 0 occurrences remain in the tree after the fix.

### CORECM-18782 — orphaned migration pages
Added two rows to the "Find your guide" table in `migration/overview.mdx`:
- **Secure Fields** → `migration/web/secure-fields` (existed with full content, omitted from the table)
- **Status** → `migration/web/status` (existed with full content, zero inbound links site-wide)

Both are Web-only (no iOS/Android counterparts exist), so their iOS/Android columns are *(not applicable)*, matching the Seamless Lite / Fraud row style.

## Jira
- [CORECM-18773](https://yunopayments.atlassian.net/browse/CORECM-18773)
- [CORECM-18782](https://yunopayments.atlassian.net/browse/CORECM-18782)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only: snippet typo fixes and overview table links. No runtime or security impact.
> 
> **Overview**
> Fixes copy-pasteable Web Seamless migration examples that used a nonexistent `addEventController` API, replacing it with `addEventListener` so the merchant pay-button snippets actually run.
> 
> Also adds **Secure Fields** and **Status** rows to the migration overview table so those existing Web-only guides are discoverable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a465ffacade565421d0531066648ab9b50316db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[CORECM-18773]: https://yunopayments.atlassian.net/browse/CORECM-18773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ