### PR TITLE
docs(stripe-proxy): webhook setup uses the public /v1/stripe/webhook endpoint

### DIFF
--- a/docs/stripe-proxy/overview.mdx
+++ b/docs/stripe-proxy/overview.mdx
@@ -63,14 +63,15 @@ request.
 ### 2. Webhook setup
 
 1. **Register this webhook in your Yuno Dashboard.** Go to *Developers →
-   Webhooks* and add the Stripe Proxy endpoint for your environment, so the
-   payment events of the hosted page reach the proxy (see
+   Webhooks* and add the Stripe Proxy endpoint so the hosted-page payment
+   events reach the proxy (see
    [Configure webhooks](/docs/webhooks/configure-webhooks)):
 
-   | Environment | Webhook URL |
-   | --- | --- |
-   | Sandbox | `https://internal-sandbox.y.uno/stripe-proxy-ms/v1/webhooks/payment` |
-   | Production | Provided by your KAM/TAM |
+   - **URL** — `{baseUrl}/v1/stripe/webhook` (Sandbox: `https://api-sandbox.y.uno/v1/stripe/webhook`, Production US: `https://api.y.uno/v1/stripe/webhook`, EMEA: `https://api.eu.y.uno/v1/stripe/webhook`).
+   - **API Key** — your Yuno Public API Key (`PUBLIC-API-KEY`).
+   - **Secret** — your Yuno Private Secret Key (`PRIVATE-SECRET-KEY`).
+
+   The proxy authenticates each event with these keys before converting and relaying it.
 
 2. **Send your webhook URL to your TAM.** The URL where you want to receive the
    Stripe events (`checkout.session.completed`, `checkout.session.expired`) —


### PR DESCRIPTION
## What
Updates the Stripe Proxy *Webhook setup* table to the **public** webhook endpoint under the merchant's base URL, matching the deployed `public-api` route (`POST /v1/stripe/webhook`):

| Environment | Webhook URL |
| --- | --- |
| Production (US) | `https://api.y.uno/v1/stripe/webhook` |
| Production (EMEA) | `https://api.eu.y.uno/v1/stripe/webhook` |
| Sandbox | `https://api-sandbox.y.uno/v1/stripe/webhook` |

Previously it pointed at the internal `internal-sandbox.y.uno/stripe-proxy-ms/v1/webhooks/payment`, which merchants can't reach — `stripe-proxy-ms` is internal; the public entrypoint is `/v1/stripe/webhook` on public-api, which authenticates and forwards to the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction of merchant-facing webhook URLs and dashboard registration steps; no application code changes.
> 
> **Overview**
> Updates **Webhook setup** in the Stripe Proxy overview so merchants register the **public** `POST {baseUrl}/v1/stripe/webhook` endpoint in the Yuno Dashboard instead of the old internal `stripe-proxy-ms` URL (which merchants could not reach).
> 
> The environment table is replaced with bullet-style fields: **URL** (Sandbox, Production US, and EMEA examples aligned with the page’s Base URL table), plus **API Key** and **Secret** (`PUBLIC-API-KEY`, `PRIVATE-SECRET-KEY`), and a short note that the proxy validates events with those credentials before converting and relaying them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8646a91738167b6d737b39e386b6379d9b76f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->