### PR TITLE
docs(payment-methods-direct-workflow): fix typos and broken cross-page anchors

### DIFF
--- a/reference/payment-methods-direct-workflow/enroll-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/enroll-payment-method-api.mdx
@@ -6,7 +6,7 @@ description: "Enrolls a customer's payment method and returns a vaulted token fo
 
 This request enrolls a payment method for a customer. With the information provided by Yuno after the customer selects the payment method to enroll, you will be able to save that information for future purchases using the payment method object created.
 
-Check the [Available payment methods in Yuno](/reference/payment-type-list). You'll need to set your credentials for each payment method in the Yuno dashboard in order to to be able to use them.
+Check the [Available payment methods in Yuno](/reference/payment-type-list). You'll need to set your credentials for each payment method in the Yuno dashboard in order to be able to use them.
 
 Note that this request requires an `X-Idempotency-Key`. Check the [Authentication](/reference/authentication#idempotency) page for more information.
 

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx
@@ -9,5 +9,5 @@ Retrieve a specific payment method that a user has enrolled in.
 <Note>
 **Retrieve Enrolled Payment Method**
 
-To recover the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
+To recover the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.
 </Note>

--- a/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
+++ b/reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.mdx
@@ -9,7 +9,7 @@ Retrieve a specific payment method that a user has enrolled in, including the fu
 <Note>
 **Retrieve Enrolled Payment Method**
 
-To retrieve the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
+To retrieve the enrolled payment method information, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.
 </Note>
 
 <Warning>

--- a/reference/payment-methods-direct-workflow/the-payment-method-object-api.mdx
+++ b/reference/payment-methods-direct-workflow/the-payment-method-object-api.mdx
@@ -46,13 +46,13 @@ This object represents a payment method that can be associated with a customer f
   Possible enum values: Check the <a href="/reference/country-reference">Country reference</a>.
 </ParamField>
 
-<ParamField body="last_successfuly_used" type="bool">
+<ParamField body="last_successfully_used" type="bool">
   Indicates if the enrolled payment method was the last successfully used by the customer ).
 
   Example: True
 </ParamField>
 
-<ParamField body="last_successfuly_used_at" type="timestamp">
+<ParamField body="last_successfully_used_at" type="timestamp">
   Indicates the date of the last succeeded payment if the enrolled payment method was the last successfully
           used by the customer ).
 
@@ -60,11 +60,11 @@ This object represents a payment method that can be associated with a customer f
 </ParamField>
 
 <ParamField body="workflow" type="enum">
-  The payment workflow indicates whether the integration will use Yuno´s SDK or will be a back to back
+  The payment workflow indicates whether the integration will use Yuno's SDK or will be a back to back
           connection.
 
-  Possible enum values: If `CHECKOUT` you will use Yuno SDK. If `DIRECT` you
-            will back to back integration.
+  Possible enum values: If `CHECKOUT` you will use Yuno SDK. If `DIRECT`, you
+            will use a back-to-back integration.
 </ParamField>
 
 <ParamField body="card_data" type="object">
@@ -73,8 +73,8 @@ This object represents a payment method that can be associated with a customer f
   <Expandable title="properties">
 
     <ParamField body="iin" type="integer">
-      The issuer indentificarion number (IIN) refers to the first few digits of the payment card number issued
-                by a financial insituition (MAX 8; MIN 6).
+      The issuer identification number (IIN) refers to the first few digits of the payment card number issued
+                by a financial institution (MAX 8; MIN 6).
 
       Example: 45079900
     </ParamField>
@@ -86,13 +86,13 @@ This object represents a payment method that can be associated with a customer f
     </ParamField>
 
     <ParamField body="expiration_month" type="integer">
-      The expiraton month of the card (MAX 2; MIN 2) - only available for PCI certified merchants.
+      The expiration month of the card (MAX 2; MIN 2) - only available for PCI certified merchants.
 
       Example: 12
     </ParamField>
 
     <ParamField body="expiration_year" type="integer">
-      The expiraton year of the card (MAX 2; MIN 2) - only available for PCI certified merchants.
+      The expiration year of the card (MAX 2; MIN 2) - only available for PCI certified merchants.
 
       Example: 12
     </ParamField>
@@ -137,7 +137,7 @@ This object represents a payment method that can be associated with a customer f
 </ParamField>
 
 <ParamField body="callback_url" type="string">
-  URL to return the customer after an enrollment in a provider´s environment. Only necessary for alternative
+  URL to return the customer after an enrollment in a provider's environment. Only necessary for alternative
           payment methods integrations (MAX: 64; MIN: 36).
 
   Example: https://www.company.com/customer_1231324

--- a/reference/payment-methods-direct-workflow/unenroll-payment-method-api.mdx
+++ b/reference/payment-methods-direct-workflow/unenroll-payment-method-api.mdx
@@ -9,5 +9,5 @@ Unenroll a saved payment method for the user. Once you've done the POST to the u
 <Note>
 **Unenrollment Information**
 
-To unenroll the payment method, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](#enroll-payment-method-api) endpoint.
+To unenroll the payment method, you need to provide the `payment_method_id`, which is the `vaulted_token` received when using the [Enroll Payment Method](/reference/enroll-payment-method-api) endpoint.
 </Note>


### PR DESCRIPTION
## PR Description
Applies a confirmed batch of simple fixes from a docs-evaluation report covering the Payment Methods (Direct Workflow) reference pages. Each item was verified against the actual source files before being applied — items that turned out to be false positives (e.g. links flagged as "broken" that actually work via an established redirect pattern) or that only exist in the OpenAPI JSON specs (outside docs-team edit scope) were excluded and flagged separately instead of being applied blindly.

## Changes
- `reference/payment-methods-direct-workflow/the-payment-method-object-api.mdx`: fixed `last_successfuly_used`/`last_successfuly_used_at` → `last_successfully_used`/`last_successfully_used_at`; fixed typos `indentificarion` → `identification`, `insituition` → `institution`, `expiraton` (×2) → `expiration`; fixed the wrong apostrophe character in `Yuno´s` and `provider´s` → `Yuno's`/`provider's`; rewrote the broken enum sentence "If `DIRECT` you will back to back integration" → "If `DIRECT`, you will use a back-to-back integration."
- `reference/payment-methods-direct-workflow/enroll-payment-method-api.mdx`: removed the duplicated word in "in order to to be able" → "in order to be able".
- `reference/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.mdx`, `retrieve-enrolled-payment-method-by-id-pci-api.mdx`, `unenroll-payment-method-api.mdx`: replaced the broken same-page anchor `(#enroll-payment-method-api)` — which never resolves since these pages have no such heading — with the working `(/reference/enroll-payment-method-api)` link, matching the pattern already used in the sibling `reassign-payment-method-api.mdx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reference doc text and links only; no API, SDK, or runtime behavior changes.
> 
> **Overview**
> Documentation-only cleanup across the **Payment Methods (Direct Workflow)** reference pages.
> 
> **The Payment Method Object** doc now uses the correct field names `last_successfully_used` and `last_successfully_used_at`, fixes spelling/grammar in card and workflow descriptions (e.g. identification, institution, expiration), normalizes apostrophes, and clarifies the `DIRECT` workflow enum wording.
> 
> **Enroll Payment Method** removes a duplicated “to” in the credentials sentence.
> 
> **Retrieve** (standard and PCI) and **Unenroll** pages replace broken same-page `#enroll-payment-method-api` anchors with `/reference/enroll-payment-method-api`, aligned with **Reassign Payment Method**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe5d30d7d2601d364ea56f40533d05c47e3b7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->