### PR TITLE
chore: vtex sdk changelog 4.2.347

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.347
+*August 24, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="changed" /> **Additional charges on modified orders require the Vault Card for Order Modification field**  
+  When Enable Network Tokens is on, every card is stored, so an order whose total increased could receive an additional charge even if Vault Card for Order Modification was set to No. That field is now the only switch for additional charges: with it off, an order-total increase is declined instead of charged, and enabling Network Tokens no longer implies consent to charge customers more.
+
 ## v4.2.346
 *August 21, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.347",
+      "release_date": "2026-08-24",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.347",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "CHANGED",
+          "title": "Additional charges on modified orders require the Vault Card for Order Modification field",
+          "description": "When Enable Network Tokens is on, every card is stored, so an order whose total increased could receive an additional charge even if Vault Card for Order Modification was set to No. That field is now the only switch for additional charges: with it off, an order-total increase is declined instead of charged, and enabling Network Tokens no longer implies consent to charge customers more.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.346",
       "release_date": "2026-08-21",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.347`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.346

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync; no application or connector code changes in this PR.
> 
> **Overview**
> Documents **VTEX plugin release v4.2.347** (August 24, 2026) in `changelog/source/vtex.json` and `changelog/plugins/vtex.mdx`, including the `vtex install yunopartnerbr.yuno@4.2.347` upgrade snippet.
> 
> The new **Payments** entry describes a **behavior change** for modified orders: **Vault Card for Order Modification** is now the only control for charging a higher order total. With **Enable Network Tokens**, cards could still be stored and extra charges could run even when vault-for-modification was **No**; that is corrected so turning vault off **declines** total increases instead of charging, and network tokens alone no longer imply consent for additional charges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d000e0940e7aa2cf43bd57c31647b0c96ce4287e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->