### PR TITLE
docs(payment-methods): document card_data.country_code on by-id retrieval responses

### DIFF
--- a/openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json
+++ b/openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json
@@ -119,6 +119,7 @@
                         "brand": "VISA",
                         "issuer": "JPMORGAN CHASE BANK N A",
                         "issuer_code": null,
+                        "country_code": "US",
                         "category": "CREDIT",
                         "type": "CREDIT",
                         "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
@@ -337,6 +338,11 @@
                               "example": "JPMORGAN CHASE BANK N A"
                             },
                             "issuer_code": {},
+                            "country_code": {
+                              "type": ["string", "null"],
+                              "description": "ISO 3166-1 alpha-2 country code of the card's issuing country, derived from BIN lookup when the card is vaulted. Null when BIN enrichment data is unavailable.",
+                              "example": "US"
+                            },
                             "category": {
                               "type": "string",
                               "example": "CREDIT"

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json
@@ -126,6 +126,7 @@
                         "brand": "VISA",
                         "issuer": "JPMORGAN CHASE BANK N A",
                         "issuer_code": null,
+                        "country_code": "US",
                         "category": "CREDIT",
                         "type": "CREDIT",
                         "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76"
@@ -354,6 +355,11 @@
                           "example": "JPMORGAN CHASE BANK N A"
                         },
                         "issuer_code": {},
+                        "country_code": {
+                          "type": ["string", "null"],
+                          "description": "ISO 3166-1 alpha-2 country code of the card's issuing country, derived from BIN lookup when the card is vaulted. Null when BIN enrichment data is unavailable.",
+                          "example": "US"
+                        },
                         "category": {
                           "type": "string",
                           "example": "CREDIT"

--- a/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
+++ b/openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json
@@ -127,6 +127,7 @@
                         "brand": "VISA",
                         "issuer": "JPMORGAN CHASE BANK N A",
                         "issuer_code": null,
+                        "country_code": "US",
                         "category": "CREDIT",
                         "type": "CREDIT",
                         "fingerprint": "55a7fe38-cdc3-45dc-8c5f-820751799c76",
@@ -396,6 +397,12 @@
                           "nullable": true,
                           "description": "Code of the card-issuing bank.",
                           "example": null
+                        },
+                        "country_code": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "ISO 3166-1 alpha-2 country code of the card's issuing country, derived from BIN lookup when the card is vaulted. Null when BIN enrichment data is unavailable.",
+                          "example": "US"
                         },
                         "category": {
                           "type": "string",


### PR DESCRIPTION
## What

Adds `card_data.country_code` to the response schema and 200 example of the three by-id payment-method retrieval specs:

- `openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-api.json`
- `openapi/payment-methods-direct-workflow/retrieve-enrolled-payment-method-by-id-pci-api.json`
- `openapi/payment-methods-checkout/retrieve-payment-method-by-id-checkout.json`

The field is marked nullable and described as BIN-derived at enrollment, so it stays additive and promises nothing new. Each file keeps its local nullability convention (type array vs `nullable: true`)

## Why

The API already returns the field on both `GET /v1/customers/{customer_id}/payment-methods/{payment_method_id}` and `GET /v1/payment-methods/{payment_method_id}`, and the enroll and reassign specs for the same `card_data` object document it. Only the retrieval specs omit it.

Evidence:
- Sandbox probe: 13/13 BINs across 5 brands return `country_code` populated
- Production `api_logs_v2` sample: 32/32 `card_data` objects populated
- A merchant asked whether they can rely on the field; support confirmed in the merchant thread that it is returned where available and that the docs are missing it ([merchant thread](https://yunopay.slack.com/archives/C09285U9UG5/p1787682461119589?thread_ts=1787630908.617099&cid=C09285U9UG5), [internal thread to squad Core](https://yunopay.slack.com/archives/C0AUDUNEGSH/p1787675447693779))

## Deliberately out of scope

The list endpoint spec (`retrieve-enrolled-payment-methods-api.json`) is untouched. That endpoint returns `country_code` as an always-null key (0/31 non-null in prod), and whether to populate or remove it is a pending squad Core decision in the internal thread above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI documentation and examples only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documents **`card_data.country_code`** on the three OpenAPI specs for **retrieve payment method by ID** (checkout `GET /payment-methods/{id}`, customer enrolled by-id, and PCI by-id). Each spec gets the field on the enrolled **`card_data`** example (`"US"`) and in the response schema as nullable ISO alpha-2, described as BIN-derived at vault time and null when enrichment is missing.
> 
> This aligns published docs with behavior already returned on those endpoints and with enroll/reassign specs that already define the same property; list-enrolled payment methods is intentionally unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d84722045978119dd8baa178799d1a2d9d97164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->