### PR TITLE
docs: add Headless SDK to integration comparison, fix provider_barcode type

### DIFF
--- a/docs/sdks/overview/choose-integration.mdx
+++ b/docs/sdks/overview/choose-integration.mdx
@@ -4,7 +4,7 @@ deprecated: false
 hidden: false
 metadata:
   robots: index
-description: "Compare Seamless SDK, Lite SDK, and secure-fields integration types to pick the right fit"
+description: "Compare Seamless SDK, Lite SDK, Headless SDK, and secure-fields integration types to pick the right fit"
 ---
 Within each platform's SDK, Yuno offers various **integration methods** allowing varying degrees of control over the UI and user experience.
 
@@ -20,18 +20,18 @@ Yuno recommends using **Seamless SDK** for its flexibility and ease of integrati
 
 Below, you can see the specifications for each integration type.
 
-| Feature | [seamless-sdk](#seamless-sdk) | [lite-sdk](#lite-sdk) | [secure-fields](#secure-fields) |
-| :--- | :---: | :---: | :---: |
-| Add new payment methods without code | ✅ | ❌ | ❌ |
-| Handle hundreds of payment methods with a single API | ✅ | ✅ | ✅ |
-| Tokenize cards and payment methods without code | ✅ | ✅ | ✅ |
-| Use Yuno's PCI-DSS Certification | ✅ | ✅ | ✅ |
-| Use 3D Secure | ✅ | ✅ | ✅ |
-| Use an antifraud solution without code | ✅ | ✅ | ✅ |
-| Set checkout conditions using the Yuno Dashboard | ✅ | ❌ | ❌ |
-| Customize the look and feel of your checkout using the Yuno Dashboard | ✅ | ❌ | ❌ |
+| Feature | [seamless-sdk](#seamless-sdk) | [lite-sdk](#lite-sdk) | [headless-sdk](#headless-sdk) | [secure-fields](#secure-fields) |
+| :--- | :---: | :---: | :---: | :---: |
+| Add new payment methods without code | ✅ | ❌ | ❌ | ❌ |
+| Handle hundreds of payment methods with a single API | ✅ | ✅ | ✅ | ✅ |
+| Tokenize cards and payment methods without code | ✅ | ✅ | ✅ | ✅ |
+| Use Yuno's PCI-DSS Certification | ✅ | ✅ | ✅ | ✅ |
+| Use 3D Secure | ✅ | ✅ | ✅ | ✅ |
+| Use an antifraud solution without code | ✅ | ✅ | ✅ | ✅ |
+| Set checkout conditions using the Yuno Dashboard | ✅ | ❌ | ❌ | ❌ |
+| Customize the look and feel of your checkout using the Yuno Dashboard | ✅ | ❌ | ❌ | ❌ |
 
-<CardGroup cols={3}>
+<CardGroup cols={4}>
   <Card title="seamless-sdk" icon="browser">
     The most flexible and recommended integration solution. Provides pre-built UI components with full control over the payment experience and automatic payment method management.
     * **User experience management**: You control the UI while Yuno handles the heavy lifting.
@@ -43,6 +43,12 @@ Below, you can see the specifications for each integration type.
     * **Full UI control**: You decide how and where to display each payment method.
     * **Developer focused**: Requires manual implementation of payment method selection.
     * **Customizable**: Best for businesses with highly specific UX requirements. Use [Web](/docs/sdks/lite-web/payment), [Android](/docs/sdks/lite-android/checkout), or [iOS](/docs/sdks/lite-ios/checkout).
+  </Card>
+  <Card title="headless-sdk" icon="code">
+    Maximum flexibility: you build and manage the entire payment UI yourself, while Yuno handles the underlying payment logic and security (like 3DS) through direct SDK function calls.
+    * **Full UI ownership**: No prebuilt components at all — every screen and interaction is yours to build.
+    * **Developer focused**: You request and send the mandatory fields each payment provider requires yourself.
+    * **Customizable**: Best for businesses needing a fully custom checkout experience. Use [Web](/docs/sdks/headless-web/payment), [Android](/docs/sdks/headless-android/checkout), or [iOS](/docs/sdks/headless-ios/checkout).
   </Card>
   <Card title="secure-fields" icon="shield-check">
     Prebuilt secure input fields you embed directly into your own payment form, so raw card data never touches your servers (Web Only).

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -1105,8 +1105,8 @@ This object represents the payment created after generating the checkout session
               Example: 13141
             </ParamField>
 
-            <ParamField body="provider_barcode" type="integer">
-              The ticket's barcode.
+            <ParamField body="provider_barcode" type="string">
+              The ticket's barcode, as a text value. For the barcode image, see `provider_logo`.
 
               Example: 456789009878765u7654
             </ParamField>
@@ -3807,8 +3807,8 @@ This object represents the payment created after generating the checkout session
                   Example: 13141
                 </ParamField>
 
-                <ParamField body="provider_barcode" type="integer">
-                  The ticket's barcode.
+                <ParamField body="provider_barcode" type="string">
+                  The ticket's barcode, as a text value. For the barcode image, see `provider_logo`.
 
                   Example: 456789009878765u7654
                 </ParamField>
@@ -4652,8 +4652,8 @@ This object represents the payment created after generating the checkout session
                   Example: 13141
                 </ParamField>
 
-                <ParamField body="provider_barcode" type="integer">
-                  The ticket's barcode.
+                <ParamField body="provider_barcode" type="string">
+                  The ticket's barcode, as a text value. For the barcode image, see `provider_logo`.
 
                   Example: 456789009878765u7654
                 </ParamField>


### PR DESCRIPTION
## Summary
- Added Headless SDK as a fourth option in the SDK integration comparison table and card group in `choose-integration.mdx`, based on what `headless-web/ios/android` docs confirm it supports (no prebuilt UI/dashboard config, but Yuno-handled tokenization, 3DS, and antifraud via direct SDK calls).
- Fixed `provider_barcode` in `the-payment-object.mdx` (3 occurrences): type `integer` → `string`, and clarified in the description that it's the barcode's text value (the image is already covered by the sibling `provider_logo` field).

Both gaps were flagged in the July 2026 AI-analytics report (reports.writechoice.io/yuno/2026/07).

## Test plan
- [ ] Render `choose-integration.mdx` and confirm the 4-column table and 4-card group display correctly
- [ ] Confirm `provider_barcode` reads as `string` in all 3 occurrences in `the-payment-object.mdx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes; the barcode type fix aligns docs with alphanumeric examples.
> 
> **Overview**
> **Choose Integration** now lists **Headless SDK** alongside Seamless, Lite, and secure-fields: the meta description, feature comparison table (fourth column), and card group (`cols={4}`) were expanded, including a new card that positions headless as full UI ownership with Yuno handling payment logic via SDK calls and links to web/Android/iOS headless docs.
> 
> In **The Payment Object** reference, `provider_barcode` on ticket payment details is corrected in three duplicated sections: documented type changes from `integer` to `string`, with copy clarifying it is the barcode text (images remain on `provider_logo`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3feb81fa85f339e86830b6e9b938bad762d854cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->