### PR TITLE
docs: document edit_payment_method_list toggle in payment-methods-list (CORECM-19331)

### DIFF
--- a/docs/yuno-sdk/features/payment-methods-list.mdx
+++ b/docs/yuno-sdk/features/payment-methods-list.mdx
@@ -152,6 +152,10 @@ The controller you pass to `getPaymentMethodsViews`. Only `onPaymentSelected` is
 **\* `onHeightChange` is optional to _implement_, but you must apply the reported height when your layout constrains the list.**
 </Note>
 
+<Note>
+The **Edit / remove** control that lets a shopper delete a saved method — and the only thing that makes `onUnenroll` fire — is rendered only when **`edit_payment_method_list`** is enabled in **Checkout Builder → Styling** in your [Yuno Dashboard](https://dashboard.y.uno/). It is **off by default** on iOS and Android, so until you turn it on the saved methods show no remove affordance and `onUnenroll` is never invoked.
+</Note>
+
 ## Notes
 
 - `getPaymentMethodsViews` is synchronous.


### PR DESCRIPTION
## What

The payment-methods-list docs describe `PaymentListController.onUnenroll` but never mention that the Edit / remove control it depends on is only rendered when **`edit_payment_method_list`** is enabled in **Checkout Builder → Styling** — and that toggle is **off by default** on both iOS and Android. A merchant reading the docs had no way to know the toggle exists, which was the missing piece behind CORECM-19152.

## Change

Adds a `<Note>` under the `PaymentListController` table (next to the `onUnenroll` row) stating that:
- the Edit / remove affordance renders only when `edit_payment_method_list` is enabled in Checkout Builder → Styling,
- it is off by default on iOS and Android,
- so until it is enabled the saved methods show no remove control and `onUnenroll` never fires.

Cross-platform (iOS/Android). Docs-only; no SDK code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime or SDK behavior changes.
> 
> **Overview**
> **Payment Methods List** docs now explain why **`onUnenroll`** may never run on iOS and Android.
> 
> A new note under **`PaymentListController`** states that the **Edit / remove** UI (and thus **`onUnenroll`**) appears only when **`edit_payment_method_list`** is turned on in **Checkout Builder → Styling** in the Yuno Dashboard, and that the toggle is **off by default** on those platforms until merchants enable it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a7f99455b7f28b44f92c6419520b49d386dd20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->