### PR TITLE
docs: apply docs-evaluation fixes (3DS2, Unreferenced Refunds, Dry-run, Transaction Reporting)

### DIFF
--- a/reference/dry-run/register-dry-run-provider-event.mdx
+++ b/reference/dry-run/register-dry-run-provider-event.mdx
@@ -4,18 +4,18 @@ description: "Register provider request, response, or webhook payloads for pre-p
 openapi: "/openapi/dry-run/register-dry-run-provider-event.json POST /dry-run/provider-events"
 ---
 
-Dry-run is a pre-production validation surface. It receives the API calls your integration sends to a payment provider — request, response, and webhook payloads — and correlates them with the equivalent Yuno public-API call you make **in parallel** with the `X-Dry-Run: true` header set.
+Dry-run is a pre-production validation surface. It receives the API calls your integration sends to a payment provider (request, response, and webhook payloads). It correlates them with the equivalent Yuno public-API call you make **in parallel** with the `X-Dry-Run: true` header set.
 
 Yuno then executes an automated validation pipeline that grades the quality of the public-API request against the provider payload: missing fields, shape mismatches, wrong enum values, unmapped metadata, and any other inconsistency that would cause the real payment to fail or behave differently once you go live.
 
 ### How the pair works
 
-1. Your integration makes its normal call to the provider (e.g. Stripe, Adyen, dlocal).
-2. Your integration also calls the relevant Yuno public-API endpoint (e.g. `POST /v1/payments`) with the header **`X-Dry-Run: true`**. Yuno accepts the request, does not route it to any provider, and stores it for comparison.
+1. Your integration makes its normal call to the provider (for example Stripe, Adyen, dlocal).
+2. Your integration also calls the relevant Yuno public-API endpoint (for example `POST /v1/payments`) with the header **`X-Dry-Run: true`**. Yuno accepts the request, does not route it to any provider, and stores it for comparison.
 3. Your integration calls `POST /v1/dry-run/provider-events` with the raw provider exchange (request, response, webhook) it just performed, correlated to the same `merchant_reference`.
 4. Yuno pairs the two records by `merchant_reference` + `account_id` and runs the validation pipeline. Results are available through the dashboard and via `GET /v1/dry-run/provider-events/{id}` (read API, separate reference).
 
-The outcome tells you whether the public-API request you are building today would produce the same provider behavior once Yuno starts routing it — without touching production money or sending a live transaction to the provider through Yuno.
+The outcome tells you whether the public-API request you are building today would produce the same provider behavior once Yuno starts routing it, without touching production money or sending a live transaction to the provider through Yuno.
 
 ### When to use it
 
@@ -38,7 +38,7 @@ Use `X-Idempotency-Key` for safe retries. Same key + same payload returns the or
 <Warning>
 **PCI boundary**
 
-`headers` and `body` are sent **base64-encoded**. Yuno base64-decodes on ingest, applies deterministic PAN/CVV/auth-token redaction, and persists only the redacted form. See [PCI Compliance](/docs/security-and-compliance/pci-compliance).
+`headers` and `body` are sent **base64-encoded**. Yuno base64-decodes on ingestion, applies deterministic PAN/CVV/auth-token redaction, and persists only the redacted form. See [PCI Compliance](/docs/security-and-compliance/pci-compliance).
 </Warning>
 
 ---
@@ -47,4 +47,4 @@ Use `X-Idempotency-Key` for safe retries. Same key + same payload returns the or
 
 - `merchant_reference` is always required and uniquely identifies the order on your side. Yuno uses it to resolve the event to a payment asynchronously when `payment_id` is not supplied.
 - `payment_id`, if supplied, is resolved immediately. If the id is unknown for your account the request returns `404 PAYMENT_NOT_FOUND`.
-- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (e.g. `stripe` + `CREDIT_CARD`). If omitted, Yuno uses the information from the associated payment.
+- `provider_id` + `payment_method_type` optionally identify which integration surface the dry-run exercises (for example `stripe` + `CREDIT_CARD`). If omitted, Yuno uses the information from the associated payment.

--- a/reference/reporting/report-transactions.mdx
+++ b/reference/reporting/report-transactions.mdx
@@ -19,15 +19,19 @@ This API requires activation for your organization. Contact your Key Account Man
 
 ## How it works
 
-1. You process a transaction directly with your provider (e.g. a purchase on your own Adyen account).
-2. You report it here — one event or a batch of up to 500. For latency-sensitive integrations we recommend batches of up to 100 events: the full 500-event batch is processed synchronously and can take several seconds.
-3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type: a `PURCHASE` with result `SUCCEEDED` lands the payment `SUCCEEDED`; an `AUTHORIZE` with result `SUCCEEDED` lands `PENDING` with sub-status `AUTHORIZED` (an approved authorization is not captured money — it mirrors how Yuno-processed authorizations behave); a `VERIFY` with result `SUCCEEDED` lands `SUCCEEDED` with sub-status `VERIFIED` (the verification completed; no money moves — it mirrors how Yuno-processed verifications persist); `DECLINED` → `DECLINED`, `ERROR` → `ERROR`.
+1. You process a transaction directly with your provider (for example a purchase on your own Adyen account).
+2. You report it here: one event or a batch of up to 500. For latency-sensitive integrations, batches of up to 100 events are recommended. The full 500-event batch is processed synchronously and can take several seconds.
+3. Each accepted event creates **one payment** with one transaction, with the status derived from `result` and the event type:
+   - A `PURCHASE` with result `SUCCEEDED` lands the payment `SUCCEEDED`.
+   - An `AUTHORIZE` with result `SUCCEEDED` lands `PENDING` with sub-status `AUTHORIZED`. An approved authorization is not captured money; it mirrors how Yuno-processed authorizations behave.
+   - A `VERIFY` with result `SUCCEEDED` lands `SUCCEEDED` with sub-status `VERIFIED`. The verification completed and no money moves; it mirrors how Yuno-processed verifications persist.
+   - `DECLINED` lands `DECLINED`, and `ERROR` lands `ERROR`.
 
 In this version the supported operations are `PURCHASE` (default), `AUTHORIZE`, and `VERIFY`. A `VERIFY` reports a card verification (zero-dollar authorization), typically reported with `amount.value: 0`. Lifecycle events (captures, refunds, chargebacks) are on the roadmap.
 
 ## Retries and deduplication
 
-There is **no idempotency header on this endpoint — and none is needed**. The `report_id` you generate per event is the deduplication key: an event whose `report_id` was already ingested is counted in `duplicates` and never ingested twice, no matter when or in which batch it arrives. Retrying a whole batch after a network failure is always safe.
+There is **no idempotency header on this endpoint, and none is needed**. The `report_id` you generate per event is the deduplication key. An event whose `report_id` was already ingested is counted in `duplicates` and never ingested twice, no matter when or in which batch it arrives. Retrying a whole batch after a network failure is always safe.
 
 Because `report_id` alone decides, an event that reuses an already-ingested `report_id` with a *different* payload is also counted as a duplicate and silently discarded — never reuse a `report_id` across different transactions.
 

--- a/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
+++ b/reference/three-d-secure-setups/create-three-d-secure-setup.mdx
@@ -5,14 +5,14 @@ keywords: ["3DS2", "three_d_secure_setup_id", "browser_info", "device_fingerprin
 openapi: "/openapi/three-d-secure-setups/create-three-d-secure-setup.json POST /three-d-secure/setups"
 ---
 
-Register the 3D Secure 2 setup data your integration has collected — the cardholder's browser environment and any pre-computed device fingerprints — and receive a `three_d_secure_setup_id` to reference on the subsequent `POST /v1/payments`.
+Register the 3D Secure 2 setup data your integration has collected: the cardholder's browser environment and any pre-computed device fingerprints. In return, receive a `three_d_secure_setup_id` to reference on the subsequent `POST /v1/payments`.
 
 <Note>
 **Server-to-server integrations only**
 
-Use this endpoint when you operate a server-to-server (B2B) integration and collect 3DS2 device data on your side — through your own SDK, a fraud-screening provider's collector, or a 3DS2 server you call directly.
+Use this endpoint when you operate a server-to-server (B2B) integration and collect 3DS2 device data on your side, through your own SDK, a fraud-screening provider's collector, or a 3DS2 server you call directly.
 
-If you integrate through the Yuno Web/Mobile SDK and a checkout session, you can skip this endpoint entirely — the SDK collects the device data and registers it automatically as part of the checkout flow.
+If you integrate through the Yuno Web/Mobile SDK and a checkout session, you can skip this endpoint entirely. The SDK collects the device data and registers it automatically as part of the checkout flow.
 </Note>
 
 <Note>
@@ -30,7 +30,7 @@ The payment provider uses `browser_info` and `device_fingerprints` to score risk
 <Note>
 **How the merchant supplies device data**
 
-The `type` field tells Yuno where the device data was gathered. `MERCHANT_PROVIDED` — currently the only supported value — means you collected the browser environment and device fingerprints on your side and are passing them in directly. Yuno does not run its own collector for this endpoint; if you need Yuno to capture the browser/device data, use the [SDK variant](/docs/payment-features/3ds-standalone) instead.
+The `type` field tells Yuno where the device data was gathered. `MERCHANT_PROVIDED`, currently the only supported value, means you collected the browser environment and device fingerprints on your side and are passing them in directly. Yuno does not run its own collector for this endpoint. If you need Yuno to capture the browser/device data, use the [SDK variant](/docs/payment-features/3ds-standalone) instead.
 </Note>
 
 ## How to use the response

--- a/reference/unreferenced-refunds/create-unreferenced-refund.mdx
+++ b/reference/unreferenced-refunds/create-unreferenced-refund.mdx
@@ -125,7 +125,7 @@ Use for SEPA / IBAN, ACH, and GoCardless mandate refunds.
 <ParamField body="provider_token" type="string">Provider-side reference to a pre-existing bank object. **Required for GoCardless** — carries the `mandate_id` (e.g. `MD000ABCDEF123`). When supplied, `bank_account` and `bank_id` are optional.</ParamField>
 <ParamField body="bank_account" type="string">IBAN (SEPA) or account number (ACH / local). Required when no `provider_token` is supplied.</ParamField>
 <ParamField body="bank_id" type="string">BIC / SWIFT (non-SEPA EU corridors) or ABA-9 routing number (ACH). Required for ACH.</ParamField>
-<ParamField body="account_type" type="string" required>One of: `IBAN`, `CHECKING`, `SAVINGS`, `CLABE`, `CCI`, `LOCAL`, `MANDATE` (new — used for GoCardless).</ParamField>
+<ParamField body="account_type" type="string" required>One of: `IBAN`, `CHECKING`, `SAVINGS`, `CLABE`, `CCI`, `LOCAL`, `MANDATE`.</ParamField>
 <ParamField body="beneficiary_name" type="string" required>Recipient name on the account.</ParamField>
 <ParamField body="beneficiary_type" type="string">`INDIVIDUAL` or `ENTITY`.</ParamField>
 <ParamField body="beneficiary_document" type="object">

--- a/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
+++ b/reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx
@@ -16,7 +16,7 @@ The `provider` object carries the untouched provider exchange in two fields. The
 | `raw_request` | The exact payload Yuno sent to the provider. | Requires your account to be enabled for provider raw data. Contact your Yuno account manager to request access. Not affected by `include_raw_responses`. |
 | `raw_response` | The full payload the provider returned. | Pass `include_raw_responses=true` on this request. |
 
-`raw_response_code` and `raw_response_message` are summaries of the provider's answer and are always returned, independently of both fields above.
+`raw_response_code` and `raw_response_message` are summaries of the provider's answer and are always returned, independently of both preceding fields.
 </Info>
 
 <ParamField header="public-api-key" type="string" required>

--- a/reference/unreferenced-refunds/unreferenced-refund-status.mdx
+++ b/reference/unreferenced-refunds/unreferenced-refund-status.mdx
@@ -12,7 +12,7 @@ The `status` field reports the current lifecycle stage. The `sub_status` field p
 | `CREATED`   | `CREATED`              | Temporary state. Yuno has persisted the refund after validation and is in the process of routing it to a provider.                                                                                                                                                                  |
 | `PENDING`   | `APPROVED`             | The provider has accepted the refund and is awaiting async network or bank settlement. Typical for ACH, SEPA, GoCardless.                                                                                                                                                           |
 | `SUCCEEDED` | `SUCCEEDED`            | Terminal. The refund has been delivered to the destination — either sync-settled by the provider (Stripe, Nuvei card refunds) or confirmed asynchronously via provider webhook (ACH, SEPA, GoCardless).                                                                            |
-| `FAILED`    | `DECLINED_BY_PROVIDER` | Terminal. The refund did not complete. Encompasses sync declines, async returns (ACH R-codes, SEPA RJCT), OFAC blocks, invalid accounts, insufficient merchant balance, SLA timeouts, and fraud declines. Detail lives in `provider.response_code` and `provider.response_message`. |
+| `FAILED`    | `DECLINED_BY_PROVIDER` | Terminal. The refund did not complete. Encompasses sync declines, async returns (ACH R-codes, SEPA RJCT), OFAC blocks, invalid accounts, insufficient merchant balance, SLA timeouts, and fraud declines. Detail lives in `provider.raw_response_code` and `provider.raw_response_message`. |
 
 </div>
 


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged em dashes, "e.g." usage, an outdated field name, a stale annotation, and long run-on sentences across five reference sections. This PR applies the confirmed fixes to the prose .mdx pages.

## Changes
- **reference/three-d-secure-setups/create-three-d-secure-setup.mdx**: rewrote em dashes into normal punctuation and split long sentences.
- **reference/unreferenced-refunds/unreferenced-refund-status.mdx**: fixed provider.response_code/response_message -> raw_response_code/raw_response_message, matching every sibling page and their JSON response examples.
- **reference/unreferenced-refunds/create-unreferenced-refund.mdx**: removed the stale "(new — used for GoCardless)" annotation from the account_type enum.
- **reference/unreferenced-refunds/retrieve-unreferenced-refund-by-id.mdx**: reworded "above" to "preceding".
- **reference/dry-run/register-dry-run-provider-event.mdx**: rewrote em dashes, replaced "e.g." with "for example", reworded "on ingest" to "on ingestion" (matching the convention already used in reporting/report-transactions.mdx), and split a long sentence.
- **reference/reporting/report-transactions.mdx**: replaced "e.g." with "for example", removed first-person "we", and split two long run-on sentences (the per-event status mapping and the idempotency paragraph).

Not applied: the report's suggestion to fix the amount.currency link on create-unreferenced-refund.mdx was skipped — that link (/reference/country-reference) is the same established, correct pattern already confirmed for currency-enum fields across the repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to reference prose; the status-page field rename aligns docs with existing API examples elsewhere in the same section.
> 
> **Overview**
> This PR applies **monthly docs-evaluation** prose fixes across five reference `.mdx` pages. There are no API or OpenAPI changes—only readability, style consistency, and one factual field-name correction.
> 
> **Style and clarity:** Em dashes are replaced with commas, colons, or split sentences in dry-run, 3DS2 setup, and related pages. **"e.g."** is standardized to **"for example"** in dry-run and transaction reporting. Transaction reporting also drops first-person **"we"**, breaks the long status-mapping paragraph into bullets, and tightens the idempotency / `report_id` wording. Dry-run uses **"on ingestion"** to match reporting docs.
> 
> **Unreferenced refunds:** The status lifecycle table now points failure detail to **`provider.raw_response_code`** and **`provider.raw_response_message`**, matching sibling pages and JSON examples. **`account_type`** enum text drops the stale **"(new — used for GoCardless)"** note. Retrieve-by-id rephrases **"above"** to **"preceding fields"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f538116806c80bf755fb97a2ce397365f614e904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->