### PR TITLE
docs: add required-fields table to Apple Pay direct integration

### DIFF
--- a/docs/wallets/apple-pay/apple-pay-direct-integration.mdx
+++ b/docs/wallets/apple-pay/apple-pay-direct-integration.mdx
@@ -19,6 +19,34 @@ Yuno's Apple Pay Direct integration supports one-time and recurring payments (us
 4. Yuno processes with your configured provider or providers and returns a response
 5. Monitor response status via [webhooks](/docs/webhooks)
 
+## Request fields
+
+The [create payment](/reference/create-payment) request for Apple Pay uses the fields below. The requirement is shown per flow: one-time, CIT (the first payment of a recurring series), and MIT (subsequent recurring payments).
+
+| Field | One-time | CIT | MIT |
+| --- | --- | --- | --- |
+| `account_id` | Required | Required | Required |
+| `description` | Required | Required | Required |
+| `country` | Required | Required | Required |
+| `merchant_order_id` | Required | Required | Required |
+| `amount.currency`, `amount.value` | Required | Required | Required |
+| `workflow` | Required: `"DIRECT"` | Required: `"DIRECT"` | Required: `"DIRECT"` |
+| `payment_method.type` | Required: `"APPLE_PAY"` | Required: `"APPLE_PAY"` | Required: `"APPLE_PAY"` |
+| `payment_method.detail.wallet.payment_token` | Required | Required | Not sent |
+| `payment_method.vaulted_token` | Not sent | Not sent | Required |
+| `payment_method.vault_on_success` | Optional | Required: `true` | Optional |
+| `payment_method.detail.wallet.stored_credentials` | Not sent | Required: `usage: "FIRST"` | Not sent |
+| `payment_method.detail.card.stored_credentials` | Not sent | Not sent | Required: `usage: "USED"` |
+| `customer_payer` | Optional | Optional | Optional |
+| `soft_descriptor` (inside `detail.wallet`, or `detail.card` for MIT) | Optional | Optional | Optional |
+
+<Note>
+  * `payment_token` is the complete Apple Pay SDK response sent as a JSON string (stringified).
+  * If you do not send `workflow: "DIRECT"`, the API requires a `checkout.session` instead.
+  * Send the `X-Idempotency-Key` header on every create payment call to avoid duplicate charges.
+  * The required fields for Apple Pay are the same for every provider. No provider requires additional customer data fields for Apple Pay.
+</Note>
+
 ## One-time payments
 
 To integrate a single transaction, such as an online purchase, use Yuno's API to [create a payment](/reference/create-payment). This requires you to obtain certain information from the Apple SDK's response, which is generated when the customer authorizes the payment.
@@ -72,19 +100,17 @@ curl --location 'https://api-sandbox.y.uno/v1/payments' \
     },
     "workflow": "DIRECT",
     "payment_method": {
-        "vault_on_success": true,
         "type": "APPLE_PAY",
         "detail": {
             "wallet": {
                 "payment_token": "{\r\n   \"paymentMethod\":{\r\n      \"type\":\"credit\",\r\n      \"displayName\":\"Visa 3748\",\r\n      \"network\":\"Visa\"\r\n   },\r\n   \"paymentData\":{\r\n      \"data\":\"B5NSQI0TdXuLwqadBCL0yOwtik\/rJx7v41xxE8rNSlFBTHR2W88iRck7a6bH9Kx\/bBFsk2ZyinIEl2aXusHp22a0pSmuCUoPgbkFc1\/D3PRAoWITfZkalBeuzMhHJGhhCe2wqOgMmjS2w97nN9vifb1cMrS3kOqpPPMihHVvhLYbwtNhh8lfeTOyL+RBXbdFScVTFCB1eFQ4znUFV79SHVK\/SRjLxLawO1HGIO0VIUTj8uVgG4MmBrfQhDBD\/P9a4lWypiNoyURHm7ubgcOEelbVDGlKSNDmYFD10i554b+7z8GXBtWdQc1zhWKcGOn8RsOYtxxdqzHEtJzcFsf92\/rEhfpEThXjsLLMTmovGyQS30qM\/qO2YgqduEID7IS+xOH\/FXpplT5Yqur7\/+FgEwcv2lGsa0K6kNMEUn1xSWc=\",\r\n      \"signature\":\"MIAGCSqGSIb3DQEHAqCAMIACAQExDTALBglghkgBZQMEAgEwgAYJKoZIhvcNAQcBAACggDCCA+MwggOIoAMCAQICCBZjTIsOMFcXMAoGCCqGSM49BAMCMHoxLjAsBgNVBAMMJUFwcGxlIEFwcGxpY2F0aW9uIEludGVncmF0aW9uIENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzAeFw0yNDA0MjkxNzQ3MjdaFw0yOTA0MjgxNzQ3MjZaMF8xJTAjBgNVBAMMHGVjYy1zbXAtYnJva2VyLXNpZ25fVUM0LVBST0QxFDASBgNVBAsMC2lPUyBTeXN0ZW1zMRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABMIVd+3r1seyIY9o3XCQoSGNx7C9bywoPYRgldlK9KVBG4NCDtgR80B+gzMfHFTD9+syINa61dTv9JKJiT58DxOjggIRMIICDTAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFCPyScRPk+TvJ+bE9ihsP6K7\/S5LMEUGCCsGAQUFBwEBBDkwNzA1BggrBgEFBQcwAYYpaHR0cDovL29jc3AuYXBwbGUuY29tL29jc3AwNC1hcHBsZWFpY2EzMDIwggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB\/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMDQGA1UdHwQtMCswKaAnoCWGI2h0dHA6Ly9jcmwuYXBwbGUuY29tL2FwcGxlYWljYTMuY3JsMB0GA1UdDgQWBBSUV9tv1XSBhomJdi9+V4UH55tYJDAOBgNVHQ8BAf8EBAMCB4AwDwYJKoZIhvdjZAYdBAIFADAKBggqhkjOPQQDAgNJADBGAiEAxvAjyyYUuzA4iKFimD4ak\/EFb1D6eM25ukyiQcwU4l4CIQC+PNDf0WJH9klEdTgOnUTCKKEIkKOh3HJLi0y4iJgYvDCCAu4wggJ1oAMCAQICCEltL786mNqXMAoGCCqGSM49BAMCMGcxGzAZBgNVBAMMEkFwcGxlIFJvb3QgQ0EgLSBHMzEmMCQGA1UECwwdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxEzARBgNVBAoMCkFwcGxlIEluYy4xCzAJBgNVBAYTAlVTMB4XDTE0MDUwNjIzNDYzMFoXDTI5MDUwNjIzNDYzMFowejEuMCwGA1UEAwwlQXBwbGUgQXBwbGljYXRpb24gSW50ZWdyYXRpb24gQ0EgLSBHMzEmMCQGA1UECwwdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxEzARBgNVBAoMCkFwcGxlIEluYy4xCzAJBgNVBAYTAlVTMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8BcRhBnXZIXVGl4lgQd26ICi7957rk3gjfxLk+EzVtVmWzWuItCXdg0iTnu6CP12F86Iy3a7ZnC+yOgphP9URaOB9zCB9DBGBggrBgEFBQcBAQQ6MDgwNgYIKwYBBQUHMAGGKmh0dHA6Ly9vY3NwLmFwcGxlLmNvbS9vY3NwMDQtYXBwbGVyb290Y2FnMzAdBgNVHQ4EFgQUI\/JJxE+T5O8n5sT2KGw\/orv9LkswDwYDVR0TAQH\/BAUwAwEB\/zAfBgNVHSMEGDAWgBS7sN6hWDOImqSKmd6+veuv2sskqzA3BgNVHR8EMDAuMCygKqAohiZodHRwOi8vY3JsLmFwcGxlLmNvbS9hcHBsZXJvb3RjYWczLmNybDAOBgNVHQ8BAf8EBAMCAQYwEAYKKoZIhvdjZAYCDgQCBQAwCgYIKoZIzj0EAwIDZwAwZAIwOs9yg1EWmbGG+zXDVspiv\/QX7dkPdU2ijr7xnIFeQreJ+Jj3m1mfmNVBDY+d6cL+AjAyLdVEIbCjBXdsXfM4O5Bn\/Rd8LCFtlk\/GcmmCEm9U+Hp9G5nLmwmJIWEGmQ8Jkh0AADGCAYgwggGEAgEBMIGGMHoxLjAsBgNVBAMMJUFwcGxlIEFwcGxpY2F0aW9uIEludGVncmF0aW9uIENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUwIIFmNMiw4wVxcwCwYJYIZIAWUDBAIBoIGTMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTI1MTAwMjE5MjYyNFowKAYJKoZIhvcNAQk0MRswGTALBglghkgBZQMEAgGhCgYIKoZIzj0EAwIwLwYJKoZIhvcNAQkEMSIEIIglNywQdAxKnixbc4TJLaopplLPs5m84zjbAlsJuvnOMAoGCCqGSM49BAMCBEcwRQIhANjW5bxOlsS4oBDrxUn6OtIHWxpHshyj0ozI518Ty\/rbAiAW+dbxN9OQJ9a2B3VMps89dm0ZB6MdQCG7iHM2g2Tn1gAAAAAAAA==\",\r\n      \"header\":{\r\n         \"publicKeyHash\":\"YK8kdoBXLGqBQKBtCZOl0DQTUHOWidRCxgOgf\/1gBMM=\",\r\n         \"ephemeralPublicKey\":\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEVv32VVJYlg+E0zMsthvBaldJcH45NUWhVckme\/CQYFtHf60FEdFtzwabOEMY3u1De+6e+IuBv53OxmWx+1w2w==\",\r\n         \"transactionId\":\"87a03c4cc1b242a25d74257d4bc990a6473b9866392850e584a9f680dcdf3d0f\"\r\n      },\r\n      \"version\":\"EC_v1\"\r\n   }\r\n}",
                 "soft_descriptor": "TEST"
-                }
             }
         }
     },
     "account_id": "fe14c7c6-c75e-43b7-bdbe-4c87ad52c482",
-    "description": "Apple Pay recurring setup",
-    "merchant_order_id": "recurring-setup-123"
+    "description": "Apple Pay one-time payment",
+    "merchant_order_id": "order-123"
 }'
 ```
 


### PR DESCRIPTION
## Why

Reported by Bernabé: the Apple Pay direct integration page shows only JSON examples, with no indication of which fields are required. The create-payment OpenAPI spec does not help either: the `payment_method.detail.wallet` object has no `required` list, so every wallet field (including `payment_token`) renders as optional in the API reference.

## What

- Adds a **Request fields** section to `docs/wallets/apple-pay/apple-pay-direct-integration.mdx` with a per-flow table (one-time / CIT / MIT) marking each field Required, Optional, or Not sent, plus notes on `payment_token` stringification, the `workflow: DIRECT` vs `checkout.session` rule, and idempotency.
- Fixes the one-time payment example, which was a copy of the CIT request (`vault_on_success: true`, "recurring setup" description/order id) and contained an extra closing brace that made it invalid JSON. All 3 examples on the page now parse as valid JSON.

## Grounding

- Top-level required fields taken from `openapi/payments/create-payment.json` (`account_id`, `description`, `country`, `merchant_order_id`, `amount`, `payment_method`; `checkout` is not required for `DIRECT`).
- Per-flow wallet fields taken from the page's own CIT/MIT contract.
- Provider note: catalog-int registers APPLE_PAY with all customer required fields false for every provider, so the required set does not vary by provider.

Deliberately does NOT add a `required` list to the shared `wallet` schema in the OpenAPI spec: that object also serves flows where `payment_token` is legitimately absent (MIT, SDK token flows, verify), so marking it required there would be wrong globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to an integration guide; no runtime, API, or schema behavior is modified.
> 
> **Overview**
> Adds a **Request fields** section to the Apple Pay direct integration guide with a table that spells out which create-payment fields are required, optional, or omitted for **one-time**, **CIT**, and **MIT** flows (including `payment_token` vs `vaulted_token`, vaulting, and stored-credentials placement).
> 
> The section also documents operational notes: stringified `payment_token`, the **`workflow: "DIRECT"`** vs **`checkout.session`** rule, **`X-Idempotency-Key`**, and that required Apple Pay fields do not vary by provider.
> 
> The **one-time payment** curl example is corrected so it no longer mirrors the CIT setup (`vault_on_success`, recurring copy) and the JSON structure is fixed (invalid extra brace removed; description and `merchant_order_id` updated for a one-time purchase).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f890dc66e00522d38e3d6e7679860f40213a4998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->