### PR TITLE
docs(DAS-17671, DAS-18142): add find-user-by-email and find-account-g…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -598,6 +598,7 @@
                 "group": "Account Groups",
                 "pages": [
                   "reference/organizations/list-account-groups",
+                  "reference/organizations/find-account-groups-by-merchant-id",
                   "reference/organizations/create-account-group",
                   "reference/organizations/retrieve-account-group",
                   "reference/organizations/update-account-group",
@@ -628,6 +629,7 @@
                 "group": "Users",
                 "pages": [
                   "reference/organizations/list-users",
+                  "reference/organizations/find-user-by-email",
                   "reference/organizations/create-user",
                   "reference/organizations/retrieve-user",
                   "reference/organizations/update-user",

--- a/openapi/organizations/find-account-groups-by-merchant-id.json
+++ b/openapi/organizations/find-account-groups-by-merchant-id.json
@@ -24,14 +24,14 @@
       "get": {
         "summary": "Find Account Groups by Merchant ID",
         "operationId": "find-account-groups-by-merchant-id",
-        "description": "Returns all account groups that match the given `merchant_id`. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group carries that merchant ID the response contains an empty `data` array — it is not an error. Only groups belonging to the authenticated organization are ever returned; deleted groups are excluded.",
+        "description": "Returns account groups, optionally filtered by `merchant_id`. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group matches the given filter the response contains an empty `data` array — it is not an error. Only groups belonging to the authenticated organization are ever returned; deleted groups are excluded.",
         "parameters": [
           {
             "name": "merchant_id",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": { "type": "string" },
-            "description": "The merchant-side identifier to look up. Must be an exact match."
+            "description": "Filter by merchant-side identifier. Must be an exact match."
           }
         ],
         "responses": {
@@ -129,7 +129,7 @@
             }
           },
           "400": {
-            "description": "Bad Request — `merchant_id` query parameter is missing or blank."
+            "description": "Bad Request — `merchant_id`, if provided, is blank."
           },
           "401": {
             "description": "Unauthorized — invalid or missing API credentials."

--- a/openapi/organizations/find-account-groups-by-merchant-id.json
+++ b/openapi/organizations/find-account-groups-by-merchant-id.json
@@ -24,14 +24,14 @@
       "get": {
         "summary": "Find Account Groups by Merchant ID",
         "operationId": "find-account-groups-by-merchant-id",
-        "description": "Returns account groups, optionally filtered by `merchant_id`. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group matches the given filter the response contains an empty `data` array — it is not an error. Only groups belonging to the authenticated organization are ever returned; deleted groups are excluded.",
+        "description": "Returns all account groups that match the given `merchant_id`. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group carries that merchant ID the response contains an empty `data` array — it is not an error. Only groups belonging to the authenticated organization are ever returned; deleted groups are excluded.",
         "parameters": [
           {
             "name": "merchant_id",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": { "type": "string" },
-            "description": "Filter by merchant-side identifier. Must be an exact match."
+            "description": "The merchant-side identifier to look up. Must be an exact match."
           }
         ],
         "responses": {
@@ -129,7 +129,7 @@
             }
           },
           "400": {
-            "description": "Bad Request — `merchant_id`, if provided, is blank."
+            "description": "Bad Request — `merchant_id` query parameter is missing or blank."
           },
           "401": {
             "description": "Unauthorized — invalid or missing API credentials."

--- a/openapi/organizations/find-account-groups-by-merchant-id.json
+++ b/openapi/organizations/find-account-groups-by-merchant-id.json
@@ -1,0 +1,141 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Account Groups API - Find by Merchant ID",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/account-groups": {
+      "get": {
+        "summary": "Find Account Groups by Merchant ID",
+        "operationId": "find-account-groups-by-merchant-id",
+        "description": "Returns all account groups that match the given `merchant_id`. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group carries that merchant ID the response contains an empty `data` array — it is not an error. Only groups belonging to the authenticated organization are ever returned; deleted groups are excluded.",
+        "parameters": [
+          {
+            "name": "merchant_id",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The merchant-side identifier to look up. Must be an exact match."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK — zero or more matching account groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "List of account groups that carry the requested merchant_id. Empty when no match is found.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Yuno-generated unique identifier of the account group."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Display name of the account group."
+                          },
+                          "merchant_id": {
+                            "type": "string",
+                            "description": "Merchant-side identifier stored on this group."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "ISO 8601 timestamp of when the group was created."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "ISO 8601 timestamp of the last update."
+                          }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "page": { "type": "integer" },
+                        "page_size": { "type": "integer" },
+                        "total_items": { "type": "integer" },
+                        "total_pages": { "type": "integer" },
+                        "has_next": { "type": "boolean" },
+                        "has_previous": { "type": "boolean" }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "match_found": {
+                    "summary": "One group matched",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                          "name": "Acme Corp - LATAM",
+                          "merchant_id": "MCH-00123",
+                          "created_at": "2024-03-15T10:00:00Z",
+                          "updated_at": "2024-06-01T08:30:00Z"
+                        }
+                      ],
+                      "pagination": {
+                        "page": 1,
+                        "page_size": 20,
+                        "total_items": 1,
+                        "total_pages": 1,
+                        "has_next": false,
+                        "has_previous": false
+                      }
+                    }
+                  },
+                  "no_match": {
+                    "summary": "No group matched — empty result",
+                    "value": {
+                      "data": [],
+                      "pagination": {
+                        "page": 1,
+                        "page_size": 20,
+                        "total_items": 0,
+                        "total_pages": 0,
+                        "has_next": false,
+                        "has_previous": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request — `merchant_id` query parameter is missing or blank."
+          },
+          "401": {
+            "description": "Unauthorized — invalid or missing API credentials."
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/organizations/find-user-by-email.json
+++ b/openapi/organizations/find-user-by-email.json
@@ -24,15 +24,19 @@
       "get": {
         "summary": "Find Users by Email",
         "operationId": "find-user-by-email",
-        "description": "Returns the user(s) whose email matches the given address, scoped to the authenticated organization. An email address may belong to users in multiple organizations; only matches within the calling organization are returned. When no user carries that email the response contains an empty `data` array — it is not an error.",
+        "description": "Returns users, optionally filtered by email, account_id, or account_group_id — all filters are optional and can be combined. An email address may belong to users in multiple organizations; only matches within the calling organization are returned. When no user matches the given filters the response contains an empty `data` array — it is not an error.",
         "parameters": [
           {
             "name": "email",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": { "type": "string", "format": "email" },
-            "description": "Email address to search for. Must be an exact, case-insensitive match."
-          }
+            "description": "Filter by email address. Must be an exact, case-insensitive match."
+          },
+          { "name": "account_group_id", "in": "query", "schema": { "type": "string", "format": "uuid" }, "description": "Filter by account group." },
+          { "name": "account_id", "in": "query", "schema": { "type": "string", "format": "uuid" }, "description": "Filter by account." },
+          { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1 }, "description": "Page number." },
+          { "name": "page_size", "in": "query", "schema": { "type": "integer", "default": 20, "maximum": 100 }, "description": "Page size." }
         ],
         "responses": {
           "200": {
@@ -177,7 +181,7 @@
             }
           },
           "400": {
-            "description": "Bad Request — `email` query parameter is missing or not a valid email address."
+            "description": "Bad Request — `email`, if provided, is not a valid email address."
           },
           "401": {
             "description": "Unauthorized — invalid or missing API credentials."

--- a/openapi/organizations/find-user-by-email.json
+++ b/openapi/organizations/find-user-by-email.json
@@ -24,19 +24,15 @@
       "get": {
         "summary": "Find Users by Email",
         "operationId": "find-user-by-email",
-        "description": "Returns users, optionally filtered by email, account_id, or account_group_id — all filters are optional and can be combined. An email address may belong to users in multiple organizations; only matches within the calling organization are returned. When no user matches the given filters the response contains an empty `data` array — it is not an error.",
+        "description": "Returns the user(s) whose email matches the given address, scoped to the authenticated organization. An email address may belong to users in multiple organizations; only matches within the calling organization are returned. When no user carries that email the response contains an empty `data` array — it is not an error.",
         "parameters": [
           {
             "name": "email",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": { "type": "string", "format": "email" },
-            "description": "Filter by email address. Must be an exact, case-insensitive match."
-          },
-          { "name": "account_group_id", "in": "query", "schema": { "type": "string", "format": "uuid" }, "description": "Filter by account group." },
-          { "name": "account_id", "in": "query", "schema": { "type": "string", "format": "uuid" }, "description": "Filter by account." },
-          { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1 }, "description": "Page number." },
-          { "name": "page_size", "in": "query", "schema": { "type": "integer", "default": 20, "maximum": 100 }, "description": "Page size." }
+            "description": "Email address to search for. Must be an exact, case-insensitive match."
+          }
         ],
         "responses": {
           "200": {
@@ -181,7 +177,7 @@
             }
           },
           "400": {
-            "description": "Bad Request — `email`, if provided, is not a valid email address."
+            "description": "Bad Request — `email` query parameter is missing or not a valid email address."
           },
           "401": {
             "description": "Unauthorized — invalid or missing API credentials."

--- a/openapi/organizations/find-user-by-email.json
+++ b/openapi/organizations/find-user-by-email.json
@@ -1,0 +1,189 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Users API - Find by Email",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api-sandbox.y.uno/v1"
+    },
+    {
+      "url": "https://api.eu.y.uno/v1"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "sec0": { "type": "apiKey", "in": "header", "name": "PUBLIC-API-KEY", "x-default": "<Your PUBLIC-API-KEY>" },
+      "sec1": { "type": "apiKey", "in": "header", "name": "PRIVATE-SECRET-KEY", "x-default": "<Your PRIVATE-SECRET-KEY>" }
+    }
+  },
+  "security": [ { "sec0": [], "sec1": [] } ],
+  "paths": {
+    "/organizations/users": {
+      "get": {
+        "summary": "Find Users by Email",
+        "operationId": "find-user-by-email",
+        "description": "Returns the user(s) whose email matches the given address, scoped to the authenticated organization. An email address may belong to users in multiple organizations; only matches within the calling organization are returned. When no user carries that email the response contains an empty `data` array — it is not an error.",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "email" },
+            "description": "Email address to search for. Must be an exact, case-insensitive match."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK — zero or more users matching the email address.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "description": "List of users whose email matches the requested address within the calling organization. Empty when no match is found.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Yuno-generated unique identifier of the user."
+                          },
+                          "email": {
+                            "type": "string",
+                            "description": "Email address of the user."
+                          },
+                          "first_name": {
+                            "type": "string",
+                            "description": "User's first name."
+                          },
+                          "last_name": {
+                            "type": "string",
+                            "description": "User's last name."
+                          },
+                          "account_permissions": {
+                            "type": "array",
+                            "description": "List of account-level permissions assigned to this user.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "account_id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Account the permission applies to."
+                                },
+                                "role_id": {
+                                  "type": "string",
+                                  "description": "Role assigned to the user on this account."
+                                }
+                              }
+                            }
+                          },
+                          "account_group_permissions": {
+                            "type": "array",
+                            "description": "List of account-group-level permissions assigned to this user.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "account_group_id": {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "description": "Account group the permission applies to."
+                                },
+                                "role_id": {
+                                  "type": "string",
+                                  "description": "Role assigned to the user on this account group."
+                                }
+                              }
+                            }
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "ISO 8601 timestamp of when the user was created."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "ISO 8601 timestamp of the last update."
+                          }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "page": { "type": "integer" },
+                        "page_size": { "type": "integer" },
+                        "total_items": { "type": "integer" },
+                        "total_pages": { "type": "integer" },
+                        "has_next": { "type": "boolean" },
+                        "has_previous": { "type": "boolean" }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "match_found": {
+                    "summary": "User found",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "f1e2d3c4-b5a6-7890-fedc-ba0987654321",
+                          "email": "jane.doe@acme.com",
+                          "first_name": "Jane",
+                          "last_name": "Doe",
+                          "account_permissions": [
+                            {
+                              "account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                              "role_id": "ADMIN"
+                            }
+                          ],
+                          "account_group_permissions": [],
+                          "created_at": "2024-01-10T09:00:00Z",
+                          "updated_at": "2024-05-20T14:15:00Z"
+                        }
+                      ],
+                      "pagination": {
+                        "page": 1,
+                        "page_size": 20,
+                        "total_items": 1,
+                        "total_pages": 1,
+                        "has_next": false,
+                        "has_previous": false
+                      }
+                    }
+                  },
+                  "no_match": {
+                    "summary": "No user matched — empty result",
+                    "value": {
+                      "data": [],
+                      "pagination": {
+                        "page": 1,
+                        "page_size": 20,
+                        "total_items": 0,
+                        "total_pages": 0,
+                        "has_next": false,
+                        "has_previous": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request — `email` query parameter is missing or not a valid email address."
+          },
+          "401": {
+            "description": "Unauthorized — invalid or missing API credentials."
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference/organizations/find-account-groups-by-merchant-id.mdx
+++ b/reference/organizations/find-account-groups-by-merchant-id.mdx
@@ -4,7 +4,7 @@ openapi: "/openapi/organizations/find-account-groups-by-merchant-id.json GET /or
 description: "Look up account groups using a merchant-side identifier instead of a Yuno group ID"
 ---
 
-Returns every account group within the authenticated organization that carries the given `merchant_id`. Use this endpoint to locate Yuno group records using the identifier that already exists on your side, without having to store or look up Yuno-generated group IDs.
+Returns account groups within the authenticated organization, optionally filtered by `merchant_id`. Use this endpoint to locate Yuno group records using the identifier that already exists on your side, without having to store or look up Yuno-generated group IDs.
 
 <Note>
 **Multiple matches and empty results**

--- a/reference/organizations/find-account-groups-by-merchant-id.mdx
+++ b/reference/organizations/find-account-groups-by-merchant-id.mdx
@@ -4,7 +4,7 @@ openapi: "/openapi/organizations/find-account-groups-by-merchant-id.json GET /or
 description: "Look up account groups using a merchant-side identifier instead of a Yuno group ID"
 ---
 
-Returns account groups within the authenticated organization, optionally filtered by `merchant_id`. Use this endpoint to locate Yuno group records using the identifier that already exists on your side, without having to store or look up Yuno-generated group IDs.
+Returns every account group within the authenticated organization that carries the given `merchant_id`. Use this endpoint to locate Yuno group records using the identifier that already exists on your side, without having to store or look up Yuno-generated group IDs.
 
 <Note>
 **Multiple matches and empty results**

--- a/reference/organizations/find-account-groups-by-merchant-id.mdx
+++ b/reference/organizations/find-account-groups-by-merchant-id.mdx
@@ -1,7 +1,13 @@
 ---
 title: "Find Account Groups by Merchant ID"
 openapi: "/openapi/organizations/find-account-groups-by-merchant-id.json GET /organizations/account-groups"
-description: "Look up account groups using a merchant-side identifier"
+description: "Look up account groups using a merchant-side identifier instead of a Yuno group ID"
 ---
 
-Returns all account groups that carry the given `merchant_id`, scoped to the authenticated organization. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group matches, the response contains an empty `data` array — it is not an error. Deleted groups are never returned.
+Returns every account group within the authenticated organization that carries the given `merchant_id`. Use this endpoint to locate Yuno group records using the identifier that already exists on your side, without having to store or look up Yuno-generated group IDs.
+
+<Note>
+**Multiple matches and empty results**
+
+A `merchant_id` is not guaranteed to be unique — more than one group can share the same value. All matching groups are returned. When no group carries the requested `merchant_id`, the response contains an empty `data` array rather than an error. Deleted groups are never included.
+</Note>

--- a/reference/organizations/find-account-groups-by-merchant-id.mdx
+++ b/reference/organizations/find-account-groups-by-merchant-id.mdx
@@ -1,0 +1,7 @@
+---
+title: "Find Account Groups by Merchant ID"
+openapi: "/openapi/organizations/find-account-groups-by-merchant-id.json GET /organizations/account-groups"
+description: "Look up account groups using a merchant-side identifier"
+---
+
+Returns all account groups that carry the given `merchant_id`, scoped to the authenticated organization. Because a merchant ID is not guaranteed to be unique, every matching group is returned. When no group matches, the response contains an empty `data` array — it is not an error. Deleted groups are never returned.

--- a/reference/organizations/find-user-by-email.mdx
+++ b/reference/organizations/find-user-by-email.mdx
@@ -1,0 +1,7 @@
+---
+title: "Find Users by Email"
+openapi: "/openapi/organizations/find-user-by-email.json GET /organizations/users"
+description: "Look up organization users by email address"
+---
+
+Returns the user(s) whose email matches the given address, scoped to the authenticated organization. Only users within the calling organization are returned, even if the same email exists in another organization. When no match is found, the response contains an empty `data` array — it is not an error.

--- a/reference/organizations/find-user-by-email.mdx
+++ b/reference/organizations/find-user-by-email.mdx
@@ -4,7 +4,7 @@ openapi: "/openapi/organizations/find-user-by-email.json GET /organizations/user
 description: "Look up organization users by email address instead of a user ID"
 ---
 
-Returns users within the authenticated organization, optionally filtered by email address. Use this endpoint to resolve a user record when you have an email address but not the Yuno user ID. The `email` filter can be combined with the `account_id` and `account_group_id` filters.
+Returns the user(s) within the authenticated organization whose email address matches the given value. Use this endpoint to resolve a user record when you have an email address but not the Yuno user ID.
 
 <Note>
 **Organization scope and empty results**

--- a/reference/organizations/find-user-by-email.mdx
+++ b/reference/organizations/find-user-by-email.mdx
@@ -1,7 +1,13 @@
 ---
 title: "Find Users by Email"
 openapi: "/openapi/organizations/find-user-by-email.json GET /organizations/users"
-description: "Look up organization users by email address"
+description: "Look up organization users by email address instead of a user ID"
 ---
 
-Returns the user(s) whose email matches the given address, scoped to the authenticated organization. Only users within the calling organization are returned, even if the same email exists in another organization. When no match is found, the response contains an empty `data` array — it is not an error.
+Returns the user(s) within the authenticated organization whose email address matches the given value. Use this endpoint to resolve a user record when you have an email address but not the Yuno user ID.
+
+<Note>
+**Organization scope and empty results**
+
+Results are always scoped to the calling organization. If the same email exists in another organization it will not appear here. When no user in the organization matches the address, the response contains an empty `data` array rather than an error.
+</Note>

--- a/reference/organizations/find-user-by-email.mdx
+++ b/reference/organizations/find-user-by-email.mdx
@@ -4,7 +4,7 @@ openapi: "/openapi/organizations/find-user-by-email.json GET /organizations/user
 description: "Look up organization users by email address instead of a user ID"
 ---
 
-Returns the user(s) within the authenticated organization whose email address matches the given value. Use this endpoint to resolve a user record when you have an email address but not the Yuno user ID.
+Returns users within the authenticated organization, optionally filtered by email address. Use this endpoint to resolve a user record when you have an email address but not the Yuno user ID. The `email` filter can be combined with the `account_id` and `account_group_id` filters.
 
 <Note>
 **Organization scope and empty results**


### PR DESCRIPTION
…roups-by-merchant-id endpoints

- openapi/organizations/find-user-by-email.json: GET /organizations/users?email= Returns users matching an email address within the calling org. Empty data array (not an error) when no match found.

- openapi/organizations/find-account-groups-by-merchant-id.json: GET /organizations/account-groups?merchant_id= Returns all account groups carrying the given merchant_id within the calling org. Supports multiple matches (merchant_id is not unique). Empty data array (not an error) when no match found. Deleted groups excluded.

- reference/organizations/find-user-by-email.mdx: Mintlify page wired to new OpenAPI spec
- reference/organizations/find-account-groups-by-merchant-id.mdx: Mintlify page wired to new OpenAPI spec
- docs.json: added both pages to Organizations nav (Account Groups and Users groups)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI only; no runtime or auth implementation changes in this diff.
> 
> **Overview**
> Adds API reference for two **Organizations** lookup flows that use query parameters on existing list routes instead of Yuno IDs.
> 
> **Find account groups by `merchant_id`** (`GET /organizations/account-groups?merchant_id=`) is documented with OpenAPI, a Mintlify page, and nav entry under Account Groups. The spec calls out org scoping, multiple matches when `merchant_id` is not unique, empty `data` on no match, and exclusion of deleted groups.
> 
> **Find users by `email`** (`GET /organizations/users?email=`) follows the same pattern under Users: case-insensitive exact email match within the calling org, empty `data` when nothing matches, plus response fields for account and account-group permissions.
> 
> `docs.json` wires both new reference pages into the Organizations sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 127ace429662759bbeafdecee22fd5430dc56bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->