### PR TITLE
docs(changelog): regenerate vtex.mdx for 4.2.336-4.2.346

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,74 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.346
+*August 21, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Cancellations of a card payment that was never completed are approved**  
+  When an order paid with two cards is cancelled because one card is declined, the other card's payment may have an open checkout session but no payment behind it. The connector answered VTEX's cancellation of that payment with a "payment not found" error, so after three attempts VTEX emailed the store asking for a manual cancellation of a payment that never charged anything. The connector now recognizes this case and confirms the cancellation, as it already did for payments that never reached Yuno at all.
+
+## v4.2.345
+*August 20, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="added" /> **Network Token support for card payments**  
+  A new "Enable Network Tokens" setting on the affiliation lets the connector securely store each card on its first purchase and recognize it on later purchases by the same customer, so Yuno can process repeat purchases with a network token instead of the card number. Network tokens significantly improve approval rates for returning shoppers. The feature covers all card payments, including fraud-defense, multi-seller split orders and setups where the payment is completed from a different VTEX account than the one that authorized it. If the stored reference is unavailable for any reason the payment proceeds exactly as today, so checkout is never affected. Stores that keep the default setting are unaffected.  
+  *Migration:* To enable it, open the Yuno affiliation in the VTEX admin and set both "Enable Network Tokens" and "Create Customer" to Yes; then confirm with Yuno that network tokens are enabled on the routes used by the store. In franchise or multi-store setups, apply the settings on every store's affiliation. No storefront changes are required.
+
+## v4.2.344
+*August 19, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Installment count reported correctly on digital wallet payments**  
+  Apple Pay and Google Pay payments created through the pre-created session flow reported a single installment in the payment's informational metadata even when the shopper selected more. The amount actually charged and the installments sent to the payment provider were always correct; the reported value now matches them, so dashboards and reconciliation no longer show a misleading count.
+
+## v4.2.343
+*August 12, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="added" /> **Support for stores on VTEX Legacy checkout**  
+  Stores still running VTEX's Legacy checkout, where the embedded payment form cannot be shown, can now process payments through Yuno. A new "Payment Mode" setting on the affiliation switches those stores to a redirect flow in which the shopper completes the payment on a Yuno-hosted checkout page and is then returned to the store. Cards, Pix, boleto, digital wallets and the alternative methods already supported all work through it, and order status, settlement, cancellation and refunds behave exactly as they do today. Stores keep the default setting and are unaffected.
+
+## v4.2.339
+*August 6, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="added" /> **Orders paid with two cards are identified in Yuno**  
+  Payments belonging to an order the shopper split across two cards now carry a `two_card_payment` flag, so routing rules and reports can treat them differently from a payment that covers the full cart on its own. Both cards of the order are flagged, and every other payment reports `false`.
+
+- <ChangelogBadge type="fixed" /> **Acquirer reported on declined and pending payments**  
+  The acquirer that processed a payment is now returned on declined and pending authorizations, not only on approved ones. Merchants can see which acquirer handled a decline directly in the order's payment data, so declines can be reconciled and troubleshooted without opening a support request. Payments that never reached an acquirer keep the field empty, as before.
+
+## v4.2.338
+*August 6, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="added" /> **Apple Pay installments resolved by the connector**  
+  A new endpoint retrieves the installment options that apply to a checkout session, with eligibility and per-installment amounts computed by Yuno. Each option is returned with display-ready, localized texts (English, Spanish, and Portuguese), including formatted amounts and any financial cost details, so storefronts render them without additional formatting. If the lookup fails for any reason, the response is an empty list so the payment always proceeds, at most without installment options.
+
+## v4.2.337
+*August 5, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Automatic cancellation of unpaid orders**  
+  When an order is cancelled after the shopper never completed the payment, the cancellation is now confirmed instead of reported as failed. Merchants no longer receive requests to cancel or refund payments that never charged anything, and the orders close on their own. Cancellations of payments that do hold funds are unchanged, and one that cannot be voided or refunded is still reported so it can be handled manually.
+
+## v4.2.336
+*August 4, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Split orders charged in a single payment**  
+  When a cart is split across sellers or delivery groups but the payment is authorized once for the full amount, the order is now processed through the standard payment flow. Digital wallet payments such as Apple Pay prepared at checkout are completed instead of being requested again and left unpaid until the order expires. Split orders whose suborders are authorized separately keep working exactly as before.
+
 ## v4.2.335
 *July 29, 2026*
 


### PR DESCRIPTION
## What

PR #807... wait wrong PR. changelog/source/vtex.json was updated in the CORECM-19362 network-tokens-feedback branch (merged in 9a107163) with releases 4.2.336 through 4.2.346, but changelog/plugins/vtex.mdx was never regenerated — it still topped out at v4.2.335. Regenerated it with scripts/generate_changelog.js so the published changelog page matches the source JSON.

Jira: CORECM-19362

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only sync of an already-maintained changelog source; no application logic or configuration behavior changes in this diff.
> 
> **Overview**
> Regenerates **`changelog/plugins/vtex.mdx`** from the existing source so the public VTEX plugin changelog page is no longer stuck at **v4.2.335**. The JSON source already contained **v4.2.336–v4.2.346**; this PR only updates the rendered MDX (via `scripts/generate_changelog.js`), with no connector or runtime code changes.
> 
> The newly surfaced release notes span payment fixes (split-order single charge, unpaid-order cancellations, two-card cancel edge cases), additions (Legacy checkout redirect mode, network tokens, Apple Pay installments API, `two_card_payment` flag), and metadata fixes (wallet installment counts, acquirer on declined/pending).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f99347c9afc6a6bef07d5cbddf2696f97e51a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->