### PR TITLE
docs(stripe-proxy): update endpoint path to /v1/stripe/hosted-page

### DIFF
--- a/docs/stripe-proxy/overview.mdx
+++ b/docs/stripe-proxy/overview.mdx
@@ -26,7 +26,7 @@ To migrate, you only change **two things** in your integration:
 
 | | Stripe | Yuno Stripe Proxy |
 | --- | --- | --- |
-| Host + path | `https://api.stripe.com/v1/checkout/sessions` | `{baseUrl}/v1/stripe-proxy/hosted-page` |
+| Host + path | `https://api.stripe.com/v1/checkout/sessions` | `{baseUrl}/v1/stripe/hosted-page` |
 | Authentication | `Authorization: Bearer sk_...` (or `-u sk_...:`) | Yuno headers (`PUBLIC-API-KEY`, `PRIVATE-SECRET-KEY`, `X-account-code`) |
 | Request body | Stripe Hosted Page body | **Unchanged** |
 | Response | `checkout.session` object | **Unchanged** (Stripe-shaped) |
@@ -86,7 +86,7 @@ request.
 | Sandbox | `https://api-sandbox.y.uno` |
 
 ```
-POST {baseUrl}/v1/stripe-proxy/hosted-page
+POST {baseUrl}/v1/stripe/hosted-page
 ```
 
 All examples on this page use the production (US) base URL; substitute the host
@@ -155,7 +155,7 @@ curl https://api.stripe.com/v1/checkout/sessions \
 ```
 
 ```bash Same request through the Yuno Stripe Proxy
-curl https://api.y.uno/v1/stripe-proxy/hosted-page \
+curl https://api.y.uno/v1/stripe/hosted-page \
   -H "PUBLIC-API-KEY: <your-public-key>" \
   -H "PRIVATE-SECRET-KEY: <your-private-secret>" \
   -H "X-account-code: <your-account-code>" \
@@ -173,7 +173,7 @@ curl https://api.y.uno/v1/stripe-proxy/hosted-page \
 ```
 
 ```bash Existing Stripe price
-curl https://api.y.uno/v1/stripe-proxy/hosted-page \
+curl https://api.y.uno/v1/stripe/hosted-page \
   -H "PUBLIC-API-KEY: <your-public-key>" \
   -H "PRIVATE-SECRET-KEY: <your-private-secret>" \
   -H "X-account-code: <your-account-code>" \
@@ -242,7 +242,7 @@ In both cases the paid webhook carries `subscription` like Stripe does.
 <CodeGroup>
 
 ```bash Stripe Billing (BILLING: STRIPE)
-curl https://api.y.uno/v1/stripe-proxy/hosted-page \
+curl https://api.y.uno/v1/stripe/hosted-page \
   -H "PUBLIC-API-KEY: <your-public-key>" \
   -H "PRIVATE-SECRET-KEY: <your-private-secret>" \
   -H "X-account-code: <your-account-code>" \
@@ -259,7 +259,7 @@ curl https://api.y.uno/v1/stripe-proxy/hosted-page \
 ```
 
 ```bash Yuno subscriptions (BILLING: YUNO) — coming soon
-curl https://api.y.uno/v1/stripe-proxy/hosted-page \
+curl https://api.y.uno/v1/stripe/hosted-page \
   -H "PUBLIC-API-KEY: <your-public-key>" \
   -H "PRIVATE-SECRET-KEY: <your-private-secret>" \
   -H "X-account-code: <your-account-code>" \


### PR DESCRIPTION
Updates the Stripe-compatible Checkout doc to the renamed endpoint path **`/v1/stripe/hosted-page`** (was `/v1/stripe-proxy/hosted-page`), matching public-api yuno-payments/public-api#2159. Covers the Base URL table, the endpoint block and all curl examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path updates with no runtime or security impact.
> 
> **Overview**
> Updates the **Stripe Proxy** overview so the documented hosted-page URL is **`/v1/stripe/hosted-page`** instead of **`/v1/stripe-proxy/hosted-page`**, in line with the public API rename.
> 
> The migration comparison table, the Base URL `POST` snippet, and every Yuno proxy `curl` example (one-time payment, existing Stripe price, and subscription flows) now use the new path. Request bodies, auth headers, and behavior described on the page are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fe055a8a302976bb52b645058a2c54a45db514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->