### PR TITLE
docs: Stripe Proxy — onboarding via KAM/TAM and webhook setup (hidden) [C2-18252]

### DIFF
--- a/docs/stripe-proxy/overview.mdx
+++ b/docs/stripe-proxy/overview.mdx
@@ -35,71 +35,37 @@ To migrate, you only change **two things** in your integration:
 Everything else — your success page, your webhook handler, your error handling —
 keeps working as it does with Stripe today.
 
-## Before you start: register your Stripe credentials
+## Before you start
 
-If you want Yuno to keep using **Stripe Billing** for your subscriptions
-(`BILLING: STRIPE`, see [Proxy subscriptions](#subscriptions)) or to resolve
-existing `price_...` ids from your Stripe catalog, you first register a Stripe
-**restricted key** with Yuno. This is a one-time step per account: Yuno stores
-the key encrypted and uses it server-side, so you never send Stripe credentials
-on each request.
+The Stripe Proxy is set up once per account by Yuno. Share the following with
+your KAM/TAM and they will enable it for you — none of this is sent on the
+API requests.
 
-```bash
-curl -X POST '{baseUrl}/v1/onboarding' \
-  -H "PUBLIC-API-KEY: <your-public-key>" \
-  -H "PRIVATE-SECRET-KEY: <your-private-secret>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "organization_code": "<your-organization-code>",
-    "account_id": "<your-account-code>",
-    "stripe_restricted_key": "rk_live_...",
-    "stripe_custom_payment_method_type": "cpmt_..."
-  }'
-```
+### 1. Stripe credentials
 
-<ParamField body="organization_code" type="string" required>
-  Your Yuno organization code (UUID).
-</ParamField>
+Needed if you use `BILLING: STRIPE` (see [Proxy subscriptions](#subscriptions))
+or send existing `price_...` ids from your Stripe catalog. Yuno stores the key
+encrypted and uses it server-side, so you never send Stripe credentials on each
+request.
 
-<ParamField body="account_id" type="string" required>
-  The Yuno account the Stripe credentials belong to (UUID). Must match the
-  `X-account-code` you send on the hosted page requests.
-</ParamField>
-
-<ParamField body="stripe_restricted_key" type="string" required>
-  A Stripe **restricted key** (`rk_...`) with access to Hosted Page (Checkout Sessions),
-  Prices, Customers and Subscriptions. It is never logged and only stored
-  encrypted.
-</ParamField>
-
-<ParamField body="stripe_custom_payment_method_type" type="string" required>
-  The id of the Stripe custom payment method type (`cpmt_...`) Yuno uses to
-  report charges back to Stripe Billing.
-</ParamField>
-
-```json
-{
-  "merchant_ref": "mref_...",
-  "organization_code": "...",
-  "account_id": "...",
-  "status": "ACTIVE",
-  "webhook_url": "https://.../v1/onboarding/mref_.../stripe-webhook",
-  "stripe": {
-    "custom_payment_method_type": "cpmt_...",
-    "webhook_endpoint_id": "we_..."
-  }
-}
-```
-
-To rotate the key later use `POST /v1/onboarding/{merchant_ref}/rotate-keys`
-with `{"stripe_restricted_key": "rk_..."}`; to turn the link off use
-`POST /v1/onboarding/{merchant_ref}/disable`.
+| What we need | Description |
+| --- | --- |
+| **Stripe restricted key** (`rk_...`) | Created in your Stripe Dashboard under *Developers → API keys → Create restricted key*, with access to Checkout Sessions, Prices, Customers and Subscriptions. It is never logged and only stored encrypted. |
+| **Stripe custom payment method type** (`cpmt_...`) | The custom payment method type Yuno uses to report charges back to Stripe Billing. |
+| **Yuno organization and account** | The organization and the `X-account-code` you will send on the hosted page requests. |
 
 <Warning>
   Sending `mode=subscription` with `BILLING: STRIPE` (or a `price_...` id)
-  before completing this step returns a Stripe-shaped `authentication_error`,
+  before this step is enabled returns a Stripe-shaped `authentication_error`,
   since Yuno has no Stripe key to act on your behalf.
 </Warning>
+
+### 2. Webhooks
+
+| What we need | Description |
+| --- | --- |
+| **Your webhook URL** | The URL where you want to receive the Stripe events (`checkout.session.completed`, `checkout.session.expired`) — the same one your Stripe handler listens on today. Yuno relays the signed events there. |
+| **Yuno registered in your Stripe Dashboard** | Add the Yuno endpoint under *Developers → Webhooks → Add endpoint* so Stripe Billing events reach the proxy. Sandbox: `https://internal-sandbox.y.uno/stripe-proxy-ms/v1/webhooks/payment`. Production: provided by your KAM/TAM. |
 
 ## Base URL
 
@@ -252,7 +218,7 @@ both cases.
 
 | `BILLING` | What Yuno does | Requires |
 | --- | --- | --- |
-| `STRIPE` | Calls Stripe and creates the subscription in **Stripe Billing** (customer + subscription). Stripe keeps deciding *when and how much* to charge; Yuno executes the charges. | Stripe credentials registered ([step above](#before-you-start-register-your-stripe-credentials)) |
+| `STRIPE` | Calls Stripe and creates the subscription in **Stripe Billing** (customer + subscription). Stripe keeps deciding *when and how much* to charge; Yuno executes the charges. | Stripe credentials shared with your KAM/TAM ([Before you start](#before-you-start)) |
 | `YUNO` — **coming soon** | Creates a **Yuno subscription** from the plan in `X-Subscription-Plan-Id`. No call to Stripe is made. | `X-Subscription-Plan-Id` with a Yuno plan id |
 
 In both cases the paid webhook carries `subscription` like Stripe does.
@@ -340,6 +306,11 @@ verification works unchanged.
   }
 }
 ```
+
+<Note>
+  Your webhook URL and the Yuno endpoint in your Stripe Dashboard are configured
+  once with your KAM/TAM — see [Before you start](#before-you-start).
+</Note>
 
 ## Errors
 

--- a/docs/stripe-proxy/overview.mdx
+++ b/docs/stripe-proxy/overview.mdx
@@ -60,7 +60,7 @@ request.
   since Yuno has no Stripe key to act on your behalf.
 </Warning>
 
-### 2. Webhooks
+### 2. Webhook setup
 
 1. **Register this webhook in your Yuno Dashboard.** Go to *Developers →
    Webhooks* and add the Stripe Proxy endpoint for your environment, so the

--- a/docs/stripe-proxy/overview.mdx
+++ b/docs/stripe-proxy/overview.mdx
@@ -62,10 +62,20 @@ request.
 
 ### 2. Webhooks
 
-| What we need | Description |
-| --- | --- |
-| **Your webhook URL** | The URL where you want to receive the Stripe events (`checkout.session.completed`, `checkout.session.expired`) — the same one your Stripe handler listens on today. Yuno relays the signed events there. |
-| **Yuno registered in your Stripe Dashboard** | Add the Yuno endpoint under *Developers → Webhooks → Add endpoint* so Stripe Billing events reach the proxy. Sandbox: `https://internal-sandbox.y.uno/stripe-proxy-ms/v1/webhooks/payment`. Production: provided by your KAM/TAM. |
+1. **Register this webhook in your Yuno Dashboard.** Go to *Developers →
+   Webhooks* and add the Stripe Proxy endpoint for your environment, so the
+   payment events of the hosted page reach the proxy (see
+   [Configure webhooks](/docs/webhooks/configure-webhooks)):
+
+   | Environment | Webhook URL |
+   | --- | --- |
+   | Sandbox | `https://internal-sandbox.y.uno/stripe-proxy-ms/v1/webhooks/payment` |
+   | Production | Provided by your KAM/TAM |
+
+2. **Send your webhook URL to your TAM.** The URL where you want to receive the
+   Stripe events (`checkout.session.completed`, `checkout.session.expired`) —
+   the same one your Stripe handler listens on today. Yuno relays the signed
+   events there.
 
 ## Base URL
 
@@ -308,8 +318,8 @@ verification works unchanged.
 ```
 
 <Note>
-  Your webhook URL and the Yuno endpoint in your Stripe Dashboard are configured
-  once with your KAM/TAM — see [Before you start](#before-you-start).
+  The Stripe Proxy webhook in your Yuno Dashboard and the URL where you receive
+  the Stripe events are configured once — see [Before you start](#before-you-start).
 </Note>
 
 ## Errors


### PR DESCRIPTION
## Summary

Follow-up to #821 (Stripe Proxy, hidden page). Fixes the onboarding section: `POST /v1/onboarding` is an **internal** route of `billing-bridge-ms` (no edge route), so the page must not document it as something the merchant calls.

## Changes

- **Before you start** now lists what the merchant shares with their **KAM/TAM** so Yuno enables the proxy for their account — no curl, no endpoint:
  - Stripe credentials: restricted key (`rk_...`), custom payment method type (`cpmt_...`), Yuno organization + account. Needed for `BILLING: STRIPE` and for `price_...` ids.
  - Webhooks: the merchant's webhook URL for the relayed `checkout.session.*` events, and the Yuno endpoint to register in their Stripe Dashboard (sandbox: `https://internal-sandbox.y.uno/stripe-proxy-ms/v1/webhooks/payment`; production via KAM/TAM).
- **Webhooks** section points to that setup instead of repeating it.

Page stays hidden (not in `docs.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a hidden MDX page; no runtime or API behavior changes.
> 
> **Overview**
> Updates the hidden **Stripe Proxy** overview so merchants no longer see a self-service **`POST /v1/onboarding`** flow (internal route, not for public docs).
> 
> **Before you start** is reframed as a one-time account setup handled by **KAM/TAM**: a table of what to share (restricted key, `cpmt_...`, org/account) replaces the curl, `ParamField`s, sample onboarding response, and rotate/disable key instructions. A new **Webhook setup** subsection tells merchants to register the Stripe Proxy endpoint in the **Yuno Dashboard** (sandbox URL documented; production via KAM/TAM) and send their relay target URL to their TAM.
> 
> Cross-links now point at **Before you start** (subscriptions **Requires** column and a note under **Webhooks**) instead of the old credentials anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea19cbcdce27d73c19c521721a592ecb7f599caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->