### PR TITLE
docs(vtex): document antifraud session (deviceFingerprints) and Cielo MID prefix

### DIFF
--- a/docs/plugins/vtex/direct-sdk-integration.mdx
+++ b/docs/plugins/vtex/direct-sdk-integration.mdx
@@ -129,7 +129,7 @@ Authorization is **step 1** of the VTEX [payment transaction flow](https://help.
       | `onPaymentDone` | Optional. Callback invoked when the payment finishes. Receives a result object with `success` and a `payments` array. |
       | `onError` | Optional. Callback invoked when an error occurs during the payment. |
       | `onLoading` | Optional. Callback invoked when the SDK changes its loading state. |
-      | `deviceFingerprints` | Optional. Device fingerprinting identifiers for fraud prevention, each with a `provider_id` and a `session_id`. |
+      | `deviceFingerprints` | Optional. Antifraud session ids to report per provider, each with a `provider_id` (as configured in your Yuno dashboard, for example `RISKIFIED`, `SIGNIFYD`, `CYBERSOURCE`, `CIELO_CYBERSOURCE_FRAUD`) and a `session_id`. The supplied `session_id` replaces the one the provider's script generates; entries for providers you have not configured are ignored. To share one antifraud session with the Yuno Payment Connector (required for split orders), use the VTEX `orderFormId` as the `session_id`. See [Antifraud session](/docs/plugins/vtex/set-up-yuno-on-vtex#antifraud-session-device-fingerprints). |
     </Accordion>
   </Step>
 </Steps>

--- a/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
+++ b/docs/plugins/vtex/set-up-yuno-on-vtex.mdx
@@ -149,6 +149,28 @@ When a shopper's cart contains products from **different sellers or franchises**
 
 This works automatically; no extra setup is required. If you want to control which antifraud providers receive the shared session, use the **Antifraud Providers for Split Orders** field in the provider configuration (see the field reference in Step 1). Valid values are `RISKIFIED`, `CYBERSOURCE`, `SIGNIFYD`, and `CIELO_CYBERSOURCE_FRAUD`; when left empty, it defaults to `RISKIFIED` + `CYBERSOURCE`.
 
+### Antifraud session (device fingerprints)
+
+Antifraud providers (Riskified, Signifyd, CyberSource, Cielo CyberSource) score a payment by matching the device data collected in the shopper's browser with the session id Yuno sends in the payment. For that match to work, the browser and the server must use the **same** session id.
+
+The Yuno Payment App handles this for you: on the checkout page it reads the VTEX cart id (`window.vtexjs.checkout.orderFormId`) and reports it as the antifraud session id for `RISKIFIED`, `SIGNIFYD`, `CYBERSOURCE`, and `CIELO_CYBERSOURCE_FRAUD`. The Yuno Payment Connector sends the same `orderFormId` on the server side, so the session is consistent across the browser, every suborder of a split order, and the payment itself. No configuration is needed; if the cart id is not available, each provider falls back to its own generated session id and the payment is not blocked.
+
+<Accordion title="Cielo CyberSource: merchant ID prefix">
+  Cielo CyberSource requires the antifraud session id to start with your Cielo merchant ID (MID) prefix. Until this prefix is configurable in the Yuno dashboard, set it in your VTEX checkout custom JavaScript **before** the checkout loads:
+
+  ```javascript
+  window.yunoFingerprintPrefix = 'YOUR_MID_PREFIX_'
+  ```
+
+  The Payment App prepends it only to the `CIELO_CYBERSOURCE_FRAUD` session id (`YOUR_MID_PREFIX_<orderFormId>`); the other providers are not affected. When the variable is not defined, no prefix is applied.
+
+  <Note>
+    This global variable is an interim mechanism. Once the fingerprint prefix can be configured in the Yuno dashboard, it will no longer be needed.
+  </Note>
+</Accordion>
+
+If you integrate the SDK directly instead of using the Payment App, pass the session ids yourself through the `deviceFingerprints` mount option. See [Direct SDK integration](/docs/plugins/vtex/direct-sdk-integration).
+
 ### Order modifications (changed order totals)
 
 VTEX lets you **change an order after checkout**, when the final total turns out to be different from the amount that was authorized. This applies, for example, if you sell products **by weight**, where the exact total is only known once the order is picked and packed.


### PR DESCRIPTION
Documents how the VTEX Payment App builds `deviceFingerprints` (VTEX `orderFormId` as the shared antifraud `session_id` for RISKIFIED / SIGNIFYD / CYBERSOURCE / CIELO_CYBERSOURCE_FRAUD, plus the interim `window.yunoFingerprintPrefix` MID prefix for Cielo) and expands the `deviceFingerprints` reference on the Direct SDK page.

Docs only, no behavior change.

Jira: https://yunopayments.atlassian.net/browse/CORECM-19525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no application or payment logic changes.
> 
> **Overview**
> **Documentation-only** update for the VTEX plugin: it explains how antifraud `deviceFingerprints` work end-to-end and how merchants should configure them.
> 
> On **Set up Yuno on VTEX**, a new **Antifraud session (device fingerprints)** section describes why browser and server must share the same session id, how the Payment App uses VTEX `orderFormId` for Riskified/Signifyd/CyberSource/Cielo (including split orders), fallback when the cart id is missing, and the interim `window.yunoFingerprintPrefix` for Cielo CyberSource. It points direct-SDK integrators to pass sessions via `deviceFingerprints`.
> 
> On **Direct SDK integration**, the `deviceFingerprints` mount-option reference is expanded with provider ids, override behavior, split-order guidance (`orderFormId` as `session_id`), and a link to the setup guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e97467c595a20565f6cb5808fb17ba5dee1cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->