### PR TITLE
docs(checkout-builder): apply docs-evaluation text fixes

### DIFF
--- a/openapi/checkout-builder/create-checkout.json
+++ b/openapi/checkout-builder/create-checkout.json
@@ -80,13 +80,13 @@
     "/checkouts": {
       "post": {
         "summary": "Create Checkout",
-        "description": "Creates a new custom checkout as a published clone of the account's default checkout: payment methods — including icon/name overrides and required-field condition sets — are copied from the default; general settings and styling inherit the account baseline until the checkout's first publish. The new checkout is born with status PUBLISHED and is never the account's default. The identifier is exposed as the top-level `id`.",
+        "description": "Creates a new custom checkout as a published clone of the account's default checkout: payment methods (including icon/name overrides and required-field condition sets) are copied from the default; general settings and styling inherit the account baseline until the checkout's first publish. The new checkout is born with status PUBLISHED and is never the account's default. The identifier is exposed as the top-level `id`.",
         "operationId": "create-checkout",
         "parameters": [
           {
             "name": "X-Idempotency-Key",
             "in": "header",
-            "description": "Optional client key, up to 64 characters. Best-effort — re-sending the same key is not guaranteed to be de-duplicated.",
+            "description": "Optional client key, up to 64 characters. Best-effort; re-sending the same key is not guaranteed to be de-duplicated.",
             "required": false,
             "schema": {
               "type": "string"

--- a/openapi/checkout-builder/fetch-checkout-configuration.json
+++ b/openapi/checkout-builder/fetch-checkout-configuration.json
@@ -48,7 +48,7 @@
     "/checkouts/{checkout_code}": {
       "get": {
         "summary": "Fetch Checkout Configuration",
-        "description": "Returns the full custom checkout for the given code — configuration and styling composed in a single response. The checkout identifier is exposed as the top-level `id`.",
+        "description": "Returns the full custom checkout for the given code: configuration and styling composed in a single response. The checkout identifier is exposed as the top-level `id`.",
         "operationId": "get-checkout-configuration",
         "parameters": [
           {
@@ -194,7 +194,7 @@
                       "properties": {
                         "payment_methods": {
                           "type": "array",
-                          "description": "Payment methods configured for this checkout. Order is driven by `order_to_show` (lower = first). Returns the full payment-method catalog available to the account, not only the ones active for this checkout — filter by `is_active: true` to get only the enabled ones.",
+                          "description": "Payment methods configured for this checkout. Order is driven by `order_to_show` (lower = first). Returns the full payment-method catalog available to the account, not only the ones active for this checkout. Filter by `is_active: true` to get only the enabled ones.",
                           "items": { "type": "object" }
                         },
                         "general_settings": {

--- a/openapi/checkout-builder/manage-checkout-lifecycle.json
+++ b/openapi/checkout-builder/manage-checkout-lifecycle.json
@@ -80,7 +80,7 @@
     "/checkouts/{checkout_code}": {
       "patch": {
         "summary": "Manage Checkout Lifecycle",
-        "description": "Renames, publishes, unpublishes, archives, restores, or promotes the checkout. The body carries any combination of `name`, `description`, `status`, and `is_default` — at least one field is required (an empty body is rejected with 400). Status transitions follow the lifecycle state machine: publish (`PUBLISHED`) is only valid from `NOT_PUBLISHED`; an ARCHIVED checkout is restored in two steps (`status: NOT_PUBLISHED` first, then `status: PUBLISHED`); patching to the current status is rejected. Metadata (`name`/`description`) remains editable while ARCHIVED. `is_default` accepts only `true`: it promotes the checkout to account default, force-publishing it from any state, and atomically demotes the previous default; when `is_default: true` is sent together with `status`, the promotion wins and `status` is ignored. The default checkout cannot be archived or unpublished.",
+        "description": "Renames, publishes, unpublishes, archives, restores, or promotes the checkout. The body carries any combination of `name`, `description`, `status`, and `is_default`; at least one field is required (an empty body is rejected with 400). Status transitions follow the lifecycle state machine: publish (`PUBLISHED`) is only valid from `NOT_PUBLISHED`; an ARCHIVED checkout is restored in two steps (`status: NOT_PUBLISHED` first, then `status: PUBLISHED`); patching to the current status is rejected. Metadata (`name`/`description`) remains editable while ARCHIVED. `is_default` accepts only `true`: it promotes the checkout to account default, force-publishing it from any state, and atomically demotes the previous default; when `is_default: true` is sent together with `status`, the promotion wins and `status` is ignored. The default checkout cannot be archived or unpublished.",
         "operationId": "manage-checkout-lifecycle",
         "parameters": [
           {
@@ -95,7 +95,7 @@
           {
             "name": "X-Idempotency-Key",
             "in": "header",
-            "description": "Optional client key, up to 64 characters. Best-effort — re-sending the same key is not guaranteed to be de-duplicated.",
+            "description": "Optional client key, up to 64 characters. Best-effort; re-sending the same key is not guaranteed to be de-duplicated.",
             "required": false,
             "schema": {
               "type": "string"
@@ -120,11 +120,11 @@
                   "status": {
                     "type": "string",
                     "enum": ["PUBLISHED", "NOT_PUBLISHED", "ARCHIVED"],
-                    "description": "Target lifecycle status. PUBLISHED is only reachable from NOT_PUBLISHED; NOT_PUBLISHED is reachable from PUBLISHED (unpublish) or ARCHIVED (restore); ARCHIVED is reachable from PUBLISHED or NOT_PUBLISHED. Any other transition — including patching to the current status — is rejected with 400. Unknown values are rejected with 400."
+                    "description": "Target lifecycle status. PUBLISHED is only reachable from NOT_PUBLISHED; NOT_PUBLISHED is reachable from PUBLISHED (unpublish) or ARCHIVED (restore); ARCHIVED is reachable from PUBLISHED or NOT_PUBLISHED. Any other transition (including patching to the current status) is rejected with 400. Unknown values are rejected with 400."
                   },
                   "is_default": {
                     "type": "boolean",
-                    "description": "Only `true` is accepted: promotes this checkout to account default, force-publishing it from any state and atomically demoting the previous default. `false` is rejected with 400 — demote by promoting another checkout instead."
+                    "description": "Only `true` is accepted: promotes this checkout to account default, force-publishing it from any state and atomically demoting the previous default. `false` is rejected with 400; demote by promoting another checkout instead."
                   }
                 }
               },

--- a/openapi/checkout-builder/publish-checkout-configuration.json
+++ b/openapi/checkout-builder/publish-checkout-configuration.json
@@ -48,7 +48,7 @@
     "/checkouts/{checkout_code}": {
       "put": {
         "summary": "Publish Checkout Configuration",
-        "description": "Writes configuration and/or styling for the checkout in a single call. The body may contain a `config` object, a `styling` object, or both — at least one is required. Each part is validated independently before being applied; if any rule fails, the request is rejected with a single aggregated 400 and nothing is applied. Configuration is a sparse upsert (omitted payment methods keep their previous state; new methods cannot be created). Styling is a partial merge (omitted or null fields are preserved).",
+        "description": "Writes configuration and/or styling for the checkout in a single call. The body may contain a `config` object, a `styling` object, or both; at least one is required. Each part is validated independently before being applied; if any rule fails, the request is rejected with a single aggregated 400 and nothing is applied. Configuration is a sparse upsert (omitted payment methods keep their previous state; new methods cannot be created). Styling is a partial merge (omitted or null fields are preserved).",
         "operationId": "publish-checkout-configuration",
         "parameters": [
           {
@@ -128,7 +128,7 @@
                 "properties": {
                   "config": {
                     "type": "object",
-                    "description": "Checkout configuration: payment methods and general settings. Sparse upsert — omitted payment methods keep their previous state.",
+                    "description": "Checkout configuration: payment methods and general settings. Sparse upsert; omitted payment methods keep their previous state.",
                     "properties": {
                       "payment_methods": {
                         "type": "array",
@@ -173,7 +173,7 @@
                   },
                   "styling": {
                     "type": "object",
-                    "description": "Checkout styling and SDK settings. Partial merge — omitted or null fields are preserved; use `flags.force_default_styles` to reset. `settings.urls`, `settings.click_to_pay`, `settings.form` and `settings.google_pay` are beta-locked and rejected if sent with a non-empty value.",
+                    "description": "Checkout styling and SDK settings. Partial merge; omitted or null fields are preserved; use `flags.force_default_styles` to reset. `settings.urls`, `settings.click_to_pay`, `settings.form` and `settings.google_pay` are beta-locked and rejected if sent with a non-empty value.",
                     "properties": {
                       "styles": { "type": "object", "description": "global, header and button styles. All `*_color` fields must be a 6- or 8-digit hex color (#RRGGBB / #RRGGBBAA); `font_weight` must be one of 100..900 (step 100); `font_family` must be in the supported catalog or declared in `external_fonts`. Logos must be an HTTPS URL to a public host or a relative path (no data:/SVG/javascript:)." },
                       "settings": {

--- a/reference/checkout-builder/create-checkout.mdx
+++ b/reference/checkout-builder/create-checkout.mdx
@@ -6,8 +6,8 @@ description: "Creates a new custom checkout as a published clone of the account'
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>
 
-The new checkout is born **`PUBLISHED`** as a clone of the account's default: payment methods — including icon/name overrides and required-field condition sets — are copied; general settings and styling inherit the account baseline until the checkout's first [Publish](/reference/checkout-builder/publish-checkout-configuration). It is never created as the account's default.
+The new checkout is born **`PUBLISHED`** as a clone of the account's default: payment methods (including icon/name overrides and required-field condition sets) are copied; general settings and styling inherit the account baseline until the checkout's first [Publish](/reference/checkout-builder/publish-checkout-configuration). It is never created as the account's default.
 
 The response's top-level `id` is the `checkout_code` used by the [Fetch](/reference/checkout-builder/fetch-checkout-configuration), [Publish](/reference/checkout-builder/publish-checkout-configuration), and [Manage Checkout Lifecycle](/reference/checkout-builder/manage-checkout-lifecycle) endpoints.
 
-`name` is required, non-blank, and unique per account — a duplicate is rejected with `409`. If the account has no default checkout to clone from, the request is rejected with `404`.
+`name` is required, non-blank, and unique per account; a duplicate is rejected with `409`. If the account has no default checkout to clone from, the request is rejected with `404`.

--- a/reference/checkout-builder/manage-checkout-lifecycle.mdx
+++ b/reference/checkout-builder/manage-checkout-lifecycle.mdx
@@ -6,7 +6,7 @@ description: "Renames, publishes, unpublishes, archives, restores, or promotes a
 
 <Note>This API is in **Beta**. Endpoints and schemas may change without prior notice.</Note>
 
-The body carries any combination of `name`, `description`, `status`, and `is_default` — at least one field is required. Metadata (`name`/`description`) is editable in **any** status, including `ARCHIVED`; configuration and styling of an archived checkout stay frozen (the [Publish](/reference/checkout-builder/publish-checkout-configuration) endpoint rejects it).
+The body carries any combination of `name`, `description`, `status`, and `is_default`; at least one field is required. Metadata (`name`/`description`) is editable in **any** status, including `ARCHIVED`; configuration and styling of an archived checkout stay frozen (the [Publish](/reference/checkout-builder/publish-checkout-configuration) endpoint rejects it).
 
 ## Lifecycle state machine
 
@@ -23,5 +23,5 @@ stateDiagram-v2
 - **Publish** (`status: PUBLISHED`) is only valid from `NOT_PUBLISHED`.
 - **Restore is two-step**: an `ARCHIVED` checkout goes back to draft first (`status: NOT_PUBLISHED`), then can be published (`status: PUBLISHED`). A direct `ARCHIVED → PUBLISHED` patch is rejected with `400 INVALID_STATUS_TRANSITION`.
 - Patching to the **current** status is also rejected with `400`.
-- **Promote** (`is_default: true`) force-publishes the checkout from any state — including `ARCHIVED` — and atomically demotes the previous default. When sent together with `status`, the promotion wins and `status` is ignored. `is_default: false` is rejected with `400`; demote a default by promoting another checkout.
+- **Promote** (`is_default: true`) force-publishes the checkout from any state (including `ARCHIVED`) and atomically demotes the previous default. When sent together with `status`, the promotion wins and `status` is ignored. `is_default: false` is rejected with `400`; demote a default by promoting another checkout.
 - The **default checkout is guarded**: archiving or unpublishing it is rejected with `409` so the account's storefront is never left without a live checkout.

--- a/reference/checkout-builder/overview.mdx
+++ b/reference/checkout-builder/overview.mdx
@@ -1,27 +1,28 @@
 ---
-title: "Overview"
+title: "Checkout Builder Overview"
 sidebarTitle: "Overview"
-description: "Programmatically configure a merchant's Yuno checkout — payment methods, conditions, required fields, and styling — via Yuno's public B2B API."
+description: "Programmatically configure a merchant's Yuno checkout (payment methods, conditions, required fields, and styling) via Yuno's public B2B API."
 badge: "Beta"
 ---
 
 <Warning>
-**BETA — access is granted per account.** This API is in closed beta and is enabled per account. Your account must be explicitly allowlisted; requests from a non-allowlisted account are rejected with `401`. Endpoints are stable in shape but subject to additive changes during the BETA window.
+**BETA: access is granted per account.** This API is in closed beta and is enabled per account. Your account must be explicitly allowlisted; requests from a non-allowlisted account are rejected with `401`. Endpoints are stable in shape but subject to additive changes during the BETA window.
 </Warning>
 
-Configure a merchant's Yuno checkout **server-to-server** — the same configuration surface that powers the Yuno Dashboard's Checkout Builder — so a partner can manage its merchants' checkouts programmatically, without using the Yuno UI:
+Configure a merchant's Yuno checkout **server-to-server**, using the same configuration surface that powers the Yuno Dashboard's Checkout Builder. This lets a partner manage its merchants' checkouts programmatically, without using the Yuno UI:
 
-- **Payment methods** — which methods are shown and in what display order
-- **Conditions** — per-method rules (currency, country, amount, metadata) that gate when a method appears
-- **Required fields** — per-method form field configuration (CVV, installments, billing address, etc.) for both the enrolled (saved-card) and non-enrolled (first-time) flows
-- **General settings** — accepted document types per country
-- **Styling & SDK settings** — colors, fonts, button shapes, logos, and Payment Link branding
+- **Payment methods**: which methods are shown and in what display order
+- **Conditions**: per-method rules (currency, country, amount, metadata) that gate when a method appears
+- **Required fields**: per-method form field configuration (CVV, installments, billing address, etc.) for both the enrolled (saved-card) and non-enrolled (first-time) flows
+- **General settings**: accepted document types per country
+- **Styling & SDK settings**: colors, fonts, button shapes, logos, and Payment Link branding
 
 ## Base URL
 
 | Environment | Base URL |
 | --- | --- |
-| Production | `https://api.y.uno` |
+| Production (US) | `https://api.y.uno` |
+| Production (EMEA) | `https://api.eu.y.uno` |
 | Sandbox | `https://api-sandbox.y.uno` |
 
 All examples in this reference use the production base URL. The sandbox host accepts the same endpoints and payload shapes.
@@ -35,49 +36,49 @@ Every request is authenticated with your merchant API credentials and scoped to 
 | Header | Required | Description |
 | --- | --- | --- |
 | `PUBLIC-API-KEY` | Yes | Merchant public API key. Found in your Yuno dashboard under **Settings → API Keys**. |
-| `PRIVATE-SECRET-KEY` | Yes | Merchant private secret key, paired with the public key. Server-side only — never embed it in client-side code. |
+| `PRIVATE-SECRET-KEY` | Yes | Merchant private secret key, paired with the public key. Server-side only. Never embed it in client-side code. |
 | `X-Account-Code` | Yes | UUID of the merchant account. The account is resolved **only** from this header (never from the request body or path) and must be in the beta allowlist. |
-| `X-Idempotency-Key` | No | Optional client key, up to 64 characters. Best-effort — see [Idempotency](#idempotency). |
+| `X-Idempotency-Key` | No | Optional client key, up to 64 characters. Best-effort. See [Idempotency](#idempotency). |
 | `Content-Type` | Yes (POST/PUT/PATCH) | `application/json` |
 
 </div>
 
 <Note>
-The organization is resolved by Yuno from your credentials — **do not send** an organization header. Missing/invalid credentials, or a non-allowlisted account, return `401`.
+The organization is resolved by Yuno from your credentials. **Do not send** an organization header. Missing/invalid credentials, or a non-allowlisted account, return `401`.
 </Note>
 
 ## Endpoints
 
-A **custom checkout** is identified by a `checkout_code` (a UUID). It is created, listed, read, written, and lifecycle-managed through the same resource — five operations:
+A **custom checkout** is identified by a `checkout_code` (a UUID). It is created, listed, read, written, and lifecycle-managed through the same resource, in five operations:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `POST` | `/v1/checkouts` | Create a new custom checkout as a published clone of the account's default. |
 | `GET` | `/v1/checkouts` | List the account's custom checkouts (summaries only): ids, names, statuses, default flag. Supports filters and opt-in pagination. |
-| `GET` | `/v1/checkouts/{checkout_code}` | Fetch the full custom checkout — configuration **and** styling, together. |
+| `GET` | `/v1/checkouts/{checkout_code}` | Fetch the full custom checkout: configuration **and** styling, together. |
 | `PUT` | `/v1/checkouts/{checkout_code}` | Publish configuration and/or styling. |
-| `PATCH` | `/v1/checkouts/{checkout_code}` | Manage the lifecycle — rename, publish, unpublish, archive, restore, or promote to default. |
+| `PATCH` | `/v1/checkouts/{checkout_code}` | Manage the lifecycle: rename, publish, unpublish, archive, restore, or promote to default. |
 
 `{checkout_code}` must be a valid UUID; other values are rejected with `400` before any processing.
 
 <Note>
-You obtain a `checkout_code` by calling [Create Checkout](/reference/checkout-builder/create-checkout) (the response's top-level `id`), by calling [List Checkouts](/reference/checkout-builder/list-checkouts) (each item's `id` is the `checkout_code`), or when the custom checkout is created in the Yuno dashboard / embedded Checkout Builder.
+You obtain a `checkout_code` by calling [Create Checkout](/reference/checkout-builder/create-checkout) (the response's top-level `id`) or by calling [List Checkouts](/reference/checkout-builder/list-checkouts) (each item's `id` is the `checkout_code`). You can also get one when the custom checkout is created in the Yuno dashboard / embedded Checkout Builder.
 </Note>
 
 ## Key behaviors
 
 <Note>
-**`PUT` is a sparse upsert for configuration, not a full replace.** Payment methods omitted from the `payment_methods` array retain their previous state — they are not removed or disabled. To disable a method, include it with `is_active: false`.
+**`PUT` is a sparse upsert for configuration, not a full replace.** Payment methods omitted from the `payment_methods` array retain their previous state. They are not removed or turned off. To turn off a method, include it with `is_active: false`.
 </Note>
 
-- **Configuration — sparse update.** Only the payment methods you include are updated; omitted methods keep their previous state. Publishing updates existing methods only — **new payment methods cannot be created** via the API (contact your Yuno TAM to add methods).
-- **Styling — partial merge.** Fields you omit (or send as `null`) are preserved; only the fields you include change. Partial styling updates are safe — you do not need to resend the entire `styles` object. To reset styling to defaults, use `flags.force_default_styles`.
+- **Configuration: sparse update.** Only the payment methods you include are updated; omitted methods keep their previous state. Publishing updates existing methods only. **New payment methods cannot be created** via the API (contact your Yuno TAM to add methods).
+- **Styling: partial merge.** Fields you omit (or send as `null`) are preserved; only the fields you include change. Partial styling updates are safe. You do not need to resend the entire `styles` object. To reset styling to defaults, use `flags.force_default_styles`.
 - **Order is driven by `order_to_show`**, not by array position. Lower values are shown first.
 - **At most one condition set per required field.** Sending more than one condition set on a field is rejected with `400` (`conditions_to_override must contain at most one condition set`).
 - **Enrolled and non-enrolled flows are independent.** For CARD, configure the non-enrolled flow via `fields` and the enrolled (saved-card) flow via `enrollment_fields`. To leave one flow untouched, pass an empty array for that side.
-- **Lifecycle transitions follow a state machine.** Publish is only valid from `NOT_PUBLISHED`; an `ARCHIVED` checkout is restored in two steps (`NOT_PUBLISHED` first, then `PUBLISHED`); the default checkout cannot be archived or unpublished. See [Manage Checkout Lifecycle](/reference/checkout-builder/manage-checkout-lifecycle) for the full rules.
+- **Lifecycle transitions follow a state machine.** Publish is only valid from `NOT_PUBLISHED`. An `ARCHIVED` checkout is restored in two steps (`NOT_PUBLISHED` first, then `PUBLISHED`). The default checkout cannot be archived or unpublished. See [Manage Checkout Lifecycle](/reference/checkout-builder/manage-checkout-lifecycle) for the full rules.
 - **Changes take effect immediately.** Validate payloads against the sandbox base URL before applying to production.
-- Each request body is validated independently; on any rule failure the whole request is rejected with a single aggregated `400` and nothing is applied. See the [Publish](/reference/checkout-builder/publish-checkout-configuration) endpoint for the full request shape, allowed values, and error catalog.
+- Each request body is validated independently; on any rule failure the whole request is rejected with a single aggregated `400` and nothing is applied. See the [Publish](/reference/checkout-builder/publish-checkout-configuration) endpoint for the full request shape and allowed values.
 
 ## Errors
 
@@ -93,7 +94,7 @@ Validation failures return HTTP `400` with a single aggregated body listing ever
 }
 ```
 
-Other statuses: `401` (authentication / account not allowlisted), `404` (checkout not found for the account, or no default checkout to clone on create), `409` (duplicate checkout name, or archiving/unpublishing the default checkout). The full per-rule error catalog is on the [Publish](/reference/checkout-builder/publish-checkout-configuration) page.
+Other statuses include `401` (authentication / account not allowlisted) and `404` (checkout not found for the account, or no default checkout to clone on create). `409` covers a duplicate checkout name, or archiving/unpublishing the default checkout. See the [Publish](/reference/checkout-builder/publish-checkout-configuration) page for the full request/response schema and example validation messages.
 
 ## Idempotency
 


### PR DESCRIPTION
## PR Description
Applies a docs-evaluation pass across the five Checkout Builder (Beta) reference pages: style/termbase cleanup, a couple of real gaps (missing base URL host, a broken "error catalog" promise), and long-sentence splits.

## Changes

**Overview**
- Renamed the generic `title: "Overview"` to `"Checkout Builder Overview"` for clarity and SEO (sidebarTitle unchanged, still short under the "Checkout Builder" nav group)
- Rewrote all em dashes (colons, semicolons, parentheticals, or sentence splits depending on context)
- Applied the termbase swap "disabled"/"disable" → "turned off"/"turn off"
- Split several 25+ word sentences (obtaining a `checkout_code`, lifecycle transitions, other error statuses)
- Added the missing `https://api.eu.y.uno` (Production EMEA) host to the Base URL table, alongside the existing US host
- Removed the "full per-rule error catalog" claim (in two places) pointing at the Publish page — that page has no such catalog, only a generic error shape with two example messages — replaced with an accurate pointer to what's actually there

**Create Checkout, Fetch Checkout Configuration, Publish Checkout Configuration, Manage Checkout Lifecycle**
- Rewrote em dashes both in the `.mdx` prose and in the underlying OpenAPI spec (`openapi/checkout-builder/*.json`) `description` fields, since these pages render content from both sources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and OpenAPI description strings only; no runtime, auth, or contract changes beyond clarified prose.
> 
> **Overview**
> Documentation-only pass on **Checkout Builder (Beta)** reference and matching OpenAPI `description` fields so rendered API docs stay in sync.
> 
> **Overview** renames the page title to **Checkout Builder Overview**, adds **Production (EMEA)** `https://api.eu.y.uno` to the Base URL table, and tightens prose: em dashes become colons/semicolons/parentheses, list labels use colons, **disabled** → **turn off** / **turned off**, and long sentences are split. It also drops references to a **full per-rule error catalog** on Publish (not present there) and points readers to schemas and example validation messages instead.
> 
> **Create, Fetch, Publish, and Manage Lifecycle** pages get the same punctuation and readability edits in both `.mdx` and `openapi/checkout-builder/*.json` (operation summaries, idempotency header text, lifecycle/status/`is_default` copy, sparse upsert and styling merge wording). No API behavior or schema changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3edc7554c754ee916c2d62171ee7002296c9ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->