### PR TITLE
docs(vtex): Network Tokens feedback — activation, ramp-up, franchise scope, public changelog 4.2.336–4.2.346

### DIFF
--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,158 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.346",
+      "release_date": "2026-08-21",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.346",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Cancellations of a card payment that was never completed are approved",
+          "description": "When an order paid with two cards is cancelled because one card is declined, the other card's payment may have an open checkout session but no payment behind it. The connector answered VTEX's cancellation of that payment with a \"payment not found\" error, so after three attempts VTEX emailed the store asking for a manual cancellation of a payment that never charged anything. The connector now recognizes this case and confirms the cancellation, as it already did for payments that never reached Yuno at all.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.345",
+      "release_date": "2026-08-20",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.345",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Network Token support for card payments",
+          "description": "A new \"Enable Network Tokens\" setting on the affiliation lets the connector securely store each card on its first purchase and recognize it on later purchases by the same customer, so Yuno can process repeat purchases with a network token instead of the card number. Network tokens significantly improve approval rates for returning shoppers. The feature covers all card payments, including fraud-defense, multi-seller split orders and setups where the payment is completed from a different VTEX account than the one that authorized it. If the stored reference is unavailable for any reason the payment proceeds exactly as today, so checkout is never affected. Stores that keep the default setting are unaffected.",
+          "group": "Payments",
+          "migration_guide": "To enable it, open the Yuno affiliation in the VTEX admin and set both \"Enable Network Tokens\" and \"Create Customer\" to Yes; then confirm with Yuno that network tokens are enabled on the routes used by the store. In franchise or multi-store setups, apply the settings on every store's affiliation. No storefront changes are required.",
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.344",
+      "release_date": "2026-08-19",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.344",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Installment count reported correctly on digital wallet payments",
+          "description": "Apple Pay and Google Pay payments created through the pre-created session flow reported a single installment in the payment's informational metadata even when the shopper selected more. The amount actually charged and the installments sent to the payment provider were always correct; the reported value now matches them, so dashboards and reconciliation no longer show a misleading count.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.343",
+      "release_date": "2026-08-12",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.343",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Support for stores on VTEX Legacy checkout",
+          "description": "Stores still running VTEX's Legacy checkout, where the embedded payment form cannot be shown, can now process payments through Yuno. A new \"Payment Mode\" setting on the affiliation switches those stores to a redirect flow in which the shopper completes the payment on a Yuno-hosted checkout page and is then returned to the store. Cards, Pix, boleto, digital wallets and the alternative methods already supported all work through it, and order status, settlement, cancellation and refunds behave exactly as they do today. Stores keep the default setting and are unaffected.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.339",
+      "release_date": "2026-08-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.339",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Orders paid with two cards are identified in Yuno",
+          "description": "Payments belonging to an order the shopper split across two cards now carry a `two_card_payment` flag, so routing rules and reports can treat them differently from a payment that covers the full cart on its own. Both cards of the order are flagged, and every other payment reports `false`.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        },
+        {
+          "type": "FIXED",
+          "title": "Acquirer reported on declined and pending payments",
+          "description": "The acquirer that processed a payment is now returned on declined and pending authorizations, not only on approved ones. Merchants can see which acquirer handled a decline directly in the order's payment data, so declines can be reconciled and troubleshooted without opening a support request. Payments that never reached an acquirer keep the field empty, as before.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.338",
+      "release_date": "2026-08-06",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.338",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Apple Pay installments resolved by the connector",
+          "description": "A new endpoint retrieves the installment options that apply to a checkout session, with eligibility and per-installment amounts computed by Yuno. Each option is returned with display-ready, localized texts (English, Spanish, and Portuguese), including formatted amounts and any financial cost details, so storefronts render them without additional formatting. If the lookup fails for any reason, the response is an empty list so the payment always proceeds, at most without installment options.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.337",
+      "release_date": "2026-08-05",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.337",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Automatic cancellation of unpaid orders",
+          "description": "When an order is cancelled after the shopper never completed the payment, the cancellation is now confirmed instead of reported as failed. Merchants no longer receive requests to cancel or refund payments that never charged anything, and the orders close on their own. Cancellations of payments that do hold funds are unchanged, and one that cannot be voided or refunded is still reported so it can be handled manually.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
+      "version": "4.2.336",
+      "release_date": "2026-08-04",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.336",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Split orders charged in a single payment",
+          "description": "When a cart is split across sellers or delivery groups but the payment is authorized once for the full amount, the order is now processed through the standard payment flow. Digital wallet payments such as Apple Pay prepared at checkout are completed instead of being requested again and left unpaid until the order expires. Split orders whose suborders are authorized separately keep working exactly as before.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.335",
       "release_date": "2026-07-29",
       "upgrade": {

--- a/docs/plugins/vtex/faqs.mdx
+++ b/docs/plugins/vtex/faqs.mdx
@@ -50,7 +50,7 @@ description: "Answers to the most common questions about the Yuno VTEX integrati
 </Accordion>
 
 <Accordion title="Can repeat purchases be processed with network tokens?">
-  Yes. Set **Enable Network Tokens** and **Create Customer** to **Yes** in your provider configuration, and ask Yuno to enable network tokens on the routes your store uses. The first purchase with a card is processed with the card number; later purchases of the same card by the same customer are processed with a network token, which improves approval rates. If the stored card reference is unavailable, the payment proceeds as today. See [Network tokens](/docs/plugins/vtex/set-up-yuno-on-vtex#network-tokens-repeat-card-purchases) for prerequisites and multi-account considerations.
+  Yes. Set **Enable Network Tokens** and **Create Customer** to **Yes** in your provider configuration, and ask your Yuno KAM or support to activate network tokens on the routes your store uses: the VTEX fields have no effect until that activation is done. The first purchase with a card is processed with the card number; later purchases of the same card by the same customer are processed with a network token, which improves approval rates, so the benefit builds up gradually as customers return. If the stored card reference is unavailable, the payment proceeds as today. Storing a card for network tokens does not allow additional charges on order-total increases; those remain controlled by **Vault Card for Order Modification**. See [Network tokens](/docs/plugins/vtex/set-up-yuno-on-vtex#network-tokens-repeat-card-purchases) for prerequisites and multi-account considerations.
 </Accordion>
 
 <Accordion title="Where can I troubleshoot a specific order?">

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -47,8 +47,8 @@ Have the following ready:
       | **Payment Mode** | Optional | **Payment App** (modern) or **Legacy** (redirect). |
       | **Transaction Identification From** | Optional | **Yuno TID** or **Provider TID**. |
       | **Antifraud Providers for Split Orders** | Optional | Comma-separated antifraud providers (`RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, `CIELO_CYBERSOURCE_FRAUD`) that receive the shared session for split orders. Defaults to `RISKIFIED` + `CYBERSOURCE` when left empty. |
-      | **Vault Card for Order Modification** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores the card used on each order so that, if the order total later increases, the additional amount can be charged automatically. See [Order modifications](#order-modifications-changed-order-totals). |
-      | **Enable Network Tokens** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores each card on its first purchase and recognizes it on later purchases by the same customer, so Yuno can process repeat purchases with a network token instead of the card number. See [Network tokens](#network-tokens-repeat-card-purchases). |
+      | **Vault Card for Order Modification** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores the card used on each order and allows the additional amount to be charged automatically if the order total later increases. This is the only field that authorizes additional charges: when it is **No**, an order-total increase is declined even if the card was stored for network tokens. See [Order modifications](#order-modifications-changed-order-totals). |
+      | **Enable Network Tokens** | Optional | When set to **Yes** (and **Create Customer** is also **Yes**), the plugin securely stores each card on its first purchase and recognizes it on later purchases by the same customer, so Yuno can process repeat purchases with a network token instead of the card number. **The toggle has no effect until Yuno activates network tokens on the routes your store uses**: until then cards are stored but no tokens are issued. Contact your Yuno KAM or support to activate it. See [Network tokens](#network-tokens-repeat-card-purchases). |
     </Accordion>
 
     <Accordion title="Settlement Options">
@@ -178,10 +178,18 @@ To enable automatic charges when an order total **increases**, configure the fol
 
 Yuno can only attach a network token to a card it has securely stored. When **Enable Network Tokens** is on, the plugin stores each card the first time a customer pays with it and reuses that stored reference on every later purchase of the same card by the same customer. No storefront or Payment App change is needed; everything happens on the Yuno side of the integration.
 
-#### Prerequisites
+#### What has to be switched on
 
-*   Yuno VTEX plugin version **4.2.345 or later** installed in **every** VTEX account that runs the plugin (see [Multiple accounts](#multiple-accounts-and-franchises) below).
-*   Network tokens enabled by Yuno on the routes your store uses. This is configured on the Yuno side: contact your Yuno representative or [support](/docs/security-and-compliance/network-tokens#1-let-yuno-provision-and-collect-network-tokens) to activate it.
+| Requirement | Where |
+| :--- | :--- |
+| **Enable Network Tokens** | Provider configuration in VTEX (Step 1), set to **Yes**. Has no effect on its own. |
+| **Create Customer** | Same place, set to **Yes**. The stored card is bound to a Yuno customer, so both fields are required together. |
+| **Plugin 4.2.345+** | Every VTEX account that runs the plugin, including the account that authorizes rather than pays (see [Multiple accounts](#multiple-accounts-and-franchises)). |
+| **Route activation** | Done by Yuno on the routes your store uses. Not something you can set yourself: contact your Yuno KAM or [support](/docs/security-and-compliance/network-tokens#1-let-yuno-provision-and-collect-network-tokens). Activation is per route, and routes belong to a Yuno Account ID, so each account you process with needs its own activation. |
+
+<Warning>
+  **Enabling the fields in VTEX is not enough.** Until Yuno activates network tokens on your routes, the plugin stores cards but every payment is still processed with the card number and no network token is issued. Confirm the activation with your KAM or support before expecting any change in approval rates.
+</Warning>
 
 #### Enable it
 
@@ -189,28 +197,45 @@ In your provider configuration (Step 1), set the following two fields and save:
 
 | Field | Value |
 | :--- | :--- |
-| **Enable Network Tokens** | **Yes** |
+| **Enable Network Tokens** | **Yes**. Has no effect until Yuno activates network tokens on your routes (see above). |
 | **Create Customer** | **Yes**: required, because the stored card is bound to a Yuno customer. Both fields must be enabled together; **Enable Network Tokens** has no effect on its own. |
 
 #### What to expect
 
 *   **First purchase with a card**: processed with the card number, as today. The card is stored at the end of that purchase.
 *   **Later purchases of the same card by the same customer**: processed with the network token.
+*   **Gradual ramp-up**: because every card's first purchase still uses the card number, you will see almost no network tokens on day one. The benefit builds up as customers return with a card they have already used on your store.
 *   **Reissued cards** (for example, a new expiration date after a renewal) keep being recognized, so the network token continues to be used.
 *   **Fallback**: if the stored reference is not available for any reason, the payment proceeds with the card number exactly as it does today. Enabling this feature never causes a payment to fail.
 *   **VTEX subscriptions** are not affected. Recurring charges have their own stored-credential flow, which keeps working as described in the [FAQs](/docs/plugins/vtex/faqs).
 *   Applies to all card payments processed through the plugin, including fraud-defense payments and [split orders](#split-orders-multiple-sellers).
 
 <Note>
-  **Side effect on order modifications.** Because the card is stored on every first purchase, any order paid with a stored card can also receive an [additional charge when its total increases](#order-modifications-changed-order-totals), even if **Vault Card for Order Modification** is set to **No**. If you do not want order-total increases to be charged automatically, do not enable order modifications in VTEX.
+  **Order modifications are not affected.** Storing a card for network tokens does not by itself allow the plugin to charge it again. [Additional charges when an order total increases](#order-modifications-changed-order-totals) remain controlled only by **Vault Card for Order Modification**: with that field set to **No**, an order-total increase is declined even though the card is stored.
 </Note>
+
+```mermaid
+flowchart LR
+  subgraph single["Single store"]
+    direction LR
+    A1["First purchase<br/>card number"] --> A2["Card stored<br/>store A"] --> A3["Buys again<br/>same store"] --> A4["Network token<br/>better approval"]
+  end
+  subgraph franchise["Franchise, many store accounts"]
+    direction LR
+    B1["First purchase<br/>at store A"] --> B2["Card stored<br/>store A only"] --> B3["Buys again<br/>at store B"] --> B4["Card number<br/>no token"]
+  end
+  style A4 fill:#e6f2ec,stroke:#2e7d5b,color:#1f5c42
+  style B4 fill:#f9ebe3,stroke:#b5541f,color:#8a3d12
+```
+
+Store B has no record of the card, so it is treated as a first purchase. The payment still succeeds; it falls back to the card number.
 
 #### Multiple accounts and franchises
 
 The card is stored in the VTEX account that **authorizes** the payment and is scoped to that account's Yuno **Account ID**. Keep this in mind in the following setups:
 
 *   **Authorization and payment in different VTEX accounts** (for example, a B2B storefront that completes the payment in a second account): enable both fields on the affiliation of the account that **authorizes** the order, not only on the account that completes the payment. Both accounts must run plugin version **4.2.345 or later**.
-*   **Franchises / multiple store accounts** (many store accounts sharing a main account): enable both fields on **every** franchise affiliation. A card stored by one store account is not shared with another, and a card stored under one Yuno Account ID is not visible to another, so each store builds its own card history.
+*   **Franchises / multiple store accounts** (many store accounts sharing a main account): enable both fields on **every** franchise affiliation. A card stored by one store account is not shared with another, and a card stored under one Yuno Account ID is not visible to another, so each store builds its own card history. **The benefit therefore accrues per store**: a chain whose customers buy across several stores gets materially fewer tokenized payments than a single-store merchant, because each store only recognizes the cards first used in that same store. Route activation is also per Yuno Account ID, so Yuno must activate network tokens on the routes of **every** franchise account, not only the main one.
 
 <Accordion title="Verifying the setup (for Yuno TAMs)">
   Place two orders with the same card and the same customer on the store, then look up the plugin logs for each order in Datadog and filter by the `step_function` attribute:

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -188,7 +188,7 @@ Yuno can only attach a network token to a card it has securely stored. When **En
 | **Route activation** | Done by Yuno on the routes your store uses. Not something you can set yourself: contact your Yuno KAM or [support](/docs/security-and-compliance/network-tokens#1-let-yuno-provision-and-collect-network-tokens). Activation is per route, and routes belong to a Yuno Account ID, so each account you process with needs its own activation. |
 
 <Warning>
-  **Enabling the fields in VTEX is not enough.** Until Yuno activates network tokens on your routes, the plugin stores cards but every payment is still processed with the card number and no network token is issued. Confirm the activation with your KAM or support before expecting any change in approval rates.
+  **Both sides are required.** Until Yuno activates network tokens on your routes, the plugin stores cards but every payment is still processed with the card number and no network token is issued. The reverse also holds: if network tokens are active on your routes but **Enable Network Tokens** and **Create Customer** are not set in VTEX, no card is stored and every payment remains a regular card-number transaction. Confirm the activation with your KAM or support before expecting any change in approval rates.
 </Warning>
 
 #### Enable it

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -184,7 +184,7 @@ Yuno can only attach a network token to a card it has securely stored. When **En
 | :--- | :--- |
 | **Enable Network Tokens** | Provider configuration in VTEX (Step 1), set to **Yes**. Has no effect on its own. |
 | **Create Customer** | Same place, set to **Yes**. The stored card is bound to a Yuno customer, so both fields are required together. |
-| **Plugin 4.2.345+** | Every VTEX account that runs the plugin, including the account that authorizes rather than pays (see [Multiple accounts](#multiple-accounts-and-franchises)). |
+| **Plugin 4.2.347+** | Every VTEX account that runs the plugin, including the account that authorizes rather than pays (see [Multiple accounts](#multiple-accounts-and-franchises)). |
 | **Route activation** | Done by Yuno on the routes your store uses. Not something you can set yourself: contact your Yuno KAM or [support](/docs/security-and-compliance/network-tokens#1-let-yuno-provision-and-collect-network-tokens). Activation is per route, and routes belong to a Yuno Account ID, so each account you process with needs its own activation. |
 
 <Warning>
@@ -234,7 +234,7 @@ Store B has no record of the card, so it is treated as a first purchase. The pay
 
 The card is stored in the VTEX account that **authorizes** the payment and is scoped to that account's Yuno **Account ID**. Keep this in mind in the following setups:
 
-*   **Authorization and payment in different VTEX accounts** (for example, a B2B storefront that completes the payment in a second account): enable both fields on the affiliation of the account that **authorizes** the order, not only on the account that completes the payment. Both accounts must run plugin version **4.2.345 or later**.
+*   **Authorization and payment in different VTEX accounts** (for example, a B2B storefront that completes the payment in a second account): enable both fields on the affiliation of the account that **authorizes** the order, not only on the account that completes the payment. Both accounts must run plugin version **4.2.347 or later**.
 *   **Franchises / multiple store accounts** (many store accounts sharing a main account): enable both fields on **every** franchise affiliation. A card stored by one store account is not shared with another, and a card stored under one Yuno Account ID is not visible to another, so each store builds its own card history. **The benefit therefore accrues per store**: a chain whose customers buy across several stores gets materially fewer tokenized payments than a single-store merchant, because each store only recognizes the cards first used in that same store. Route activation is also per Yuno Account ID, so Yuno must activate network tokens on the routes of **every** franchise account, not only the main one.
 
 <Accordion title="Verifying the setup (for Yuno TAMs)">


### PR DESCRIPTION
## Why

Addresses Carolina Torneiro's review of the VTEX Network Tokens docs ([Slack](https://yunopay.slack.com/archives/C0BK5MA442X/p1787511121716609), CORECM-19362).

## What

`docs/plugins/vtex/set-up-yuno-on-vtex.mdx`, `docs/plugins/vtex/faqs.mdx`:
- Activation note in **both** the `Enable Network Tokens` field row and the "Enable it" table, plus a Warning: the VTEX fields have no effect until Yuno activates network tokens on the store's routes (KAM / support).
- "Prerequisites" replaced by a **What has to be switched on** table (Enable Network Tokens / Create Customer / plugin version / route activation — per route, per Yuno Account ID).
- Ramp-up expectation (almost no tokens on day one; builds as customers return).
- Franchise consequence: benefit accrues per store account; route activation needed on every franchise account.
- Two-lane diagram (single store → network token; franchise → card number).
- Order modifications: no longer a side effect — additional charges stay gated on `Vault Card for Order Modification` (connector 4.2.347, yuno-payments/sdk-vtex-connector PR). Field row and FAQ reworded; required version raised to 4.2.347.

`changelog/source/vtex.json`:
- Publishes 4.2.336, 4.2.337, 4.2.338, 4.2.339, 4.2.343, 4.2.344, 4.2.345, 4.2.346 (the public page stopped at 4.2.335; 4.2.342 is internal). Objects are the curated `changelog/*.json` from the connector repo; the release webhook is idempotent so later GitHub Releases won't duplicate them.

`node scripts/check-descriptions.cjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog JSON only; no runtime or payment logic in this repo.
> 
> **Overview**
> **VTEX Network Tokens documentation** is updated from review feedback: merchants must get **route activation from Yuno (KAM/support)** before the VTEX toggles do anything, with a new requirements table, warning, and ramp-up expectation (tokens build as repeat shoppers return). **Franchise/multi-account** behavior is spelled out with a mermaid flow (per-store card history and per–Account ID route activation).
> 
> **Order modifications** are corrected: storing a card for network tokens no longer documented as enabling extra charges—only **Vault Card for Order Modification** gates increases; field reference, FAQ, and the network-tokens note align with connector **4.2.347+**.
> 
> **Public changelog** (`changelog/source/vtex.json`) adds curated release notes for **4.2.336 through 4.2.346** (network tokens, legacy checkout, cancellation/installment/split-order fixes, two-card flag, Apple Pay installments, etc.), catching up past 4.2.335.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb2ecd3cafafac2ba7bf478f6d192427879a729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->