### PR TITLE
docs(SUB-107): scheduled cancellation — schedule.after_cycles / schedule.at, past_due_behavior, cancel_scheduled, new webhook events (DRAFT, Sep-1)

### DIFF
--- a/docs/payment-features/subscriptions/retries.mdx
+++ b/docs/payment-features/subscriptions/retries.mdx
@@ -91,6 +91,8 @@ Where the `PAST_DUE` status is enabled for the account, a failed recurring charg
 
 Where the status is not enabled, a failed charge leaves the subscription in `ACTIVE` while the retries run, and only the `payment.purchase` webhook reports the decline. Contact your Yuno representative to have `PAST_DUE` enabled.
 
+Canceling a `PAST_DUE` subscription — immediately, or because a scheduled cancellation becomes due — never errors and always stops that cycle's retries. See [Cancel Subscription](/reference/subscriptions/cancel-subscription) for scheduling a cancellation ahead of time, including the `past_due_behavior` option that controls whether a pending schedule waits for retries to finish or fires right away.
+
 ### Canceling a subscription when retries run out
 
 By default, when every retry for a billing cycle has been attempted and none succeeded, the subscription stays in its current status and billing rolls forward to the next cycle. A subscription backed by a permanently dead card therefore keeps generating failed charges indefinitely.

--- a/docs/webhooks/index.mdx
+++ b/docs/webhooks/index.mdx
@@ -104,13 +104,15 @@ Yuno sends event notifications for various activities within the payment ecosyst
 | `subscription.plan_change_scheduled` | Sent when a plan change is scheduled for the next billing cycle via `PATCH /v1/subscriptions/{id}`.             |
 | `subscription.plan_change_canceled` | Sent when a pending plan change is undone by the merchant (`MERCHANT_UNDO`) or aborted because the target plan was canceled (`TARGET_PLAN_CANCELED`). Not sent when the subscription itself is canceled — only `subscription.cancel` fires then. |
 | `subscription.plan_changed`     | Sent when a plan change takes effect. A scheduled change is applied at the renewal that first bills the new plan and keeps the same subscription `code`. `POST /v1/subscriptions/{id}/plan` instead replaces the subscription: the payload carries a new `code` with `previous_subscription_id` set, and a separate `subscription.cancel` (`cancellation_source: PLAN_CHANGE`) fires for the original. |
+| `subscription.cancel_scheduled` | Sent when a cancellation is scheduled for a future date or billing cycle via `POST /v1/subscriptions/{id}/cancel`. See [Cancel Subscription](/reference/subscriptions/cancel-subscription). |
+| `subscription.cancel_schedule_canceled` | Sent when a pending scheduled cancellation is undone via `"schedule": null` on the same endpoint. Not sent when the schedule instead fires — `subscription.cancel` fires then. |
 
 <Note>
 Each renewal charge is delivered as a `payment.purchase` webhook tied to the subscription, with the outcome (success or decline) carried in the `status`/`sub_status` fields. `$0`/trial cycles emit no payment webhook — for plan-based subscriptions they are reported as `subscription.cycle_executed` instead. There is no `subscription.error` event: a failed renewal is signaled by `subscription.past_due` where that status is enabled, and by the `payment.purchase` webhook everywhere.
 </Note>
 
 <Note>
-Treat the plan-change events as notifications, not as the source of truth. Reconcile against `GET /v1/subscriptions/{id}` — `pending_plan_change` for a scheduled change and `plan_id` for an applied one — rather than relying on webhook delivery alone.
+Treat the plan-change events as notifications, not as the source of truth. Reconcile against `GET /v1/subscriptions/{id}` — `pending_plan_change` for a scheduled change and `plan_id` for an applied one — rather than relying on webhook delivery alone. The same applies to the cancel-scheduling events: reconcile against `cancel_scheduled`.
 </Note>
 
 ### Enrollment events

--- a/openapi/subscriptions/cancel-subscription.json
+++ b/openapi/subscriptions/cancel-subscription.json
@@ -51,6 +51,70 @@
             "required": true
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "examples": {
+                "IMMEDIATE (empty body)": {
+                  "value": {}
+                },
+                "SCHEDULE AFTER 3 CYCLES": {
+                  "value": {
+                    "schedule": {
+                      "after_cycles": 3
+                    }
+                  }
+                },
+                "SCHEDULE AT A DATE": {
+                  "value": {
+                    "schedule": {
+                      "at": "2026-11-01T00:00:00Z"
+                    }
+                  }
+                },
+                "SCHEDULE AND SKIP RETRIES IF PAST_DUE": {
+                  "value": {
+                    "schedule": {
+                      "after_cycles": 1,
+                      "past_due_behavior": "SKIP_RETRIES"
+                    }
+                  }
+                },
+                "UNDO A PENDING SCHEDULE": {
+                  "value": {
+                    "schedule": null
+                  }
+                }
+              },
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "schedule": {
+                    "type": ["object", "null"],
+                    "properties": {
+                      "after_cycles": {
+                        "type": "integer",
+                        "description": "Cancel after this many more billing cycles. 1-60, capped at the cycles remaining. Exactly one of after_cycles/at is required.",
+                        "example": 3
+                      },
+                      "at": {
+                        "type": "string",
+                        "description": "Cancel at this ISO-8601 date-time (UTC offset required). Must be in the future and before availability.finish_at. Exactly one of after_cycles/at is required.",
+                        "example": "2026-11-01T00:00:00Z"
+                      },
+                      "past_due_behavior": {
+                        "type": "string",
+                        "description": "EXHAUST_RETRIES (default) waits for the in-flight cycle's retries before firing; SKIP_RETRIES fires immediately even if the subscription is PAST_DUE.",
+                        "example": "EXHAUST_RETRIES"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "200",
@@ -110,6 +174,90 @@
                       "payments": [
                         "5104911d-5df9-229e-8468-bd41abea1a4s"
                       ],
+                      "created_at": "2023-12-16T20:46:54.786342Z",
+                      "updated_at": "2023-12-16T21:00:54.786342Z"
+                    }
+                  },
+                  "CANCELLATION SCHEDULED": {
+                    "value": {
+                      "id": "7304911d-5df9-429e-8488-ad41abea1a4c",
+                      "name": "sub_001",
+                      "description": "streaming service",
+                      "account_id": "2404911d-5df9-429e-8488-ad41abea1a4b",
+                      "merchant_reference": "001_marzo_23",
+                      "status": "ACTIVE",
+                      "subscription_plan_id": "1904911d-5df9-429e-8488-ad41abea1a4d",
+                      "amount": {
+                        "currency": "USD",
+                        "value": 12100
+                      },
+                      "frequency": {
+                        "type": "MONTH",
+                        "value": 1
+                      },
+                      "billing_cycles": {
+                        "total": 10,
+                        "current": 2,
+                        "next_at": "2023-02-16T20:00:00.786342Z"
+                      },
+                      "customer_payer": {
+                        "id": "3t04911d-5df9-429e-8488-ad41abea1a2c"
+                      },
+                      "retries": {
+                        "retry_on_decline": true,
+                        "amount": 4,
+                        "strategy": "SMART"
+                      },
+                      "cancel_scheduled": {
+                        "mode": "AFTER_CYCLES",
+                        "after_cycles": 3,
+                        "at": "<example>",
+                        "requested_at": "<example>",
+                        "past_due_behavior": "EXHAUST_RETRIES"
+                      },
+                      "created_at": "2023-12-16T20:46:54.786342Z",
+                      "updated_at": "2023-12-16T21:00:54.786342Z"
+                    }
+                  },
+                  "CANCELED FROM PAST_DUE (RETRIES STOPPED, UNPAID CYCLE)": {
+                    "value": {
+                      "id": "7304911d-5df9-429e-8488-ad41abea1a4c",
+                      "name": "sub_001",
+                      "description": "streaming service",
+                      "account_id": "2404911d-5df9-429e-8488-ad41abea1a4b",
+                      "merchant_reference": "001_marzo_23",
+                      "status": "CANCELED",
+                      "subscription_plan_id": "1904911d-5df9-429e-8488-ad41abea1a4d",
+                      "amount": {
+                        "currency": "USD",
+                        "value": 12100
+                      },
+                      "billing_cycles": {
+                        "total": 10,
+                        "current": 2,
+                        "next_at": "2023-02-16T20:00:00.786342Z"
+                      },
+                      "customer_payer": {
+                        "id": "3t04911d-5df9-429e-8488-ad41abea1a2c"
+                      },
+                      "retries": {
+                        "retry_on_decline": true,
+                        "amount": 4,
+                        "strategy": "SMART",
+                        "stopped": true,
+                        "attempts_made": 2,
+                        "outcome": "ABANDONED"
+                      },
+                      "unpaid_cycle": {
+                        "cycle_number": 2,
+                        "amount": {
+                          "currency": "USD",
+                          "value": 12100
+                        },
+                        "attempts": 2,
+                        "last_failure_code": "<example>"
+                      },
+                      "cancel_scheduled": null,
                       "created_at": "2023-12-16T20:46:54.786342Z",
                       "updated_at": "2023-12-16T21:00:54.786342Z"
                     }
@@ -293,6 +441,86 @@
                         "example": "5104911d-5df9-229e-8468-bd41abea1a4s"
                       }
                     },
+                    "retries": {
+                      "type": "object",
+                      "properties": {
+                        "retry_on_decline": {
+                          "type": "boolean"
+                        },
+                        "amount": {
+                          "type": "integer"
+                        },
+                        "strategy": {
+                          "type": "string"
+                        },
+                        "stopped": {
+                          "type": "boolean",
+                          "description": "Present only when the subscription is PAST_DUE or has cancel_scheduled pending."
+                        },
+                        "attempts_made": {
+                          "type": "integer",
+                          "description": "Present only when the subscription is PAST_DUE or has cancel_scheduled pending."
+                        },
+                        "outcome": {
+                          "type": "string",
+                          "description": "RECOVERED, EXHAUSTED or ABANDONED. Present only when the subscription is PAST_DUE or has cancel_scheduled pending."
+                        },
+                        "next_retry_at": {
+                          "type": "string",
+                          "description": "Present only when the subscription is PAST_DUE or has cancel_scheduled pending."
+                        }
+                      }
+                    },
+                    "unpaid_cycle": {
+                      "type": "object",
+                      "description": "Present only when the current billing cycle is PAST_DUE and has not settled.",
+                      "properties": {
+                        "cycle_number": {
+                          "type": "integer"
+                        },
+                        "amount": {
+                          "type": "object",
+                          "properties": {
+                            "currency": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "integer"
+                            }
+                          }
+                        },
+                        "attempts": {
+                          "type": "integer"
+                        },
+                        "last_failure_code": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "cancel_scheduled": {
+                      "type": ["object", "null"],
+                      "description": "null when no cancellation is pending.",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "example": "AFTER_CYCLES"
+                        },
+                        "after_cycles": {
+                          "type": "integer",
+                          "example": 3
+                        },
+                        "at": {
+                          "type": "string"
+                        },
+                        "requested_at": {
+                          "type": "string"
+                        },
+                        "past_due_behavior": {
+                          "type": "string",
+                          "example": "EXHAUST_RETRIES"
+                        }
+                      }
+                    },
                     "created_at": {
                       "type": "string",
                       "example": "2023-12-16T20:46:54.786342Z"
@@ -311,11 +539,43 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "Result": {
+                  "INVALID_STATE": {
                     "value": {
                       "code": "INVALID_STATE",
                       "messages": [
                         "The subscription state does not support the action requested."
+                      ]
+                    }
+                  },
+                  "UNKNOWN KEY": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": [
+                        "<example>"
+                      ]
+                    }
+                  },
+                  "SCHEDULE MUST CARRY EXACTLY ONE OF at OR after_cycles": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": [
+                        "schedule must carry exactly one of at or after_cycles"
+                      ]
+                    }
+                  },
+                  "at NOT IN THE FUTURE": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": [
+                        "schedule.at must be in the future"
+                      ]
+                    }
+                  },
+                  "ORGANIZATION NOT ENABLED": {
+                    "value": {
+                      "code": "BAD_REQUEST",
+                      "messages": [
+                        "Scheduled cancellation is not enabled for this organization"
                       ]
                     }
                   }

--- a/reference/subscriptions/cancel-subscription.mdx
+++ b/reference/subscriptions/cancel-subscription.mdx
@@ -1,9 +1,157 @@
 ---
 title: "Cancel Subscription"
 openapi: "/openapi/subscriptions/cancel-subscription.json POST /subscriptions/{subscription_id}/cancel"
-description: "Cancels a subscription permanently, changing its status to CANCELED with no reversal."
+description: "Cancels a subscription immediately, or schedules the cancellation for a future date or billing cycle."
 ---
 
-Calling this endpoint will cancel a subscription, changing its `status` to CANCELED. This change cannot be reverted back, being a final point for the respective subscription.
+Calling this endpoint with an empty body (or no body at all) cancels the subscription right away,
+changing its `status` to `CANCELED`. This is unchanged and still final: once immediate, it cannot
+be reverted.
 
-You can cancel from `CREATED`, `ACTIVE`, `TRIALING`, `PAST_DUE` and `PAUSED`. `COMPLETED` and `CANCELED` are terminal, so canceling from either returns `400 INVALID_STATE` — including a second cancel on a subscription that is already canceled. See [Subscription Status](/reference/subscriptions/status-subscriptions).
+You can cancel from `CREATED`, `ACTIVE`, `TRIALING`, `PAST_DUE` and `PAUSED`. `COMPLETED` and
+`CANCELED` are terminal, so canceling from either returns `400 INVALID_STATE` — including a second
+cancel on a subscription that is already canceled. See [Subscription Status](/reference/subscriptions/status-subscriptions).
+
+## Scheduling a cancellation instead
+
+<Note>
+**Allowlisted organizations only**
+
+Scheduled cancellation is gated per organization. If your calls return `400` `"Scheduled
+cancellation is not enabled for this organization"`, contact your Yuno representative to have it
+enabled.
+</Note>
+
+Send a `schedule` object to defer the cancellation instead of applying it now. The subscription
+stays in its current status — billing continues normally — until the schedule fires.
+
+```json Schedule after 3 more billing cycles
+{
+  "schedule": {
+    "after_cycles": 3
+  }
+}
+```
+
+```json Schedule for a specific date
+{
+  "schedule": {
+    "at": "2026-11-01T00:00:00Z"
+  }
+}
+```
+
+`schedule` takes exactly one of:
+
+| Field | Type | Rules |
+|---|---|---|
+| `after_cycles` | integer | 1–60, and cannot exceed the billing cycles remaining on the subscription (`billing_cycles.total − billing_cycles.current`, when the plan has a total). |
+| `at` | Timestamp | ISO-8601 with a UTC offset, must be in the future, and must fall before `availability.finish_at` when the subscription has one. |
+
+Sending both or neither returns `400`.
+
+A `PIX_AUTOMATIC` subscription billed with `frequency.execution: MERCHANT` cannot schedule a
+cancellation — schedule it as `at` or `after_cycles` on a different payment method type, or cancel
+immediately instead.
+
+### Behavior while retries are running
+
+<Note>
+**`past_due_behavior` is echoed on `cancel_scheduled`, pending product confirmation**
+
+The engine currently stamps whatever `past_due_behavior` resolved for the schedule (explicit value,
+or the `EXHAUST_RETRIES` default) onto the `cancel_scheduled.past_due_behavior` field in every
+response. Treat this echo as provisional until product confirms it as the intended external
+contract — it may change.
+</Note>
+
+`past_due_behavior` controls what a scheduled cancellation does if the subscription is `PAST_DUE`
+when the schedule would otherwise fire:
+
+| Value | Behavior |
+|---|---|
+| `EXHAUST_RETRIES` (default) | The scheduled cancel waits — retries keep running for the cycle in progress, and the cancellation only fires once the subscription leaves `PAST_DUE` (recovered or retries exhausted). |
+| `SKIP_RETRIES` | The scheduled cancel fires immediately, without waiting for the outstanding retries to finish. |
+
+```json Schedule and skip retries if PAST_DUE when it fires
+{
+  "schedule": {
+    "after_cycles": 1,
+    "past_due_behavior": "SKIP_RETRIES"
+  }
+}
+```
+
+Independently of `past_due_behavior`, canceling a `PAST_DUE` subscription — whether immediately or
+because a schedule became due — never errors and always stops that cycle's retries. See
+[Subscription Status](/reference/subscriptions/status-subscriptions) and
+[Retries](/docs/payment-features/subscriptions/retries).
+
+<Note>
+Refund handling for an unpaid cycle at cancellation time is a separate, not-yet-documented
+behavior — it does not ship with scheduled cancellation.
+</Note>
+
+## Undoing a scheduled cancellation
+
+Send `"schedule": null` to clear a pending schedule. The subscription is unaffected otherwise — no
+status change, no charge.
+
+```json Undo a scheduled cancellation
+{
+  "schedule": null
+}
+```
+
+Sending `"schedule": null` when nothing is scheduled is a no-op: `200`, `cancel_scheduled` stays
+`null`, and no webhook is sent. When a schedule is cleared, `subscription.cancel_schedule_canceled`
+fires instead.
+
+## Reading the result
+
+The response carries the same [Subscription](/reference/subscriptions/the-subscription-object)
+shape as every other subscription endpoint. Three fields are relevant here:
+
+- `cancel_scheduled` — `null` when no cancellation is pending, otherwise the schedule's `mode`,
+  `after_cycles`/`at`, `requested_at` and `past_due_behavior`.
+- `retries.stopped`, `retries.attempts_made`, `retries.outcome`, `retries.next_retry_at` — populated
+  whenever the subscription is `PAST_DUE` or has a `cancel_scheduled` pending; omitted otherwise.
+- `unpaid_cycle` — present when the current billing cycle is `PAST_DUE` and has not settled.
+
+<Note>
+**Persistence of `retries` and `unpaid_cycle` after cancellation is pending product confirmation**
+
+Both fields are computed from the subscription's live state at request time. Whether a `GET
+/v1/subscriptions/{id}` issued after the subscription reaches `CANCELED` continues to surface the
+retry snapshot / unpaid cycle from the cycle that was in flight, or omits them once terminal, is not
+yet confirmed as a stable contract — verify against a live response before depending on it.
+</Note>
+
+See [the Subscription object](/reference/subscriptions/the-subscription-object) for the full field
+reference.
+
+## Webhooks
+
+- `subscription.cancel_scheduled` — sent when a cancellation is scheduled via this endpoint.
+- `subscription.cancel_schedule_canceled` — sent when a pending scheduled cancellation is undone via
+  `"schedule": null`.
+
+An immediate cancellation (empty body, or a schedule becoming due) still emits `subscription.cancel`
+as before — scheduling emits its own events only for the scheduling and undoing actions themselves.
+
+## Errors
+
+<div className="code-nowrap-table dense-table">
+
+| HTTP | `code` | When |
+|---|---|---|
+| `400` | `BAD_REQUEST` | An unrecognized top-level key, or an unrecognized key inside `schedule`. |
+| `400` | `BAD_REQUEST` | `schedule` carries both `at` and `after_cycles`, or neither. |
+| `400` | `BAD_REQUEST` | `after_cycles` is not an integer between 1 and 60, or exceeds the billing cycles remaining. |
+| `400` | `BAD_REQUEST` | `at` is not an ISO-8601 date-time with a UTC offset, is not in the future, or falls on/after `availability.finish_at`. |
+| `400` | `BAD_REQUEST` | `past_due_behavior` is not `EXHAUST_RETRIES` or `SKIP_RETRIES`. |
+| `400` | `BAD_REQUEST` | Scheduled cancellation is not enabled for this organization. |
+| `400` | `BAD_REQUEST` | A `PIX_AUTOMATIC` subscription billed with `frequency.execution: MERCHANT` cannot schedule a cancellation. |
+| `400` | `INVALID_STATE` | The subscription's status does not support cancellation (`COMPLETED` or already `CANCELED`). |
+
+</div>

--- a/reference/subscriptions/status-subscriptions.mdx
+++ b/reference/subscriptions/status-subscriptions.mdx
@@ -61,3 +61,6 @@ You can cancel a subscription in `CREATED`, `ACTIVE`, `TRIALING`, `PAST_DUE` and
 through [Cancel Subscription](/reference/subscriptions/cancel-subscription) and from the dashboard.
 `COMPLETED` and `CANCELED` are terminal — canceling from either returns `400 INVALID_STATE`, which
 is also what a repeated cancel on an already-canceled subscription returns.
+
+The same endpoint can also schedule the cancellation for a future date or billing cycle instead of
+applying it immediately — see [Cancel Subscription](/reference/subscriptions/cancel-subscription#scheduling-a-cancellation-instead).

--- a/reference/subscriptions/the-subscription-object.mdx
+++ b/reference/subscriptions/the-subscription-object.mdx
@@ -440,6 +440,82 @@ This object represents a subscription that can be associated with a customer.
 
       Example: TRUE
     </ParamField>
+
+    <ParamField body="stopped" type="bool">
+      Whether retries for the current cycle have stopped. Present only while the subscription is `PAST_DUE` or has `cancel_scheduled` pending; omitted otherwise.
+
+      <Note>
+        Whether this field (and `attempts_made`, `outcome`, `next_retry_at` below) keeps reporting the last cycle's retry snapshot once the subscription reaches `CANCELED`, or is omitted at that point, is pending product confirmation — verify against a live response before depending on it.
+      </Note>
+    </ParamField>
+
+    <ParamField body="attempts_made" type="int">
+      Retry attempts made for the current cycle so far. Present only while the subscription is `PAST_DUE` or has `cancel_scheduled` pending; omitted otherwise.
+    </ParamField>
+
+    <ParamField body="outcome" type="enum">
+      How the current cycle's retries resolved. One of `RECOVERED`, `EXHAUSTED`, or `ABANDONED` (retries stopped by a cancellation before exhausting on their own). Present only while the subscription is `PAST_DUE` or has `cancel_scheduled` pending; omitted otherwise.
+    </ParamField>
+
+    <ParamField body="next_retry_at" type="Timestamp">
+      When the next retry is scheduled. Present only while the subscription is `PAST_DUE` with retries still running; omitted otherwise.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="cancel_scheduled" type="object">
+  The cancellation scheduled for this subscription, or `null` when none is pending. Schedule one with the `schedule` block on `POST /v1/subscriptions/{id}/cancel`; undo it with `"schedule": null`. See [Cancel Subscription](/reference/subscriptions/cancel-subscription).
+
+  <Expandable title="properties">
+    <ParamField body="mode" type="enum">
+      `AFTER_CYCLES` or `AT_DATE`, matching whichever of `after_cycles`/`at` was sent when the schedule was created.
+    </ParamField>
+
+    <ParamField body="after_cycles" type="int">
+      The number of billing cycles that were requested, when `mode` is `AFTER_CYCLES`. `null` when `mode` is `AT_DATE`.
+    </ParamField>
+
+    <ParamField body="at" type="Timestamp">
+      The resolved date and time the cancellation will fire.
+    </ParamField>
+
+    <ParamField body="requested_at" type="Timestamp">
+      When the cancellation was scheduled.
+    </ParamField>
+
+    <ParamField body="past_due_behavior" type="enum">
+      `EXHAUST_RETRIES` (default) or `SKIP_RETRIES` — what the schedule does if the subscription is `PAST_DUE` when it would otherwise fire. See [Cancel Subscription](/reference/subscriptions/cancel-subscription#behavior-while-retries-are-running).
+
+      <Note>
+        This echo is pending product confirmation as a stable external contract — see the note on [Cancel Subscription](/reference/subscriptions/cancel-subscription#behavior-while-retries-are-running).
+      </Note>
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<ParamField body="unpaid_cycle" type="object">
+  The current billing cycle, when it is `PAST_DUE` and has not settled. Omitted — not `null` — for every other state.
+
+  <Note>
+    Whether this field keeps reporting the unsettled cycle once the subscription reaches `CANCELED`, or is omitted at that point, is pending product confirmation — verify against a live response before depending on it.
+  </Note>
+
+  <Expandable title="properties">
+    <ParamField body="cycle_number" type="int">
+      The billing cycle that is unpaid, matching `billing_cycles.current` at the time it was computed.
+    </ParamField>
+
+    <ParamField body="amount" type="object">
+      The amount due for the unpaid cycle. Same shape as the subscription-level `amount`.
+    </ParamField>
+
+    <ParamField body="attempts" type="int">
+      Total charge attempts made for this cycle so far, including the original attempt.
+    </ParamField>
+
+    <ParamField body="last_failure_code" type="string">
+      The decline/failure code from the most recent attempt. `null` if unavailable.
+    </ParamField>
   </Expandable>
 </ParamField>
 


### PR DESCRIPTION
Documents the scheduled-cancellation feature added to `POST /v1/subscriptions/{id}/cancel`:
`schedule.after_cycles` | `schedule.at` (exactly one, with `past_due_behavior` EXHAUST_RETRIES
default | SKIP_RETRIES), undo via `schedule: null`, immediate cancel unchanged (`{}`/no body).
Covers the new `cancel_scheduled`/`retries`/`unpaid_cycle` response fields, the two new webhook
events, the full 400 matrix, and the already-ruled PAST_DUE behavior (cancel never errors, stops
retries). Refund-on-cancel (SUB-108) is explicitly out of scope and flagged as such inline.

Field shapes are verified against `subscription-ms` @`119f1937` (engine E1+E2, PASS zero-findings).
Two behaviors are marked "pending product confirmation" per Dani asks 0.7/0.8 rather than presented
as settled contract: the `past_due_behavior` echo on `cancel_scheduled`, and whether `retries`/
`unpaid_cycle` persist on a GET after the subscription reaches `CANCELED`. Scalar values with no
live capture (a handful of timestamps/failure codes) are left as `<example>` placeholders for
tester-107 to fill from real bruno signatures rather than invented.

**Test plan:** prose/schema only, no code path — request review from Dani on the two
pending-confirmation notes before those get resolved one way or the other; swap `<example>`
placeholders for live captures once available.

---
**DRAFT — do not publish before the Sep-1 engine train** (subscription-ms #355 + gateways public-api #2170 / transaction-rails #302 / dashboard-bff #1623 / organization-webhook-ms #180). `<example>` placeholders get replaced by real stg captures after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wL3NCKXkHp9UJH2DSeW5L
