### PR TITLE
docs(payments): apply docs-evaluation fixes across Payments reference

### DIFF
--- a/reference/payments/authorize-payment.mdx
+++ b/reference/payments/authorize-payment.mdx
@@ -4,4 +4,4 @@ openapi: "/openapi/payments/authorize-payment.json POST /payments"
 description: "Authorizes a payment amount on a card without charging the customer immediately."
 ---
 
-This request allows you to authorize a payment after you created a checkout session. It just authorizes the amount on the `credit_card` (the client is not charged). If you want to make an authorization for a payment, you will need to send the `capture` as "false" within the card object, which is located inside the `payment_method` object.
+This request allows you to authorize a payment after you created a checkout session. It just authorizes the amount on the `card` (the client is not charged). If you want to make an authorization for a payment, you will need to send the `capture` as "false" within the card object, which is located inside the `payment_method` object.

--- a/reference/payments/cancel-payment.mdx
+++ b/reference/payments/cancel-payment.mdx
@@ -18,6 +18,6 @@ Payments in a **PENDING** status due to 3DS authentication cannot be canceled. T
 Alternative payment methods such as PIX also support payment cancellation with a PENDING status. Reach out to your technical account manager for more information.
 </Note>
 
-If you need a receipt for the canceled transaction, you can retrieve it after it has been created. To do this, use the [Retrieve Payment by ID](/reference/retrieve-payment-by-id) endpoint and check the `receipt_url` field in the `payment.transaction` object. See [The Payment Object](/reference/the-payment-object) for `receipt`, `receipt_url`, and `receipt_language`.
+If you need a receipt for the canceled transaction, you can retrieve it after it has been created. To do this, use the [Retrieve Payment by ID](/reference/payments/retrieve-payment-by-id-v2) endpoint and check the `receipt_url` field in the `payment.transaction` object. See [The Payment Object](/reference/payments/the-payment-object) for `receipt`, `receipt_url`, and `receipt_language`.
 
 To use this endpoint, you have to provide an `X-Idempotency-Key` in your request. Check the [Authentication](/reference/authentication#idempotency) page for more information.

--- a/reference/payments/disputes.mdx
+++ b/reference/payments/disputes.mdx
@@ -4,7 +4,7 @@ openapi: "/openapi/payments/disputes.json POST /payments/{payment_id}/transactio
 description: "Submits chargeback dispute evidence for Yuno to forward to the issuer for processing."
 ---
 
-This request enables clients to [submit dispute documentation for chargeback management](/docs/chargeback-management), allowing Yuno to forward these documents to the appropriate issuers for processing.
+This request enables clients to [submit dispute documentation for chargeback management](/docs/payouts-and-disputes/chargeback-management), allowing Yuno to forward these documents to the appropriate issuers for processing.
 
 The endpoint returns a standard payment response structure containing the updated payment information, including the chargeback/dispute status.
 

--- a/reference/payments/manage-payments.mdx
+++ b/reference/payments/manage-payments.mdx
@@ -9,9 +9,9 @@ The Payments API lets you create and manage payments through Yuno. Here you’ll
 
 <CardGroup cols={3}>
   <Card title="Status and response codes" icon="arrow-up-right-from-square" href="/reference/payments/status-and-response-codes/payment" />
-  <Card title="Payment examples" icon="arrow-up-right-from-square" href="/reference/payment-examples" />
-  <Card title="The payment object" icon="arrow-up-right-from-square" href="/reference/the-payment-object" />
-  <Card title="Payment endpoints" icon="arrow-up-right-from-square" href="/reference/create-payment" />
+  <Card title="Payment examples" icon="arrow-up-right-from-square" href="/reference/payments/payment-examples" />
+  <Card title="The payment object" icon="arrow-up-right-from-square" href="/reference/payments/the-payment-object" />
+  <Card title="Payment endpoints" icon="arrow-up-right-from-square" href="/reference/payments/create-payment" />
 </CardGroup>
 
 <br />

--- a/reference/payments/payment-examples/bank-transfer.mdx
+++ b/reference/payments/payment-examples/bank-transfer.mdx
@@ -519,8 +519,6 @@ curl --request POST \
 }
 ```
 
-###
-
 ### PIX
 
 Example of a request for a Bank Transfer payment using PIX. Below you find the JSON body request example.

--- a/reference/payments/payment-examples/index.mdx
+++ b/reference/payments/payment-examples/index.mdx
@@ -19,11 +19,11 @@ The `SDK_CHECKOUT` workflow allows you to manage the entire payment experience b
 For detailed payment examples, refer to the respective sections for each payment method category.
 </Note>
 
-For the `SDK_CHECKOUT` workflow, all the information is going to be stored in the [`One-time token`](/docs/network-tokens#/on-time-use-token-vs-vaulted-token-vs-network-token) returned by Yuno's SDK, so you don't have to change your integration depending on the payment method. The basic structure of the payment will be the same for every payment method, as in the example below.
+For the `SDK_CHECKOUT` workflow, all the information is going to be stored in the [`One-time token`](/docs/security-and-compliance/network-tokens#one-time-use-token-vs-vaulted-token-vs-network-token) returned by Yuno's SDK, so you don't have to change your integration depending on the payment method. The basic structure of the payment will be the same for every payment method, as in the example below.
 
 ```sh Request (cURL)
 curl --location 'https://api-sandbox.y.uno/v1/payments' \
---header 'X-idempotency-key: <your-X-idempotency-key>' \
+--header 'X-Idempotency-Key: <your-X-idempotency-key>' \
 --header 'public-api-key: <your-public-api-key>' \
 --header 'private-secret-key: <your-private-secret-key>' \
 --header 'Content-Type: application/json' \

--- a/reference/payments/payment-examples/wallet.mdx
+++ b/reference/payments/payment-examples/wallet.mdx
@@ -26,7 +26,7 @@ Some payment methods and providers may only be available in specific countries a
   <Card title="DolarApp" icon="https://icons.prod.y.uno/dolarapp_logosimbolo.png" href="#dolarapp" />
 </CardGroup>
 
-## Mercado Pago Checkout Pro
+### Mercado Pago Checkout Pro
 
 Example of a request for a payment using Mercado Pago Checkout Pro. Below are examples of a request and the received response for successful payment creation. The request is presented using the cURL format, and the response is a JSON object.
 
@@ -225,7 +225,7 @@ curl --request POST \
 }
 ```
 
-## Astropay
+### Astropay
 
 Example of a request for a payment using Astropay. Below are examples of a request and the received response for successful payment creation. The request is presented using the cURL format, and the response is a JSON object.
 
@@ -510,7 +510,7 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
 }
 ```
 
-## Apple Pay
+### Apple Pay
 
 Example of a request for a payment using Apple Pay and enabling card verification flow (e.g., zero-dollar auth). Below are examples of a request and the received response for successful payment creation.
 
@@ -560,7 +560,7 @@ curl --request POST \
 The `verify` field already existed for `CARD` payment method type. This change extends the same capability to `APPLE_PAY`.
 </Note>
 
-## Nupay Enrollment
+### Nupay Enrollment
 
 Example of a request for creating a payment using Nupay Enrollment. Below are examples of a request and the received response for successful payment creation. The request is presented using the cURL format, and the response is a JSON object.
 
@@ -838,7 +838,7 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
 
 ```
 
-## Nequi
+### Nequi
 
 Below is an example of a payment request using Nequi. This example demonstrates how to create a payment operation using the cURL format.
 
@@ -1158,7 +1158,7 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
 }
 ```
 
-## DolarApp
+### DolarApp
 
 Example of a request for a payment using DolarApp. Below are examples of a request and the received response for successful payment creation. The request is presented using the cURL format, and the response is a JSON object.
 

--- a/reference/payments/status-and-response-codes/merchant-advice-codes-mac.mdx
+++ b/reference/payments/status-and-response-codes/merchant-advice-codes-mac.mdx
@@ -41,7 +41,7 @@ Yuno’s public API includes dedicated fields to facilitate the use of Merchant 
 Yuno provides a standardized set of Merchant Advice Codes that simplify provider responses. These codes let you build retry logic and routing rules without needing to manage every provider’s unique variations.
 
 * **`transactions.merchant_advice_code`**: A Yuno-normalized MAC returned when a transaction is declined. This code helps you understand the reason for the denial, whether a retry is possible, and what actions to take before reattempting the payment.
-* **`transactions.merchant_advice_code_message`**: This fields complements the `merchant_advice_code` seen above, providing an explanation of the code in human‑readable terms. This message will allow you to act on the information without having to memorize the meaning of each code.
+* **`transactions.merchant_advice_code_message`**: This field complements the `merchant_advice_code` seen above, providing an explanation of the code in human‑readable terms. This message will allow you to act on the information without having to memorize the meaning of each code.
 
 ### Raw MACs
 
@@ -51,7 +51,7 @@ Alongside normalized values, Yuno also exposes the original codes and messages r
 * **`transactions.provider_data.merchant_advice_code_message`**: A human-readable message from the provider that explains the meaning of the raw MAC. Use this message to understand provider-specific guidance without needing to interpret code values.
 
 <Note>
-  Please note these fields are located inside the ‎`transactions` object in API responses.
+  Please note these fields are located inside the `transactions` object in API responses.
 </Note>
 
 ## About retries
@@ -159,7 +159,7 @@ Elo classifies reversible and irreversible codes into three separate groups:
   “CNPJ” refers to the Brazilian business taxpayer identification for the establishment (Root CNPJ at the group level).
 </Note>
 
-Refer to the for all Elo [MACs list](#macs-list)and Yuno-normalized equivalents.
+Refer to the [MACs list](#macs-list) for all Elo codes and their Yuno-normalized equivalents.
 
 ## Other brands
 
@@ -175,7 +175,7 @@ Before attempting again, follow the guidance received in the denied transaction 
 
 ## Routing with MAC
 
-Retry behavior should be implemented via [routing](/docs/routing) conditions. Update routes to include the new MAC conditions.
+Retry behavior should be implemented via [routing](/docs/using-yuno/dashboard-overview/routing) conditions. Update routes to include the new MAC conditions.
 
 When creating a decline group in the [Yuno dashboard](https://dashboard.y.uno/), you can choose to add conditions by Response Code or by MAC Code.
 

--- a/reference/payments/status-and-response-codes/payment.mdx
+++ b/reference/payments/status-and-response-codes/payment.mdx
@@ -15,7 +15,7 @@ In the following workflow, you can find the different payment statuses and how t
 
 <Frame><img src="/images/reference/payment/image1.png" /></Frame>
 
-For every implementation, we recommend taking the payment <code>status</code> and <code>sub\_status</code> as the main reference for the payment's state. A payment could have different [transactions](/reference/transaction) associated with it. By focusing on the payment <code>status</code> / <code>sub\_status</code>, you can have the latest state regardless of how many transactions were made, giving you clear inputs for decision-making.
+For every implementation, we recommend taking the payment <code>status</code> and <code>sub_status</code> as the main reference for the payment's state. A payment could have different [transactions](/reference/payments/status-and-response-codes/transaction) associated with it. By focusing on the payment <code>status</code> / <code>sub\_status</code>, you can have the latest state regardless of how many transactions were made, giving you clear inputs for decision-making.
 
 ## Payments status
 
@@ -74,7 +74,7 @@ The payments can have the following status and sub status.
       <td class="substatus"><StatusBadge type="warning" text="PENDING_PROVIDER_CONFIRMATION" /></td>
       <td>Purchase</td>
       <td>Pending</td>
-      <td>Wating for providers payment confirmation.</td>
+      <td>Waiting for providers payment confirmation.</td>
     </tr>
     <tr>
       <td class="substatus"><StatusBadge type="warning" text="PENDING_FRAUD_REVIEW" /></td>
@@ -206,7 +206,7 @@ The payments can have the following status and sub status.
       <td class="substatus"><StatusBadge type="secondary" text="CAPTURE_RETRY_PROCESS_FAILED" /></td>
       <td>Capture</td>
       <td>Declined</td>
-      <td>Transaction was declined and retry scheme it's finished.</td>
+      <td>Transaction was declined and retry scheme is finished.</td>
     </tr>
     <tr>
       <td rowspan="2" class="status"><StatusBadge type="secondary" text="REFUNDED" /></td>

--- a/reference/payments/status-and-response-codes/transaction.mdx
+++ b/reference/payments/status-and-response-codes/transaction.mdx
@@ -33,7 +33,7 @@ Each payment has one or more associated transactions. The following documentatio
 
 ## Transaction codes
 
-With every transaction, you´ll receive a `response_code` detailing more info about it. The details related to each status are presented below. Use the following buttons to navigate to the desired content.
+With every transaction, you'll receive a `response_code` detailing more info about it. The details related to each status are presented below. Use the following buttons to navigate to the desired content.
 
 
 <CardGroup cols={3}>
@@ -331,9 +331,9 @@ Merchant Advice Codes provide guidance from issuers/providers about retry behavi
 
 ***
 
-### Chargebacks specific response\_codes
+### Chargebacks specific response_codes
 
-For more details, please refer to the [reason codes page](/docs/reason-codes) in the [Chargeback guides](/docs/chargeback-management) section.
+For more details, please refer to the [reason codes page](/docs/payouts-and-disputes/reason-codes) in the [Chargeback guides](/docs/payouts-and-disputes/chargeback-management) section.
 
 
 <Accordion title={<><code>CREATED</code> status details</>}>

--- a/reference/payments/the-payment-object.mdx
+++ b/reference/payments/the-payment-object.mdx
@@ -307,7 +307,7 @@ This object represents the payment created after generating the checkout session
             </ParamField>
 
             <ParamField body="soft_descriptor" type="string">
-              The descriptor passed per transaction to out platform. It will be presented on the customer's
+              The descriptor passed per transaction to our platform. It will be presented on the customer's
                                 physical bank statement (MAX 15; MIN 0).
 
               Example: COMPANY1
@@ -3092,7 +3092,7 @@ This object represents the payment created after generating the checkout session
                 </ParamField>
 
                 <ParamField body="soft_descriptor" type="string">
-                  The descriptor passed per transaction to out platform. It will be presented on the customer's
+                  The descriptor passed per transaction to our platform. It will be presented on the customer's
                                         physical bank statement (MAX 15; MIN 0).
 
                   Example: COMPANY1
@@ -4208,7 +4208,7 @@ This object represents the payment created after generating the checkout session
                 </ParamField>
 
                 <ParamField body="soft_descriptor" type="string">
-                  The descriptor passed per transaction to out platform. It will be presented on the customer's
+                  The descriptor passed per transaction to our platform. It will be presented on the customer's
                                         physical bank statement (MAX 15; MIN 0).
 
                   Example: COMPANY1


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged broken links, typos, an invisible Unicode character, and a heading-hierarchy inconsistency across the Payments reference section. This PR applies the confirmed fixes to the prose .mdx pages.

## Changes
- **reference/payments/manage-payments.mdx**: fixed 3 Card links missing the payments/ segment.
- **reference/payments/status-and-response-codes/payment.mdx**: fixed the "Wating" typo, an escaped underscore in sub_status, a broken /reference/transaction link, and "it's finished" -> "is finished" (verified this fix actually belongs here, not in transaction.mdx as the report grouped it).
- **reference/payments/status-and-response-codes/transaction.mdx**: fixed the wrong accent-apostrophe in "you've", an escaped underscore in a heading, and broken /docs/chargeback-management and /docs/reason-codes links.
- **reference/payments/status-and-response-codes/merchant-advice-codes-mac.mdx**: fixed "This fields" -> "This field", reworded a malformed sentence about the Elo MACs list, removed an invisible U+200E character before a backtick, and fixed a broken /docs/routing link.
- **reference/payments/payment-examples/index.mdx**: fixed X-idempotency-key casing and a broken/malformed network-tokens link and anchor.
- **reference/payments/the-payment-object.mdx**: fixed "to out platform" -> "to our platform" (3 occurrences of the same repeated field description).
- **reference/payments/authorize-payment.mdx**: fixed credit_card -> card, matching the real schema field name used throughout the guide.
- **reference/payments/cancel-payment.mdx**: pointed the Retrieve Payment by ID link to the current v2 page instead of the legacy v1 page (hidden from nav since July), and fixed a broken /reference/the-payment-object link.
- **reference/payments/disputes.mdx**: fixed a broken /docs/chargeback-management link.
- **reference/payments/payment-examples/bank-transfer.mdx**: removed a stray empty heading before the PIX section.
- **reference/payments/payment-examples/wallet.mdx**: downgraded per-example headings from H2 to H3, matching the sibling bank-transfer.mdx page's hierarchy.

Not applied: the report's suggestion to add an INVALID_DATA row to the embedded MAC table in transaction.mdx was skipped — that table appears deliberately filtered to entries with a real Mastercard code, and INVALID_DATA is the one canonical entry with none, so adding it would break the table's existing pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits (links, typos, headings) with no changes to payment APIs, auth, or application code.
> 
> **Overview**
> This PR applies **monthly docs-evaluation fixes** across the Payments reference: broken internal links, typos, schema naming, and small structural consistency issues—no API or runtime changes.
> 
> **Navigation and cross-links** are updated to the current URL layout: Payments overview cards now point under `/reference/payments/…`; cancel-payment links to **Retrieve Payment by ID v2** and the payment object under `payments/`; chargeback and MAC pages link to `/docs/payouts-and-disputes/…` and dashboard routing docs; payment status links to the transaction reference under `payments/status-and-response-codes/`.
> 
> **Accuracy fixes** include `credit_card` → `card` on authorize-payment, `sub_status` display/link cleanup on payment status, MAC prose (“This field”, Elo MACs list sentence, removal of invisible Unicode before a backtick), and three repeated **“to our platform”** fixes on `soft_descriptor` in the payment object.
> 
> **Examples and polish**: SDK checkout example uses correct `X-Idempotency-Key` casing and a fixed network-tokens doc link; bank-transfer removes a stray empty heading before PIX; wallet example sections use **H3** headings to match bank-transfer; payment status table fixes “Wating” and capture retry wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107ec7ddfe3d188fcc2c8f65479091764f007cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->