### PR TITLE
[CORECM-18869][CORECM-18775] Get Started: complete /v1/payments example, correct SRI hash source

### DIFF
--- a/docs/yuno-sdk/get-started.mdx
+++ b/docs/yuno-sdk/get-started.mdx
@@ -48,7 +48,7 @@ Load the SDK from the CDN. It exposes a global `SdkPayments` and dispatches a `s
   crossorigin="anonymous"></script>
 ````
 
-Get the `integrity` hash from [`versions-sri.json`](https://sdk-web.y.uno/versions-sri.json): use `latest.integrity`, or the entry that matches your pinned version under `history`. `crossorigin="anonymous"` lets the browser validate the hash for the cross-origin script. See [Subresource Integrity](/docs/sdks/resources/references/web#subresource-integrity-sri) for details.
+Get the `integrity` hash from [`versions-sri.json`](https://sdk-web.y.uno/versions-sri.json): copy the `integrity` of the entry under `history` whose `version` matches the version in your script `src` (here `2.0.0-alpha.2`). Do **not** use `latest.integrity` — `latest` tracks the stable 1.x release, so its hash never matches the alpha bundle and the browser will block the script with an SRI error. `crossorigin="anonymous"` lets the browser validate the hash for the cross-origin script. See [Subresource Integrity](/docs/sdks/resources/references/web#subresource-integrity-sri) for details.
 
 Then wait for the `sdk-payments-ready` event and initialize:
 
@@ -317,7 +317,7 @@ By default, the SDK creates the payment for you. You don't need this endpoint.
 If you override `createPayment` to take control of payment creation, your backend calls this endpoint with the One-Time Token delivered by the SDK.
 
 - **Endpoint**: `POST /v1/payments`
-- **Required**: One-Time Token, checkout session
+- **Required**: One-Time Token, checkout session, `account_id`, `merchant_order_id`, `description`, `country`, and `amount` (`value` + `currency`)
 - **Reference**: [`POST /v1/payments`](https://docs.y.uno/reference/payments/create-payment)
 
 ````http
@@ -326,6 +326,11 @@ public-api-key: <your-public-api-key>
 private-secret-key: <your-private-secret-key>
 
 {
+  "account_id": "your-account-id",
+  "merchant_order_id": "order-123",
+  "description": "Order 123",
+  "country": "US",
+  "amount": { "currency": "USD", "value": 2500 },
   "payment_method": { "token": "one-time-token-from-sdk" },
   "checkout": { "session": "checkout-session-id" }
 }


### PR DESCRIPTION
## What

Two Web 2.0.0-alpha.2 docs-feedback fixes on the Get Started page (`docs/yuno-sdk/get-started.mdx`), one commit:

### CORECM-18869 — POST /v1/payments example missing six required fields
The "Creating the payment yourself" section documented only the One-Time Token + checkout session; the API rejects that body with `INVALID_PARAMETERS`. The example body and the **Required** bullet now include all six missing fields: `account_id`, `merchant_order_id`, `description`, `country`, `amount.value`, `amount.currency` — reusing the same example values as the checkout-session body earlier on the page.

### CORECM-18775 — SRI hash instructions point at the stable release
The install section told merchants to copy `latest.integrity` from `versions-sri.json`, but `latest` tracks the stable 1.x release (1.10.1 at report time, **1.10.8 today** — verified against the live file), so the hash never matches the alpha bundle and SRI blocks the script. The instructions now say to copy the `history` entry matching the version in the script `src`, with an explicit warning not to use `latest.integrity`. No stable version number is hardcoded, so the text stays correct as stable moves.

## Jira
- [CORECM-18869](https://yunopayments.atlassian.net/browse/CORECM-18869)
- [CORECM-18775](https://yunopayments.atlassian.net/browse/CORECM-18775)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-18869]: https://yunopayments.atlassian.net/browse/CORECM-18869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and example-body fixes; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Corrects two Get Started issues that would break a first sandbox integration.
> 
> SRI install instructions now tell merchants to copy the `history` hash that matches the pinned script version (`2.0.0-alpha.2`) and **not** `latest.integrity`, which tracks stable 1.x and would fail SRI.
> 
> The optional `POST /v1/payments` example and required-fields list now include `account_id`, `merchant_order_id`, `description`, `country`, and `amount` so the sample body is actually accepted by the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8cd3decdcbd8054d836a937dd6ad4792351cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->