### PR TITLE
docs(YSHUB-6665): document per-surface semantics of transactions and geolocation field naming

### DIFF
--- a/docs/webhooks/object-and-examples.mdx
+++ b/docs/webhooks/object-and-examples.mdx
@@ -83,6 +83,14 @@ Example payload:
   Each transaction includes `connection_data`, which identifies the provider connection that processed it. Use `connection_data.id` as the stable identifier to attribute transactions to a specific connection when you operate multiple connections for the same provider. `connection_data.name` is the display name configured in the Yuno dashboard and can be `null` on some events, such as follow-up transactions.
 </Info>
 
+<Info>
+  The `transactions` field carries a different meaning per surface. In webhook payloads, `data.payment.transactions` is a **single object** — the transaction that triggered the event — and `transactions_history` carries the full list of the payment's transactions. In the payment retrieve endpoints (`GET /payments/{payment_id}` and `GET /payments?merchant_order_id=`), `transactions` is an **array** containing every transaction of the payment.
+</Info>
+
+<Info>
+  Field naming: the customer geolocation is serialized as `geo_location` in webhook payloads and as `geolocation` in the payment retrieve endpoints. Parse each surface accordingly.
+</Info>
+
 ```json
 {
     "type": "payment",

--- a/reference/payments/retrieve-payment-by-id-v2.mdx
+++ b/reference/payments/retrieve-payment-by-id-v2.mdx
@@ -5,3 +5,7 @@ description: "Retrieves payment details using the payment ID provided in the req
 ---
 
 This request enables you to retrieve details of payments based on their `id`,  which needs to be provided in the request path.
+
+<Info>
+  `transactions` in this response is an array containing every transaction of the payment. In webhook payloads the same field name carries a single object — the transaction that triggered the event — with the full list under `transactions_history`. See [Webhook object and examples](/docs/object-and-examples).
+</Info>

--- a/reference/payments/retrieve-payment-by-merchant-order-id.mdx
+++ b/reference/payments/retrieve-payment-by-merchant-order-id.mdx
@@ -6,3 +6,7 @@ description: "Retrieves payment details using the merchant order ID provided in 
 
 This request enables you to retrieve details of payments based on their `merchant_order_id`,  which needs to be provided in the request path.
 
+<Info>
+  `transactions` in this response is an array containing every transaction of the payment. In webhook payloads the same field name carries a single object — the transaction that triggered the event — with the full list under `transactions_history`. See [Webhook object and examples](/docs/object-and-examples).
+</Info>
+


### PR DESCRIPTION
## What

Documents two per-surface differences that nothing in the docs stated until now (raised by Solutions while onboarding Zuora — YSHUB-6665):

1. **`transactions` means different things per surface.** Webhook payloads carry it as a **single object** (the transaction that triggered the event) plus `transactions_history` with the full list; the payment retrieve endpoints (`GET /payments/{payment_id}`, `GET /payments?merchant_order_id=`) return it as an **array** with every transaction of the payment. A merchant consuming both surfaces needs to know the same field name is not the same shape.
2. **The customer geolocation field is named differently per surface**: `geo_location` on webhooks, `geolocation` on the retrieve endpoints.

## Where

- `docs/webhooks/object-and-examples.mdx` — two `<Info>` callouts next to the existing payload notes.
- `reference/payments/retrieve-payment-by-merchant-order-id.mdx` — mirrored note.
- `reference/payments/retrieve-payment-by-id-v2.mdx` — mirrored note.

No behavior described here changes — this writes down what the APIs already do, so merchants can code one parser per surface deliberately.

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no API or runtime behavior changes.
> 
> **Overview**
> Documents two **per-surface** payment payload differences that were easy to miss when using webhooks and retrieve APIs together.
> 
> The webhook guide now explains that **`transactions`** is a single object (the event’s transaction) with the full set in **`transactions_history`**, while **`GET /payments/{payment_id}`** and **`GET /payments?merchant_order_id=`** return **`transactions`** as an array of all transactions. It also notes the geolocation name split: **`geo_location`** on webhooks vs **`geolocation`** on retrieve responses.
> 
> The same **`transactions`** vs webhook shape note is added on both retrieve reference pages, with a link back to the webhook examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a174e54f61f40af2a1b0d14c1bf8b42e8cdb6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->