### PR TITLE
chore: vtex sdk changelog 4.2.348

### DIFF
--- a/changelog/plugins/vtex.mdx
+++ b/changelog/plugins/vtex.mdx
@@ -5,6 +5,14 @@ description: "Latest updates and version history for the Yuno VTEX Plugin"
 
 import { ChangelogBadge } from '/snippets/ChangelogBadge.jsx';
 
+## v4.2.348
+*August 25, 2026*
+
+**Payments**
+
+- <ChangelogBadge type="fixed" /> **Network Tokens on 3DS and antifraud-held cards**  
+  Cards whose first purchase was approved only after a 3DS challenge or an antifraud review were never registered for Network Token reuse, so every later purchase with the same card kept going through as a raw card. The connector now records the card on the authorization retry that confirms the approval.
+
 ## v4.2.347
 *August 24, 2026*
 

--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.348",
+      "release_date": "2026-08-25",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.348",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "FIXED",
+          "title": "Network Tokens on 3DS and antifraud-held cards",
+          "description": "Cards whose first purchase was approved only after a 3DS challenge or an antifraud review were never registered for Network Token reuse, so every later purchase with the same card kept going through as a raw card. The connector now records the card on the authorization retry that confirms the approval.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.347",
       "release_date": "2026-08-24",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.348`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.348

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog sync with no runtime or config changes in this repository.
> 
> **Overview**
> Documents **VTEX plugin release v4.2.348** (August 25, 2026) in the public changelog and structured release feed.
> 
> The new entry is a **Payments** fix: cards whose first approval only happened after **3DS** or **antifraud** review were not registered for **Network Token** reuse, so repeat purchases stayed on raw card data. The release notes state the connector now vaults the card on the **authorization retry** that confirms approval.
> 
> `changelog/plugins/vtex.mdx` gets the MDX section with a fixed badge; `changelog/source/vtex.json` adds the matching release (install snippet `yunopartnerbr.yuno@4.2.348` and FIXED entry). No application code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e50fa646e4f29741fe5e1e14115bcd6da272f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->