### PR TITLE
docs(payment-links): apply docs-evaluation fixes

### DIFF
--- a/reference/payment-links/status-payment-links.mdx
+++ b/reference/payment-links/status-payment-links.mdx
@@ -3,7 +3,7 @@ title: "Payment Link Status"
 description: "Describes the possible statuses of a payment link and how they transition"
 ---
 
-Yuno's payment links solution enables businesses to accept payments effortlessly and offer subscriptions without additional websites or applications. These versatile links can be shared across various platforms, including social media, emails, and websites. Supporting diverse payment methods like credit and debit cards, Apple Pay, and Google Pay, payment links provide a secure and rapid way to collect payments.
+Yuno's payment links solution enables businesses to accept payments and offer subscriptions without additional websites or applications. These versatile links can be shared across various platforms, including social media, emails, and websites. Supporting diverse payment methods like credit and debit cards, Apple Pay, and Google Pay, payment links provide a secure and rapid way to collect payments.
 
 ## Workflow
 

--- a/reference/payment-links/the-payment-link-object.mdx
+++ b/reference/payment-links/the-payment-link-object.mdx
@@ -10,7 +10,7 @@ This object represents a payment link that can be associated with a customer.
 
 
 <ParamField body="id" type="string">
-  The unique identifier of the customer (MAX 64 ; MIN 36).
+  The unique identifier of the payment link (MAX 64; MIN 36).
 
   Example: 8546df3a-b83e-4bb5-a4b3-57aa6385924f
 </ParamField>
@@ -36,7 +36,7 @@ This object represents a payment link that can be associated with a customer.
 <ParamField body="status" type="enum">
   The status of the Payment link (MAX 255; MIN 3) (CREATED, USED, CANCELED, EXPIRED, ERROR).
 
-  Example: ACTIVE
+  Example: CREATED
 </ParamField>
 
 <ParamField body="merchant_order_id" type="string">
@@ -60,7 +60,7 @@ This object represents a payment link that can be associated with a customer.
 <ParamField body="capture" type="boolean">
   Decides whether to authorize the payment or capture it. Authorizing a card payment allows you to reserve
           funds in a customer's bank account. If the field is not sent, we will take it as true. You can later capture the
-          payment vía Yuno's dashboard or <a href="/reference/payments/capture-authorization">API method</a> .
+          payment via Yuno's dashboard or <a href="/reference/payments/capture-authorization">API method</a> .
 
   Example: true
 </ParamField>
@@ -312,7 +312,7 @@ This object represents a payment link that can be associated with a customer.
             <ParamField body="base_fare_currency" type="string">
               The currency used to transaction amount (MAX 3; MIN 3; <a href="/reference/country-reference">ISO 4217</a> ).
 
-              Example: Check the <a href="/reference/country-reference">Country reference</a>.
+              Possible enum values: Check the <a href="/reference/country-reference">Country reference</a>.
             </ParamField>
 
             <ParamField body="carrier_code" type="string">
@@ -481,7 +481,7 @@ This object represents a payment link that can be associated with a customer.
             </ParamField>
 
             <ParamField body="restricted" type="boolean">
-              Indicates if the ticket is refunfable or not.
+              Indicates if the ticket is refundable or not.
 
               Possible values: `True` or `False`
             </ParamField>
@@ -656,13 +656,13 @@ This object represents a payment link that can be associated with a customer.
         <ParamField body="name" type="string">
           The seller's legal name (MAX 255; MIN 3).
 
-          Example: Jhon Doe
+          Example: John Doe
         </ParamField>
 
         <ParamField body="email" type="string">
           The seller's e-mail (MAX 255; MIN 3).
 
-          Example: jhondoe@business.com
+          Example: john.doe@business.com
         </ParamField>
 
         <ParamField body="reference" type="string">


### PR DESCRIPTION
## PR Description
Monthly docs-evaluation review flagged a promotional adjective, a copy-pasted field description, an invalid enum example, a mislabeled enum-explanation text, and a few typos on the Payment Links reference pages. This PR applies the confirmed fixes to the prose .mdx pages.

## Changes
- **reference/payment-links/status-payment-links.mdx**: removed the promotional "effortlessly".
- **reference/payment-links/the-payment-link-object.mdx**: fixed the id field description (was copied from the Customer object) and its stray space in "MAX 64 ; MIN 36"; fixed the status field's invalid ACTIVE example to CREATED, matching the real status values listed two lines above; fixed base_fare_currency's "Example:" label, which held enum-explanation text instead of an example value; fixed "vía" -> "via", "refunfable" -> "refundable", and "Jhon Doe" -> "John Doe" (plus the derived jhondoe@business.com email example).

Not applied: the report's IATA-link and currency/country-link items were skipped. The IATA links are syntactically well-formed with no concrete defect found (flagged for clarification). The currency/country links are the same established, correct pattern already confirmed elsewhere in the repo (ISO 4217 fields linking to the country reference page, which documents currency codes per country).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to MDX reference pages with no runtime, API, or security impact.
> 
> **Overview**
> Applies **monthly docs-evaluation** corrections on the Payment Links reference pages—documentation-only, no API or behavior changes.
> 
> On **Payment Link Status**, the intro drops the promotional word **“effortlessly”** so the overview stays neutral.
> 
> On **The Payment Link Object**, several field docs are aligned with the real model: **`id`** now describes the payment link (not a pasted customer description) with normalized length formatting; **`status`**’s example changes from invalid **`ACTIVE`** to **`CREATED`**, matching the documented enum; **`base_fare_currency`** uses **“Possible enum values:”** instead of mislabeled **“Example:”** text; and small copy fixes (**via**, **refundable**, **John Doe** / **john.doe@business.com**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96dc81a2be2e00f39b12a5b9eb233768dae0882b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->