### PR TITLE
docs(pix-automatico): fix subscription_id to subscription_code

### DIFF
--- a/docs/additional-services/qr-and-instant-pay.mdx
+++ b/docs/additional-services/qr-and-instant-pay.mdx
@@ -9,7 +9,7 @@ After the initial scan and payment, each **subsequent request** is sent by the m
 
 ## Step 1: First payment and subscription creation
 
-To initiate the flow, you must start with a standard [Pix payment](/reference/create-payment#/) that also sets up the subscription. This generates a QR code or redirect screen for the customer to authorize the recurrence. Once paid, the subscription is created and a `subscription_id` is returned.
+To initiate the flow, you must start with a standard [Pix payment](/reference/create-payment#/) that also sets up the subscription. This generates a QR code or redirect screen for the customer to authorize the recurrence. Once paid, the subscription is created and a `subscription_code` is returned.
 
 You can define the frequency, availability window, and the amount type (fixed or variable) as part of the subscription payload.
 
@@ -52,12 +52,12 @@ After the initial payment is confirmed, the customer has an active subscription,
 
 ## Step 2: Future payments
 
-As defined by the central bank, payments must be created at most **2 days before the scheduled billing date and at least 10 days** after the subscription was created. Use the subscription\_id to identify the recurrence in the [payment creation](/reference/create-payment#/).
+As defined by the central bank, payments must be created at most **2 days before the scheduled billing date and at least 10 days** after the subscription was created. Use the `subscription_code` to identify the recurrence in the [payment creation](/reference/create-payment#/).
 
 | Fields for future payments |                                                                                                                                      |
 | :------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `subscription_id`          | ID of the subscription obtained in the first step.                                                                                   |
-| billing\_date              | By specifying the billing\_date object, the merchant can define the logic behind the exact date for the billing of the subscription. |
+| `subscription_code`        | ID of the subscription obtained in the first step.                                                                                   |
+| `billing_date`             | By specifying the `billing_date` object, the merchant can define the logic behind the exact date for the billing of the subscription. |
 
 ```json Example
 "workflow": "DIRECT",


### PR DESCRIPTION
## PR Description
The Pix Automático guide named the wrong field for the value returned after the first payment. Pedro Scarapicchia Junior reported that a merchant (LastLink) got tripped up integrating because the guide said `subscription_id`, while the Create Payment response actually returns `subscription_code` at the root of the payment object — confirmed both in sandbox and against `openapi/payments/create-payment.json`, where `subscription_id` doesn't appear at all.

## Changes
- `docs/additional-services/qr-and-instant-pay.mdx` — Step 1: changed `subscription_id` to `subscription_code` in the prose describing what's returned after the first payment.
- `docs/additional-services/qr-and-instant-pay.mdx` — Step 2: changed `subscription_id` to `subscription_code` in both the prose and the "Fields for future payments" table.
- `docs/additional-services/qr-and-instant-pay.mdx` — cleaned up unnecessary backslash-escaped underscores (`subscription\_code`, `billing\_date`) in favor of proper backtick code formatting, matching the rest of the table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> **Corrects the Pix Automático integration guide** so it matches the Create Payment API: merchants should use **`subscription_code`** (returned on the payment object after the first QR payment), not `subscription_id`.
> 
> Updates **Step 1** prose and **Step 2** instructions plus the “Fields for future payments” table to reference `subscription_code`. Also replaces escaped underscores with backtick formatting for `billing_date` in that table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b57b558b48fa38adb2ed6c1ac427555c4e87f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->