### PR TITLE
docs(pci-proxy): apply docs-evaluation style fixes

### DIFF
--- a/reference/pci-proxy/destination-status.mdx
+++ b/reference/pci-proxy/destination-status.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Destination Status"
-description: "Explains the enabled, disabled, and removed states of a PCI Proxy allowlist destination"
+description: "Explains the enabled, turned off, and removed states of a PCI Proxy allowlist destination"
 ---
 
-Every host on your PCI Proxy [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) has a status that controls whether the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) may send card data to it. A destination is created in the `ENABLED` state and can be toggled without losing its configuration or audit history. Only `ENABLED` destinations are reachable — a request to a `DISABLED` (or removed) host is rejected with `403 DESTINATION_NOT_ALLOWED`.
+Every host on your PCI Proxy [destination allowlist](/docs/security-and-compliance/pci-proxy/allowlist) has a status that controls whether the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) may send card data to it. A destination is created in the `ENABLED` state and can be toggled without losing its configuration or audit history. Only `ENABLED` destinations are reachable. A request to a `DISABLED` (or removed) host is rejected with `403 DESTINATION_NOT_ALLOWED`.
 
 ## Workflow
 
@@ -16,7 +16,7 @@ stateDiagram-v2
   DISABLED --> [*]: Remove
 ```
 
-A destination can be **removed** from either state — enabled or disabled. Removal is permanent; the record leaves the allowlist, though the deletion stays in the append-only audit log.
+A destination can be **removed** from either state, enabled or turned off. Removal is permanent; the record leaves the allowlist, though the deletion stays in the append-only audit log.
 
 ## Destination status
 

--- a/reference/pci-proxy/disable-destination.mdx
+++ b/reference/pci-proxy/disable-destination.mdx
@@ -5,4 +5,4 @@ keywords: ["pci proxy", "allowlist", "destination", "security"]
 openapi: "/openapi/pci-proxy/manage-destinations.json POST /pci-proxy/destinations/{id}/disable"
 ---
 
-Turns a destination off without removing it — the record and its audit history are kept, but the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) rejects it with `403 DESTINATION_NOT_ALLOWED` until it is enabled again. Useful for temporarily suspending a destination without losing its configuration. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).
+Turns a destination off without removing it. The record and its audit history are kept, but the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) rejects it with `403 DESTINATION_NOT_ALLOWED` until it is enabled again. Useful for temporarily suspending a destination without losing its configuration. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).

--- a/reference/pci-proxy/enable-destination.mdx
+++ b/reference/pci-proxy/enable-destination.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Enable Destination"
-description: "Re-enable a disabled destination on your PCI Proxy allowlist so the forward proxy can use it again."
+description: "Re-enable a turned-off destination on your PCI Proxy allowlist so the forward proxy can use it again."
 keywords: ["pci proxy", "allowlist", "destination", "security"]
 openapi: "/openapi/pci-proxy/manage-destinations.json POST /pci-proxy/destinations/{id}/enable"
 ---
 
-Re-enables a disabled destination so the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) will use it again. Only `ENABLED` destinations are reachable — a request to a `DISABLED` host is rejected with `403 DESTINATION_NOT_ALLOWED`. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).
+Re-enables a turned-off destination so the [forward proxy](/reference/pci-proxy/invoke-forward-proxy) will use it again. Only `ENABLED` destinations are reachable. A request to a `DISABLED` host is rejected with `403 DESTINATION_NOT_ALLOWED`. See the [Destination Allowlist guide](/docs/security-and-compliance/pci-proxy/allowlist).

--- a/reference/pci-proxy/invoke-forward-proxy.mdx
+++ b/reference/pci-proxy/invoke-forward-proxy.mdx
@@ -5,12 +5,12 @@ keywords: ["pci proxy", "forward proxy", "yuno-proxy-destination-url", "vaulted_
 openapi: "/openapi/pci-proxy/invoke-forward-proxy.json POST /pci-proxy/forward"
 ---
 
-Forwards your request to the destination in the `yuno-proxy-destination-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions inside Yuno's secure environment with the data stored under the vaulted token: the card (PAN, expiration, holder name), its network token (DPAN and its expiration), and its network transaction ID (NTID). For destinations that require HMAC-signed requests, send `yuno-proxy-auth` + `yuno-proxy-auth-secret-key` and the proxy signs the resolved body for you — see [Signed destinations](/docs/security-and-compliance/pci-proxy/forward-proxy#signed-destinations-hmac-request-signing). See the [Forward Proxy guide](/docs/security-and-compliance/pci-proxy/forward-proxy) for a step-by-step integration.
+Forwards your request to the destination in the `yuno-proxy-destination-url` header, replacing `{{vaulted_token.<TOKEN>.<field>}}` expressions inside Yuno's secure environment with the data stored under the vaulted token: the card (PAN, expiration, holder name), its network token (DPAN and its expiration), and its network transaction ID (NTID). For destinations that require HMAC-signed requests, send `yuno-proxy-auth` + `yuno-proxy-auth-secret-key` and the proxy signs the resolved body for you. See [Signed destinations](/docs/security-and-compliance/pci-proxy/forward-proxy#signed-destinations-hmac-request-signing) for details. See the [Forward Proxy guide](/docs/security-and-compliance/pci-proxy/forward-proxy) for a step-by-step integration.
 
 <Note>
 **Beta**
 
-The PCI Proxy is in beta and is enabled per organization. In production, requests return `403 PRODUCT_NOT_ENABLED` until your organization is activated — contact your Key Account Manager (KAM). The sandbox is open for testing.
+The PCI Proxy is in beta and is enabled per organization. In production, requests return `403 PRODUCT_NOT_ENABLED` until your organization is activated; contact your Key Account Manager (KAM). The sandbox is open for testing.
 </Note>
 
 <Warning>


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged banned-word usage, em dashes, and a run-on sentence across PCI Proxy destination pages. This PR applies the confirmed style fixes to the prose .mdx pages.

## Changes
- **reference/pci-proxy/destination-status.mdx**: reworded "disabled" (banned word) to "turned off" in the frontmatter description and body prose; rewrote two em dashes into separate sentences.
- **reference/pci-proxy/enable-destination.mdx**: reworded "disabled" to "turned-off" in the frontmatter description and body prose; rewrote an em dash into a separate sentence.
- **reference/pci-proxy/disable-destination.mdx**: split a 29-word run-on sentence into two, removing the em dash between them.
- **reference/pci-proxy/invoke-forward-proxy.mdx**: rewrote two em dashes into a separate sentence and a semicolon clause.

All ENABLED/DISABLED API enum values (backticked) were left untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and punctuation updates with no runtime, API, or security logic changes.
> 
> **Overview**
> Applies **docs-evaluation** style fixes to four PCI Proxy reference pages—no API or behavior changes.
> 
> **Destination status docs** (`destination-status`, `enable-destination`, `disable-destination`): prose now says **turned off** instead of “disabled” where it describes user-facing state (frontmatter and body). Backticked `DISABLED` enum values are unchanged. **Em dashes** are replaced with separate sentences or clearer punctuation (e.g. splitting reachability rules from `403 DESTINATION_NOT_ALLOWED`).
> 
> **Invoke Forward Proxy** (`invoke-forward-proxy.mdx`): tightens HMAC signing copy into its own “See … for details” sentence; beta note uses a **semicolon** instead of an em dash before the KAM contact line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc7c6a804285ec172f0fa70af8e17c4e2893429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->