### PR TITLE
docs(changelog): correct v2026-08 date (was stamped August 31, a future date)

### DIFF
--- a/changelog/api.mdx
+++ b/changelog/api.mdx
@@ -6,7 +6,7 @@ description: "Latest updates to the Yuno Payments API and platform features"
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
 ## v2026-08
-*August 31, 2026*
+*August 15, 2026*
 
 **Security**
 


### PR DESCRIPTION
## Summary
The live API changelog (https://docs.y.uno/changelog/api) shows the v2026-08 entry dated **August 31, 2026** — a date in the future (today is Aug 26).

## Evidence
- The entry was added on Aug 12 by commit 74e372b5 with a month-end placeholder date.
- The feature it documents (cryptogram-only mode, **C2-18162**) is **Done** in Jira, resolved **2026-08-15**, fixVersion `spacex - 08/aug/2026`.
- Changelog convention uses actual release dates (v2026-07 = *July 11, 2026*).

## Change
One line: `*August 31, 2026*` → `*August 15, 2026*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only date correction on the public API changelog with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **v2026-08** API changelog heading date from *August 31, 2026* to *August 15, 2026* in `changelog/api.mdx`.
> 
> The earlier date was a month-end placeholder and appeared in the future relative to publication; the new date matches the documented release for the network-token cryptogram changes in that section. No API or feature text is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92aa9e0d1a093c7ddc72146fec3c8c15ed4adff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->