### PR TITLE
chore: vtex sdk changelog 4.2.349

### DIFF
--- a/changelog/source/vtex.json
+++ b/changelog/source/vtex.json
@@ -2,6 +2,24 @@
   "sdk": "vtex",
   "releases": [
     {
+      "version": "4.2.349",
+      "release_date": "2026-08-26",
+      "upgrade": {
+        "snippet": "vtex install yunopartnerbr.yuno@4.2.349",
+        "language": "bash"
+      },
+      "entries": [
+        {
+          "type": "ADDED",
+          "title": "Marketplace seller and affiliate identity in payment metadata",
+          "description": "Every payment now carries the VTEX seller id (`seller_id`) and, for stores selling through a VTEX marketplace in affiliate mode, the affiliate code (`affiliate_id`), so transactions can be attributed to the right seller in Yuno reporting and routing rules. Stores that do not sell through a marketplace report `NA` for the affiliate code and nothing else changes.",
+          "group": "Payments",
+          "migration_guide": null,
+          "links": []
+        }
+      ]
+    },
+    {
       "version": "4.2.348",
       "release_date": "2026-08-25",
       "upgrade": {


### PR DESCRIPTION
Auto-generated changelog entry for **vtex** SDK `4.2.349`.

Source: https://github.com/yuno-payments/sdk-vtex-connector/releases/tag/v4.2.349

1 entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only update with no application code changes in this repository.
> 
> **Overview**
> This PR **prepends** VTEX SDK **4.2.349** (2026-08-26) to `changelog/source/vtex.json`, including the `vtex install yunopartnerbr.yuno@4.2.349` upgrade snippet.
> 
> The new release documents one **ADDED** Payments change: payments now include **`seller_id`** and, for marketplace affiliate stores, **`affiliate_id`** in metadata for Yuno reporting and routing; non-marketplace stores send **`NA`** for affiliate and behavior is otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612b39654b4901ae9b69fc4fffba3254fd30296b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->